### PR TITLE
fix(firmware): bump 3 undersized task stacks (W14-H07)

### DIFF
--- a/main/heap_watchdog.c
+++ b/main/heap_watchdog.c
@@ -279,7 +279,15 @@ void heap_watchdog_start(void)
     xTaskCreatePinnedToCore(
         heap_watchdog_task,
         "heap_wd",
-        3072,           /* Stack: 3KB — heap_caps + LVGL mem_monitor + task HWM queries + logging */
+        /* Wave 14 W14-H07: bumped 3 KB → 4 KB.  The task does
+         * heap_caps_get_free_size + takes NVS mutex (via
+         * tab5_settings_get_nvs_write_count) + ESP_LOGI with formatted
+         * args.  Formatted logging alone can burn 400-600 B of stack.
+         * Ironic failure: the task designed to *detect* low-memory
+         * conditions could itself stack_chk_fail during a real frag
+         * storm, masking the root cause with a cryptic guru rather
+         * than the intended controlled reboot. */
+        4096,
         NULL,
         1,              /* Priority 1 — lowest, background monitoring */
         NULL,

--- a/main/ui_audio.c
+++ b/main/ui_audio.c
@@ -42,7 +42,12 @@ static const char *TAG = "ui_audio";
 
 /* ── Audio buffer ────────────────────────────────────────────── */
 #define AUDIO_CHUNK_SAMPLES  8192
-#define PLAYBACK_STACK_SIZE  4096
+/* Wave 14 W14-H07: bumped 4 KB → 8 KB.  The playback task holds an
+ * open FATFS FILE (~2-4 KB sector buffers), an I2S handle, and
+ * LVGL calls that grab the display mutex (tab5_ui_lock +
+ * lv_label_set_text_fmt at 100-137).  Long WAV playback on a fresh
+ * boot was trapping stack_chk_fail.  PSRAM cost is trivial. */
+#define PLAYBACK_STACK_SIZE  8192
 
 /* ── WAV header (standard 44-byte RIFF/PCM) ──────────────────── */
 typedef struct __attribute__((packed)) {

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -1444,10 +1444,16 @@ static void cb_new_voice(lv_event_t *e)
             ESP_LOGI(TAG, "Dictation started (SD + Dragon): %s", wav);
         }
     } else {
-        /* Offline or busy — SD-only recording with standalone mic task */
+        /* Offline or busy — SD-only recording with standalone mic task.
+         * Wave 14 W14-H07: stack bumped from 4 KB to 8 KB. The task
+         * calls tab5_mic_read (I2S DMA path) then funnels through
+         * FATFS/VFS (~2-4 KB of FATFS sector buffers + libc FILE state)
+         * plus ESP_LOGI with formatted args. 4 KB trapped stack_chk_fail
+         * on long offline recordings (>20 s). 8 KB matches the voice
+         * mic task and gives comfortable headroom in PSRAM. */
         s_sd_rec_running = true;
         xTaskCreatePinnedToCore(
-            sd_record_task, "sd_rec", 4096, NULL, 5, &s_sd_rec_task, 1);
+            sd_record_task, "sd_rec", 8192, NULL, 5, &s_sd_rec_task, 1);
         ESP_LOGI(TAG, "Recording to SD only: %s", wav);
 
         /* Try to connect Dragon in background for later transcription */


### PR DESCRIPTION
## Summary

Phase 4 stability — 3 one-line stack bumps that fix realistic stack_chk_fail traps under FATFS + I2S workloads.

| Task | Old | New | Why |
|------|-----|-----|-----|
| `sd_record_task` | 4 KB | 8 KB | FATFS buffers (2-4 KB) + libc FILE + I2S DMA + logging. Long offline recording (>20 s) tripped guru. |
| `PLAYBACK_STACK_SIZE` (`playback_task_fn`) | 4 KB | 8 KB | Same class + LVGL lock + label updates per frame. |
| `heap_wd` | 3 KB | 4 KB | Observability task that could stack-overflow *inside* a real frag storm, masking the root cause. |

PSRAM cost negligible.

## Test plan

Verified live on 192.168.1.90:
- [x] `idf.py build` clean (27% partition free)
- [x] `idf.py flash` successful, boots in <10 s
- [x] `/info` post-flash: `wifi=true dragon=true voice=true tasks=25 heap_min=21724236`
- [x] Home screenshot renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)