### PR TITLE
feat(firmware): shared job-queue worker — kill per-action task leak (W14-H06)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -37,6 +37,7 @@ else()
              "ui_core.c" ${UI_SRCS}
              "settings.c" "ota.c" "media_cache.c"
              "widget_store.c"
+             "task_worker.c"
         INCLUDE_DIRS "."
         REQUIRES tab5
                  esp_lcd esp_psram driver nvs_flash esp_system heap esp_mm esp_timer

--- a/main/chat_session_drawer.c
+++ b/main/chat_session_drawer.c
@@ -10,6 +10,7 @@
  * aren't touched from Core 1.
  */
 #include "chat_session_drawer.h"
+#include "task_worker.h"
 #include "ui_theme.h"
 #include "config.h"
 #include "settings.h"
@@ -322,13 +323,15 @@ static void parse_sessions_json(const char *json_txt, size_t len,
     cJSON_Delete(root);
 }
 
+/* Wave 14 W14-H06: runs on the shared tab5_worker, not its own task.
+ * Plain function body — early returns instead of vTaskSuspend(NULL). */
 static void drawer_fetch_task(void *arg)
 {
     drawer_fetch_ctx_t *ctx = (drawer_fetch_ctx_t *)arg;
-    if (!ctx) { vTaskSuspend(NULL); return; }
+    if (!ctx) return;
 
     drawer_fetch_result_t *res = calloc(1, sizeof(*res));
-    if (!res) { free(ctx); vTaskSuspend(NULL); return; }
+    if (!res) { free(ctx); return; }
     res->d = ctx->d;
     res->gen = ctx->gen;
 
@@ -367,7 +370,6 @@ static void drawer_fetch_task(void *arg)
 
     lv_async_call(on_result_async, res);
     free(ctx);
-    vTaskSuspend(NULL);
 }
 
 /* ── Public API ────────────────────────────────────────────────── */
@@ -488,10 +490,10 @@ void chat_session_drawer_show(chat_session_drawer_t *d)
     if (!host[0]) snprintf(host, sizeof(host), "%s", TAB5_DRAGON_HOST);
     snprintf(ctx->url, sizeof(ctx->url),
              "http://%s:%u/api/v1/sessions?limit=10", host, port);
-    BaseType_t ok = xTaskCreatePinnedToCore(drawer_fetch_task, "drawer_fetch",
-                                             8192, ctx, 3, NULL, 1);
-    if (ok != pdPASS) {
-        ESP_LOGE(TAG, "drawer_fetch spawn failed");
+    /* W14-H06: shared worker; ctx is freed inside drawer_fetch_task. */
+    esp_err_t enq = tab5_worker_enqueue(drawer_fetch_task, ctx, "drawer_fetch");
+    if (enq != ESP_OK) {
+        ESP_LOGE(TAG, "drawer_fetch enqueue failed: %s", esp_err_to_name(enq));
         free(ctx);
     }
 }

--- a/main/main.c
+++ b/main/main.c
@@ -53,6 +53,7 @@
 #include "mode_manager.h"
 #include "service_registry.h"
 #include "heap_watchdog.h"
+#include "task_worker.h"
 
 static const char *TAG = "tab5";
 
@@ -456,6 +457,12 @@ void app_main(void)
 
     // Print service status table
     tab5_services_print_status();
+
+    // Wave 14 W14-H06: start the shared job-worker task before any UI
+    // surface dispatches background work through it.  Must come before
+    // heap_watchdog_start() and user-reachable UI callbacks so the
+    // first enqueue doesn't race the init.
+    tab5_worker_init();
 
     // Start PSRAM heap fragmentation watchdog (background, Core 1, prio 1)
     heap_watchdog_start();

--- a/main/task_worker.c
+++ b/main/task_worker.c
@@ -1,0 +1,103 @@
+/*
+ * task_worker.c — wave 14 W14-H06 shared job queue implementation.
+ *
+ * One persistent task on Core 1, 16 KB stack (matches the combined
+ * worst case of the four job types: mode_switch_* + wifi_connect +
+ * media_fetch + drawer_fetch).
+ */
+
+#include "task_worker.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+
+static const char *TAG = "worker";
+
+/* A single queue entry: function pointer + arg + short tag for the
+ * trace log. */
+typedef struct {
+    tab5_worker_fn_t fn;
+    void *arg;
+    const char *tag;   /* stored as-is; must be a string literal or a
+                          pointer that outlives the job — callers in
+                          this repo pass literals from call sites. */
+} job_t;
+
+static QueueHandle_t s_queue = NULL;
+static TaskHandle_t s_task = NULL;
+static bool s_inited = false;
+
+static void worker_task(void *arg)
+{
+    (void)arg;
+    ESP_LOGI(TAG, "worker task started (queue depth=%d)",
+             TAB5_WORKER_QUEUE_DEPTH);
+    job_t job;
+    for (;;) {
+        /* Block indefinitely waiting for the next job. */
+        if (xQueueReceive(s_queue, &job, portMAX_DELAY) != pdTRUE) {
+            continue;  /* spurious wakeup */
+        }
+        if (!job.fn) {
+            ESP_LOGW(TAG, "skipped job with NULL fn (tag=%s)",
+                     job.tag ? job.tag : "-");
+            continue;
+        }
+        ESP_LOGD(TAG, "run job tag=%s", job.tag ? job.tag : "-");
+        job.fn(job.arg);
+        ESP_LOGD(TAG, "done job tag=%s", job.tag ? job.tag : "-");
+    }
+}
+
+esp_err_t tab5_worker_init(void)
+{
+    if (s_inited) {
+        return ESP_OK;
+    }
+    s_queue = xQueueCreate(TAB5_WORKER_QUEUE_DEPTH, sizeof(job_t));
+    if (!s_queue) {
+        ESP_LOGE(TAG, "xQueueCreate failed");
+        return ESP_ERR_NO_MEM;
+    }
+    BaseType_t ok = xTaskCreatePinnedToCore(
+        worker_task, "tab5_worker",
+        16384,         /* stack: sized for the largest job family. */
+        NULL, 5, &s_task, 1);
+    if (ok != pdPASS) {
+        vQueueDelete(s_queue);
+        s_queue = NULL;
+        ESP_LOGE(TAG, "xTaskCreatePinnedToCore failed");
+        return ESP_ERR_NO_MEM;
+    }
+    s_inited = true;
+    return ESP_OK;
+}
+
+esp_err_t tab5_worker_enqueue(tab5_worker_fn_t fn,
+                              void *arg,
+                              const char *tag)
+{
+    if (!s_inited || !s_queue) {
+        ESP_LOGE(TAG, "enqueue(%s): worker not initialized",
+                 tag ? tag : "-");
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!fn) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    job_t job = {.fn = fn, .arg = arg, .tag = tag};
+    /* Non-blocking: if the queue is full, drop + log.  This is
+     * preferable to blocking the caller (usually an LVGL event
+     * handler) — jobs piling up past 16 indicates a dispatch
+     * problem that should be visible in logs. */
+    if (xQueueSend(s_queue, &job, 0) != pdTRUE) {
+        ESP_LOGW(TAG, "queue full, dropping job tag=%s",
+                 tag ? tag : "-");
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}

--- a/main/task_worker.h
+++ b/main/task_worker.h
@@ -1,0 +1,41 @@
+/*
+ * task_worker.h — wave 14 W14-H06 shared job queue.
+ *
+ * Replaces the "spawn a throwaway task that does one thing then
+ * vTaskSuspend(NULL)" pattern that was leaking 8 KB of PSRAM + one TCB
+ * per user-reachable action (mic tap, wifi retry, widget-media URL
+ * change, session-drawer open). After ~40 mic taps or ~200 drawer
+ * opens the PSRAM fragmentation watchdog eventually rebooted the
+ * device. With this queue, every "background blip" becomes a single
+ * enqueue() call, and one long-lived worker task handles them all in
+ * sequence.
+ *
+ * Concurrency: single worker, single-threaded with respect to the
+ * jobs it runs. Jobs must not block LVGL.  If a job needs the LVGL
+ * mutex it takes it itself.
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include <stdbool.h>
+
+/* Maximum number of queued jobs. Jobs past this are dropped + logged. */
+#define TAB5_WORKER_QUEUE_DEPTH 16
+
+/* Jobs are just a function pointer + a single void* argument.  The
+ * worker does NOT free(arg) — if the caller malloc'd it, the job
+ * function must free it.  `tag` is a short string used in the
+ * ESP_LOGI "running job X" trace. */
+typedef void (*tab5_worker_fn_t)(void *arg);
+
+/* Create the worker task.  Idempotent.  Must be called once at boot
+ * before any enqueue — typically from main.c after NVS init. */
+esp_err_t tab5_worker_init(void);
+
+/* Post a job to the worker.  Returns ESP_OK on success,
+ * ESP_ERR_NO_MEM if the queue is full (caller MUST handle — the
+ * argument they passed will not be freed by the worker). */
+esp_err_t tab5_worker_enqueue(tab5_worker_fn_t fn,
+                              void *arg,
+                              const char *tag);

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -44,6 +44,7 @@
 #include "dragon_link.h"
 #include "wifi.h"
 #include "widget.h"
+#include "task_worker.h"
 #include "media_cache.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -1416,10 +1417,13 @@ static void media_image_clear_cb(void *arg)
     memset(&s_media_dsc, 0, sizeof(s_media_dsc));
 }
 
+/* Wave 14 W14-H06: dispatched via tab5_worker; no longer its own
+ * FreeRTOS task.  Plain function — early returns instead of
+ * vTaskSuspend(NULL), and the trailing suspend is gone. */
 static void media_fetch_task(void *pv)
 {
     char *url = (char *)pv;
-    if (!url) { vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */; return; }
+    if (!url) return;
     ESP_LOGI(TAG, "widget_media fetch: %s", url);
     lv_image_dsc_t dsc = {0};
     esp_err_t err = media_cache_fetch(url, &dsc);
@@ -1432,7 +1436,6 @@ static void media_fetch_task(void *pv)
     }
     free(url);
     s_media_fetch_inflight = false;
-    vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
 }
 
 static void refresh_media_image(const widget_t *w)
@@ -1459,10 +1462,10 @@ static void refresh_media_image(const widget_t *w)
     char *copy = strdup(w->media_url);
     if (!copy) return;
     s_media_fetch_inflight = true;
-    BaseType_t ok = xTaskCreatePinnedToCore(
-        media_fetch_task, "widget_media", 8192, copy, 3, NULL, 1);
-    if (ok != pdPASS) {
-        ESP_LOGW(TAG, "widget_media: failed to spawn fetch task");
+    /* W14-H06: shared worker. */
+    esp_err_t enq = tab5_worker_enqueue(media_fetch_task, copy, "widget_media");
+    if (enq != ESP_OK) {
+        ESP_LOGW(TAG, "widget_media: enqueue failed (%s), dropping", esp_err_to_name(enq));
         free(copy);
         s_media_fetch_inflight = false;
     }

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -18,6 +18,7 @@
 #include "mode_manager.h"
 #include "config.h"
 #include "settings.h"
+#include "task_worker.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
@@ -29,8 +30,8 @@
 static const char *TAG = "ui_voice";
 
 /* Forward declarations for mode switch helper tasks */
-static void mode_switch_voice_task(void *arg);
-static void mode_switch_idle_task(void *arg);
+static void mode_switch_voice_job(void *arg);
+static void mode_switch_idle_job(void *arg);
 
 /* ── Palette — Voice overlay (v5 Zero Interface — amber-led) ─────
    Names kept for minimal-diff; values map to the v5 ui_theme palette.
@@ -345,11 +346,13 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
             ESP_LOGI(TAG, "Boot connect ended (IDLE)");
         }
         /* Voice session ended — return to IDLE (no auto-streaming).
-         * Must defer to a task because we're inside the LVGL mutex here. */
+         * Must defer because we're inside the LVGL mutex here.
+         * Wave 14 W14-H06: dispatch via the shared tab5_worker queue
+         * instead of spawning a one-shot task that would leak its
+         * 8 KB stack + TCB. */
         if (tab5_mode_get() == MODE_VOICE) {
             ESP_LOGI(TAG, "Voice ended, scheduling switch to IDLE");
-            xTaskCreatePinnedToCore(
-                mode_switch_idle_task, "mode_idle", 8192, NULL, 5, NULL, 1);
+            tab5_worker_enqueue(mode_switch_idle_job, NULL, "mode_idle");
         }
         /* C5: Offline recording fallback — if connect failed and user wanted
          * to record, fall back to local SD card recording via Notes. */
@@ -1566,16 +1569,21 @@ static void rec_timer_cb(lv_timer_t *t)
 /* ================================================================
  *  Mode switch helper (runs outside LVGL context to avoid watchdog)
  * ================================================================ */
-static void mode_switch_voice_task(void *arg)
+/* Wave 14 W14-H06: these are now plain job functions, not FreeRTOS
+ * tasks.  The tab5_worker task runs them one at a time, so the old
+ * "spawn 8 KB task + vTaskSuspend forever" leak pattern is gone.
+ * Firing the mic orb 40 times no longer costs 320 KB of PSRAM + 40
+ * permanently-suspended TCBs. */
+static void mode_switch_voice_job(void *arg)
 {
+    (void)arg;
     tab5_mode_switch(MODE_VOICE);
-    vTaskSuspend(NULL);  /* P4 TLSP crash workaround (#20) */
 }
 
-static void mode_switch_idle_task(void *arg)
+static void mode_switch_idle_job(void *arg)
 {
+    (void)arg;
     tab5_mode_switch(MODE_IDLE);
-    vTaskSuspend(NULL);  /* P4 TLSP crash workaround (#20) */
 }
 
 /* ================================================================
@@ -1591,11 +1599,11 @@ static void mic_click_cb(lv_event_t *e)
 
     switch (state) {
     case VOICE_STATE_IDLE:
-        /* Not connected — connect to Dragon, then auto-start Ask mode */
+        /* Not connected — connect to Dragon, then auto-start Ask mode.
+         * W14-H06: dispatched on the shared worker. */
         ESP_LOGI(TAG, "Requesting VOICE mode (pending: ask)...");
         s_pending_ask = true;
-        xTaskCreatePinnedToCore(
-            mode_switch_voice_task, "mode_voice", 8192, NULL, 5, NULL, 1);
+        tab5_worker_enqueue(mode_switch_voice_job, NULL, "mode_voice");
         break;
     case VOICE_STATE_READY: {
         /* Connected — start Ask mode, but stop streaming first if active */
@@ -1603,8 +1611,7 @@ static void mic_click_cb(lv_event_t *e)
         if (cur_mode == MODE_STREAMING || cur_mode == MODE_BROWSING) {
             ESP_LOGI(TAG, "READY but streaming active — mode switch first");
             s_pending_ask = true;
-            xTaskCreatePinnedToCore(
-                mode_switch_voice_task, "mode_voice", 8192, NULL, 5, NULL, 1);
+            tab5_worker_enqueue(mode_switch_voice_job, NULL, "mode_voice");
         } else {
             ESP_LOGI(TAG, "READY → Ask mode");
             voice_start_listening();
@@ -1636,14 +1643,12 @@ static void mic_long_press_cb(lv_event_t *e)
     s_dictation_from_anywhere = true;
 
     if (state == VOICE_STATE_IDLE) {
-        xTaskCreatePinnedToCore(
-            mode_switch_voice_task, "mode_voice", 8192, NULL, 5, NULL, 1);
+        tab5_worker_enqueue(mode_switch_voice_job, NULL, "mode_voice");
     } else if (state == VOICE_STATE_READY) {
         tab5_mode_t cur_mode = tab5_mode_get();
         if (cur_mode == MODE_STREAMING || cur_mode == MODE_BROWSING) {
             ESP_LOGI(TAG, "READY but streaming — mode switch, then dictate");
-            xTaskCreatePinnedToCore(
-                mode_switch_voice_task, "mode_voice", 8192, NULL, 5, NULL, 1);
+            tab5_worker_enqueue(mode_switch_voice_job, NULL, "mode_voice");
         } else {
             esp_err_t ret = voice_start_dictation();
             if (ret != ESP_OK) {

--- a/main/ui_wifi.c
+++ b/main/ui_wifi.c
@@ -18,6 +18,7 @@
 #include "wifi.h"
 #include "settings.h"
 #include "config.h"
+#include "task_worker.h"
 
 #include "esp_wifi.h"
 #include "esp_netif.h"
@@ -164,8 +165,8 @@ static void cb_network_row(lv_event_t *e)
     if (s_ap_records[idx].authmode == WIFI_AUTH_OPEN) {
         strncpy(s_selected_ssid, ssid, sizeof(s_selected_ssid) - 1);
         s_selected_ssid[sizeof(s_selected_ssid) - 1] = '\0';
-        /* Connect with empty password */
-        xTaskCreate(wifi_connect_task, "wifi_conn", 8192, strdup(""), 5, NULL);
+        /* Connect with empty password (W14-H06: shared worker, no task leak). */
+        tab5_worker_enqueue(wifi_connect_task, strdup(""), "wifi_conn");
     } else {
         show_password_dialog(ssid);
     }
@@ -198,7 +199,8 @@ static void cb_pwd_connect(lv_event_t *e)
     ui_keyboard_hide();
 
     char *pwd_copy = strdup(pwd);
-    xTaskCreate(wifi_connect_task, "wifi_conn", 8192, pwd_copy, 5, NULL);
+    /* W14-H06: shared worker, no task leak. */
+    tab5_worker_enqueue(wifi_connect_task, pwd_copy, "wifi_conn");
 }
 
 static void cb_pwd_cancel(lv_event_t *e)
@@ -273,11 +275,15 @@ static void scan_done_handler(void *arg, esp_event_base_t event_base,
 
 /* ── WiFi connect background task ──────────────────────────────────── */
 
+/* Wave 14 W14-H06: dispatched via tab5_worker; no longer its own
+ * FreeRTOS task.  Early-exit paths now just `return` — caller owns
+ * nothing past this point and the worker loops back to service the
+ * next job. */
 static void wifi_connect_task(void *arg)
 {
     char *password = (char *)arg;
 
-    if (s_destroying) { free(password); vTaskSuspend(NULL); return; }
+    if (s_destroying) { free(password); return; }
 
     ESP_LOGI(TAG, "Connecting to '%s'...", s_selected_ssid);
 
@@ -314,7 +320,6 @@ static void wifi_connect_task(void *arg)
             tab5_ui_unlock();
         }
         free(password);
-        vTaskSuspend(NULL);
         return;
     }
 
@@ -330,7 +335,6 @@ static void wifi_connect_task(void *arg)
             tab5_ui_unlock();
         }
         free(password);
-        vTaskSuspend(NULL);
         return;
     }
 
@@ -379,7 +383,6 @@ static void wifi_connect_task(void *arg)
     }
 
     free(password);
-    vTaskSuspend(NULL);
 }
 
 /* ── RSSI to signal bars ───────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

The biggest wave-14 firmware finding. Four task families all shared a broken pattern:

```c
xTaskCreatePinnedToCore(one_shot_fn, ..., NULL /* no handle */);
void one_shot_fn(void *arg) { do_work(); vTaskSuspend(NULL); /* P4 TLSP */ }
```

Every spawn leaked 8 KB stack + 1 TCB permanently (can't `vTaskDelete(NULL)` on P4 per issue #20). 40 mic taps = 320 KB PSRAM gone; 200 drawer opens = 1.5 MB and a watchdog reboot.

### Fix

One long-lived `tab5_worker` (16 KB stack, Core 1, 16-deep queue) owns all background work. New module `main/task_worker.{h,c}`. Every leak site now does a single `tab5_worker_enqueue(fn, arg, "tag")` call; the four task functions lose their `vTaskSuspend(NULL)` trailers and become plain jobs.

Converted sites:
- `main/ui_voice.c` — `mode_switch_{voice,idle}` (5 spawns → 5 enqueues)
- `main/ui_wifi.c` — `wifi_connect_task` (2 spawns)
- `main/ui_home.c` — `media_fetch_task`
- `main/chat_session_drawer.c` — `drawer_fetch_task`

Initialized from `app_main()` before `heap_watchdog_start()`.

## Test plan

Live verified on 192.168.1.90:
- [x] `idf.py build` clean (27% partition free)
- [x] Flash + reboot; `/info`: `tasks=26` (baseline 25 + the new worker itself)
- [x] **20-tap user story:**
  - baseline: `tasks=26 heap_free=21734072 psram_free=21733576`
  - after 20 taps: `tasks=26 heap_free=21733448 psram_free=21733152`
  - **delta: tasks=+0, psram=-424 B** (pre-H06 expected: +20 tasks, -160 KB)
- [x] Voice overlay opened mid-stress and dismissed cleanly
- [x] Home UI renders clean post-dismiss; Dragon `active_connections=1` throughout

Screenshots at `/tmp/wave14_proof/h06_*.jpg`.

## Follow-up (not in scope)

10 other `vTaskSuspend(NULL)` sites exist in `main.c`, `mjpeg_stream.c`, `sdcard.c`, `touch_ws.c`, `udp_stream.c`, `ui_audio.c`, `ui_notes.c`, `debug_server.c`, `chat_msg_view.c`, `ui_memory.c`. Those fire exactly once at startup or infrequently and are bounded — keeping the wave-13 C4 workaround for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)