### PR TITLE
fix(firmware): wave 14 Phase 6 TT — 8 MED/LOW races + polish (M01-M04, M08, L01-L03)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1732,16 +1732,17 @@ static esp_err_t voice_state_handler(httpd_req_t *req)
     int st = (int)voice_get_state();
     cJSON_AddStringToObject(root, "state_name", (st >= 0 && st <= 6) ? state_names[st] : "UNKNOWN");
 
-    /* Include last LLM text if available */
-    const char *llm_text = voice_get_llm_text();
-    if (llm_text && llm_text[0]) {
-        cJSON_AddStringToObject(root, "last_llm_text", llm_text);
+    /* Wave 14 W14-M01: the debug httpd task races with voice.c's
+     * WS RX task.  Use the copy-under-mutex variants to avoid
+     * observing a mid-strcat string. */
+    char llm_buf[512];
+    if (voice_get_llm_text_copy(llm_buf, sizeof(llm_buf)) && llm_buf[0]) {
+        cJSON_AddStringToObject(root, "last_llm_text", llm_buf);
     }
 
-    /* Include last STT text */
-    const char *stt_text = voice_get_stt_text();
-    if (stt_text && stt_text[0]) {
-        cJSON_AddStringToObject(root, "last_stt_text", stt_text);
+    char stt_buf[512];
+    if (voice_get_stt_text_copy(stt_buf, sizeof(stt_buf)) && stt_buf[0]) {
+        cJSON_AddStringToObject(root, "last_stt_text", stt_buf);
     }
 
     char *json = cJSON_PrintUnformatted(root);

--- a/main/dragon_link.c
+++ b/main/dragon_link.c
@@ -27,7 +27,11 @@
 static const char *TAG = "dragon_link";
 
 // State
-static dragon_state_t s_state = DRAGON_STATE_IDLE;
+/* Wave 14 W14-M03: volatile — written on dragon_link_task (Core 0),
+ * read on LVGL home refresh loop from any core.  Without volatile
+ * the compiler may cache the load and pin the home pill on
+ * "discovering" after a real reconnect. */
+static volatile dragon_state_t s_state = DRAGON_STATE_IDLE;
 static volatile bool s_stop_requested = false;
 static volatile bool s_start_requested = false;
 static uint32_t s_backoff_ms = TAB5_DRAGON_RECONNECT_BASE_MS;

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -482,7 +482,11 @@ static lv_obj_t *s_rec_text_lbl = NULL;   /* "Recording..." or "Paused" */
 static lv_obj_t *s_topbar_meta  = NULL;   /* v5 right-aligned count/size */
 static lv_timer_t *s_rec_timer = NULL;    /* 1s update timer */
 static int s_rec_seconds = 0;
-static bool s_rec_paused = false;         /* TODO: pause/resume not yet implemented */
+/* Wave 14 W14-L01: deleted `s_rec_paused` + its three callsites.
+ * Pause/resume was never implemented; the variable was always false,
+ * the guard in rec_timer_cb was a no-op, and the two assignments-to-
+ * false at recording start/stop were dead stores. If/when we actually
+ * add pause/resume, re-introduce with a matching toggle path. */
 
 /* ── Edit overlay state ────────────────────────────────── */
 static lv_obj_t *s_edit_overlay = NULL;
@@ -511,7 +515,6 @@ static void hide_recording_indicator(void);
 static void rec_timer_cb(lv_timer_t *t)
 {
     (void)t;
-    if (s_rec_paused) return;
     s_rec_seconds++;
     if (s_rec_time_lbl) {
         lv_label_set_text_fmt(s_rec_time_lbl, "%d:%02d", s_rec_seconds / 60, s_rec_seconds % 60);
@@ -531,7 +534,6 @@ static void show_recording_indicator(void)
     if (s_rec_indicator) return;  /* already showing */
 
     s_rec_seconds = 0;
-    s_rec_paused = false;
 
     /* Bar: full width, 40px tall, positioned below search bar above notes list.
      * Search bar ends at TOPBAR_H + BTN_ROW_H + SEARCH_H + 4.
@@ -599,7 +601,6 @@ static void hide_recording_indicator(void)
     s_rec_text_lbl = NULL;
     s_rec_time_lbl = NULL;
     s_rec_seconds = 0;
-    s_rec_paused = false;
 
     /* Restore list position */
     if (s_list) {
@@ -1030,21 +1031,35 @@ static void transcription_queue_task(void *arg)
             notes_save();
             continue;
         }
-        /* Fix WAV header if it was from a crashed recording (header says 0 data) */
+        /* Fix WAV header if it was from a crashed recording (header says 0 data).
+         * Wave 14 W14-M04: check every fread/fwrite return.  A short
+         * read used to leave `hdr_data_size` with stack garbage, which
+         * then got written to disk — silent corruption of the RIFF
+         * size fields on a flaky SD card. */
         if (file_size > 44) {
             uint32_t hdr_data_size = 0;
-            fseek(f, 40, SEEK_SET);
-            fread(&hdr_data_size, 4, 1, f);
-            if (hdr_data_size == 0 || hdr_data_size > (uint32_t)(file_size - 44)) {
+            if (fseek(f, 40, SEEK_SET) != 0 ||
+                fread(&hdr_data_size, 4, 1, f) != 1) {
+                ESP_LOGW(TAG, "WAV header read failed for %s — skipping repair",
+                         n->audio_path);
+            } else if (hdr_data_size == 0 ||
+                       hdr_data_size > (uint32_t)(file_size - 44)) {
                 /* Fix the header in place */
                 uint32_t actual_data = (uint32_t)(file_size - 44);
                 uint32_t riff_size = actual_data + 36;
-                fseek(f, 4, SEEK_SET);
-                fwrite(&riff_size, 4, 1, f);
-                fseek(f, 40, SEEK_SET);
-                fwrite(&actual_data, 4, 1, f);
-                fflush(f);
-                ESP_LOGI(TAG, "Fixed WAV header: %lu data bytes", (unsigned long)actual_data);
+                bool ok =
+                    (fseek(f, 4, SEEK_SET) == 0) &&
+                    (fwrite(&riff_size, 4, 1, f) == 1) &&
+                    (fseek(f, 40, SEEK_SET) == 0) &&
+                    (fwrite(&actual_data, 4, 1, f) == 1);
+                if (ok) {
+                    fflush(f);
+                    ESP_LOGI(TAG, "Fixed WAV header: %lu data bytes",
+                             (unsigned long)actual_data);
+                } else {
+                    ESP_LOGW(TAG, "WAV header repair fwrite failed for %s",
+                             n->audio_path);
+                }
             }
             fseek(f, 0, SEEK_SET);
         }

--- a/main/voice.c
+++ b/main/voice.c
@@ -22,6 +22,7 @@
  */
 
 #include "voice.h"
+#include <limits.h>  /* W14-L02: INT_MAX for WS size_t->int bound */
 #include "afe.h"
 #include "widget.h"
 #include "ui_voice.h"
@@ -159,7 +160,12 @@ static SemaphoreHandle_t s_state_mutex = NULL;
 static volatile uint32_t s_session_gen = 0;
 
 // WebSocket client (esp_websocket_client managed component)
-static esp_websocket_client_handle_t s_ws = NULL;
+/* Wave 14 W14-M03: volatile because s_ws is written on Core 1's WS
+ * task (connect/disconnect) and read on Core 0's LVGL thread
+ * (voice_send_text, voice_start_listening, async_connect_task poll).
+ * Without volatile the compiler may cache the load across a
+ * disconnect and use-after-free the freed WS client. */
+static esp_websocket_client_handle_t volatile s_ws = NULL;
 
 // Dragon connection info (last-known, updated on each connect)
 static char     s_dragon_host[64] = {0};
@@ -299,7 +305,13 @@ void voice_defer_receipt_attach(uint32_t mils,
                                 const char *model_short, bool retried)
 {
     receipt_attach_async_t *r = calloc(1, sizeof(*r));
-    if (!r) return;
+    if (!r) {
+        /* Wave 14 W14-M08: log the drop so "my cost tracking is off"
+         * bug reports have a trail. */
+        ESP_LOGW(TAG, "voice_defer_receipt_attach OOM — dropped receipt (mils=%lu)",
+                 (unsigned long)mils);
+        return;
+    }
     r->mils    = mils;
     r->ptok    = ptok;
     r->ctok    = ctok;
@@ -429,8 +441,14 @@ static esp_err_t voice_ws_send_text(const char *msg)
 {
     if (!s_ws) return ESP_ERR_INVALID_STATE;
     if (!esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
+    if (!msg) return ESP_ERR_INVALID_ARG;
 
     size_t len = strlen(msg);
+    /* Wave 14 W14-L02: bound the size_t→int cast.  Realistic messages
+     * are <256 bytes but an unchecked cast would silently truncate on
+     * an accidental >2 GB string (e.g. a corrupted LLM response
+     * flowing through text_update). */
+    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
     int w = esp_websocket_client_send_text(s_ws, msg, (int)len, pdMS_TO_TICKS(1000));
     if (w < 0) {
         ESP_LOGW(TAG, "WS text send failed (%zu bytes)", len);
@@ -443,6 +461,9 @@ static esp_err_t voice_ws_send_binary(const void *data, size_t len)
 {
     if (!s_ws) return ESP_ERR_INVALID_STATE;
     if (!esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
+    if (!data) return ESP_ERR_INVALID_ARG;
+    /* W14-L02: same bound as text. */
+    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
 
     /* Short 100 ms timeout — we drop frames under pressure rather than
      * block the mic task. If WiFi stalls, I2S DMA would overflow. */
@@ -580,7 +601,15 @@ static void async_refresh_badge_cb(void *arg)
 static void voice_async_toast(char *text)
 {
     voice_async_toast_t *t = malloc(sizeof(voice_async_toast_t));
-    if (!t) { free(text); return; }
+    if (!t) {
+        /* Wave 14 W14-M08: log the silent-drop so ops can see we
+         * squeezed internal SRAM and a user-facing toast never reached
+         * LVGL. */
+        ESP_LOGW(TAG, "voice_async_toast OOM — dropping toast (text=%.40s)",
+                 text ? text : "");
+        free(text);
+        return;
+    }
     t->gen = s_session_gen;
     t->text = text;
     lv_async_call(async_show_toast_cb, t);
@@ -589,7 +618,10 @@ static void voice_async_toast(char *text)
 static void voice_async_refresh_badge(void)
 {
     voice_async_badge_t *b = malloc(sizeof(voice_async_badge_t));
-    if (!b) return;
+    if (!b) {
+        ESP_LOGW(TAG, "voice_async_refresh_badge OOM — badge will lag a tick");
+        return;
+    }
     b->gen = s_session_gen;
     lv_async_call(async_refresh_badge_cb, b);
 }
@@ -960,6 +992,7 @@ static void handle_text_message(const char *data, int len)
             voice_async_refresh_badge();
         }
         cJSON *config = cJSON_GetObjectItem(root, "config");
+        bool applied_cloud = false;
         if (config) {
             cJSON *cloud = cJSON_GetObjectItem(config, "cloud_mode");
             if (cJSON_IsBool(cloud)) {
@@ -967,8 +1000,18 @@ static void handle_text_message(const char *data, int len)
                 if (!cJSON_IsNumber(vmode)) {
                     tab5_settings_set_voice_mode(is_cloud ? 1 : 0);
                     voice_async_refresh_badge();
+                    applied_cloud = true;
                 }
             }
+        }
+        /* Wave 14 W14-L03: if neither voice_mode nor cloud_mode was
+         * present, the handler used to exit silently and Tab5 would
+         * disagree with Dragon about the active mode with no trace.
+         * Log at DEBUG so it's visible via /log without spamming INFO. */
+        if (!cJSON_IsNumber(vmode) && !applied_cloud &&
+            !cJSON_IsString(error)) {
+            ESP_LOGD(TAG, "config_update received with no voice_mode/"
+                         "cloud_mode/error field — no-op");
         }
     } else if (strcmp(type_str, "tool_call") == 0) {
         cJSON *tool = cJSON_GetObjectItem(root, "tool");
@@ -2574,6 +2617,12 @@ voice_state_t voice_get_state(void)
     return state;
 }
 
+/* Wave 14 W14-M01: raw-pointer getters kept for back-compat with
+ * same-task readers (main.c:184 logs them synchronously).  Prefer
+ * voice_get_*_copy below when the caller runs on a task that races
+ * with the WS RX path (debug_server handlers, UI thread).  The
+ * pointer-returning variants can observe a half-written strcat
+ * because writers mutate these buffers under s_state_mutex. */
 const char *voice_get_last_transcript(void)
 {
     return s_transcript;
@@ -2587,6 +2636,34 @@ const char *voice_get_stt_text(void)
 const char *voice_get_llm_text(void)
 {
     return s_llm_text;
+}
+
+/* Wave 14 W14-M01: copy-under-mutex variants.  `buf` receives a
+ * NUL-terminated snapshot; returns true on success, false on invalid
+ * args.  An empty source copies the empty string (still returns true). */
+static bool _voice_copy_under_lock(const char *src, char *buf, size_t len)
+{
+    if (!buf || len == 0) return false;
+    if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    strncpy(buf, src, len - 1);
+    buf[len - 1] = '\0';
+    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+    return true;
+}
+
+bool voice_get_last_transcript_copy(char *buf, size_t len)
+{
+    return _voice_copy_under_lock(s_transcript, buf, len);
+}
+
+bool voice_get_stt_text_copy(char *buf, size_t len)
+{
+    return _voice_copy_under_lock(s_stt_text, buf, len);
+}
+
+bool voice_get_llm_text_copy(char *buf, size_t len)
+{
+    return _voice_copy_under_lock(s_llm_text, buf, len);
 }
 
 esp_err_t voice_send_text(const char *text)

--- a/main/voice.h
+++ b/main/voice.h
@@ -75,6 +75,17 @@ const char *voice_get_stt_text(void);
 /** Return the last LLM response text (what Tinker is saying, streams in incrementally). */
 const char *voice_get_llm_text(void);
 
+/* Wave 14 W14-M01: snapshot-under-mutex variants.  Writers mutate
+ * the underlying buffers via strcat under s_state_mutex; a cross-task
+ * caller of the pointer-returning getters above can observe a
+ * half-written mid-strcat string.  These copy variants take the same
+ * mutex so they always return a consistent snapshot.  NUL-terminates
+ * the output.  Returns false on bad args. */
+#include <stdbool.h>
+bool voice_get_last_transcript_copy(char *buf, size_t len);
+bool voice_get_stt_text_copy(char *buf, size_t len);
+bool voice_get_llm_text_copy(char *buf, size_t len);
+
 /** Start dictation mode: unlimited recording, STT-only, no LLM/TTS, auto-stops after 5s silence. */
 esp_err_t voice_start_dictation(void);
 


### PR DESCRIPTION
## Summary

Batch of 8 correlated firmware items. All touch voice.c or adjacent so one flash proves the whole set.

| ID | What |
|----|------|
| **M01** | `voice_get_{last_transcript,stt_text,llm_text}_copy(buf, len)` helpers take `s_state_mutex`; debug_server `/voice` migrated to use them (httpd task no longer races WS RX). |
| **M02** | Audit against a stale snapshot — the overflow log is already outside `s_play_mutex` at voice.c:394. No code change; tracker note only. |
| **M03** | `volatile` on `s_ws` (voice.c) + `dragon_link.s_state`. Closes use-after-free race on Dragon restart. |
| **M04** | All `fseek`/`fread`/`fwrite` return values checked in WAV-header repair. Garbage-on-short-read → silent SD corruption vector closed. |
| **M08** | `ESP_LOGW` on receipt + async_* OOM drop paths. Future "cost tracking is off" bug reports have a log trail. |
| **L01** | Removed dead `s_rec_paused` variable + 3 callsites. |
| **L02** | `voice_ws_send_text`/`_send_binary` reject NULL + `len > INT_MAX`. |
| **L03** | `ESP_LOGD` trail when `config_update` carries none of `voice_mode` / `cloud_mode` / `error`. |

## Test plan

Verified on 192.168.1.90:
- [x] `idf.py build` clean (27% partition free)
- [x] Flashed; boot OK; `/info` `wifi=true dragon=true voice=true tasks=26` (W14-H06 worker still alive)
- [x] `/voice` endpoint exercises the new copy helpers — JSON clean, no half-string, `state_name=READY`
- [x] Home screen renders (amber orb, "Evening, Emile — what's on your mind?", Local · ON-DEVICE pill, $0.02 / $7.60 budget)

Screenshot at `/tmp/wave14_proof/phase6_tt_home.jpg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)