### PR TITLE
docs: wave 14 — IDF pin, debug-server count, settings vmode comment (M18/M19/M22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ sudo journalctl -u tinkerclaw-voice --no-pager -n 50
 
 ## Build & Flash
 ```bash
-# Always use ESP-IDF v5.4.3 — matches dependencies.lock
+# Always use ESP-IDF v5.5.2 — matches dependencies.lock
 . /home/rebelforce/esp/esp-idf/export.sh
 
 cd /home/rebelforce/projects/TinkerTab
@@ -216,7 +216,7 @@ curl -s http://192.168.1.90:8080/selftest | python3 -m json.tool
 - **Mic audio:** Slot 0 = MIC-L (primary). Extract from 4-ch TDM interleaved buffer.
 
 ## IDF Version
-- **Use IDF v5.4.3** — matches `dependencies.lock`. Build always requires `idf.py set-target esp32p4` after any clean build or target change. Run `idf.py fullclean build` when in doubt.
+- **Use IDF v5.5.2** — matches `dependencies.lock`. Build always requires `idf.py set-target esp32p4` after any clean build or target change. Run `idf.py fullclean build` when in doubt.
 - Tab5 camera is SC202CS at SCCB 0x36 (NOT SC2336 at 0x30)
 - SD card uses SDMMC SLOT 0 with LDO channel 4
 
@@ -431,7 +431,8 @@ main/service_network.c    — Wi-Fi service (STA, connect, reconnect)
 main/service_storage.c    — SD card + NVS storage service
 main/task_worker.{c,h}    — Shared FreeRTOS job queue (W14-H06) — kills per-action task leaks
 main/heap_watchdog.{c,h}  — Periodic heap + PSRAM monitoring, logs to /heap debug endpoint
-main/debug_server.{c,h}   — HTTP debug server (22 endpoints, bearer-auth except /info /selftest)
+main/debug_server.{c,h}   — HTTP debug server (bearer-auth except /info /selftest);
+                             count endpoints with: grep -c 'httpd_register_uri_handler' main/debug_server.c
 ```
 
 ### Hardware

--- a/main/settings.c
+++ b/main/settings.c
@@ -372,7 +372,7 @@ esp_err_t tab5_settings_set_volume(uint8_t vol)
 
 uint8_t tab5_settings_get_voice_mode(void)
 {
-    return get_u8("vmode", 0);  /* 0=local, 1=hybrid, 2=cloud */
+    return get_u8("vmode", 0);  /* 0=local, 1=hybrid, 2=cloud, 3=tinkerclaw */
 }
 
 esp_err_t tab5_settings_set_voice_mode(uint8_t mode)


### PR DESCRIPTION
## Summary
Closes W14-M18, W14-M19, W14-M22. Docs + one single-line comment fix. No behavior change.

- **M18** — CLAUDE.md: ESP-IDF v5.4.3 → v5.5.2 (matches dependencies.lock)
- **M19** — CLAUDE.md Key Files entry for debug_server drops the "22 endpoints" fixed number (actual is 25 today, drifts). Replaced with grep formula.
- **M22** — settings.c:375 `/* 0=local, 1=hybrid, 2=cloud */` → `/* 0=local, 1=hybrid, 2=cloud, 3=tinkerclaw */`. Three lines below there's `if (mode > 3) mode = 0;` so the comment needed to know about mode 3.

## Test plan
- [x] grep confirms IDF pin in dependencies.lock is 5.5.2
- [x] Actual route count in debug_server.c verified via grep
- [x] No build required (comment-only + doc-only changes)