### PR TITLE
fix(debug): wave 15 — store httpd handle + stop API (W15-C02)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -54,6 +54,12 @@ static const char *TAG = "debug_srv";
 
 #define DEBUG_PORT 8080
 
+/* Wave 15 W15-C02: file-scoped httpd handle so `tab5_debug_server_stop()`
+ * can actually stop the server on demand.  The original code stashed the
+ * handle in a function-local and leaked it — making the server a one-shot
+ * with no recovery path. */
+static httpd_handle_t s_httpd = NULL;
+
 /* ======================================================================== */
 /*  Bearer token authentication                                              */
 /* ======================================================================== */
@@ -2006,12 +2012,22 @@ esp_err_t tab5_debug_server_init(void)
     config.core_id = 1;
     config.task_priority = tskIDLE_PRIORITY + 6;  /* Above LVGL (prio 5) */
 
+    if (s_httpd != NULL) {
+        /* Already running — treat as idempotent.  Caller should stop
+         * first if they want a restart.  Returning ESP_OK preserves
+         * the old pre-W15-C02 behaviour where a second call was a
+         * benign no-op (would have leaked a second server). */
+        ESP_LOGW(TAG, "debug server already running, skipping re-init");
+        return ESP_OK;
+    }
+
     httpd_handle_t server = NULL;
     esp_err_t ret = httpd_start(&server, &config);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to start debug server: %s", esp_err_to_name(ret));
         return ret;
     }
+    s_httpd = server;
 
     /* Register URI handlers */
     const httpd_uri_t uri_index = {
@@ -2128,4 +2144,19 @@ esp_err_t tab5_debug_server_init(void)
     ESP_LOGI(TAG, "Debug server: http://%s:%d/", ip, DEBUG_PORT);
 
     return ESP_OK;
+}
+
+esp_err_t tab5_debug_server_stop(void)
+{
+    if (s_httpd == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    esp_err_t err = httpd_stop(s_httpd);
+    s_httpd = NULL;
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "Debug server stopped");
+    } else {
+        ESP_LOGW(TAG, "httpd_stop returned %s", esp_err_to_name(err));
+    }
+    return err;
 }

--- a/main/debug_server.h
+++ b/main/debug_server.h
@@ -24,6 +24,22 @@
 esp_err_t tab5_debug_server_init(void);
 
 /**
+ * Stop the debug HTTP server (if running).
+ *
+ * Wave 15 W15-C02: `tab5_debug_server_init()` used to leak the
+ * `httpd_handle_t` in a function-local `server` variable, so once
+ * the server was started there was no way to stop it — not even on
+ * clean shutdown or a recovery path.  The handle is now cached in
+ * a file-scoped static and exposed via this function so future work
+ * can tear it down and re-start it on a fresh port or with different
+ * config.
+ *
+ * Returns ESP_OK when the server was stopped, or ESP_ERR_INVALID_STATE
+ * when no server was running.
+ */
+esp_err_t tab5_debug_server_stop(void);
+
+/**
  * Check if the debug server is injecting a touch event.
  * Call from the LVGL touch read callback. If true, use the returned
  * coordinates instead of the physical touch controller.


### PR DESCRIPTION
## Summary
Closes **W15-C02**. Defensive-hygiene cleanup on `main/debug_server.c`.

- `tab5_debug_server_init()` used to stash the `httpd_handle_t` in a function-local that was discarded on return → the server was a one-shot, no way to stop/restart.
- File-scope static `s_httpd` holds it now.
- New public `tab5_debug_server_stop()` for clean teardown.
- Idempotent init: a second call while running returns `ESP_OK` without leaking a second server.

## Related
- Earlier I filed `TinkerTab#94` claiming "httpd dies after Dragon outage" — I was probing port 3500 (Dragon's dashboard) instead of Tab5's 8080. Port 8080 **stays alive** across Dragon restarts. Closed that issue with correction.
- The real crash that causes "Dragon unreachable" is a separate UAF panic — filed as `TinkerTab#95` (W15-C05) and will be fixed in a follow-up PR.

## Test plan
- [x] `idf.py build` — clean
- [x] Flashed to Tab5 at 192.168.1.90
- [x] `/info`: voice_connected=true dragon_connected=true
- [x] `/selftest`: 6/6 pass (wifi, voice_ws, sd_card, psram, display, camera)
- [x] `reset_reason: USB` (clean flash, no panic introduced)
- [x] Second init call logs warning + returns OK (tested via `tab5_debug_server_init()` twice — behaviour idempotent)