### PR TITLE
fix(heap_wd+debug): wave 15 — stop panic-rebooting Tab5 during Dragon restarts (W15-C05)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -45,6 +45,7 @@
 #include "esp_lcd_mipi_dsi.h"
 #include "esp_netif.h"
 #include "esp_core_dump.h"
+#include "esp_partition.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "cJSON.h"
@@ -866,6 +867,96 @@ static esp_err_t crashlog_handler(httpd_req_t *req)
     esp_err_t ret = httpd_resp_sendstr(req, json);
     free(json);
     return ret;
+}
+
+/* ── Coredump binary download ─────────────────────────────────────────── */
+
+/* Wave 15 W15-C05: stream the raw coredump partition bytes so we can
+ * decode them offline with `espcoredump.py info_corefile -t elf`.
+ * Partition reads are chunked into 4 KiB so the httpd task stack stays
+ * tiny regardless of the dump size (~3 MB on this board).  Erase is
+ * NOT performed here — the operator explicitly calls /crashlog?erase=1
+ * or runs the esptool after confirming the dump was captured.  This
+ * avoids the pathological loop where a corrupted dump keeps crashing
+ * the decoder and gets wiped on every fetch attempt. */
+static esp_err_t coredump_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+
+    size_t addr = 0, size = 0;
+    esp_err_t err = esp_core_dump_image_get(&addr, &size);
+    if (err != ESP_OK) {
+        if (err == ESP_ERR_NOT_FOUND) {
+            httpd_resp_set_status(req, "404 Not Found");
+            httpd_resp_send(req, "{\"error\":\"no coredump\"}", HTTPD_RESP_USE_STRLEN);
+            return ESP_OK;
+        }
+        ESP_LOGE(TAG, "coredump_image_get failed: %s", esp_err_to_name(err));
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "read error");
+        return ESP_FAIL;
+    }
+    if (size == 0) {
+        httpd_resp_set_status(req, "404 Not Found");
+        httpd_resp_send(req, "{\"error\":\"empty coredump\"}", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    /* Find the coredump partition so we can read via partition-relative
+     * offsets.  `esp_core_dump_image_get` returns absolute flash addrs
+     * but `esp_partition_read` wants offset-from-partition-start. */
+    const esp_partition_t *part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP, NULL);
+    if (!part) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "no coredump partition");
+        return ESP_FAIL;
+    }
+    if (addr < part->address || addr + size > part->address + part->size) {
+        ESP_LOGE(TAG, "coredump range 0x%zx+%zu outside partition 0x%lx+%lu",
+                 addr, size, (unsigned long)part->address, (unsigned long)part->size);
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "range mismatch");
+        return ESP_FAIL;
+    }
+    const size_t rel = addr - part->address;
+
+    httpd_resp_set_type(req, "application/octet-stream");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+    httpd_resp_set_hdr(req, "Content-Disposition",
+                      "attachment; filename=\"tab5_coredump.elf\"");
+    /* Advertise size via X-Content-Length so the client can track
+     * progress without conflicting with the chunked Transfer-Encoding
+     * that httpd_resp_send_chunk() emits. */
+    char len[32];
+    snprintf(len, sizeof(len), "%zu", size);
+    httpd_resp_set_hdr(req, "X-Content-Length", len);
+
+    /* Stream in 4 KiB chunks. */
+    const size_t CHUNK = 4096;
+    uint8_t *buf = heap_caps_malloc(CHUNK, MALLOC_CAP_DEFAULT);
+    if (!buf) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom");
+        return ESP_FAIL;
+    }
+    size_t sent = 0;
+    while (sent < size) {
+        size_t to_read = size - sent;
+        if (to_read > CHUNK) to_read = CHUNK;
+        err = esp_partition_read(part, rel + sent, buf, to_read);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "partition_read@%zu: %s", rel + sent, esp_err_to_name(err));
+            break;
+        }
+        if (httpd_resp_send_chunk(req, (const char *)buf, to_read) != ESP_OK) {
+            /* Client dropped — bail silently. */
+            break;
+        }
+        sent += to_read;
+    }
+    heap_caps_free(buf);
+    /* Terminate chunked stream. */
+    httpd_resp_send_chunk(req, NULL, 0);
+    ESP_LOGI(TAG, "/coredump: sent %zu/%zu bytes", sent, size);
+    return ESP_OK;
 }
 
 /* ── SD card file listing ─────────────────────────────────────────────── */
@@ -2058,6 +2149,9 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_open = {
         .uri = "/open", .method = HTTP_POST, .handler = open_handler
     };
+    const httpd_uri_t uri_coredump = {
+        .uri = "/coredump", .method = HTTP_GET, .handler = coredump_handler
+    };
     const httpd_uri_t uri_crashlog = {
         .uri = "/crashlog", .method = HTTP_GET, .handler = crashlog_handler
     };
@@ -2121,6 +2215,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_log);
     httpd_register_uri_handler(server, &uri_open);
     httpd_register_uri_handler(server, &uri_crashlog);
+    httpd_register_uri_handler(server, &uri_coredump);
     httpd_register_uri_handler(server, &uri_sdcard);
     httpd_register_uri_handler(server, &uri_wake);
     httpd_register_uri_handler(server, &uri_settings_get);

--- a/main/heap_watchdog.c
+++ b/main/heap_watchdog.c
@@ -71,19 +71,44 @@ static const char *TAG = "heap_wd";
 
 /* DMA pool exhaustion thresholds (audit #80):
  * WiFi driver + TLS need DMA-capable buffers for RX/TX descriptors. When
- * free DMA pool drops below 8KB the driver silently fails — packets never
+ * free DMA pool drops too low the driver silently fails — packets never
  * leave the chip, ARP responses stop, device becomes unreachable but the
  * LVGL loop keeps running so the heap_wd/SRAM/PSRAM paths don't trigger.
  * Before this guard the device would sit in a "Dragon unreachable" state
- * until the user reflashed. Reboot after 2 consecutive minutes to recover
- * automatically; honors the same voice-active grace window as SRAM. */
-/* Observed on device (#80 soak 2026-04-20): the voice pipeline sits at
- * ~25KB DMA free in steady state and WiFi starts dropping packets as soon
- * as that drops to ~15KB. Set the reboot threshold at 16KB so we catch
- * the downhill slide BEFORE WiFi has been dead for a full minute — still
- * well under the baseline so legitimate bursts don't trip it. */
-#define HEAP_WD_DMA_CRITICAL_BYTES     (16 * 1024)  /* 16KB — below this WiFi starves */
-#define HEAP_WD_DMA_REBOOT_COUNT       2            /* 2 consecutive checks (2 minutes) */
+ * until the user reflashed. Reboot after N consecutive minutes to recover
+ * automatically; honors the voice-active grace window.
+ *
+ * Wave 15 W15-C05: the original 16 KB threshold was set based on a
+ * single soak run (#80, 2026-04-20). On the current firmware the
+ * steady-state DMA free is ~6 KB with WiFi and voice working fine —
+ * /info, /heap, and WS voice all respond. So the 16 KB threshold was
+ * permanently below the "critical" line, and the ONLY thing keeping
+ * the device from rebooting constantly was the voice-active grace
+ * check (if user is LISTENING/SPEAKING/PROCESSING, defer the reboot).
+ *
+ * When Dragon's voice service restarts, voice state transitions to
+ * RECONNECTING — which was NOT in the grace list — so the watchdog
+ * decided "DMA exhausted + voice idle → reboot", and Tab5 would
+ * panic-reboot ~30 s into the Dragon restart.  From the user's POV
+ * this looked like the "Dragon unreachable" UI banner, but was
+ * actually Tab5 full-rebooting each time Dragon's voice service
+ * cycled.
+ *
+ * Fix has two halves:
+ *   1. Drop the threshold to 4 KB (below observed steady-state
+ *      floor).  At this level the device really is close to WiFi
+ *      failure — not just "bit low".  The 8 KB soft-warning log
+ *      below still fires at the old level for observability.
+ *   2. Add RECONNECTING to the grace list so Dragon-side blips
+ *      never reboot Tab5, even with truly exhausted DMA — the
+ *      reconnect watchdog in voice.c should resolve it within
+ *      seconds.
+ *   3. Bump reboot-count from 2 to 5 (5 minute sustained
+ *      exhaustion, not a transient 2-minute spike).
+ */
+#define HEAP_WD_DMA_CRITICAL_BYTES     (4 * 1024)   /* 4KB — below observed floor */
+#define HEAP_WD_DMA_REBOOT_COUNT       5            /* 5 consecutive checks (5 minutes) */
+#define HEAP_WD_DMA_WARN_BYTES         (16 * 1024)  /* 16KB — soft warning only */
 
 static void heap_watchdog_task(void *arg)
 {
@@ -159,11 +184,12 @@ static void heap_watchdog_task(void *arg)
             internal_frag_count = 0;
         }
 
-        /* Audit #80: DMA exhaustion reboot path — WiFi TX/RX dies silently
-         * without this.  Log at 16KB (soft warning), count toward reboot
-         * below HEAP_WD_DMA_CRITICAL_BYTES. */
-        if (dma_free < 16384) {
-            ESP_LOGE(TAG, "DMA pool critically low: %zu bytes free (largest block %zu)", dma_free, dma_largest);
+        /* Audit #80 + W15-C05: DMA exhaustion reboot path.  Soft warn at
+         * HEAP_WD_DMA_WARN_BYTES (16 KB) for observability, only count
+         * toward reboot below HEAP_WD_DMA_CRITICAL_BYTES (4 KB). */
+        if (dma_free < HEAP_WD_DMA_WARN_BYTES) {
+            ESP_LOGW(TAG, "DMA pool low: %zu bytes free (largest %zu) — warn only",
+                     dma_free, dma_largest);
         }
         if (dma_free < HEAP_WD_DMA_CRITICAL_BYTES) {
             dma_critical_count++;
@@ -173,8 +199,15 @@ static void heap_watchdog_task(void *arg)
             if (dma_critical_count >= HEAP_WD_DMA_REBOOT_COUNT) {
                 extern voice_state_t voice_get_state(void);
                 voice_state_t vs = voice_get_state();
+                /* W15-C05: include CONNECTING + RECONNECTING in the grace
+                 * list.  Dragon-side restarts briefly leave Tab5 in
+                 * RECONNECTING state — rebooting during that window
+                 * caused the "Dragon unreachable → Tab5 panic-reboot"
+                 * production regression. */
                 if (vs == VOICE_STATE_LISTENING || vs == VOICE_STATE_SPEAKING
-                    || vs == VOICE_STATE_PROCESSING) {
+                    || vs == VOICE_STATE_PROCESSING
+                    || vs == VOICE_STATE_CONNECTING
+                    || vs == VOICE_STATE_RECONNECTING) {
                     ESP_LOGW(TAG, "Heap watchdog: deferring DMA reboot, voice active (state=%d)", vs);
                 } else {
                     ESP_LOGE(TAG, "Heap watchdog: DMA exhausted %d min; free=%zuKB largest=%zu internal=%uKB PSRAM=%uKB — rebooting to restore WiFi",


### PR DESCRIPTION
## Summary
Closes **W15-C05** (issue #95). The **actual** root cause of the "Dragon unreachable" user-visible regression — Tab5 was **panic-rebooting** on every Dragon voice-service restart, not just flashing a banner.

## Evidence (decoded coredump)

Added a `/coredump` bearer-gated streaming endpoint first, pulled a fresh dump, decoded with `espcoredump.py info_corefile`:

```
Crashed task: heap_wd
Panic reason: heap_wd: dma_exhausted
#0  panic_abort (details="heap_wd: dma_exhausted")
#1  esp_system_abort
#2  hw_restart_with_coredump (reason="dma_exhausted")  main/heap_watchdog.c:53
#3  heap_watchdog_task                                  main/heap_watchdog.c:185
```

The panic is an **intentional** `esp_system_abort()` the heap watchdog fires when DMA-capable memory drops below threshold. My earlier `exc_pc=0xA5A5A5A5` reading was a stale/garbled crashlog entry — the fresh coredump tells the truth.

## Why it fires on Dragon restart

- `HEAP_WD_DMA_CRITICAL_BYTES = 16 KB` (set in wave 10)
- Current firmware steady-state DMA free: **6 KB** (WiFi + voice both fine at this level — all endpoints respond normally)
- So the threshold was permanently below the "critical" line
- Only the voice-active grace check (LISTENING/SPEAKING/PROCESSING) prevented constant reboots
- Dragon restart → voice state briefly transitions to RECONNECTING (not in grace list) → watchdog panics Tab5

## Fix (3 pieces)

1. **Drop threshold 16 KB → 4 KB** (below observed steady-state floor). Keep 16 KB as a soft-warning log line.
2. **Extend grace list** to include `CONNECTING` + `RECONNECTING` — Dragon blips never reboot Tab5.
3. **Bump reboot count 2 → 5** (5 min sustained, not a 2 min transient).

## Live verification

| metric | before | after |
|---|---|---|
| Tab5 uptime at t=0 | 36 s | 36 s |
| Dragon `systemctl restart tinkerclaw-voice` | — | — |
| Tab5 uptime at t=40 s | **rebooted** (~15 s) | **136 s** (no reboot) |
| voice reconnected | (via reboot) | yes, cleanly |
| reset_reason | PANIC (dma_exhausted) | USB (no change) |

## Bonus: `/coredump` download endpoint

New bearer-gated `/coredump` that streams the raw coredump partition in 4 KiB chunks. Pairs with existing `/crashlog` JSON summary. Any developer on the LAN can pull the ELF + decode offline with `espcoredump.py info_corefile` — no more serial cable required for post-mortem.

## Test plan
- [x] `idf.py build` — clean
- [x] Flashed to Tab5
- [x] Reproduced pre-fix panic (Dragon restart → Tab5 reboots within 30 s, coredump `dma_exhausted`)
- [x] Post-fix: Dragon restart → Tab5 uptime monotonic (+100 s across the restart window)
- [x] `/coredump` endpoint works (30 KB download, decodes cleanly)
- [x] `/selftest` still passes (wifi, voice_ws, sd_card, psram, display, camera)