### PR TITLE
fix(wifi): detect zombie association + kick when AP black-holes us (W15-H08)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -2072,12 +2072,22 @@ void voice_lan_probe_task(void *arg)
 {
     (void)arg;
     ESP_LOGI(TAG, "Link probe task started (both LAN + ngrok every 30 s)");
+    /* Wave 15 W15-H08: "zombie association" detector.  Counts
+     * consecutive rounds where BOTH LAN and ngrok TCP connects fail
+     * while the Wi-Fi layer still claims we're associated.  After
+     * W15_ZOMBIE_THRESHOLD consecutive fails we call tab5_wifi_kick()
+     * to force a fresh association.  Threshold is 2 → 60 s of total
+     * unreachability before we intervene (avoids kicking on a
+     * transient router blip or a brief internet outage). */
+    int zombie_rounds = 0;
+    const int ZOMBIE_THRESHOLD = 2;
     for (;;) {
         vTaskDelay(pdMS_TO_TICKS(30000));
         if (!tab5_wifi_connected()) {
             s_lan_tcp_ok   = false;
             s_ngrok_tcp_ok = false;
             s_last_probe_ms = lv_tick_get();
+            zombie_rounds = 0;   /* fresh start once Wi-Fi is back */
             continue;
         }
 
@@ -2094,9 +2104,26 @@ void voice_lan_probe_task(void *arg)
         s_lan_tcp_ok   = lan_ok;
         s_ngrok_tcp_ok = ngrok_ok;
         s_last_probe_ms = lv_tick_get();
-        ESP_LOGI(TAG, "Link probe: lan[%s]=%d ngrok=%d (current=%s)",
+        ESP_LOGI(TAG, "Link probe: lan[%s]=%d ngrok=%d (current=%s) zombie_rounds=%d",
                  lan_host, lan_ok, ngrok_ok,
-                 s_using_ngrok ? "ngrok" : "lan");
+                 s_using_ngrok ? "ngrok" : "lan", zombie_rounds);
+
+        /* W15-H08 zombie-association check: both probes failed while
+         * Wi-Fi reports associated.  That means the AP has black-holed
+         * our client (bridge flush, client isolation, deauth-without-
+         * notify).  Kick Wi-Fi after two consecutive fails. */
+        if (!lan_ok && !ngrok_ok) {
+            zombie_rounds++;
+            if (zombie_rounds >= ZOMBIE_THRESHOLD) {
+                ESP_LOGW(TAG, "Zombie Wi-Fi detected: both probes failed "
+                              "%d rounds in a row — kicking association",
+                         zombie_rounds);
+                tab5_wifi_kick();
+                zombie_rounds = 0;
+            }
+        } else {
+            zombie_rounds = 0;
+        }
 
         /* Auto-mode: if we're stuck on ngrok but LAN is reachable, swap back. */
         uint8_t conn_mode = tab5_settings_get_connection_mode();

--- a/main/wifi.c
+++ b/main/wifi.c
@@ -142,3 +142,19 @@ bool tab5_wifi_connected(void)
     if (!s_wifi_event_group) return false;
     return (xEventGroupGetBits(s_wifi_event_group) & WIFI_CONNECTED_BIT) != 0;
 }
+
+void tab5_wifi_kick(void)
+{
+    /* Wave 15 W15-H08: force a fresh association.  Used by the link
+     * probe when both LAN and ngrok TCP connects fail while the radio
+     * still reports associated — i.e. the AP has silently stopped
+     * passing our traffic.  esp_wifi_disconnect() synthesises a
+     * WIFI_EVENT_STA_DISCONNECTED which our handler already routes
+     * into esp_wifi_connect(), so one call is enough. */
+    if (!s_wifi_event_group) return;
+    ESP_LOGW(TAG, "Kicking Wi-Fi (forcing re-association)");
+    esp_err_t r = esp_wifi_disconnect();
+    if (r != ESP_OK) {
+        ESP_LOGW(TAG, "esp_wifi_disconnect failed: %s", esp_err_to_name(r));
+    }
+}

--- a/main/wifi.h
+++ b/main/wifi.h
@@ -5,3 +5,11 @@
 esp_err_t tab5_wifi_init(void);
 esp_err_t tab5_wifi_wait_connected(int timeout_ms);
 bool tab5_wifi_connected(void);
+
+/* Force a fresh Wi-Fi association: disconnect + connect.  Used by the
+ * link-probe task to recover from "zombie association" — radio still
+ * reports associated but the AP has stopped routing Tab5's traffic
+ * (client isolation, bridge-table flush, 802.11 deauth-without-notify).
+ * No-op if we're currently not associated (the normal retry path will
+ * handle it). */
+void tab5_wifi_kick(void);


### PR DESCRIPTION
## Summary

Follow-up to #100 (retry-forever). Second half of the *"keeps connecting but unable to hold a connection"* symptom.

During hardware cycling through all four voice modes, Tab5's radio reported `wifi_connected=true` but BOTH LAN probe (`192.168.1.91:3502`) AND ngrok probe (port 443) returned 0. Workstation on the same SSID could reach Dragon fine; only Tab5 was black-holed. Classic **zombie association** — AP bridge-table flush / client isolation / deauth-without-notify. The radio never fires `WIFI_EVENT_STA_DISCONNECTED` so retry-forever alone can't recover.

## Fix

1. New [`tab5_wifi_kick()`](main/wifi.c) — calls `esp_wifi_disconnect()` which synthesises `DISCONNECTED` → the W15-H07 retry handler calls `esp_wifi_connect()` → fresh association.
2. [`voice_lan_probe_task`](main/voice.c#L2071) counts consecutive rounds where both probes fail while Wi-Fi reports associated. At `ZOMBIE_THRESHOLD = 2` (60 s), calls `tab5_wifi_kick()` and resets.

Threshold is deliberately conservative — 60 s so a transient AP blip doesn't cause spurious kicks.

## Test plan

- [x] `idf.py build` — clean
- [x] Flash, Tab5 booted, debug server reachable
- [x] Cycled **all four voice modes**, each prompt got a coherent response:
  - **Local (qwen3:0.6b)** → `"2 plus 2 equals 4."`
  - **Hybrid** → `"Hello there you."`
  - **Cloud (Haiku)** → `"5 times 5 equals 25."`
  - **TinkerClaw** → `"Paris."`
- [x] Heap stable ~21 MB free, voice+dragon connected throughout
- [ ] Long-soak: simulate AP client isolation, confirm kick fires + recovers within ~60 s

(Supersedes auto-closed #101 — original base branch was squash-merged into main.)

Refs wave-15 audit (W15-H08).

🤖 Generated with [Claude Code](https://claude.com/claude-code)