### PR TITLE
fix(chat): drop 1 px border on AI bubble to avoid LVGL rasterizer crash (W15-C09)

### DIFF
--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -392,8 +392,15 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
         lv_obj_set_style_text_color(slot->body, lv_color_hex(TH_BG), 0);
     } else {
         lv_obj_set_style_bg_color(slot->bubble, lv_color_hex(TH_CARD), 0);
-        lv_obj_set_style_border_width(slot->bubble, 1, 0);
-        lv_obj_set_style_border_color(slot->bubble, lv_color_hex(0x1E1E2A), 0);
+        /* Wave 15 W15-C09: was `border_width=1 + radius=22`.  LVGL's
+         * draw_border_complex → lv_draw_mask_radius → get_next_line
+         * path crashed drawing a 1 px border on a 22 px-rounded widget
+         * (coredump captured this during second-turn chat render).
+         * Same class of rasterizer bug as W15-C07 (voice overlay fade).
+         * Dark card (0x111119) on near-black (0x08080E) is visibly
+         * distinct without a border, so dropping it eliminates the
+         * crash path while keeping the bubble readable. */
+        lv_obj_set_style_border_width(slot->bubble, 0, 0);
         lv_obj_set_style_radius(slot->bubble, BUBBLE_RADIUS, 0);
         lv_obj_set_style_text_color(slot->body, lv_color_hex(TH_TEXT_PRIMARY), 0);
     }


### PR DESCRIPTION
## Summary

User-visible: typing the second message in a chat session reliably crashed Tab5 mid-render. Coredump pinned the fault in [lv_draw_sw_mask.c:1239](https://github.com/lvgl/lvgl/blob/master/src/draw/sw/lv_draw_sw_mask.c) (`get_next_line`) via `lv_draw_mask_radius` → `draw_border_complex` → `lv_draw_sw_border` with `rout=22` — the AI chat bubble's 1 px border against its 22 px rounded corners.

Same class of rasterizer bug as W15-C07 (voice overlay fade-in): LVGL's software mask code faults when compositing a thin border on a heavily-rounded widget under certain pool/cache states. Non-deterministic but reliably reproducible by sending a second chat turn.

## Fix

Drop the 1 px border on the AI bubble in [main/chat_msg_view.c:393-407](main/chat_msg_view.c#L393). The card bg (`0x111119`) on near-black (`0x08080E`) is already visibly distinct; the border was cosmetic. User (orange `TH_AMBER`) bubbles already had `border=0` and never crashed.

## Test plan

- [x] `idf.py build` — clean
- [x] Flash, navigate to chat
- [x] 3 `/chat` turns in Cloud/Haiku mode:
  - `"hi"` → `"Hello! How can I assist you today?"`
  - `"hi"` → `"Hello again! I'm happy to chat. Is there anything in particular you'd like help with..."`
  - `"tell me a jon"` → `"I don't feel comfortable telling inappropriate or offensive jokes..."`
- [x] All bubbles rendered cleanly, no crash, uptime monotonic, heap stable ~21 MB, fps=16

Refs wave-15 audit (W15-C09). Pairs with keyboard OOM fix #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)