### PR TITLE
feat(voice): orb reacts to user voice via live RMS during LISTENING (W15-P02)

### DIFF
--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -142,6 +142,11 @@ static void mic_dot_pulse_cb(void *obj, int32_t val);
 
 static void start_breathe_anim(void);
 static void start_pulse_anim(void);
+/* W15-P02: RMS-driven "listening back" glow on the innermost orb layer
+ * during LISTENING so the orb visibly reacts to the user's voice. */
+static void start_rms_anim(void);
+static void stop_rms_anim(void);
+static void rms_tick_cb(lv_timer_t *t);
 static void start_wave_anim(void);
 static void stop_all_anims(void);
 
@@ -212,6 +217,7 @@ static lv_timer_t *s_dot_timer    = NULL;
 static lv_timer_t *s_hide_timer   = NULL;
 static lv_timer_t *s_stuck_timer  = NULL;  /* watchdog for stuck PROCESSING state */
 static lv_timer_t *s_auto_hide   = NULL;   /* READY-state auto-dismiss (was local static — caused UAF) */
+static lv_timer_t *s_rms_timer   = NULL;   /* W15-P02: live RMS → inner-glow opa during LISTENING */
 static int         s_dot_phase    = 0;
 
 /* Current state tracking */
@@ -1085,6 +1091,9 @@ static void show_state_listening(void)
     lv_obj_clear_flag(s_send_btn, LV_OBJ_FLAG_HIDDEN);
 
     start_breathe_anim();
+    /* W15-P02: overlay the breathe anim's innermost layer with live
+     * RMS so the orb visibly reacts to the user's voice. */
+    start_rms_anim();
 }
 
 /* v4·D Gauntlet G1: render the "+N QUEUED" badge on the sub-caption slot
@@ -1437,6 +1446,77 @@ static void start_pulse_anim(void)
     }
 }
 
+/* ================================================================
+ * W15-P02: live RMS → inner-glow opacity.
+ * Makes the orb visibly "listen back" to the user's voice during
+ * LISTENING.  Without this, the overlay feels static/unresponsive —
+ * all the user got was the breathe animation, which doesn't track
+ * what they're saying.  voice.c computes s_current_rms every mic
+ * frame (int16 PCM magnitude); typical values:
+ *    ambient quiet room : ~200-400
+ *    normal speech      : ~1500-3000
+ *    loud / shout       : 6000+
+ * Map RMS → opacity so the innermost (hottest) glow layer modulates
+ * with voice energy.  Keep the other 3 layers on the existing breathe
+ * anim so the orb still feels alive even in silence.
+ * ================================================================ */
+static void rms_tick_cb(lv_timer_t *t)
+{
+    (void)t;
+    /* Only run when the overlay is visible and in LISTENING; the
+     * LVGL timer system lives on the UI task, so we're serialized
+     * with state transitions. */
+    if (!s_visible) return;
+    if (s_cur_state != VOICE_STATE_LISTENING
+     && s_cur_state != VOICE_STATE_CONNECTING) return;
+
+    float rms = voice_get_current_rms();
+    /* Floor / ceiling clamp.  Below 200 = ambient noise, ignore.
+     * Above 3000 = already loud, cap.  30-100 opa range so the
+     * inner glow is always at least dimly visible (never goes dark). */
+    int32_t opa = 30;
+    if (rms > 200.0f) {
+        float span = rms - 200.0f;
+        if (span > 2800.0f) span = 2800.0f;
+        opa = 30 + (int32_t)(70.0f * (span / 2800.0f));
+    }
+    if (opa < 30) opa = 30;
+    if (opa > 100) opa = 100;
+
+    /* Apply to the innermost (hottest) glow layer only.  The set_orb_size
+     * loop uses i=ORB_GLOW_LAYERS-1 for the SMALLEST layer (frac=1/N),
+     * which is the bright core of the orb — exactly the one the eye
+     * reads as "intensity". */
+    lv_obj_t *core = s_orb_glow[ORB_GLOW_LAYERS - 1];
+    if (core) {
+        lv_obj_set_style_bg_opa(core, (lv_opa_t)opa, 0);
+    }
+}
+
+static void start_rms_anim(void)
+{
+    /* Remove the breathe-anim that would otherwise keep overwriting
+     * the innermost layer's opa every frame.  The other 3 layers
+     * keep breathing — they provide the "ambient alive" layer. */
+    lv_anim_delete(s_orb_glow[ORB_GLOW_LAYERS - 1], orb_breathe_cb);
+
+    if (s_rms_timer) {
+        lv_timer_delete(s_rms_timer);
+        s_rms_timer = NULL;
+    }
+    /* 60 ms cadence — fast enough to feel responsive to speech
+     * envelope, slow enough to not thrash the LVGL style system. */
+    s_rms_timer = lv_timer_create(rms_tick_cb, 60, NULL);
+}
+
+static void stop_rms_anim(void)
+{
+    if (s_rms_timer) {
+        lv_timer_delete(s_rms_timer);
+        s_rms_timer = NULL;
+    }
+}
+
 static void start_wave_anim(void)
 {
     /*
@@ -1504,6 +1584,9 @@ static void stop_all_anims(void)
         lv_timer_delete(s_hide_timer);
         s_hide_timer = NULL;
     }
+
+    /* W15-P02: cancel RMS tick if it's running. */
+    stop_rms_anim();
 
     /* Remove orb click handler if set (Fix #4 cleanup) */
     lv_obj_clear_flag(s_orb_container, LV_OBJ_FLAG_CLICKABLE);

--- a/main/voice.c
+++ b/main/voice.c
@@ -1792,13 +1792,25 @@ static void mic_capture_task(void *arg)
             break;
         }
 
-        if (s_voice_mode == VOICE_MODE_DICTATE && !s_afe_enabled) {
+        /* Wave 15 W15-P02: compute RMS for BOTH Ask and Dictate modes
+         * so the voice overlay can render a live "listening back" glow
+         * on the orb driven by voice_get_current_rms().  Previously RMS
+         * was gated to DICTATE and the UI orb stayed static during
+         * normal Ask turns, which made the overlay feel unresponsive.
+         * The expensive VAD-driven auto-stop logic below is still
+         * scoped to DICTATE (the only mode that uses it). */
+        if (!s_afe_enabled && out_idx > 0) {
             int64_t sqsum = 0;
             for (int k = 0; k < out_idx; k++) {
                 sqsum += (int64_t)mono_buf[k] * mono_buf[k];
             }
-            float rms = sqrtf((float)(sqsum / (out_idx > 0 ? out_idx : 1)));
+            float rms = sqrtf((float)(sqsum / out_idx));
             s_current_rms = rms;
+        }
+
+        if (s_voice_mode == VOICE_MODE_DICTATE && !s_afe_enabled) {
+            /* Re-read the just-computed RMS rather than recomputing. */
+            float rms = s_current_rms;
 
             if (cal_count < CALIBRATION_FRAMES) {
                 noise_sum += rms;


### PR DESCRIPTION
## Summary

User feedback on voice flow: *"feels disjointed… like nothing's happening when I speak."* Screenshot audit confirmed the orb was static during LISTENING — only a timer-driven breathing animation, no actual reaction to the microphone.

Follow-up to #105 (hollow-outline fix). Addresses point (2) on the disjointed-voice list: make the orb listen back.

## Changes

### 1. [main/voice.c](main/voice.c)

`s_current_rms` was only computed in `VOICE_MODE_DICTATE` (it gates that mode's VAD auto-stop). In ASK mode the RMS stayed at 0, so any UI consumer saw silence even while the user was speaking.

Lifted the RMS computation out of the DICTATE branch — it now runs for both modes whenever AFE is off. The VAD logic remains DICTATE-scoped; it just re-reads the shared value.

### 2. [main/ui_voice.c](main/ui_voice.c)

New `rms_tick_cb` / `start_rms_anim` / `stop_rms_anim`. LVGL timer at 60 ms cadence during LISTENING + CONNECTING reads `voice_get_current_rms()` and maps to opacity 30-100 on the innermost orb glow layer:

```
rms ≤ 200       → opa 30  (ambient floor — orb stays dimly lit)
rms 200-3000    → opa 30-100 linear
rms > 3000      → opa 100 cap
```

The other 3 glow layers keep their breathe animation so the orb feels alive in silence; only the bright core tracks voice energy. `start_rms_anim` removes the breathe anim on the innermost layer first so they don't fight every frame. Cleanup wired through `stop_all_anims` so LISTENING → PROCESSING tears the timer down cleanly.

## Test plan

- [x] `idf.py build` — clean
- [x] Flash, tap orb, capture 6 LISTENING frames over 6 s
- [x] Frame sizes vary 28–29 KB (static orb = identical sizes) → opacity modulating in real time
- [x] Uptime monotonic, fps=26, no crashes across the turn
- [ ] Real voice test — speak into the mic, visually confirm the orb's core brightens with voice level

Refs wave-15 polish (W15-P02). Pairs with #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)