### PR TITLE
fix(chat): honest suggestions that match capabilities (closes #111)

### DIFF
--- a/main/chat_suggestions.c
+++ b/main/chat_suggestions.c
@@ -20,27 +20,33 @@ static const char *TAG = "suggestions";
 
 /* Ellipsis / em-dash / NBSP-hyphen are NOT in the Montserrat font subset
  * shipped on-device — they render as tofu boxes. Stick to ASCII here. */
+/* closes #111: suggestions rewritten to match actual on-device
+ * capabilities.  web_search + web_fetch are disabled by default on
+ * the Dragon gateway (no Brave API key); there's no inbox/calendar/
+ * car integration.  Previous Claw suggestions promised features that
+ * immediately returned 'Sorry, I couldn't generate a response'. */
 static const char *s_prompts[4][4] = {
-    /* Local */
+    /* Local (voice_mode 0) — Notes + datetime + local LLM */
     { "What's the date?",
       "Add a note about...",
-      "Remind me to...",
-      "Summarize my last note" },
-    /* Hybrid */
-    { "Search the web for...",
-      "Explain like I'm 5...",
-      "What's the weather?",
-      "Brief me on..." },
-    /* Cloud */
+      "Summarize my last note",
+      "Help me remember..." },
+    /* Hybrid (voice_mode 1) — cloud STT+TTS, local LLM, no web */
+    { "Explain like I'm 5...",
+      "Translate this to...",
+      "Brainstorm ideas for...",
+      "Rewrite this to be..." },
+    /* Cloud (voice_mode 2) — Claude / GPT, full reasoning */
     { "Write a Python script...",
       "Compare X and Y",
       "Draft a reply to...",
       "Plan my day around..." },
-    /* Claw */
-    { "Search my inbox for...",
-      "Book a car at...",
-      "Update my calendar...",
-      "Pull the Tab5 docs" },
+    /* Claw (voice_mode 3) — MiniMax + MCP tools (time, memory,
+     * sequential-thinking, git); NO web. */
+    { "Help me debug...",
+      "Explain this concept...",
+      "Write a code snippet...",
+      "Talk through a design..." },
 };
 
 static const uint32_t s_mode_tint[4] = {
@@ -57,7 +63,9 @@ static const char *s_mode_lead[4] = {
     "Fast local AI -- private by default.",
     "Local model + cloud audio for clarity.",
     s_cloud_lead_buf,
-    "Your agent: memory, tools, web.",
+    /* #111: web tools are disabled on Dragon (no Brave key).  The
+     * agent still has memory + time + sequential-thinking + git MCPs. */
+    "Your agent: memory + reasoning tools.",
 };
 
 struct chat_suggestions {


### PR DESCRIPTION
Closes #111. Screenshot shows new Claw suggestions + lead.