### PR TITLE
feat(chat+voice): strip inline markdown at render (closes #116)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UI_SRCS
     "chat_suggestions.c"
     "chat_msg_view.c"
     "chat_session_drawer.c"
+    "md_strip.c"
     "fonts/fraunces_italic_32.c"
     "fonts/fraunces_italic_22.c"
     "fonts/jetbrains_mono_medium_14.c"

--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "bsp_config.h"
 #include "media_cache.h"
+#include "md_strip.h"                 /* #116: inline markdown cleanup */
 #include "esp_log.h"
 
 #include "lvgl.h"
@@ -441,7 +442,13 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
     lv_obj_set_style_text_font(slot->body, FONT_BODY, 0);
     lv_obj_set_style_text_align(slot->body, LV_TEXT_ALIGN_LEFT, 0);
     lv_obj_set_style_text_line_space(slot->body, 4, 0);
-    lv_label_set_text(slot->body, msg->text);
+    /* #116: strip inline markdown so '**bold**' doesn't render as literal
+     * asterisks in the bubble.  Uses a stack buffer capped at
+     * sizeof(chat_msg_t::text); markdown-stripped output is always
+     * same-or-shorter than input. */
+    char body_buf[sizeof(msg->text)];
+    md_strip_inline(msg->text, body_buf, sizeof(body_buf));
+    lv_label_set_text(slot->body, body_buf);
 
     /* Timestamp (+ Phase 3d receipt stamp for AI bubbles with cost).
      * Format: "9:42 · HAIKU-3.5 · $0.003"  (AI only, when receipt > 0). */

--- a/main/md_strip.c
+++ b/main/md_strip.c
@@ -1,0 +1,61 @@
+/* W15-P03 (#116): inline markdown stripper.  See md_strip.h. */
+#include "md_strip.h"
+
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+
+static bool is_line_start(const char *buf, const char *p)
+{
+    if (p == buf) return true;
+    return *(p - 1) == '\n';
+}
+
+void md_strip_inline(const char *in, char *out, size_t out_cap)
+{
+    if (!out || out_cap == 0) return;
+    if (!in) { out[0] = 0; return; }
+
+    size_t oi = 0;
+    size_t n = strlen(in);
+    for (size_t i = 0; i < n && oi + 1 < out_cap; ) {
+        char c = in[i];
+
+        /* Heading markers at line start: "# ", "## ", "### ".
+         * Drop the # and space; keep the rest of the line. */
+        if (c == '#' && is_line_start(in, &in[i])) {
+            size_t j = i;
+            while (j < n && in[j] == '#') j++;
+            if (j < n && in[j] == ' ') {
+                i = j + 1;
+                continue;
+            }
+        }
+
+        /* Leading bullet "- " / "* " → "• ". */
+        if ((c == '-' || c == '*') && is_line_start(in, &in[i])
+            && i + 1 < n && in[i + 1] == ' ') {
+            /* UTF-8 bullet (•) = E2 80 A2 */
+            if (oi + 4 < out_cap) {
+                out[oi++] = (char)0xE2;
+                out[oi++] = (char)0x80;
+                out[oi++] = (char)0xA2;
+                out[oi++] = ' ';
+            }
+            i += 2;
+            continue;
+        }
+
+        /* Bold / italic markers: '**', '__' (pair) or '*', '_' (single).
+         * Drop the markers, keep inner text. */
+        if (c == '*' || c == '_') {
+            bool doubled = (i + 1 < n && in[i + 1] == c);
+            i += doubled ? 2 : 1;
+            continue;
+        }
+
+        out[oi++] = c;
+        i++;
+    }
+    out[oi] = 0;
+}

--- a/main/md_strip.h
+++ b/main/md_strip.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <stddef.h>
+
+/* W15-P03 (#116): strip common inline-markdown markers so a chat label
+ * renders as clean prose instead of leaking '**', '*', '#', '- ', etc.
+ * to the user.  Not a full markdown parser — just visual noise removal.
+ *
+ * Rules applied in order:
+ *   - '**' and '__' pair markers        → removed, content kept
+ *   - '*' and '_' pair markers (single) → removed, content kept
+ *   - leading '# ' / '## ' / '### '     → removed from line start
+ *   - leading '- ' / '* '                → replaced with '• '
+ *   - leading '1. ' / '2. ' etc          → kept as-is (numbered lists read fine)
+ *
+ * Works in-place if `out == in`, truncates to `out_cap - 1` bytes
+ * (always NUL-terminated).  Safe for empty / NULL input.
+ */
+void md_strip_inline(const char *in, char *out, size_t out_cap);

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -14,6 +14,7 @@
  */
 
 #include "ui_voice.h"
+#include "md_strip.h"      /* #116: inline markdown cleanup */
 #include "ui_notes.h"
 #include "mode_manager.h"
 #include "config.h"
@@ -537,7 +538,8 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
         } else {
             const char *llm_txt2 = voice_get_llm_text();
             if (llm_txt2 && llm_txt2[0] && s_ai_label) {
-                lv_label_set_text(s_ai_label, llm_txt2);
+                { char _m[1024]; md_strip_inline(llm_txt2, _m, sizeof(_m));
+                  lv_label_set_text(s_ai_label, _m); }
                 if (s_ai_bubble) lv_obj_clear_flag(s_ai_bubble, LV_OBJ_FLAG_HIDDEN);
             }
             const char *stt_txt = voice_get_stt_text();
@@ -552,7 +554,8 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
             lv_obj_scroll_to_y(s_chat_cont, LV_COORD_MAX, LV_ANIM_OFF);
             /* #115: drive the fixed-position response label. */
             if (llm_txt2 && llm_txt2[0] && s_response_label) {
-                lv_label_set_text(s_response_label, llm_txt2);
+                { char _m[1024]; md_strip_inline(llm_txt2, _m, sizeof(_m));
+                  lv_label_set_text(s_response_label, _m); }
                 lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
                 lv_obj_move_foreground(s_response_label);
             }
@@ -1280,7 +1283,8 @@ static void show_state_processing(const char *detail)
             lv_obj_add_flag(s_lbl_status, LV_OBJ_FLAG_HIDDEN);
         }
 
-        lv_label_set_text(s_ai_label, llm);
+        { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+          lv_label_set_text(s_ai_label, _m); }
         lv_obj_clear_flag(s_ai_bubble, LV_OBJ_FLAG_HIDDEN);
         /* closes #115: lift above orb z-order, same as SPEAKING. */
         lv_obj_move_foreground(s_chat_cont);
@@ -1290,7 +1294,8 @@ static void show_state_processing(const char *detail)
 
         /* #115: drive the fixed-position response label too. */
         if (s_response_label) {
-            lv_label_set_text(s_response_label, llm);
+            { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+              lv_label_set_text(s_response_label, _m); }
             lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
             lv_obj_move_foreground(s_response_label);
         }
@@ -1358,7 +1363,8 @@ static void show_state_speaking(void)
         lv_obj_clear_flag(s_user_bubble, LV_OBJ_FLAG_HIDDEN);
     }
     if (llm && llm[0]) {
-        lv_label_set_text(s_ai_label, llm);
+        { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+          lv_label_set_text(s_ai_label, _m); }
         lv_obj_set_width(s_ai_label, CHAT_BUBBLE_MAX_W - 2 * CHAT_BUBBLE_PAD);
         lv_label_set_long_mode(s_ai_label, LV_LABEL_LONG_WRAP);
         lv_obj_clear_flag(s_ai_bubble, LV_OBJ_FLAG_HIDDEN);
@@ -1367,7 +1373,8 @@ static void show_state_speaking(void)
         /* #115: drive the fixed-position response label — this is the
          * reliable path when the flex chat_cont doesn't render. */
         if (s_response_label) {
-            lv_label_set_text(s_response_label, llm);
+            { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+              lv_label_set_text(s_response_label, _m); }
             lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
             lv_obj_move_foreground(s_response_label);
         }


### PR DESCRIPTION
Closes #116. Screenshot shows clean numbered-list response with no literal asterisks.