### PR TITLE
fix(chat+voice): Fraunces font swap + stop overlay hijacking chat on reconnect (closes #139, #140)

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -112,7 +112,13 @@
 LV_FONT_DECLARE(fraunces_italic_32);
 LV_FONT_DECLARE(fraunces_italic_22);
 LV_FONT_DECLARE(jetbrains_mono_medium_14);
-#define FONT_CHAT_TITLE  (&fraunces_italic_32)   /* chat header title, drawer title */
+/* closes #139: FONT_CHAT_TITLE was fraunces_italic_32.  Coredump
+ * captured in draw_letter for letter 'C' while painting the chat
+ * header title ('Chat' / 'Conversations' — both start with 'C').
+ * Intermittent, reproducible under long sessions.  Swap to the
+ * well-tested Montserrat Bold 28 (FONT_TITLE) for stability.
+ * fraunces stays available for inline emphasis via FONT_CHAT_EMPH. */
+#define FONT_CHAT_TITLE  FONT_TITLE              /* was &fraunces_italic_32 */
 #define FONT_CHAT_EMPH   (&fraunces_italic_22)   /* AI bubble <em> emphasis */
 #define FONT_CHAT_MONO   (&jetbrains_mono_medium_14)  /* kickers, timestamps, chip sub */
 #endif

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -422,6 +422,18 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
             ESP_LOGI(TAG, "Boot connect: CONNECTING (silent)");
             break;
         }
+        /* closes #140: only pop the voice overlay on CONNECTING if the
+         * user actually initiated something (mic tap pending, or
+         * overlay was already visible mid-turn).  Previously EVERY
+         * reconnect after boot would pop the overlay, even when the
+         * user was on chat or home — the typing flow got hijacked
+         * whenever WS bounced for ngrok/LAN auto-fallback.  Boot path
+         * already had its own silent gate; this adds one for runtime
+         * reconnects. */
+        if (!s_visible && !s_pending_ask && !s_dictation_from_anywhere) {
+            ESP_LOGI(TAG, "Silent reconnect: CONNECTING (no overlay popup)");
+            break;
+        }
         /* Show overlay immediately with "Connecting..." */
         if (!s_visible) {
             ui_voice_show();


### PR DESCRIPTION
Closes #139 and #140. Verified on hardware.