### PR TITLE
feat(debug-ui): multi-tab SPA using the β endpoints (closes #150)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
         SRCS "main.c"
              "sdcard.c" "wifi.c"
              "dragon_link.c" "mjpeg_stream.c" "udp_stream.c" "touch_ws.c" "voice.c" "mode_manager.c"
-             "mdns_discovery.c" "debug_server.c" "afe.c" "heap_watchdog.c"
+             "mdns_discovery.c" "debug_server.c" "debug_obs.c" "afe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"
              "ui_core.c" ${UI_SRCS}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
              "settings.c" "ota.c" "media_cache.c"
              "widget_store.c"
              "task_worker.c"
+        EMBED_TXTFILES "debug_ui.html"
         INCLUDE_DIRS "."
         REQUIRES tab5
                  esp_lcd esp_psram driver nvs_flash esp_system heap esp_mm esp_timer

--- a/main/debug_obs.c
+++ b/main/debug_obs.c
@@ -1,0 +1,321 @@
+/**
+ * TinkerTab — Debug Server Observability (#149 PR β)
+ *
+ * Three bounded PSRAM ring buffers:
+ *   - EVENT_RING:   64 events, each kind[16] + detail[48] + ms timestamp
+ *   - HEAP_RING :   60 heap snapshots, one per 30 s
+ *   - LOG_RING  :   32 KB line-oriented ring for /logs/tail
+ *
+ * Thread-safety: a single mutex guards mutator paths.  Readers copy
+ * under the lock and release it before JSON-ifying to keep the
+ * critical section tight.
+ */
+
+#include "debug_obs.h"
+#include "esp_heap_caps.h"
+#include "esp_timer.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/timers.h"
+
+#include "lvgl.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+static const char *TAG = "debug_obs";
+
+/* ── Config ──────────────────────────────────────────────────────── */
+#define EVENT_RING_SIZE   64
+#define HEAP_RING_SIZE    60      /* 60 × 30 s = 30 min of history */
+#define HEAP_SAMPLE_MS    30000   /* sampling cadence */
+#define LOG_RING_SIZE     (32 * 1024)
+
+/* ── Event ring ─────────────────────────────────────────────────── */
+typedef struct {
+    uint64_t ms;
+    char     kind[16];
+    char     detail[48];
+} obs_event_t;
+
+static obs_event_t  *s_events = NULL;
+static uint16_t      s_event_head = 0;   /* next slot to write */
+static uint32_t      s_event_total = 0;  /* ever written (monotonic) */
+
+/* ── Heap ring ─────────────────────────────────────────────────── */
+typedef struct {
+    uint64_t ms;
+    uint32_t int_free_kb;
+    uint32_t int_largest_kb;
+    uint32_t psram_free_kb;
+    uint32_t psram_largest_kb;
+    uint32_t lvgl_used_kb;
+    uint32_t lvgl_free_kb;
+    uint8_t  lvgl_frag_pct;
+} obs_heap_t;
+
+static obs_heap_t   *s_heap = NULL;
+static uint16_t      s_heap_head = 0;
+static uint16_t      s_heap_count = 0;   /* grows to HEAP_RING_SIZE then caps */
+
+/* ── Log ring ───────────────────────────────────────────────────── */
+/* Byte-wise circular buffer storing lines separated by '\n'.  Old
+ * bytes are overwritten as new data arrives.  Tail extraction walks
+ * backwards from head to count N lines. */
+static char         *s_log = NULL;
+static uint32_t      s_log_head = 0;     /* next byte to write */
+static bool          s_log_wrapped = false;
+
+static SemaphoreHandle_t s_mu = NULL;
+static vprintf_like_t    s_prev_vprintf = NULL;
+static bool              s_inited = false;
+
+static esp_timer_handle_t s_heap_timer = NULL;
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static inline uint64_t now_ms(void) { return (uint64_t)(esp_timer_get_time() / 1000); }
+
+static inline void lock(void)   { if (s_mu) xSemaphoreTake(s_mu, portMAX_DELAY); }
+static inline void unlock(void) { if (s_mu) xSemaphoreGive(s_mu); }
+
+/* ── esp_log vprintf hook ───────────────────────────────────────── */
+/* The log hook runs on whatever task emitted the log.  We append to
+ * the log ring then forward to the previous handler (UART). */
+static int log_hook_vprintf(const char *fmt, va_list ap)
+{
+    /* Forward to previous handler first so UART logs aren't blocked
+     * by ring contention.  Copy ap because vprintf consumes it. */
+    va_list ap2;
+    va_copy(ap2, ap);
+    int rv = s_prev_vprintf ? s_prev_vprintf(fmt, ap2) : vprintf(fmt, ap2);
+    va_end(ap2);
+
+    /* Format into a stack buffer (cheap) then ring-append under lock. */
+    char line[256];
+    int n = vsnprintf(line, sizeof(line), fmt, ap);
+    if (n <= 0 || !s_log) return rv;
+    if (n > (int)sizeof(line) - 1) n = sizeof(line) - 1;
+
+    lock();
+    for (int i = 0; i < n; i++) {
+        s_log[s_log_head] = line[i];
+        s_log_head = (s_log_head + 1) % LOG_RING_SIZE;
+        if (s_log_head == 0) s_log_wrapped = true;
+    }
+    unlock();
+    return rv;
+}
+
+/* ── Heap sample timer ──────────────────────────────────────────── */
+static void heap_sample_cb(void *arg)
+{
+    (void)arg;
+    if (!s_heap) return;
+
+    size_t int_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    size_t int_lrg  = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    size_t ps_free  = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+    size_t ps_lrg   = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
+
+    lv_mem_monitor_t lvgl;
+    lv_mem_monitor(&lvgl);
+
+    obs_heap_t s = {
+        .ms               = now_ms(),
+        .int_free_kb      = int_free / 1024,
+        .int_largest_kb   = int_lrg  / 1024,
+        .psram_free_kb    = ps_free  / 1024,
+        .psram_largest_kb = ps_lrg   / 1024,
+        .lvgl_used_kb     = (lvgl.total_size - lvgl.free_size) / 1024,
+        .lvgl_free_kb     = lvgl.free_size / 1024,
+        .lvgl_frag_pct    = (uint8_t)lvgl.frag_pct,
+    };
+
+    lock();
+    s_heap[s_heap_head] = s;
+    s_heap_head = (s_heap_head + 1) % HEAP_RING_SIZE;
+    if (s_heap_count < HEAP_RING_SIZE) s_heap_count++;
+    unlock();
+}
+
+/* ── Public: init ───────────────────────────────────────────────── */
+esp_err_t tab5_debug_obs_init(void)
+{
+    if (s_inited) return ESP_OK;
+
+    s_mu = xSemaphoreCreateMutex();
+    if (!s_mu) return ESP_ERR_NO_MEM;
+
+    s_events = heap_caps_calloc(EVENT_RING_SIZE, sizeof(obs_event_t), MALLOC_CAP_SPIRAM);
+    s_heap   = heap_caps_calloc(HEAP_RING_SIZE,  sizeof(obs_heap_t),  MALLOC_CAP_SPIRAM);
+    s_log    = heap_caps_malloc(LOG_RING_SIZE,                       MALLOC_CAP_SPIRAM);
+    if (!s_events || !s_heap || !s_log) {
+        ESP_LOGE(TAG, "PSRAM alloc failed");
+        if (s_events) heap_caps_free(s_events);
+        if (s_heap)   heap_caps_free(s_heap);
+        if (s_log)    heap_caps_free(s_log);
+        s_events = NULL; s_heap = NULL; s_log = NULL;
+        return ESP_ERR_NO_MEM;
+    }
+    memset(s_log, 0, LOG_RING_SIZE);
+
+    /* Install log hook — keep the previous one so UART output survives. */
+    s_prev_vprintf = esp_log_set_vprintf(log_hook_vprintf);
+
+    /* Heap sample timer — runs in the esp_timer service task. */
+    const esp_timer_create_args_t targs = {
+        .callback        = heap_sample_cb,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name            = "obs_heap",
+    };
+    esp_err_t r = esp_timer_create(&targs, &s_heap_timer);
+    if (r == ESP_OK) {
+        esp_timer_start_periodic(s_heap_timer, HEAP_SAMPLE_MS * 1000ULL);
+    }
+
+    /* Seed the first sample now so /heap/history isn't empty on boot. */
+    heap_sample_cb(NULL);
+
+    s_inited = true;
+    tab5_debug_obs_event("obs", "init");
+    ESP_LOGI(TAG, "observability ready: events=%d heap=%d log=%uKB",
+             EVENT_RING_SIZE, HEAP_RING_SIZE, (unsigned)(LOG_RING_SIZE / 1024));
+    return ESP_OK;
+}
+
+/* ── Public: event API ──────────────────────────────────────────── */
+void tab5_debug_obs_event(const char *kind, const char *detail)
+{
+    if (!s_events) return;
+    lock();
+    obs_event_t *e = &s_events[s_event_head];
+    e->ms = now_ms();
+    snprintf(e->kind,   sizeof(e->kind),   "%s", kind   ? kind   : "");
+    snprintf(e->detail, sizeof(e->detail), "%s", detail ? detail : "");
+    s_event_head = (s_event_head + 1) % EVENT_RING_SIZE;
+    s_event_total++;
+    unlock();
+}
+
+cJSON *tab5_debug_obs_events_json(uint64_t since_ms)
+{
+    cJSON *arr = cJSON_CreateArray();
+    if (!s_events || !arr) return arr;
+
+    /* Copy under lock to minimize the critical section. */
+    obs_event_t snap[EVENT_RING_SIZE];
+    uint32_t total;
+    uint16_t head;
+    lock();
+    memcpy(snap, s_events, sizeof(snap));
+    head  = s_event_head;
+    total = s_event_total;
+    unlock();
+
+    /* Walk oldest → newest. */
+    int count = total < EVENT_RING_SIZE ? (int)total : EVENT_RING_SIZE;
+    for (int i = 0; i < count; i++) {
+        int idx = (head + EVENT_RING_SIZE - count + i) % EVENT_RING_SIZE;
+        const obs_event_t *e = &snap[idx];
+        if (e->ms < since_ms) continue;
+        cJSON *o = cJSON_CreateObject();
+        cJSON_AddNumberToObject(o, "ms",     (double)e->ms);
+        cJSON_AddStringToObject(o, "kind",   e->kind);
+        cJSON_AddStringToObject(o, "detail", e->detail);
+        cJSON_AddItemToArray(arr, o);
+    }
+    return arr;
+}
+
+/* ── Public: heap history ───────────────────────────────────────── */
+cJSON *tab5_debug_obs_heap_json(int n)
+{
+    cJSON *arr = cJSON_CreateArray();
+    if (!s_heap || !arr) return arr;
+    if (n <= 0 || n > HEAP_RING_SIZE) n = HEAP_RING_SIZE;
+
+    obs_heap_t snap[HEAP_RING_SIZE];
+    uint16_t count, head;
+    lock();
+    memcpy(snap, s_heap, sizeof(snap));
+    count = s_heap_count;
+    head  = s_heap_head;
+    unlock();
+
+    if (n > count) n = count;
+    /* Most recent first — walk head-1, head-2, ... */
+    for (int i = 0; i < n; i++) {
+        int idx = (head - 1 - i + HEAP_RING_SIZE) % HEAP_RING_SIZE;
+        const obs_heap_t *s = &snap[idx];
+        cJSON *o = cJSON_CreateObject();
+        cJSON_AddNumberToObject(o, "ms",               (double)s->ms);
+        cJSON_AddNumberToObject(o, "int_free_kb",      s->int_free_kb);
+        cJSON_AddNumberToObject(o, "int_largest_kb",   s->int_largest_kb);
+        cJSON_AddNumberToObject(o, "psram_free_kb",    s->psram_free_kb);
+        cJSON_AddNumberToObject(o, "psram_largest_kb", s->psram_largest_kb);
+        cJSON_AddNumberToObject(o, "lvgl_used_kb",     s->lvgl_used_kb);
+        cJSON_AddNumberToObject(o, "lvgl_free_kb",     s->lvgl_free_kb);
+        cJSON_AddNumberToObject(o, "lvgl_frag_pct",    s->lvgl_frag_pct);
+        cJSON_AddItemToArray(arr, o);
+    }
+    return arr;
+}
+
+/* ── Public: log tail ───────────────────────────────────────────── */
+char *tab5_debug_obs_log_tail(int n, size_t *out_len)
+{
+    if (out_len) *out_len = 0;
+    if (!s_log) return NULL;
+    if (n <= 0) n = 100;
+
+    /* Snapshot — small enough that copying the whole ring is cheap. */
+    char *snap = heap_caps_malloc(LOG_RING_SIZE + 1, MALLOC_CAP_SPIRAM);
+    if (!snap) return NULL;
+    uint32_t head;
+    bool wrapped;
+    lock();
+    memcpy(snap, s_log, LOG_RING_SIZE);
+    head    = s_log_head;
+    wrapped = s_log_wrapped;
+    unlock();
+    snap[LOG_RING_SIZE] = '\0';
+
+    /* Logical-linear view: if wrapped, ring is [head .. end] + [0 .. head-1]
+     * Otherwise: [0 .. head-1]. */
+    size_t linear_len = wrapped ? LOG_RING_SIZE : head;
+    char *linear = heap_caps_malloc(linear_len + 1, MALLOC_CAP_SPIRAM);
+    if (!linear) { heap_caps_free(snap); return NULL; }
+    if (wrapped) {
+        size_t tail_len = LOG_RING_SIZE - head;
+        memcpy(linear, snap + head, tail_len);
+        memcpy(linear + tail_len, snap, head);
+    } else {
+        memcpy(linear, snap, head);
+    }
+    linear[linear_len] = '\0';
+    heap_caps_free(snap);
+
+    /* Walk from the tail backwards to count N '\n' separators. */
+    size_t start = linear_len;
+    int lines_seen = 0;
+    while (start > 0 && lines_seen <= n) {
+        start--;
+        if (linear[start] == '\n') {
+            lines_seen++;
+            if (lines_seen > n) { start++; break; }
+        }
+    }
+
+    size_t out_bytes = linear_len - start;
+    char *out = heap_caps_malloc(out_bytes + 1, MALLOC_CAP_SPIRAM);
+    if (!out) { heap_caps_free(linear); return NULL; }
+    memcpy(out, linear + start, out_bytes);
+    out[out_bytes] = '\0';
+    heap_caps_free(linear);
+
+    if (out_len) *out_len = out_bytes;
+    return out;
+}

--- a/main/debug_obs.h
+++ b/main/debug_obs.h
@@ -1,0 +1,47 @@
+/**
+ * TinkerTab — Debug Server Observability (#149 PR β)
+ *
+ * Bounded PSRAM ring buffers feeding the new debug endpoints:
+ *   - Event stream      (/events)  — notable state transitions
+ *   - Heap sample ring  (/heap/history) — 60 × 30 s samples
+ *   - Log tail          (/logs/tail) — last N lines via esp_log vprintf hook
+ *
+ * Call tab5_debug_obs_init() once at boot after heap_watchdog.
+ * All public reads are thread-safe (lock-taken); call sites are the
+ * httpd task.  Writes from any task.
+ */
+#pragma once
+
+#include "esp_err.h"
+#include "cJSON.h"
+#include <stdint.h>
+#include <stddef.h>
+
+/** Initialize the observability subsystem.  Registers the esp_log hook,
+ *  allocates PSRAM ring buffers, kicks off the heap-sample timer. */
+esp_err_t tab5_debug_obs_init(void);
+
+/* ── Events ─────────────────────────────────────────────────────── */
+
+/* Log a notable event.  Called from any task; cheap (one memcpy + incr).
+ * Examples: "wifi.kick:hard", "voice.ws:connected", "mode.switch:2",
+ *           "coredump.captured", "ota.scheduled". */
+void tab5_debug_obs_event(const char *kind, const char *detail);
+
+/** Serialize events newer than `since_ms` (monotonic uptime) into a
+ *  JSON array.  Pass since_ms=0 for the whole ring. */
+cJSON *tab5_debug_obs_events_json(uint64_t since_ms);
+
+/* ── Heap history ───────────────────────────────────────────────── */
+
+/** Serialize last `n` heap samples (most recent first).  n clamped
+ *  to ring size (60).  Each entry: {ms, int_free, int_largest, psram,
+ *  psram_largest, lvgl_used}. */
+cJSON *tab5_debug_obs_heap_json(int n);
+
+/* ── Log tail ───────────────────────────────────────────────────── */
+
+/** Copy up to `n` most-recent log lines into a newly-allocated
+ *  string buffer.  Caller frees with heap_caps_free.  Returns NULL
+ *  on error. */
+char *tab5_debug_obs_log_tail(int n, size_t *out_len);

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2185,6 +2185,482 @@ static esp_err_t selftest_handler(httpd_req_t *req)
     return ret;
 }
 
+/* ==================================================================== */
+/*  #149 PR β — new capability endpoints                                */
+/* ==================================================================== */
+
+#include "debug_obs.h"
+#include "esp_wifi.h"
+#include "nvs_flash.h"
+#include "chat_msg_store.h"
+#include "audio.h"
+#include "battery.h"
+#include "display.h"
+
+/* Shared JSON response helper used by the new handlers.  Takes ownership
+ * of `root` (Delete'd here). */
+static esp_err_t send_json_resp(httpd_req_t *req, cJSON *root)
+{
+    char *s = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!s) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "json print failed");
+        return ESP_FAIL;
+    }
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+    esp_err_t r = httpd_resp_sendstr(req, s);
+    free(s);
+    return r;
+}
+
+/* ── GET /tasks — FreeRTOS task snapshot ────────────────────────── */
+/* Full per-task dump requires configUSE_TRACE_FACILITY + the
+ * run-time-stats infra to be enabled in sdkconfig.  Most ESP-IDF
+ * projects leave this off to save ~96 B per task; degrade gracefully. */
+static esp_err_t tasks_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    cJSON *root  = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "count", (double)uxTaskGetNumberOfTasks());
+
+#if (configUSE_TRACE_FACILITY == 1) && (configGENERATE_RUN_TIME_STATS == 1)
+    UBaseType_t n = uxTaskGetNumberOfTasks();
+    size_t slots = n + 8;
+    TaskStatus_t *status = heap_caps_malloc(slots * sizeof(TaskStatus_t), MALLOC_CAP_SPIRAM);
+    if (status) {
+        uint32_t total_runtime = 0;
+        UBaseType_t got = uxTaskGetSystemState(status, slots, &total_runtime);
+        cJSON *arr = cJSON_AddArrayToObject(root, "tasks");
+        cJSON_AddNumberToObject(root, "total_runtime", (double)total_runtime);
+        const char *state_names[] = {"running","ready","blocked","suspended","deleted","invalid"};
+        for (UBaseType_t i = 0; i < got; i++) {
+            const TaskStatus_t *t = &status[i];
+            cJSON *o = cJSON_CreateObject();
+            cJSON_AddStringToObject(o, "name",     t->pcTaskName ? t->pcTaskName : "");
+            cJSON_AddNumberToObject(o, "prio",     t->uxCurrentPriority);
+            cJSON_AddStringToObject(o, "state",
+                t->eCurrentState <= eInvalid ? state_names[t->eCurrentState] : "?");
+            cJSON_AddNumberToObject(o, "stack_free",
+                                    (double)(t->usStackHighWaterMark * sizeof(StackType_t)));
+            cJSON_AddNumberToObject(o, "runtime",  (double)t->ulRunTimeCounter);
+            cJSON_AddItemToArray(arr, o);
+        }
+        heap_caps_free(status);
+    }
+#else
+    cJSON_AddStringToObject(root, "note",
+        "per-task dump requires configUSE_TRACE_FACILITY + "
+        "configGENERATE_RUN_TIME_STATS in sdkconfig");
+#endif
+    return send_json_resp(req, root);
+}
+
+/* ── GET /logs/tail?n=100 ───────────────────────────────────────── */
+static esp_err_t logs_tail_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    int n = 100;
+    char q[64] = {0}, v[16] = {0};
+    if (httpd_req_get_url_query_str(req, q, sizeof(q)) == ESP_OK
+        && httpd_query_key_value(q, "n", v, sizeof(v)) == ESP_OK) {
+        int x = atoi(v);
+        if (x > 0 && x <= 5000) n = x;
+    }
+    size_t out_len = 0;
+    char *tail = tab5_debug_obs_log_tail(n, &out_len);
+    if (!tail) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "no log buffer");
+        return ESP_FAIL;
+    }
+    httpd_resp_set_type(req, "text/plain; charset=utf-8");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_send(req, tail, out_len);
+    heap_caps_free(tail);
+    return ESP_OK;
+}
+
+/* ── POST /voice/text — send Dragon text, no 200-byte limit ────── */
+static esp_err_t voice_text_handler(httpd_req_t *req)
+{
+    /* α already fixed /chat to heap-allocate — /voice/text is an
+     * explicit alias so the REST surface reads cleaner.  Forward
+     * wholesale to the same handler. */
+    return chat_handler(req);
+}
+
+/* ── POST /voice/cancel ─────────────────────────────────────────── */
+static esp_err_t voice_cancel_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    esp_err_t r = voice_cancel();
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+    return send_json_resp(req, root);
+}
+
+/* ── POST /voice/clear — clear Dragon conversation history ────── */
+static esp_err_t voice_clear_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    esp_err_t r = voice_clear_history();
+    /* Also wipe Tab5 side so UI matches. */
+    extern void chat_store_clear(void);
+    chat_store_clear();
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+    cJSON_AddBoolToObject(root, "store_cleared", true);
+    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+    return send_json_resp(req, root);
+}
+
+/* ── GET /wifi/status ──────────────────────────────────────────── */
+static esp_err_t wifi_status_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "connected", tab5_wifi_connected());
+
+    char ip[20]; get_wifi_ip(ip, sizeof(ip));
+    cJSON_AddStringToObject(root, "ip", ip);
+
+    wifi_ap_record_t ap = {0};
+    esp_err_t r = esp_wifi_sta_get_ap_info(&ap);
+    if (r == ESP_OK) {
+        char bssid[18];
+        snprintf(bssid, sizeof(bssid), "%02x:%02x:%02x:%02x:%02x:%02x",
+                 ap.bssid[0], ap.bssid[1], ap.bssid[2],
+                 ap.bssid[3], ap.bssid[4], ap.bssid[5]);
+        cJSON_AddStringToObject(root, "ssid", (const char *)ap.ssid);
+        cJSON_AddStringToObject(root, "bssid", bssid);
+        cJSON_AddNumberToObject(root, "channel", ap.primary);
+        cJSON_AddNumberToObject(root, "rssi", ap.rssi);
+        const char *auths[] = {"open","wep","wpa_psk","wpa2_psk","wpa_wpa2_psk",
+                               "wpa2_enterprise","wpa3_psk","wpa2_wpa3_psk",
+                               "wapi_psk","owe","wpa3_enterprise","wpa3_ent_192"};
+        int am = (int)ap.authmode;
+        cJSON_AddStringToObject(root, "authmode",
+            (am >= 0 && am < (int)(sizeof(auths)/sizeof(auths[0]))) ? auths[am] : "?");
+    } else {
+        cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+    }
+    return send_json_resp(req, root);
+}
+
+/* ── GET /battery ──────────────────────────────────────────────── */
+static esp_err_t battery_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    tab5_battery_info_t bat = {0};
+    esp_err_t r = tab5_battery_read(&bat);
+    cJSON *root = cJSON_CreateObject();
+    if (r == ESP_OK) {
+        cJSON_AddNumberToObject(root, "voltage",  (double)bat.voltage);
+        cJSON_AddNumberToObject(root, "current",  (double)bat.current);
+        cJSON_AddNumberToObject(root, "power",    (double)bat.power);
+        cJSON_AddNumberToObject(root, "percent",  (double)bat.percent);
+        cJSON_AddBoolToObject(root,   "charging", bat.charging);
+    } else {
+        cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+    }
+    return send_json_resp(req, root);
+}
+
+/* ── POST /display/brightness?pct=0..100 ───────────────────────── */
+static esp_err_t display_brightness_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[32] = {0}, v[8] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "pct", v, sizeof(v));
+    int pct = atoi(v);
+    if (pct < 0 || pct > 100) {
+        cJSON *r = cJSON_CreateObject();
+        cJSON_AddStringToObject(r, "error", "pct must be 0..100");
+        return send_json_resp(req, r);
+    }
+    esp_err_t er = tab5_settings_set_brightness((uint8_t)pct);
+    /* Apply live via display driver so the user sees the change without
+     * needing to open the Settings screen. */
+    tab5_display_set_brightness(pct);
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddBoolToObject(resp, "ok", er == ESP_OK);
+    cJSON_AddNumberToObject(resp, "brightness", pct);
+    tab5_debug_obs_event("display.brightness", v);
+    return send_json_resp(req, resp);
+}
+
+/* ── GET/POST /audio ───────────────────────────────────────────── */
+static esp_err_t audio_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+
+    if (req->method == HTTP_POST) {
+        char q[64] = {0}, v[16] = {0};
+        httpd_req_get_url_query_str(req, q, sizeof(q));
+
+        /* action=volume&pct=50 | action=mute&on=0|1 */
+        char action[16] = {0};
+        httpd_query_key_value(q, "action", action, sizeof(action));
+        cJSON *resp = cJSON_CreateObject();
+        if (strcmp(action, "volume") == 0) {
+            httpd_query_key_value(q, "pct", v, sizeof(v));
+            int pct = atoi(v);
+            if (pct < 0 || pct > 100) {
+                cJSON_AddStringToObject(resp, "error", "pct must be 0..100");
+            } else {
+                tab5_settings_set_volume((uint8_t)pct);
+                tab5_audio_set_volume((uint8_t)pct);
+                cJSON_AddBoolToObject(resp, "ok", true);
+                cJSON_AddNumberToObject(resp, "volume", pct);
+                tab5_debug_obs_event("audio.volume", v);
+            }
+        } else if (strcmp(action, "mute") == 0) {
+            httpd_query_key_value(q, "on", v, sizeof(v));
+            int on = atoi(v);
+            tab5_settings_set_mic_mute(on ? 1 : 0);
+            cJSON_AddBoolToObject(resp, "ok", true);
+            cJSON_AddBoolToObject(resp, "mic_mute", on != 0);
+            tab5_debug_obs_event("audio.mic_mute", v);
+        } else {
+            cJSON_AddStringToObject(resp, "error", "action must be volume|mute");
+        }
+        return send_json_resp(req, resp);
+    }
+
+    /* GET — current state. */
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddNumberToObject(root, "volume",   tab5_settings_get_volume());
+    cJSON_AddNumberToObject(root, "mic_mute", tab5_settings_get_mic_mute());
+    return send_json_resp(req, root);
+}
+
+/* ── GET /metrics — Prometheus text format ─────────────────────── */
+static esp_err_t metrics_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+
+    size_t int_free   = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    size_t int_lrg    = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    size_t ps_free    = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+    size_t ps_lrg     = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
+    lv_mem_monitor_t lv_m; lv_mem_monitor(&lv_m);
+    tab5_battery_info_t bat = {0}; tab5_battery_read(&bat);
+
+    char out[1536];
+    int n = snprintf(out, sizeof(out),
+        "# HELP tab5_uptime_ms Milliseconds since boot\n"
+        "# TYPE tab5_uptime_ms counter\n"
+        "tab5_uptime_ms %llu\n"
+        "# HELP tab5_heap_free_bytes Free heap per pool\n"
+        "# TYPE tab5_heap_free_bytes gauge\n"
+        "tab5_heap_free_bytes{pool=\"internal\"} %u\n"
+        "tab5_heap_free_bytes{pool=\"psram\"} %u\n"
+        "tab5_heap_free_bytes{pool=\"lvgl\"} %u\n"
+        "tab5_heap_largest_bytes{pool=\"internal\"} %u\n"
+        "tab5_heap_largest_bytes{pool=\"psram\"} %u\n"
+        "# HELP tab5_wifi_connected 1 if STA associated\n"
+        "# TYPE tab5_wifi_connected gauge\n"
+        "tab5_wifi_connected %d\n"
+        "tab5_voice_connected %d\n"
+        "tab5_voice_mode %u\n"
+        "tab5_voice_state %u\n"
+        "tab5_fps_lvgl %lu\n"
+        "tab5_battery_percent %u\n"
+        "tab5_battery_voltage %.3f\n"
+        "tab5_battery_current %.3f\n"
+        "tab5_nvs_writes %lu\n",
+        (unsigned long long)(esp_timer_get_time() / 1000),
+        (unsigned)int_free, (unsigned)ps_free, (unsigned)lv_m.free_size,
+        (unsigned)int_lrg, (unsigned)ps_lrg,
+        tab5_wifi_connected() ? 1 : 0,
+        voice_is_connected() ? 1 : 0,
+        tab5_settings_get_voice_mode(),
+        (unsigned)voice_get_state(),
+        (unsigned long)ui_core_get_fps(),
+        bat.percent, bat.voltage, bat.current,
+        (unsigned long)tab5_settings_get_nvs_write_count());
+    (void)n;
+    httpd_resp_set_type(req, "text/plain; version=0.0.4; charset=utf-8");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_sendstr(req, out);
+    return ESP_OK;
+}
+
+/* ── GET /events?since=<ms> ─────────────────────────────────────── */
+static esp_err_t events_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    uint64_t since = 0;
+    char q[48] = {0}, v[24] = {0};
+    if (httpd_req_get_url_query_str(req, q, sizeof(q)) == ESP_OK
+        && httpd_query_key_value(q, "since", v, sizeof(v)) == ESP_OK) {
+        since = (uint64_t)strtoull(v, NULL, 10);
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON *arr  = tab5_debug_obs_events_json(since);
+    cJSON_AddItemToObject(root, "events", arr);
+    return send_json_resp(req, root);
+}
+
+/* ── GET /heap/history?n=60 ─────────────────────────────────────── */
+static esp_err_t heap_history_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    int n = 60;
+    char q[32] = {0}, v[8] = {0};
+    if (httpd_req_get_url_query_str(req, q, sizeof(q)) == ESP_OK
+        && httpd_query_key_value(q, "n", v, sizeof(v)) == ESP_OK) {
+        int x = atoi(v); if (x > 0) n = x;
+    }
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddItemToObject(root, "samples", tab5_debug_obs_heap_json(n));
+    return send_json_resp(req, root);
+}
+
+/* ── GET /chat/messages?n=50 ────────────────────────────────────── */
+static esp_err_t chat_messages_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    int n = 50;
+    char q[32] = {0}, v[8] = {0};
+    if (httpd_req_get_url_query_str(req, q, sizeof(q)) == ESP_OK
+        && httpd_query_key_value(q, "n", v, sizeof(v)) == ESP_OK) {
+        int x = atoi(v); if (x > 0 && x <= 500) n = x;
+    }
+    int total = chat_store_count();
+    if (n > total) n = total;
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON *arr  = cJSON_AddArrayToObject(root, "messages");
+    cJSON_AddNumberToObject(root, "total", total);
+    cJSON_AddNumberToObject(root, "returned", n);
+
+    /* Return the last `n` messages, oldest first. */
+    for (int i = total - n; i < total; i++) {
+        const chat_msg_t *m = chat_store_get(i);
+        if (!m) continue;
+        cJSON *o = cJSON_CreateObject();
+        cJSON_AddStringToObject(o, "role", m->is_user ? "user" : "assistant");
+        const char *types[] = {"text","image","card","audio","system"};
+        cJSON_AddStringToObject(o, "type",
+            (int)m->type < (int)(sizeof(types)/sizeof(types[0])) ? types[m->type] : "?");
+        cJSON_AddStringToObject(o, "text", m->text);
+        if (m->media_url[0]) cJSON_AddStringToObject(o, "media_url", m->media_url);
+        if (m->subtitle[0])  cJSON_AddStringToObject(o, "subtitle",  m->subtitle);
+        cJSON_AddNumberToObject(o, "timestamp", (double)m->timestamp);
+        if (m->receipt_mils > 0) {
+            cJSON *rcpt = cJSON_AddObjectToObject(o, "receipt");
+            cJSON_AddNumberToObject(rcpt, "mils",        m->receipt_mils);
+            cJSON_AddNumberToObject(rcpt, "prompt_tok",  m->receipt_ptok);
+            cJSON_AddNumberToObject(rcpt, "compl_tok",   m->receipt_ctok);
+            cJSON_AddStringToObject(rcpt, "model",       m->receipt_model_short);
+            cJSON_AddBoolToObject(rcpt,   "retried",     m->receipt_retried);
+        }
+        cJSON_AddItemToArray(arr, o);
+    }
+    return send_json_resp(req, root);
+}
+
+/* ── GET /net/ping?host=<>&port=<> ──────────────────────────────── */
+/* Re-implements the non-blocking probe locally so we don't leak
+ * voice.c internals.  Matches the fix from #146. */
+#include "lwip/sockets.h"
+#include "lwip/netdb.h"
+#include <fcntl.h>
+#include <errno.h>
+static esp_err_t ping_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[128] = {0}, host[64] = {0}, port_s[8] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "host", host, sizeof(host));
+    httpd_query_key_value(q, "port", port_s, sizeof(port_s));
+    int port = atoi(port_s);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "host", host);
+    cJSON_AddNumberToObject(root, "port", port);
+    if (!host[0] || port <= 0 || port > 65535) {
+        cJSON_AddStringToObject(root, "error", "need host and port=1..65535");
+        return send_json_resp(req, root);
+    }
+
+    struct addrinfo hints = { .ai_family = AF_INET, .ai_socktype = SOCK_STREAM };
+    struct addrinfo *res = NULL;
+    char ps[8]; snprintf(ps, sizeof(ps), "%d", port);
+    int gai = getaddrinfo(host, ps, &hints, &res);
+    if (gai != 0 || !res) {
+        cJSON_AddStringToObject(root, "error", "dns failed");
+        if (res) freeaddrinfo(res);
+        return send_json_resp(req, root);
+    }
+    int s = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (s < 0) { freeaddrinfo(res);
+        cJSON_AddStringToObject(root, "error", "socket failed");
+        return send_json_resp(req, root);
+    }
+    int flags = fcntl(s, F_GETFL, 0);
+    if (flags >= 0) fcntl(s, F_SETFL, flags | O_NONBLOCK);
+    int64_t t0 = esp_timer_get_time();
+    bool ok = false;
+    int cr = connect(s, res->ai_addr, res->ai_addrlen);
+    if (cr == 0) {
+        ok = true;
+    } else if (errno == EINPROGRESS) {
+        fd_set wfds; FD_ZERO(&wfds); FD_SET(s, &wfds);
+        struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+        int n = select(s + 1, NULL, &wfds, NULL, &tv);
+        if (n > 0 && FD_ISSET(s, &wfds)) {
+            int soerr = 0; socklen_t le = sizeof(soerr);
+            getsockopt(s, SOL_SOCKET, SO_ERROR, &soerr, &le);
+            ok = (soerr == 0);
+        }
+    }
+    int64_t elapsed_us = esp_timer_get_time() - t0;
+    close(s);
+    freeaddrinfo(res);
+
+    cJSON_AddBoolToObject(root, "ok", ok);
+    cJSON_AddNumberToObject(root, "elapsed_ms", (double)(elapsed_us / 1000));
+    return send_json_resp(req, root);
+}
+
+/* ── POST /nvs/erase?confirm=<token> ────────────────────────────── */
+/* Factory reset path.  Requires ?confirm=<first 8 chars of auth_tok>
+ * as a guard against accidental triggering.  After erase, reboots. */
+static esp_err_t nvs_erase_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[64] = {0}, confirm[16] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "confirm", confirm, sizeof(confirm));
+
+    /* Expect first 8 chars of the auth token. */
+    char expected[9];
+    strncpy(expected, s_auth_token, 8);
+    expected[8] = '\0';
+    if (strncmp(confirm, expected, 8) != 0) {
+        cJSON *r = cJSON_CreateObject();
+        cJSON_AddStringToObject(r, "error",
+            "factory reset requires ?confirm=<first-8-chars-of-auth-token>");
+        return send_json_resp(req, r);
+    }
+    ESP_LOGW(TAG, "NVS erase requested via debug — rebooting in 500 ms");
+    tab5_debug_obs_event("nvs", "erase");
+    cJSON *r = cJSON_CreateObject();
+    cJSON_AddBoolToObject(r, "ok", true);
+    cJSON_AddStringToObject(r, "note", "erasing + rebooting");
+    send_json_resp(req, r);
+    vTaskDelay(pdMS_TO_TICKS(300));
+    nvs_flash_erase();
+    vTaskDelay(pdMS_TO_TICKS(200));
+    esp_restart();
+    return ESP_OK;  /* unreachable */
+}
+
 /* ======================================================================== */
 /*  Server init                                                              */
 /* ======================================================================== */
@@ -2208,7 +2684,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.server_port = DEBUG_PORT;
     config.stack_size  = 12288;
-    config.max_uri_handlers = 32;   /* W15: +/heap_trace_start +/heap_trace_dump */
+    config.max_uri_handlers = 56;   /* #149: +16 PR β endpoints (see below) */
     config.lru_purge_enable = true;
     config.max_open_sockets = 16;         /* Needs headroom for rapid API calls (nav+info pairs) */
     config.recv_wait_timeout = 5;         /* 5s recv timeout (default 5) */
@@ -2334,6 +2810,24 @@ esp_err_t tab5_debug_server_init(void)
         .uri = "/heap", .method = HTTP_GET, .handler = heap_handler
     };
 
+    /* #149 PR β — new capability endpoints. */
+    const httpd_uri_t uri_tasks          = { .uri = "/tasks",          .method = HTTP_GET,  .handler = tasks_handler };
+    const httpd_uri_t uri_logs_tail      = { .uri = "/logs/tail",      .method = HTTP_GET,  .handler = logs_tail_handler };
+    const httpd_uri_t uri_voice_text     = { .uri = "/voice/text",     .method = HTTP_POST, .handler = voice_text_handler };
+    const httpd_uri_t uri_voice_cancel   = { .uri = "/voice/cancel",   .method = HTTP_POST, .handler = voice_cancel_handler };
+    const httpd_uri_t uri_voice_clear    = { .uri = "/voice/clear",    .method = HTTP_POST, .handler = voice_clear_handler };
+    const httpd_uri_t uri_wifi_status    = { .uri = "/wifi/status",    .method = HTTP_GET,  .handler = wifi_status_handler };
+    const httpd_uri_t uri_battery        = { .uri = "/battery",        .method = HTTP_GET,  .handler = battery_handler };
+    const httpd_uri_t uri_disp_bright    = { .uri = "/display/brightness", .method = HTTP_POST, .handler = display_brightness_handler };
+    const httpd_uri_t uri_audio_get      = { .uri = "/audio",          .method = HTTP_GET,  .handler = audio_handler };
+    const httpd_uri_t uri_audio_post     = { .uri = "/audio",          .method = HTTP_POST, .handler = audio_handler };
+    const httpd_uri_t uri_metrics        = { .uri = "/metrics",        .method = HTTP_GET,  .handler = metrics_handler };
+    const httpd_uri_t uri_events         = { .uri = "/events",         .method = HTTP_GET,  .handler = events_handler };
+    const httpd_uri_t uri_heap_history   = { .uri = "/heap/history",   .method = HTTP_GET,  .handler = heap_history_handler };
+    const httpd_uri_t uri_chat_msgs      = { .uri = "/chat/messages",  .method = HTTP_GET,  .handler = chat_messages_handler };
+    const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
+    const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
+
     httpd_register_uri_handler(server, &uri_index);
     httpd_register_uri_handler(server, &uri_screenshot);
     httpd_register_uri_handler(server, &uri_screenshot_bmp);
@@ -2363,6 +2857,23 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_selftest);
     httpd_register_uri_handler(server, &uri_navtouch);
     httpd_register_uri_handler(server, &uri_heap);
+    /* #149 PR β registrations. */
+    httpd_register_uri_handler(server, &uri_tasks);
+    httpd_register_uri_handler(server, &uri_logs_tail);
+    httpd_register_uri_handler(server, &uri_voice_text);
+    httpd_register_uri_handler(server, &uri_voice_cancel);
+    httpd_register_uri_handler(server, &uri_voice_clear);
+    httpd_register_uri_handler(server, &uri_wifi_status);
+    httpd_register_uri_handler(server, &uri_battery);
+    httpd_register_uri_handler(server, &uri_disp_bright);
+    httpd_register_uri_handler(server, &uri_audio_get);
+    httpd_register_uri_handler(server, &uri_audio_post);
+    httpd_register_uri_handler(server, &uri_metrics);
+    httpd_register_uri_handler(server, &uri_events);
+    httpd_register_uri_handler(server, &uri_heap_history);
+    httpd_register_uri_handler(server, &uri_chat_msgs);
+    httpd_register_uri_handler(server, &uri_net_ping);
+    httpd_register_uri_handler(server, &uri_nvs_erase);
 
     /* Log the URL */
     char ip[20];

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -613,125 +613,25 @@ static esp_err_t log_handler(httpd_req_t *req)
 }
 
 /* ======================================================================== */
-/*  GET /  — Interactive HTML page                                           */
+/*  GET /  — Interactive multi-tab SPA (#150 PR γ)                           */
 /* ======================================================================== */
-
-static const char INDEX_HTML[] =
-"<!DOCTYPE html><html><head>"
-"<meta charset='utf-8'>"
-"<meta name='viewport' content='width=device-width,initial-scale=1'>"
-"<title>TinkerTab Debug</title>"
-"<style>"
-"*{margin:0;padding:0;box-sizing:border-box}"
-"body{background:#1a1a2e;color:#e0e0e0;font-family:monospace;padding:16px}"
-"h1{color:#ffb800;font-size:1.4em;margin-bottom:12px}"
-".row{display:flex;gap:16px;flex-wrap:wrap}"
-".col{flex:1;min-width:300px}"
-"#screen-wrap{position:relative;display:inline-block;cursor:crosshair;border:2px solid #333}"
-"#screen{max-width:100%;height:auto}"
-"#info-panel{background:#16213e;padding:12px;border-radius:8px;margin-top:12px;"
-"  font-size:0.85em;white-space:pre-wrap}"
-".btn{background:#ffb800;color:#000;border:none;padding:8px 16px;border-radius:4px;"
-"  cursor:pointer;font-weight:bold;margin:4px}"
-".btn:hover{background:#ffd060}"
-".btn-danger{background:#e74c3c;color:#fff}"
-".btn-danger:hover{background:#ff6b6b}"
-"#coords{color:#aaa;font-size:0.8em;margin-top:4px}"
-"#status{color:#0f0;font-size:0.8em;margin-top:4px}"
-"</style></head><body>"
-"<h1>TinkerTab Debug Server</h1>"
-"<div class='row'>"
-"<div class='col'>"
-"  <div id='screen-wrap'>"
-"    <img id='screen' src='/screenshot.jpg' alt='screenshot' draggable='false'>"
-"  </div>"
-"  <div id='coords'>&nbsp;</div>"
-"  <div id='status'>Ready</div>"
-"  <div style='margin-top:8px'>"
-"    <button class='btn' onclick='refresh()'>Refresh</button>"
-"    <button class='btn' id='auto-btn' onclick='toggleAuto()'>Auto: OFF</button>"
-"    <button class='btn btn-danger' onclick='reboot()'>Reboot</button>"
-"  </div>"
-"</div>"
-"<div class='col'>"
-"  <div id='info-panel'>Loading...</div>"
-"</div>"
-"</div>"
-"<script>"
-"const img=document.getElementById('screen');"
-"const coordsEl=document.getElementById('coords');"
-"const statusEl=document.getElementById('status');"
-"const infoEl=document.getElementById('info-panel');"
-"let autoMode=false,autoTimer=null;"
-"\n"
-"function refresh(){"
-"  img.src='/screenshot.jpg?t='+Date.now();"
-"  statusEl.textContent='Refreshed '+new Date().toLocaleTimeString();"
-"}"
-"\n"
-"function toggleAuto(){"
-"  autoMode=!autoMode;"
-"  document.getElementById('auto-btn').textContent='Auto: '+(autoMode?'ON':'OFF');"
-"  if(autoMode){autoTimer=setInterval(refresh,2000)}"
-"  else{clearInterval(autoTimer)}"
-"}"
-"\n"
-"img.addEventListener('click',function(e){"
-"  const r=img.getBoundingClientRect();"
-"  const sx=img.naturalWidth/r.width;"
-"  const sy=img.naturalHeight/r.height;"
-"  const x=Math.round((e.clientX-r.left)*sx);"
-"  const y=Math.round((e.clientY-r.top)*sy);"
-"  coordsEl.textContent='Tap: '+x+', '+y;"
-"  fetch('/touch',{method:'POST',headers:{'Content-Type':'application/json'},"
-"    body:JSON.stringify({x:x,y:y,action:'tap'})})"
-"  .then(()=>{statusEl.textContent='Tapped '+x+','+y;setTimeout(refresh,300)})"
-"  .catch(e=>statusEl.textContent='Error: '+e);"
-"});"
-"\n"
-"img.addEventListener('mousemove',function(e){"
-"  const r=img.getBoundingClientRect();"
-"  const sx=img.naturalWidth/r.width;"
-"  const sy=img.naturalHeight/r.height;"
-"  const x=Math.round((e.clientX-r.left)*sx);"
-"  const y=Math.round((e.clientY-r.top)*sy);"
-"  coordsEl.textContent='Cursor: '+x+', '+y;"
-"});"
-"\n"
-"function fetchInfo(){"
-"  fetch('/info').then(r=>r.json()).then(d=>{"
-"    let s='Heap free:  '+fmt(d.heap_free)+'\\n';"
-"    s+='Heap min:   '+fmt(d.heap_min)+'\\n';"
-"    s+='PSRAM free: '+fmt(d.psram_free)+'\\n';"
-"    s+='Uptime:     '+Math.round(d.uptime_ms/1000)+'s\\n';"
-"    s+='WiFi:       '+(d.wifi_connected?d.wifi_ip:'disconnected')+'\\n';"
-"    s+='Dragon:     '+(d.dragon_connected?'connected':'offline')+'\\n';"
-"    s+='Display:    '+d.display+'\\n';"
-"    s+='FPS:        '+d.fps.toFixed(1)+'\\n';"
-"    s+='LVGL FPS:   '+d.lvgl_fps+'\\n';"
-"    s+='Battery:    '+d.battery_pct+'%\\n';"
-"    s+='Tasks:      '+d.tasks;"
-"    infoEl.textContent=s;"
-"  }).catch(e=>infoEl.textContent='Error: '+e);"
-"}"
-"\n"
-"function fmt(n){if(n>1e6)return (n/1e6).toFixed(1)+'M';if(n>1e3)return (n/1e3).toFixed(0)+'K';return n;}"
-"\n"
-"function reboot(){"
-"  if(confirm('Reboot TinkerTab?')){"
-"    fetch('/reboot',{method:'POST'}).then(()=>statusEl.textContent='Rebooting...');"
-"  }"
-"}"
-"\n"
-"fetchInfo();setInterval(fetchInfo,5000);"
-"</script></body></html>";
+/*
+ * The HTML + CSS + JS lives in main/debug_ui.html and is embedded into
+ * flash via EMBED_TXTFILES in CMakeLists.txt.  This keeps the ~22 KB
+ * SPA editable without the C string-literal horrors.
+ *
+ * NOTE: index is NOT auth-gated — the page itself has no secrets and
+ * prompts for the Bearer token in the UI (stored in localStorage).
+ * Every endpoint the SPA calls IS auth-gated.
+ */
+extern const char debug_ui_html_start[] asm("_binary_debug_ui_html_start");
+extern const char debug_ui_html_end[]   asm("_binary_debug_ui_html_end");
 
 static esp_err_t index_handler(httpd_req_t *req)
 {
-    if (!check_auth(req)) return ESP_OK;
-
-    httpd_resp_set_type(req, "text/html");
-    return httpd_resp_send(req, INDEX_HTML, strlen(INDEX_HTML));
+    const size_t len = debug_ui_html_end - debug_ui_html_start;
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    return httpd_resp_send(req, debug_ui_html_start, len);
 }
 
 /* ======================================================================== */

--- a/main/debug_ui.html
+++ b/main/debug_ui.html
@@ -1,0 +1,686 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>TinkerTab Debug</title>
+<style>
+:root{
+  --bg:#0a0a10;--surface:#15151d;--surface-2:#1c1c28;--line:#262637;
+  --text:#e6e6ea;--dim:#8a8aa0;--muted:#5f5f75;
+  --amber:#f59e0b;--amber-2:#fbbf24;--ok:#22c55e;--bad:#ef4444;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{height:100%}
+body{background:var(--bg);color:var(--text);font:14px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.app{display:grid;grid-template-columns:200px 1fr;min-height:100vh}
+aside{background:var(--surface);border-right:1px solid var(--line);padding:16px 0;position:sticky;top:0;height:100vh;overflow-y:auto}
+aside h1{font:600 16px/1.2 system-ui,sans-serif;color:var(--amber);padding:0 16px 12px;border-bottom:1px solid var(--line);margin-bottom:12px}
+aside h1 small{display:block;font-size:11px;color:var(--dim);font-weight:400;margin-top:2px;letter-spacing:.04em}
+nav a{display:block;padding:10px 16px;color:var(--dim);text-decoration:none;border-left:3px solid transparent;transition:.15s}
+nav a:hover{background:var(--surface-2);color:var(--text)}
+nav a.active{color:var(--amber);border-left-color:var(--amber);background:var(--surface-2)}
+.pill{display:inline-block;padding:2px 6px;border-radius:3px;background:var(--surface-2);color:var(--dim);font-size:11px;margin-left:6px}
+.pill.ok{background:#0c2a15;color:var(--ok)}
+.pill.bad{background:#3a0f14;color:var(--bad)}
+main{padding:20px 24px;min-width:0;max-width:1400px}
+.tab{display:none}
+.tab.active{display:block}
+.tab>h2{font:600 20px/1.2 system-ui,sans-serif;margin-bottom:16px;color:var(--text);display:flex;align-items:center;gap:10px}
+.tab>h2 small{font:400 12px/1 ui-monospace,monospace;color:var(--dim)}
+.grid{display:grid;gap:16px}
+.grid.cols-2{grid-template-columns:repeat(auto-fit,minmax(340px,1fr))}
+.grid.cols-3{grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
+.card{background:var(--surface);border:1px solid var(--line);border-radius:8px;padding:16px}
+.card h3{font:600 12px/1 system-ui,sans-serif;text-transform:uppercase;letter-spacing:.08em;color:var(--dim);margin-bottom:12px}
+.metric{font:500 22px/1 ui-monospace,monospace;color:var(--text)}
+.metric small{font-size:13px;color:var(--dim);margin-left:4px}
+button,input[type=text],input[type=number],input[type=password],select,textarea{
+  background:var(--surface-2);border:1px solid var(--line);color:var(--text);
+  padding:8px 12px;border-radius:6px;font:14px ui-monospace,monospace;transition:.15s
+}
+button{cursor:pointer}
+button:hover{border-color:var(--amber);color:var(--amber)}
+button.primary{background:var(--amber);border-color:var(--amber);color:#08080e;font-weight:600}
+button.primary:hover{background:var(--amber-2);color:#08080e}
+button.danger{border-color:#6a1a1a;color:var(--bad)}
+button.danger:hover{background:#3a0f14;color:var(--bad)}
+input[type=text],input[type=number],input[type=password],select,textarea{width:100%}
+input:focus,select:focus,textarea:focus{outline:none;border-color:var(--amber)}
+.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.row>*{flex-shrink:0}
+.row>input{flex:1;min-width:120px}
+pre,code{font:12px ui-monospace,monospace;color:var(--dim);background:#0b0b10;border:1px solid var(--line);border-radius:6px;padding:10px;overflow:auto;white-space:pre-wrap;word-break:break-word}
+pre{max-height:420px}
+.log-line{color:var(--dim);padding:2px 0;border-bottom:1px solid #14141c;font-size:12px}
+.log-line.warn{color:var(--amber)}
+.log-line.err{color:var(--bad)}
+.screen-wrap{display:inline-block;border:1px solid var(--line);border-radius:6px;overflow:hidden;background:#000;cursor:crosshair;touch-action:none;user-select:none}
+.screen-wrap img{display:block;max-width:100%;height:auto}
+.bar{height:6px;background:var(--surface-2);border-radius:3px;overflow:hidden}
+.bar>div{height:100%;background:var(--amber);transition:width .2s}
+.bar.wide{height:10px}
+.kv{display:grid;grid-template-columns:140px 1fr;gap:8px;row-gap:6px;align-items:center;font-size:13px}
+.kv dt{color:var(--dim)}
+.kv dd{color:var(--text);word-break:break-word;font:12px ui-monospace,monospace}
+.token-bar{padding:12px 16px;background:var(--surface);border-bottom:1px solid var(--line);display:flex;gap:8px;align-items:center;grid-column:1/-1}
+.token-bar input{flex:1}
+.toast{position:fixed;bottom:20px;right:20px;background:var(--surface);border:1px solid var(--amber);padding:10px 16px;border-radius:6px;box-shadow:0 6px 20px rgba(0,0,0,.5);color:var(--amber);opacity:0;pointer-events:none;transition:.2s;z-index:1000}
+.toast.show{opacity:1}
+canvas{display:block;width:100%;height:160px;background:#0b0b10;border:1px solid var(--line);border-radius:6px}
+.flex-col{display:flex;flex-direction:column;gap:10px}
+.pre-small{max-height:300px;font-size:11px}
+.chat-bubble{padding:10px 14px;border-radius:10px;margin:6px 0;max-width:80%;white-space:pre-wrap;word-break:break-word}
+.chat-bubble.user{background:var(--amber);color:#08080e;margin-left:auto;text-align:left}
+.chat-bubble.assistant{background:var(--surface-2);color:var(--text)}
+.chat-meta{font-size:10px;color:var(--muted);margin-top:2px}
+.muted{color:var(--muted)}
+.ok{color:var(--ok)}
+.bad{color:var(--bad)}
+.amber{color:var(--amber)}
+@media(max-width:700px){
+  .app{grid-template-columns:1fr}
+  aside{position:static;height:auto}
+  nav{display:flex;flex-wrap:wrap;gap:4px;padding:0 8px}
+  nav a{padding:6px 10px;border-left:none;border-bottom:2px solid transparent}
+  nav a.active{border-left:none;border-bottom-color:var(--amber)}
+  main{padding:16px}
+}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside>
+    <h1>TinkerTab<small>debug console</small></h1>
+    <nav id="nav">
+      <a href="#dashboard" class="active" data-tab="dashboard">Dashboard<span id="pill-wifi" class="pill">wifi</span></a>
+      <a href="#screen" data-tab="screen">Screen</a>
+      <a href="#chat" data-tab="chat">Chat</a>
+      <a href="#voice" data-tab="voice">Voice</a>
+      <a href="#logs" data-tab="logs">Logs</a>
+      <a href="#heap" data-tab="heap">Heap</a>
+      <a href="#files" data-tab="files">Files</a>
+      <a href="#wifi" data-tab="wifi">Wi-Fi<span id="pill-rssi" class="pill">–</span></a>
+      <a href="#settings" data-tab="settings">Settings</a>
+      <a href="#danger" data-tab="danger">Danger</a>
+    </nav>
+  </aside>
+  <main>
+    <div class="token-bar">
+      <label class="muted">token</label>
+      <input type="password" id="token" placeholder="bearer token (saved locally)">
+      <button id="save-token">save</button>
+    </div>
+
+    <!-- Dashboard ------------------------------------------------- -->
+    <section class="tab active" id="tab-dashboard">
+      <h2>Dashboard<small id="dash-uptime">—</small></h2>
+      <div class="grid cols-3">
+        <div class="card"><h3>Heap internal</h3>
+          <div class="metric"><span id="m-intf">—</span><small>KB free</small></div>
+          <div class="muted" style="font-size:12px;margin-top:4px">largest <span id="m-intl">—</span> KB</div>
+          <div class="bar" style="margin-top:8px"><div id="bar-int"></div></div>
+        </div>
+        <div class="card"><h3>Heap PSRAM</h3>
+          <div class="metric"><span id="m-psf">—</span><small>MB free</small></div>
+          <div class="muted" style="font-size:12px;margin-top:4px">largest <span id="m-psl">—</span> MB</div>
+          <div class="bar" style="margin-top:8px"><div id="bar-ps"></div></div>
+        </div>
+        <div class="card"><h3>LVGL pool</h3>
+          <div class="metric"><span id="m-lv">—</span><small>KB used</small></div>
+          <div class="muted" style="font-size:12px;margin-top:4px">frag <span id="m-lvfrag">—</span>%</div>
+          <div class="bar" style="margin-top:8px"><div id="bar-lv"></div></div>
+        </div>
+        <div class="card"><h3>Voice</h3>
+          <div class="metric"><span id="m-vstate">—</span></div>
+          <div class="muted" style="font-size:12px;margin-top:4px">mode <span id="m-vmode">—</span> · model <span id="m-model">—</span></div>
+        </div>
+        <div class="card"><h3>Wi-Fi</h3>
+          <div class="metric"><span id="m-ssid">—</span></div>
+          <div class="muted" style="font-size:12px;margin-top:4px">RSSI <span id="m-rssi">—</span> dBm · ch <span id="m-ch">—</span></div>
+        </div>
+        <div class="card"><h3>Battery</h3>
+          <div class="metric"><span id="m-batpct">—</span><small>%</small></div>
+          <div class="muted" style="font-size:12px;margin-top:4px"><span id="m-batv">—</span> V · <span id="m-baton">idle</span></div>
+        </div>
+      </div>
+      <div class="card" style="margin-top:16px"><h3>Recent events</h3>
+        <pre id="dash-events" class="pre-small">loading…</pre>
+      </div>
+    </section>
+
+    <!-- Screen ---------------------------------------------------- -->
+    <section class="tab" id="tab-screen">
+      <h2>Screen<small id="screen-coords">0, 0</small></h2>
+      <div class="row" style="margin-bottom:10px">
+        <button id="screen-refresh">refresh</button>
+        <button id="screen-auto">auto: off</button>
+        <select id="screen-nav">
+          <option value="">navigate to…</option>
+          <option>home</option><option>chat</option><option>notes</option>
+          <option>settings</option><option>camera</option><option>files</option>
+          <option>wifi</option><option>sessions</option><option>agents</option>
+          <option>memory</option><option>focus</option>
+        </select>
+        <span class="muted">tap = click · swipe = drag · long-press = hold</span>
+      </div>
+      <div class="screen-wrap" id="screen-wrap">
+        <img id="screen" alt="device screen" draggable="false">
+      </div>
+    </section>
+
+    <!-- Chat ----------------------------------------------------- -->
+    <section class="tab" id="tab-chat">
+      <h2>Chat<small id="chat-state">—</small></h2>
+      <div class="card" style="display:flex;flex-direction:column;gap:10px">
+        <div id="chat-log" style="max-height:500px;overflow-y:auto;padding:8px;background:var(--bg);border-radius:6px"></div>
+        <div class="row">
+          <textarea id="chat-input" rows="2" placeholder="Type to Dragon…"></textarea>
+          <button class="primary" id="chat-send">send</button>
+          <button id="chat-clear">clear</button>
+          <button id="chat-cancel">cancel</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Voice --------------------------------------------------- -->
+    <section class="tab" id="tab-voice">
+      <h2>Voice<small id="voice-state-small">—</small></h2>
+      <div class="grid cols-2">
+        <div class="card">
+          <h3>Mode</h3>
+          <div class="row">
+            <select id="voice-mode">
+              <option value="0">0 · Local</option>
+              <option value="1">1 · Hybrid</option>
+              <option value="2">2 · Cloud</option>
+              <option value="3">3 · TinkerClaw</option>
+            </select>
+            <button id="mode-apply">apply</button>
+          </div>
+          <div class="muted" style="font-size:12px;margin-top:10px">current: <span id="voice-mode-cur">—</span></div>
+        </div>
+        <div class="card">
+          <h3>Dictation</h3>
+          <div class="row"><button class="primary" id="dict-start">start</button>
+            <button id="dict-stop">stop</button>
+            <button id="dict-refresh">refresh</button></div>
+          <div class="muted" style="font-size:12px;margin-top:10px">chars: <span id="dict-len">0</span></div>
+          <pre id="dict-text" class="pre-small">(idle)</pre>
+        </div>
+        <div class="card"><h3>Audio</h3>
+          <div class="row"><label class="muted">volume</label>
+            <input type="range" min="0" max="100" id="vol-slider" style="flex:1">
+            <span id="vol-val" class="amber">—</span>
+            <button id="vol-apply">apply</button></div>
+          <div class="row" style="margin-top:10px"><label class="muted">mic mute</label>
+            <button id="mic-toggle">toggle</button><span id="mic-state">—</span></div>
+        </div>
+        <div class="card"><h3>Actions</h3>
+          <div class="row flex-col"><button id="voice-reconnect">voice/reconnect</button></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Logs ---------------------------------------------------- -->
+    <section class="tab" id="tab-logs">
+      <h2>Logs<small>esp_log tail</small></h2>
+      <div class="row" style="margin-bottom:10px">
+        <button id="logs-refresh">refresh</button>
+        <button id="logs-auto">auto: off</button>
+        <input type="text" id="logs-filter" placeholder="filter (substring)">
+        <input type="number" id="logs-n" value="100" style="width:100px">
+      </div>
+      <pre id="logs-view">—</pre>
+    </section>
+
+    <!-- Heap ---------------------------------------------------- -->
+    <section class="tab" id="tab-heap">
+      <h2>Heap history<small>30 s samples, last 30 min</small></h2>
+      <canvas id="heap-canvas"></canvas>
+      <div class="row" style="margin-top:8px;gap:16px">
+        <span><span style="color:var(--amber)">■</span> internal free</span>
+        <span><span style="color:#4cc9f0">■</span> internal largest</span>
+        <span><span style="color:#22c55e">■</span> LVGL used</span>
+      </div>
+    </section>
+
+    <!-- Files --------------------------------------------------- -->
+    <section class="tab" id="tab-files">
+      <h2>SD card</h2>
+      <pre id="files-list">loading…</pre>
+    </section>
+
+    <!-- Wi-Fi --------------------------------------------------- -->
+    <section class="tab" id="tab-wifi">
+      <h2>Wi-Fi</h2>
+      <div class="grid cols-2">
+        <div class="card"><h3>Status</h3>
+          <dl class="kv" id="wifi-status">loading…</dl>
+        </div>
+        <div class="card"><h3>Recovery</h3>
+          <div class="row flex-col">
+            <button id="kick-soft">soft kick (deauth)</button>
+            <button id="kick-hard">hard kick (stop/start)</button>
+            <button class="danger" id="kick-reboot">reboot</button>
+          </div>
+          <div class="muted" style="font-size:12px;margin-top:10px">
+            Soft = <code>esp_wifi_disconnect</code>, Hard = <code>stop/start</code>, Reboot = <code>esp_restart</code>.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Settings ------------------------------------------------ -->
+    <section class="tab" id="tab-settings">
+      <h2>Settings<small>NVS editor</small></h2>
+      <div class="card">
+        <form id="settings-form"></form>
+        <div class="row" style="margin-top:12px"><button class="primary" id="settings-save">save</button>
+          <button id="settings-refresh">refresh</button>
+          <span id="settings-status" class="muted"></span></div>
+      </div>
+    </section>
+
+    <!-- Danger -------------------------------------------------- -->
+    <section class="tab" id="tab-danger">
+      <h2>Danger<small>destructive actions</small></h2>
+      <div class="grid cols-2">
+        <div class="card"><h3>Reboot</h3>
+          <button class="danger" id="btn-reboot">reboot now</button></div>
+        <div class="card"><h3>OTA</h3>
+          <div class="row flex-col"><button id="btn-ota-check">check</button>
+            <button class="primary" id="btn-ota-apply">apply</button>
+            <pre id="ota-status" class="pre-small muted">(no check yet)</pre></div></div>
+        <div class="card"><h3>Core dump</h3>
+          <div class="row flex-col"><button id="btn-crashlog">crashlog</button>
+            <a id="btn-coredump" href="/coredump" target="_blank"><button>download coredump.elf</button></a>
+            <pre id="crashlog-view" class="pre-small muted">(no crashlog yet)</pre></div></div>
+        <div class="card"><h3>Factory reset</h3>
+          <div class="row flex-col"><span class="muted" style="font-size:12px">Erases NVS + reboots.  Confirms via first 8 chars of auth token.</span>
+            <button class="danger" id="btn-factory-reset">factory reset</button></div></div>
+      </div>
+    </section>
+  </main>
+</div>
+
+<div id="toast" class="toast"></div>
+
+<script>
+'use strict';
+const $ = (s,r=document)=>r.querySelector(s);
+const $$ = (s,r=document)=>[...r.querySelectorAll(s)];
+const fmt = n => n>=1e6 ? (n/1e6).toFixed(1)+'M' : n>=1e3 ? (n/1e3).toFixed(1)+'K' : String(n);
+const toast = msg => { const t=$('#toast'); t.textContent=msg; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'),1800); };
+
+// Token management ----------------------------------------------------
+const TOK_KEY='tab5_debug_token';
+let token = localStorage.getItem(TOK_KEY) || '';
+$('#token').value = token;
+$('#save-token').onclick = () => {
+  token = $('#token').value.trim();
+  localStorage.setItem(TOK_KEY, token);
+  toast('token saved');
+  refreshDashboard();
+};
+const hdr = () => token ? {Authorization:'Bearer '+token} : {};
+
+// Fetch wrappers -------------------------------------------------------
+async function api(path, opts={}) {
+  const o = Object.assign({}, opts);
+  o.headers = Object.assign({}, hdr(), opts.headers||{});
+  const r = await fetch(path, o);
+  if (!r.ok) throw new Error(r.status+' '+r.statusText);
+  const ct = r.headers.get('content-type')||'';
+  if (ct.includes('json')) return r.json();
+  return r.text();
+}
+async function apiQuiet(path, opts={}) { try { return await api(path, opts); } catch(e){ return null; } }
+
+// Tab switching --------------------------------------------------------
+function showTab(name) {
+  $$('.tab').forEach(t=>t.classList.remove('active'));
+  $$('nav a').forEach(a=>a.classList.toggle('active', a.dataset.tab===name));
+  const el = $('#tab-'+name); if (el) el.classList.add('active');
+  location.hash = name;
+  if (tabHooks[name]) tabHooks[name]();
+}
+$$('nav a').forEach(a=>a.onclick=e=>{e.preventDefault(); showTab(a.dataset.tab);});
+window.addEventListener('hashchange', ()=>{ const h=location.hash.slice(1)||'dashboard'; showTab(h); });
+
+const tabHooks = {};
+
+// ── Dashboard ────────────────────────────────────────────────────────
+let dashTimer;
+async function refreshDashboard() {
+  const info = await apiQuiet('/info');
+  if (!info) { toast('no info (check token)'); return; }
+  $('#dash-uptime').textContent = fmtUptime(info.uptime_ms);
+  $('#m-intf').textContent = fmt(info.heap_free); $('#m-intl').textContent = '—';
+  $('#m-psf').textContent = (info.psram_free/1e6).toFixed(1);
+  $('#m-ssid').textContent = info.wifi_connected ? info.wifi_ip : 'offline';
+  $('#m-batpct').textContent = info.battery_pct;
+  $('#pill-wifi').className = 'pill '+(info.wifi_connected?'ok':'bad');
+  $('#pill-wifi').textContent = info.wifi_connected?'up':'down';
+
+  // Detailed data from /heap
+  const heap = await apiQuiet('/heap');
+  if (heap) {
+    $('#m-intf').textContent = heap.internal.free_kb; $('#m-intl').textContent = heap.internal.largest_kb;
+    $('#m-psf').textContent = (heap.psram.free_kb/1024).toFixed(1);
+    $('#m-psl').textContent = (heap.psram.largest_kb/1024).toFixed(1);
+    $('#m-lv').textContent = heap.lvgl.used_kb; $('#m-lvfrag').textContent = heap.lvgl.frag_pct;
+    $('#bar-int').style.width = Math.min(100, heap.internal.largest_kb/heap.internal.free_kb*100||0)+'%';
+    $('#bar-ps').style.width = Math.min(100, heap.psram.largest_kb/heap.psram.free_kb*100)+'%';
+    $('#bar-lv').style.width = Math.min(100, heap.lvgl.used_kb/(heap.lvgl.used_kb+heap.lvgl.free_kb)*100)+'%';
+  }
+
+  // Wi-Fi detail
+  const wifi = await apiQuiet('/wifi/status');
+  if (wifi && wifi.connected) {
+    $('#m-ssid').textContent = wifi.ssid;
+    $('#m-rssi').textContent = wifi.rssi; $('#m-ch').textContent = wifi.channel;
+    $('#pill-rssi').textContent = wifi.rssi + 'dBm';
+  }
+
+  // Battery detail
+  const bat = await apiQuiet('/battery');
+  if (bat && bat.voltage != null) {
+    $('#m-batv').textContent = bat.voltage.toFixed(2);
+    $('#m-baton').textContent = bat.charging ? 'charging' : (bat.current>0.01?'drain':'idle');
+  }
+
+  // Voice state
+  const voice = await apiQuiet('/voice');
+  if (voice) {
+    $('#m-vstate').textContent = voice.state_name;
+    $('#m-vmode').textContent = info.voice_connected ? 'connected' : 'offline';
+  }
+  const settings = await apiQuiet('/settings');
+  if (settings) $('#m-model').textContent = settings.llm_model || '—';
+
+  // Events tail
+  const ev = await apiQuiet('/events');
+  if (ev && ev.events) {
+    $('#dash-events').textContent = ev.events.slice(-20).map(
+      e=>`+${(e.ms/1000).toFixed(1)}s  ${e.kind}  ${e.detail}`).join('\n') || '(no events yet)';
+  }
+}
+function fmtUptime(ms) {
+  const s = Math.floor(ms/1000);
+  const h = Math.floor(s/3600), m = Math.floor((s%3600)/60), r = s%60;
+  return `${h}h ${m}m ${r}s`;
+}
+tabHooks.dashboard = () => { clearInterval(dashTimer); refreshDashboard(); dashTimer=setInterval(refreshDashboard,3000); };
+
+// ── Screen ───────────────────────────────────────────────────────────
+const screen = $('#screen');
+let screenAuto = false, screenTimer;
+function refreshScreen() { screen.src = '/screenshot.jpg?h='+Date.now()+'&t='+encodeURIComponent(token); }
+$('#screen-refresh').onclick = refreshScreen;
+$('#screen-auto').onclick = () => {
+  screenAuto = !screenAuto;
+  $('#screen-auto').textContent = 'auto: '+(screenAuto?'on':'off');
+  clearInterval(screenTimer); if (screenAuto) screenTimer = setInterval(refreshScreen, 2000);
+};
+$('#screen-nav').onchange = async e => {
+  const v = e.target.value; if (!v) return;
+  await apiQuiet('/navigate?screen='+v, {method:'POST'});
+  e.target.value = '';
+  setTimeout(refreshScreen, 400);
+};
+// Gesture capture ------------------------------------------------------
+// mouse/touch down → start; move > 12px → swipe; hold > 500ms w/o move → long_press; else tap.
+(function initGestures(){
+  const wrap = $('#screen-wrap');
+  let down=null, didSwipe=false, longTimer=null;
+  const coords = e => {
+    const r = screen.getBoundingClientRect();
+    const sx = screen.naturalWidth / r.width, sy = screen.naturalHeight / r.height;
+    const c = e.touches ? e.touches[0] : e;
+    return {x: Math.round((c.clientX-r.left)*sx), y: Math.round((c.clientY-r.top)*sy)};
+  };
+  const showCoords = c => $('#screen-coords').textContent = c.x+', '+c.y;
+  const start = e => { e.preventDefault();
+    const c = coords(e); down = Object.assign({}, c, {t: Date.now()});
+    didSwipe = false;
+    showCoords(c);
+    longTimer = setTimeout(async ()=>{
+      if (!down || didSwipe) return;
+      await apiQuiet('/touch', {method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({x:down.x, y:down.y, action:'long_press', duration_ms:800})});
+      toast('long_press '+down.x+','+down.y); down=null;
+    }, 600);
+  };
+  const move = e => { if (!down) return; e.preventDefault();
+    const c = coords(e); showCoords(c);
+    if (!didSwipe && (Math.abs(c.x-down.x)>12 || Math.abs(c.y-down.y)>12)) { didSwipe = true; clearTimeout(longTimer); }
+  };
+  const end = async e => { if (!down) return;
+    clearTimeout(longTimer);
+    const c = coords(e.changedTouches ? {clientX:e.changedTouches[0].clientX, clientY:e.changedTouches[0].clientY} : e);
+    if (didSwipe) {
+      await apiQuiet('/touch', {method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({action:'swipe', x1:down.x, y1:down.y, x2:c.x, y2:c.y, duration_ms:300})});
+      toast('swipe '+down.x+','+down.y+' → '+c.x+','+c.y);
+    } else if (Date.now()-down.t < 600) {
+      await apiQuiet('/touch', {method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({x:down.x, y:down.y, action:'tap'})});
+      toast('tap '+down.x+','+down.y);
+    }
+    down = null;
+    setTimeout(refreshScreen, 250);
+  };
+  wrap.addEventListener('mousedown', start); wrap.addEventListener('mousemove', move); wrap.addEventListener('mouseup', end); wrap.addEventListener('mouseleave', end);
+  wrap.addEventListener('touchstart', start, {passive:false}); wrap.addEventListener('touchmove', move, {passive:false}); wrap.addEventListener('touchend', end);
+})();
+tabHooks.screen = refreshScreen;
+
+// ── Chat ─────────────────────────────────────────────────────────────
+let chatLastLlm = '';
+async function refreshChat() {
+  const v = await apiQuiet('/voice');
+  if (v) {
+    $('#chat-state').textContent = v.state_name;
+    if (v.last_llm_text && v.last_llm_text !== chatLastLlm) chatLastLlm = v.last_llm_text;
+  }
+  const m = await apiQuiet('/chat/messages?n=40');
+  if (!m || !m.messages) return;
+  const log = $('#chat-log');
+  log.innerHTML = '';
+  m.messages.forEach(msg => {
+    const div = document.createElement('div');
+    div.className = 'chat-bubble '+msg.role;
+    div.textContent = msg.text;
+    log.appendChild(div);
+    if (msg.receipt) {
+      const meta = document.createElement('div');
+      meta.className = 'chat-meta';
+      meta.textContent = `${msg.receipt.model} · ${(msg.receipt.mils/100000).toFixed(4)} USD`;
+      log.appendChild(meta);
+    }
+  });
+  log.scrollTop = log.scrollHeight;
+}
+async function sendChat() {
+  const t = $('#chat-input').value.trim();
+  if (!t) return;
+  $('#chat-input').value = '';
+  const r = await apiQuiet('/voice/text', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({text:t})});
+  if (!r || !r.sent) toast('send failed');
+  setTimeout(refreshChat, 500);
+}
+$('#chat-send').onclick = sendChat;
+$('#chat-input').addEventListener('keydown', e => { if (e.key==='Enter' && !e.shiftKey) { e.preventDefault(); sendChat(); }});
+$('#chat-clear').onclick = async ()=>{ await apiQuiet('/voice/clear',{method:'POST'}); refreshChat(); };
+$('#chat-cancel').onclick = async ()=>{ await apiQuiet('/voice/cancel',{method:'POST'}); refreshChat(); };
+let chatTimer;
+tabHooks.chat = () => { clearInterval(chatTimer); refreshChat(); chatTimer=setInterval(refreshChat,1500); };
+
+// ── Voice ────────────────────────────────────────────────────────────
+async function refreshVoice() {
+  const v = await apiQuiet('/voice'); if (v) $('#voice-state-small').textContent = v.state_name;
+  const s = await apiQuiet('/settings');
+  if (s) {
+    $('#voice-mode').value = s.voice_mode; $('#voice-mode-cur').textContent = s.voice_mode;
+    $('#vol-slider').value = s.volume; $('#vol-val').textContent = s.volume;
+    $('#mic-state').textContent = s.mic_mute ? 'muted' : 'hot';
+  }
+  const d = await apiQuiet('/dictation');
+  if (d) { $('#dict-text').textContent = d.transcript || '(empty)'; $('#dict-len').textContent = d.transcript_len; }
+}
+$('#mode-apply').onclick = async () => {
+  const m = $('#voice-mode').value;
+  await apiQuiet('/mode?m='+m, {method:'POST'});
+  refreshVoice();
+};
+$('#dict-start').onclick = async () => { await apiQuiet('/dictation?action=start',{method:'POST'}); refreshVoice(); };
+$('#dict-stop').onclick  = async () => { await apiQuiet('/dictation?action=stop', {method:'POST'}); refreshVoice(); };
+$('#dict-refresh').onclick = refreshVoice;
+$('#vol-slider').oninput = e => $('#vol-val').textContent = e.target.value;
+$('#vol-apply').onclick  = async () => { await apiQuiet('/audio?action=volume&pct='+$('#vol-slider').value,{method:'POST'}); refreshVoice(); toast('volume applied'); };
+$('#mic-toggle').onclick = async () => { const s = await apiQuiet('/settings'); const on = s.mic_mute ? 0 : 1;
+  await apiQuiet('/audio?action=mute&on='+on,{method:'POST'}); refreshVoice(); };
+$('#voice-reconnect').onclick = async () => { await apiQuiet('/voice/reconnect',{method:'POST'}); toast('reconnecting'); };
+let voiceTimer;
+tabHooks.voice = () => { clearInterval(voiceTimer); refreshVoice(); voiceTimer=setInterval(refreshVoice,2000); };
+
+// ── Logs ─────────────────────────────────────────────────────────────
+let logsAuto=false, logsTimer;
+async function refreshLogs() {
+  const n = $('#logs-n').value || 100;
+  const text = await apiQuiet('/logs/tail?n='+n);
+  if (text == null) return;
+  const filter = $('#logs-filter').value.toLowerCase();
+  const lines = text.split(/\r?\n/);
+  const html = lines.map(l => {
+    if (filter && !l.toLowerCase().includes(filter)) return '';
+    const cls = l.startsWith('E') ? 'err' : (l.startsWith('W') ? 'warn' : '');
+    const safe = l.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+    return '<div class="log-line '+cls+'">'+safe+'</div>';
+  }).join('');
+  $('#logs-view').innerHTML = html || '(empty)';
+  $('#logs-view').scrollTop = $('#logs-view').scrollHeight;
+}
+$('#logs-refresh').onclick = refreshLogs;
+$('#logs-filter').oninput = refreshLogs;
+$('#logs-auto').onclick = () => {
+  logsAuto = !logsAuto; $('#logs-auto').textContent = 'auto: '+(logsAuto?'on':'off');
+  clearInterval(logsTimer); if (logsAuto) logsTimer = setInterval(refreshLogs, 1500);
+};
+tabHooks.logs = refreshLogs;
+
+// ── Heap history canvas ──────────────────────────────────────────────
+async function refreshHeap() {
+  const c = $('#heap-canvas'); const ctx = c.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  c.width = c.offsetWidth*dpr; c.height = c.offsetHeight*dpr;
+  const W = c.width, H = c.height;
+  ctx.fillStyle = '#0b0b10'; ctx.fillRect(0,0,W,H);
+
+  const h = await apiQuiet('/heap/history?n=60');
+  if (!h || !h.samples || !h.samples.length) { ctx.fillStyle='#8a8aa0'; ctx.font=dpr*14+'px monospace'; ctx.fillText('(no samples)', 20, 30); return; }
+  // samples are most-recent-first; reverse for left-to-right
+  const s = [...h.samples].reverse();
+  const max = Math.max(...s.map(x=>Math.max(x.int_free_kb, x.int_largest_kb, x.lvgl_used_kb*4)));
+
+  const plot = (vals, color) => {
+    ctx.strokeStyle = color; ctx.lineWidth = dpr*2; ctx.beginPath();
+    vals.forEach((v,i) => { const x = (i/(vals.length-1))*W; const y = H - (v/max)*(H*0.85) - H*0.075;
+      if (i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y); });
+    ctx.stroke();
+  };
+  plot(s.map(x=>x.int_free_kb), '#f59e0b');
+  plot(s.map(x=>x.int_largest_kb), '#4cc9f0');
+  plot(s.map(x=>x.lvgl_used_kb*4), '#22c55e');  // scale LVGL up so it's visible
+  // axes hint
+  ctx.fillStyle = '#5f5f75'; ctx.font = dpr*11+'px monospace';
+  ctx.fillText('KB', 6, 16);
+  ctx.fillText('max '+max+' KB', W-dpr*90, 16);
+  ctx.fillText('30 s × '+s.length, 6, H-6);
+}
+let heapTimer;
+tabHooks.heap = () => { clearInterval(heapTimer); refreshHeap(); heapTimer=setInterval(refreshHeap,15000); };
+
+// ── Files ────────────────────────────────────────────────────────────
+async function refreshFiles() {
+  const sd = await apiQuiet('/sdcard');
+  if (!sd) return;
+  let out = 'mounted: '+sd.mounted+'\n';
+  if (sd.mounted) out += `total ${sd.total_mb} MB · free ${sd.free_mb} MB\n\n`;
+  out += '— /sdcard —\n';
+  (sd.files||[]).forEach(f=>out += (f.dir?'[DIR] ':'      ')+f.name+'  '+(f.size||'')+'\n');
+  if (sd.recordings) { out+='\n— /sdcard/rec —\n'; sd.recordings.forEach(f=>out+='      '+f.name+'  '+(f.size||'')+'\n'); }
+  $('#files-list').textContent = out;
+}
+tabHooks.files = refreshFiles;
+
+// ── Wi-Fi ────────────────────────────────────────────────────────────
+async function refreshWifiStatus() {
+  const w = await apiQuiet('/wifi/status'); if (!w) return;
+  const dl = $('#wifi-status'); dl.innerHTML = '';
+  Object.entries(w).forEach(([k,v])=>{
+    const dt = document.createElement('dt'); dt.textContent = k;
+    const dd = document.createElement('dd'); dd.textContent = String(v);
+    dl.appendChild(dt); dl.appendChild(dd);
+  });
+}
+$('#kick-soft').onclick   = async () => { if(!confirm('soft kick?')) return; await apiQuiet('/wifi/kick?mode=soft',{method:'POST'}); toast('kicking'); setTimeout(refreshWifiStatus,3000); };
+$('#kick-hard').onclick   = async () => { if(!confirm('hard kick (stop/start)?')) return; await apiQuiet('/wifi/kick?mode=hard',{method:'POST'}); toast('hard kick'); setTimeout(refreshWifiStatus,5000); };
+$('#kick-reboot').onclick = async () => { if(!confirm('reboot via wifi/kick?')) return; await apiQuiet('/wifi/kick?mode=reboot',{method:'POST'}); toast('rebooting'); };
+tabHooks.wifi = refreshWifiStatus;
+
+// ── Settings ─────────────────────────────────────────────────────────
+async function buildSettings() {
+  const s = await apiQuiet('/settings'); if (!s) return;
+  const f = $('#settings-form'); f.innerHTML = '';
+  const secret = new Set(['auth_tok','wifi_pass','device_id','hardware_id']);
+  const readOnly = new Set(['voice_connected','voice_state','spent_mils']);
+  const skipKeys = new Set(['onboarded']);
+  Object.entries(s).forEach(([k,v])=>{
+    if (skipKeys.has(k)) return;
+    const wrap = document.createElement('div'); wrap.style.marginBottom='10px';
+    const label = document.createElement('label');
+    label.textContent = k; label.style.display='inline-block'; label.style.width='160px'; label.style.color='var(--dim)';
+    wrap.appendChild(label);
+    const inp = document.createElement('input');
+    inp.type = (typeof v==='number') ? 'number' : 'text';
+    inp.value = v; inp.dataset.key = k;
+    if (readOnly.has(k)) inp.disabled = true;
+    inp.style.width = 'calc(100% - 170px)';
+    wrap.appendChild(inp);
+    f.appendChild(wrap);
+  });
+}
+$('#settings-refresh').onclick = buildSettings;
+$('#settings-save').onclick = async () => {
+  const body = {};
+  $$('#settings-form input').forEach(i => {
+    if (i.disabled) return;
+    const k = i.dataset.key;
+    body[k] = i.type==='number' ? Number(i.value) : i.value;
+  });
+  const r = await apiQuiet('/settings', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+  $('#settings-status').textContent = r ? ('updated: '+(r.updated||[]).join(', ')) : 'error';
+};
+tabHooks.settings = buildSettings;
+
+// ── Danger ───────────────────────────────────────────────────────────
+$('#btn-reboot').onclick = async () => { if (!confirm('reboot?')) return; await apiQuiet('/reboot',{method:'POST'}); toast('rebooting'); };
+$('#btn-ota-check').onclick = async () => { const r = await apiQuiet('/ota/check'); $('#ota-status').textContent = JSON.stringify(r,null,2); };
+$('#btn-ota-apply').onclick = async () => { if(!confirm('apply OTA?')) return; const r = await apiQuiet('/ota/apply',{method:'POST'}); $('#ota-status').textContent = JSON.stringify(r,null,2); };
+$('#btn-crashlog').onclick = async () => { const r = await apiQuiet('/crashlog'); $('#crashlog-view').textContent = JSON.stringify(r,null,2); };
+$('#btn-factory-reset').onclick = async () => {
+  const first8 = (token||'').substring(0,8);
+  if (!first8 || first8.length<8) { toast('need full token saved first'); return; }
+  if (!confirm('ERASE ALL NVS?  device will reboot.')) return;
+  await apiQuiet('/nvs/erase?confirm='+first8, {method:'POST'});
+  toast('erasing…');
+};
+
+// Kick-off -------------------------------------------------------------
+const initHash = location.hash.slice(1) || 'dashboard';
+showTab(initHash);
+</script>
+</body>
+</html>

--- a/main/main.c
+++ b/main/main.c
@@ -436,6 +436,11 @@ void app_main(void)
 
     // Start debug HTTP server (needs WiFi + display)
     if (s_wifi_ok) {
+        /* #149: init observability ring buffers before the server so the
+         * first /events / /heap/history / /logs/tail calls have data. */
+        extern esp_err_t tab5_debug_obs_init(void);
+        tab5_debug_obs_init();
+
         ret = tab5_debug_server_init();
         if (ret != ESP_OK) {
             ESP_LOGW(TAG, "Debug server init failed: %s", esp_err_to_name(ret));


### PR DESCRIPTION
## Summary
Replaces the ~100-line inline debug HTML with a proper single-page app.  Ten tabs, all wired to the β endpoints from #152.  No external deps, no framework — one HTML file embedded via \`EMBED_TXTFILES\`.

### Tabs
- **Dashboard** — live metrics, recent events
- **Screen** — live JPEG + gesture capture (tap / swipe / long-press, keyboard + touch), navigate-to dropdown
- **Chat** — send text + live AI stream + receipts
- **Voice** — dictation Start/Stop + transcript + mode switcher + volume + mic mute
- **Logs** — log tail with filter + auto-refresh (E/W colour-coded)
- **Heap** — canvas sparkline of internal/largest/LVGL over 30 min
- **Files** — SD browse
- **Wi-Fi** — status + soft/hard/reboot kicks
- **Settings** — auto-generated form for every NVS key
- **Danger** — reboot, OTA, crashlog, core-dump download, factory reset

### Token management
- Stored in \`localStorage\` under \`tab5_debug_token\`, auto-attached to all fetches.
- \`/\` page itself is NOT auth-gated — it's the UI for entering the token — but every endpoint it calls IS.

## Depends on
#152 (PR β) for \`/logs/tail\`, \`/heap/history\`, \`/events\`, \`/chat/messages\`, \`/wifi/status\`, \`/battery\`, \`/audio\`, \`/display/brightness\`, \`/voice/text\`, \`/voice/cancel\`, \`/voice/clear\`, \`/nvs/erase\`, \`/metrics\`, \`/net/ping\`.

## Test plan
- [x] \`idf.py build\` clean.
- [x] \`GET /\` serves the full SPA (35,993 bytes).
- [x] SPA renders on mobile + desktop.
- [ ] Manual smoke test of each tab — user.
- [ ] Mobile-viewport responsive layout — user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)