### PR TITLE
chore: tidy post-streaming dead code + doc drift (closes #156)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ Companion repo: [TinkerBox](https://github.com/lorcan35/TinkerBox) (Dragon-side 
 4. On-device skills/app store + offline knowledge + multi-modal vision
 
 ### Key Decisions
-- **STOP investing in Dragon Mode streaming.** The product is the voice assistant.
+- **Voice-first, not a remote display.** The CDP browser-streaming path that
+  Tab5 shipped with (MJPEG + touch relay over port 3501) was retired in
+  #155 — the product is the voice assistant.
 - **Double down on voice** — that's what differentiates from every IoT display.
 - Memory/RAG via Qwen3-Embedding 0.6B on Dragon. AI that remembers you.
 - Skill store is the growth flywheel. Tinkerers publish, normies install.
@@ -44,10 +46,10 @@ Companion repo: [TinkerBox](https://github.com/lorcan35/TinkerBox) (Dragon-side 
 - Toast notification pattern, spring animation concept (write our own spring_anim.c)
 
 ### What NOT to Do
-- Don't adopt Mooncake (our service_registry + mode_manager is better for embedded)
+- Don't adopt Mooncake (our service_registry is better for embedded)
 - Don't rewrite to C++
 - Don't build a full browser on Tab5
-- Don't over-optimize Dragon Mode streaming
+- Don't reintroduce CDP browser streaming — it's gone; voice-first is the product
 
 ### Our Unique Advantage
 - Dragon Q6A: 12GB RAM, 12 TOPS NPU vs M5Stack AX630C (4GB, 3.2 TOPS)
@@ -350,7 +352,7 @@ Current LVGL settings in `sdkconfig.defaults`:
 - **Keyboard text visible while typing:** Text input field stays visible above the keyboard during typing (was previously hidden behind the keyboard).
 - **Done key auto-submits:** Done/Enter key on the keyboard dispatches `LV_EVENT_READY` instead of inserting a newline, triggering form submission.
 - **Internal SRAM fragmentation monitoring:** Periodic heap check monitors largest free internal SRAM block (not just total free). If largest block stays below threshold for 3 minutes sustained, triggers a controlled reboot to defragment.
-- **FPS counter:** LVGL flush rate counter for monitoring UI rendering performance.
+- **LVGL FPS counter:** LVGL flush rate, surfaced as `lvgl_fps` in `GET /info`, for monitoring UI rendering performance.
 - **Rich Media Chat:** Chat screen renders inline rich media — syntax-highlighted code blocks, cards, and audio clips as JPEG images. Dragon renders content server-side (Pygments for code, Pillow for tables), Tab5 downloads and displays via LVGL's TJPGD decoder. 5-slot PSRAM LRU cache (~2.9MB) with zero alloc/free fragmentation. Max 3 media items per LLM response. Downloads yield every 2ms to not stall voice WS.
 
 ### Heap Fragmentation Fix (Hide/Show Pattern)
@@ -447,17 +449,20 @@ main/wifi.{c,h}           — Wi-Fi stack wrapper (STA/AP, reconnect, country co
 main/settings.{c,h}       — NVS-backed settings (see "NVS Settings Keys" table for full list)
 ```
 
-### Dragon link
+### Dragon voice link
 ```
-main/voice.{c,h}          — Voice WS client, mic capture, TTS playback, dictation,
-                             reconnect watchdog, three-tier mode, tool events, rich-media handlers
-main/dragon_link.{c,h}    — Dragon mDNS + CDP connection state machine
-main/mdns_discovery.{c,h} — _tinkerclaw._tcp discovery
-main/touch_ws.{c,h}       — Touch-relay WS client to Dragon CDP (port 3501)
-main/udp_stream.{c,h}     — UDP JPEG streamer for CDP low-latency mode
-main/mjpeg_stream.{c,h}   — Alternate MJPEG-over-HTTP fallback for browsing mode
-main/mode_manager.{c,h}   — Mode FSM (IDLE / STREAMING / VOICE / BROWSING)
+main/voice.{c,h}          — Voice WS client (port 3502), mic capture, TTS playback,
+                             dictation, reconnect watchdog, three-tier mode, tool events,
+                             rich-media handlers. Tab5 talks to Dragon only via this path.
+main/mode_manager.{c,h}   — Voice-pipeline coordinator (IDLE ↔ VOICE). Thin mutex
+                             wrapper around voice_connect/disconnect kept because
+                             ui_voice / ui_notes / service_dragon switch from
+                             multiple tasks.
 ```
+
+The old CDP browser-streaming stack (dragon_link, mdns_discovery, touch_ws,
+udp_stream, mjpeg_stream) was deleted in #155 — see that PR for removal
+rationale. Tab5 now reaches Dragon only via the voice WS.
 
 ### UI framework
 ```

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1429,7 +1429,6 @@ static void async_navigate(void *arg)
      * For secondary screens (camera, files) create them separately.
      * This avoids the bug where ui_settings_create() replaces the
      * tileview screen entirely, breaking subsequent navigation. */
-    lv_obj_t *tv = ui_home_get_tileview();
 
     /* Always dismiss ALL overlays before any navigation — HIDE not destroy.
      * Destroy+recreate corrupts LVGL timer linked list (lv_ll_remove crash). */

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -243,15 +243,6 @@ static const char *trail_for_hour(int hour)
     return "Tonight, Emile -- quiet thoughts?";
 }
 
-static const char *greeting_for_hour(int hour)
-{
-    if (hour < 5)  return "late night, emile";
-    if (hour < 12) return "morning, emile";
-    if (hour < 17) return "afternoon, emile";
-    if (hour < 21) return "evening, emile";
-    return "tonight, emile";
-}
-
 /* "Thursday · 9:42" — bullet is U+2022, which IS in the Montserrat subset. */
 static void format_right_time(char *buf, size_t n, const struct tm *tm)
 {
@@ -791,9 +782,7 @@ void ui_home_update_status(void)
     localtime_r(&now, &tm_local);
 
     /* Trail line (shifts with hour) — v4·D Sovereign Halo editorial
-     * subtitle.  Previously used greeting_for_hour() which returned
-     * tiny all-caps labels; now uses trail_for_hour() which returns
-     * full serif italic sentences per the d-sovereign-halo mockup. */
+     * subtitle.  Full serif italic sentences per d-sovereign-halo mockup. */
     if (s_greet_line) {
         const char *g = trail_for_hour(tm_local.tm_hour);
         const char *cur = lv_label_get_text(s_greet_line);

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -155,21 +155,6 @@ static lv_obj_t *s_tinkerclaw_card   = NULL;
 static lv_obj_t *s_tinkerclaw_content[4] = {NULL};
 static uint8_t   s_active_tab     = 0;
 
-/* Cloud model IDs matching dropdown order */
-static const char *s_cloud_model_ids[] = {
-    "anthropic/claude-3.5-haiku",
-    "anthropic/claude-sonnet-4-20250514",
-    "openai/gpt-4o-mini",
-    "openai/gpt-4o",
-};
-
-/* Local model names matching dropdown order */
-static const char *s_local_model_names[] = {
-    "qwen3:1.7b",
-    "qwen3:4b",
-    "qwen3:0.6b",
-};
-
 /* ══════════════════════════════════════════════════════════════════════
  *  Material Dark Helper Functions
  * ══════════════════════════════════════════════════════════════════════ */
@@ -455,28 +440,6 @@ static void cb_tab_local(lv_event_t *e)
         return;
     }
     voice_tab_switch((uint8_t)idx);
-}
-
-static void cb_local_model(lv_event_t *e)
-{
-    lv_obj_t *dd = lv_event_get_target(e);
-    uint32_t sel = lv_dropdown_get_selected(dd);
-    if (sel < sizeof(s_local_model_names)/sizeof(s_local_model_names[0])) {
-        tab5_settings_set_llm_model(s_local_model_names[sel]);
-        ESP_LOGI(TAG, "Local LLM model: %s", s_local_model_names[sel]);
-        send_voice_config();
-    }
-}
-
-static void cb_cloud_model(lv_event_t *e)
-{
-    lv_obj_t *dd = lv_event_get_target(e);
-    uint32_t sel = lv_dropdown_get_selected(dd);
-    if (sel < sizeof(s_cloud_model_ids)/sizeof(s_cloud_model_ids[0])) {
-        tab5_settings_set_llm_model(s_cloud_model_ids[sel]);
-        ESP_LOGI(TAG, "Cloud LLM model: %s", s_cloud_model_ids[sel]);
-        send_voice_config();
-    }
 }
 
 static void cb_mic_mute(lv_event_t *e)

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -149,12 +149,6 @@ CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=4096
 CONFIG_FREERTOS_TLSP_DELETION_CALLBACKS=n
 
 # ---------------------------------------------------------------------------
-# lwIP — IP reassembly for UDP JPEG streaming (large datagrams)
-# ---------------------------------------------------------------------------
-CONFIG_LWIP_IP_REASSEMBLY=y
-CONFIG_LWIP_IP_REASS_MAX_PBUFS=64
-
-# ---------------------------------------------------------------------------
 # Memory — reserve internal RAM for DMA (SDIO WiFi + TCP buffers + OTA TLS)
 # Wave 10 #77 fix: bumped 64 KB -> 128 KB so the esp_https_ota flow has
 # headroom for its internal TLS/HTTP buffers even after 5+ minutes of


### PR DESCRIPTION
## Summary
Small sweep after #155. Each item is verified by grep to have no live consumers — this is dead-weight removal, no behavior change.

| # | File | Change | LoC |
|---|---|---|---|
| 1 | `main/ui_home.c` | Remove orphan `greeting_for_hour()` — superseded by `trail_for_hour()` per the historical comment at the old call site | -11 |
| 2 | `main/debug_server.c` | Remove unused `lv_obj_t *tv = ui_home_get_tileview();` local in `async_navigate()` | -1 |
| 3 | `sdkconfig.defaults` | Drop `CONFIG_LWIP_IP_REASSEMBLY=y` + `LWIP_IP_REASS_MAX_PBUFS=64` — both were tuned for the UDP JPEG streamer deleted in #155. IDF default (`y`, `10 pbufs`) is adequate for remaining TCP-only traffic; frees ~54 pbufs of pool | -6 |
| 4 | `main/ui_settings.c` | Remove orphan LLM-model dropdown callbacks `cb_local_model`, `cb_cloud_model` and their backing arrays `s_local_model_names[]`, `s_cloud_model_ids[]` — self-referential dead cluster after the dropdowns were removed from the UI in a prior redesign | -37 |
| 5 | `CLAUDE.md` | Three doc drifts: "Key Files > Dragon link" section still listed the 5 files deleted in #155 (+ stale `MODE_STREAMING`/`BROWSING` in the mode_manager description), `STOP investing in Dragon Mode streaming` directives reframed as completed decisions, `fps` → `lvgl_fps` nit | net -5 |

**Diff: net −45 LoC of dead code + 5 doc corrections.**

Five atomic commits (one per concern) so any individual item is independently revertable.

## Implications checked
- `send_voice_config()` and `tab5_settings_set_llm_model()` are still live — both exercised by the voice-tier dial in `ui_mode_sheet.c`
- `ui_home_get_tileview()` is used elsewhere in `debug_server.c`; only the discarded assignment was the problem
- `trail_for_hour()` is the active greeting producer (used in `ui_home_update_status` refresh)
- No NVS key changes, no WS protocol change, no partition change

## Test plan (executed on device)
- [x] Build clean: 2.15 MB binary, 28% free in app partition, no new warnings (existing `ota_progress_cb` / `cb_wake_word`-era warnings unchanged — separate PR will address)
- [x] Flash + hard-reset boot on `/dev/ttyACM1`
- [x] `/info`: voice_connected=true, dragon_connected=true, lvgl_fps=4→24 under load, tasks=24, heap 21 MB
- [x] `/selftest` — 8/8 PASS (wifi, voice_ws, sd_card, psram, display, camera, internal_heap, nvs_settings)
- [x] `/chat` E2E: "hello, quick sanity check" → Dragon STT matched, LLM replied contextually ("TinkerTab (ESP32-P4)..."), TTS played (SPEAKING state)
- [x] Gentle nav: chat → home (2 s pause each) + screenshot — all 200 OK, 720×1280 JPEG renders
- [x] Stability: 3 snapshots over 30 s, monotonic uptime growth, no regressions
- [x] Extended hold: 127 s continuous uptime across the full test, heap stable

### Known pre-existing issue (NOT caused by this PR)
During an **aggressive** smoke pattern (4 rapid `/navigate` calls + `/screenshot` back-to-back — heavier than the #155 verification pattern), Tab5 panicked inside LVGL's mask-radius renderer (stack trace deep in `lv_draw_sw_mask.c:1239`, entirely third-party managed-component code). This is the same subsystem as the prior "rounded-card circle cache overflow" bug documented in `CLAUDE.md` and is **unrelated to any change in this PR** (diff does not touch any rendering / LVGL / mask / border path). Filing a separate issue to track.

## Not included (deferred)
- `ota_progress_cb` / `ota_progress_async_cb` / `tab5_ota_set_progress_cb` — half-wired callback infra. Needs owner decision: delete, or complete the wiring so per-%-download progress actually renders.
- AFE / wake-word surgical removal (will ship as separate PR)