### PR TITLE
fix(nav): destroy camera/files screens on nav-away (closes #167)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1441,6 +1441,17 @@ static void async_navigate(void *arg)
     extern void ui_voice_dismiss_if_idle(void);
     ui_voice_dismiss_if_idle();
 
+    /* #167: camera + files use destroy/create semantics (they own big
+     * PSRAM canvas buffers + LVGL screen trees, not hide/show overlays).
+     * If the user navigates away from them without hitting the back
+     * chevron (e.g. /navigate or nav-sheet), we must tear them down here
+     * or we leak ~1.8 MB + a zombie preview timer per camera cycle.
+     * Both functions are NULL-guarded internally. */
+    extern void ui_camera_destroy(void);
+    extern void ui_files_destroy(void);
+    ui_camera_destroy();
+    ui_files_destroy();
+
     if (strcmp(s_nav_target, "home") == 0) {
         ui_home_go_home();
     } else if (strcmp(s_nav_target, "notes") == 0) {

--- a/main/ui_nav_sheet.c
+++ b/main/ui_nav_sheet.c
@@ -84,6 +84,15 @@ static void tile_click_cb(lv_event_t *e)
      * they're navigating to. */
     extern void ui_voice_dismiss_if_idle(void);
     ui_voice_dismiss_if_idle();
+    /* #167: same reason as debug_server.c async_navigate — camera and
+     * files own PSRAM canvas buffers and full LVGL screen trees; if the
+     * user leaves them by tapping any OTHER tile, we have to destroy
+     * explicitly or ~1.8 MB / screen tree / preview timer leak per
+     * round-trip.  Both functions are NULL-guarded. */
+    extern void ui_camera_destroy(void);
+    extern void ui_files_destroy(void);
+    ui_camera_destroy();
+    ui_files_destroy();
     if (s_tiles[idx].action) s_tiles[idx].action();
 }
 


### PR DESCRIPTION
## Summary
When you \`POST /navigate?screen=<other>\` away from camera or files, or tap a nav-sheet tile while either is open, the current heavy screen was never torn down. Camera's 720×1280 RGB565 canvas lives in PSRAM (1.84 MB) plus a preview timer and a full LVGL tree — every round-trip leaked all of it.

Five-line fix: call \`ui_camera_destroy()\` + \`ui_files_destroy()\` (both already NULL-guarded) at the two existing navigation chokepoints before the new-screen create.

## Why this matters
30-min E2E stress (55 action cycles, rotating touch-nav / mode+chat / settings drill / camera+files / screenshot) crashed Tab5 nine times with \`reset_reason=PANIC\`.  Every crash followed the same pattern:

| cycle | action | heap_kB | largest_block_kB |
|-------|--------|---------|------------------|
| 3 | mode+chat | 21171 | 56 |
| 4 | **camera+files** | **19313** | 42 |
| 5 | screenshot | 19313 | 42 |
| 6 | touch-nav sweep | **CRASH** | — |

1.8 MB exactly matches \`alloc_canvas_buffer(1280, 720)\` × RGB565.  Screen tree + preview timer add fragmentation on top.

## Test plan (executed on device)
- [x] Build clean: patch adds 20 lines, no warnings
- [x] Flash + boot on \`/dev/ttyACM1\` — \`reset_reason=USB\`, /selftest 8/8 PASS
- [x] Manual leak check: \`/navigate camera → /navigate home\` → heap delta **−1 kB** (was −1800 kB)
- [x] Re-ran the 30-min stress orchestrator against patched firmware.  heap stayed rock-stable at 21,171 kB across all 55 cycles — previously dropped by 1.8 MB every camera+files cycle.
- [x] \`reset_reason\` switched from \`PANIC\` → \`SW\` (this PR fixed the PANICs; remaining SW resets are issue #159's fragmentation watchdog, out of scope here)

## Not addressed (follow-ups)
- [#159](https://github.com/lorcan35/TinkerTab/issues/159) — fragmentation watchdog still fires every ~3 min under sustained load. SW reset (clean \`esp_restart\`), not a panic. Working on this next.
- \`ui_camera_create\` / \`ui_files_create\` are not idempotent — a duplicate create while one is already open would still leak. Not needed for the current nav surface area but worth a second-pass hardening later.