### PR TITLE
fix(stability): zombie-reboot WS-alive override + LVGL bounds/NULL guards (closes #159, refs #158)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,17 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/sdkconfig.local")
     )
 endif()
 
-# #158: apply third-party managed-component patches before the build
-# reads any of their source (bounds-check on LVGL's get_next_line, etc.).
-# Idempotent — a sentinel string in each patched file skips reapply.
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(tinkertab)
+
+# #158: apply managed-component patches (LVGL bounds/NULL guards, etc.).
+# Runs AFTER project(tinkertab) so the component manager has finished
+# fetching managed_components/ — otherwise on a fresh clone the target
+# files don't exist yet and the script skips.  We run at configure time
+# AND as a PRE_BUILD custom command so any edits land before compilation
+# even if someone just ran `idf.py build` without a reconfigure.
+# Idempotent — sentinel string "TinkerTab #<issue>" in each patched
+# file makes reapply a no-op.
 execute_process(
     COMMAND bash "${CMAKE_CURRENT_SOURCE_DIR}/tools/apply_patches.sh"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -29,5 +37,11 @@ if(NOT _patch_result EQUAL 0)
     message(FATAL_ERROR "apply_patches.sh failed (rc=${_patch_result}) — aborting build")
 endif()
 
-include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(tinkertab)
+# Belt-and-suspenders: run the script once more as a pre-build step so
+# a post-fetch `idf.py build` (without `reconfigure`) still gets the patch.
+add_custom_target(apply_managed_patches ALL
+    COMMAND bash "${CMAKE_CURRENT_SOURCE_DIR}/tools/apply_patches.sh"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMENT "Applying managed-component patches (#158)"
+    VERBATIM
+)

--- a/main/voice.c
+++ b/main/voice.c
@@ -2144,8 +2144,24 @@ void voice_lan_probe_task(void *arg)
 
         /* #146 progressive escalation: both probes failed while Wi-Fi
          * reports associated — network stack is wedged.  Escalate
-         * based on how many consecutive rounds have failed. */
-        if (!lan_ok && !ngrok_ok) {
+         * based on how many consecutive rounds have failed.
+         *
+         * #159: BUT — if the voice WebSocket is currently connected, the
+         * WiFi stack is provably alive: Tab5 is actively exchanging
+         * frames with Dragon on port 3502.  A TCP-probe timeout under
+         * that condition is almost always transient back-pressure (LVGL
+         * render storm starving the probe task, SDIO queue full from a
+         * screenshot, debug-server httpd handler hogging the stack)
+         * rather than genuine WiFi failure.  Rebooting the device at
+         * that point is a false positive and destroys the user's
+         * session for no reason.  Reset the counter instead and let the
+         * next round re-probe with clean state.
+         *
+         * This fix is specifically for the "every ~3 min under stress"
+         * reboot cluster we saw in the 30-min stability test — 9 SW
+         * resets, each at zombie_rounds=6, while the WS stayed
+         * connected throughout. */
+        if (!lan_ok && !ngrok_ok && !voice_is_connected()) {
             zombie_rounds++;
             if (zombie_rounds >= ZOMBIE_REBOOT) {
                 ESP_LOGE(TAG, "Zombie Wi-Fi: %d rounds (~%d s) failed even "
@@ -2164,7 +2180,9 @@ void voice_lan_probe_task(void *arg)
                              esp_err_to_name(r));
                 }
                 /* Keep zombie_rounds ticking so the reboot fires if
-                 * hard kick didn't recover. */
+                 * the hard kick didn't recover.  Not reached when the
+                 * voice WS is alive — the outer check short-circuited
+                 * at the top of this block (see #159). */
             } else if (zombie_rounds >= ZOMBIE_SOFT) {
                 ESP_LOGW(TAG, "Zombie Wi-Fi detected: both probes failed "
                               "%d rounds in a row — soft kick (deauth+reconnect)",

--- a/patches/lvgl-get-next-line-bounds.patch
+++ b/patches/lvgl-get-next-line-bounds.patch
@@ -1,19 +1,67 @@
 --- a/src/draw/sw/lv_draw_sw_mask.c
 +++ b/src/draw/sw/lv_draw_sw_mask.c
-@@ -1235,6 +1235,16 @@ static void circ_calc_aa4(lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t radiu
- static lv_opa_t * get_next_line(lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t y, int32_t * len,
-                                 int32_t * x_start)
+@@ -1078,6 +1078,16 @@
+ 
+     c->buf = lv_malloc(radius * 6 + 6);  /*Use uint16_t for opa_start_on_y and x_start_on_y*/
+     LV_ASSERT_MALLOC(c->buf);
++    if(c->buf == NULL) {  /* TinkerTab #158: LVGL pool exhausted under stress.
++                             Leaving buf/arrays NULL is picked up by the
++                             NULL-guard in get_next_line below so the caller
++                             gracefully skips one scanline of rounded border
++                             instead of crashing with a Store access fault. */
++        c->cir_opa = NULL;
++        c->opa_start_on_y = NULL;
++        c->x_start_on_y = NULL;
++        return;
++    }
+     c->cir_opa = c->buf;
+     c->opa_start_on_y = (uint16_t *)(c->buf + 2 * radius + 2);
+     c->x_start_on_y = (uint16_t *)(c->buf + 4 * radius + 4);
+@@ -1093,6 +1103,17 @@
+ 
+     const size_t cir_xy_size = (radius + 1) * 2 * 2 * sizeof(int32_t);
+     int32_t * cir_x = lv_malloc_zeroed(cir_xy_size);
++    if(cir_x == NULL) {  /* TinkerTab #158: same fault family as the buf
++                            alloc above.  Clear arrays + return; the
++                            get_next_line guard drops the affected
++                            scanline instead of crashing. */
++        lv_free(c->buf);
++        c->buf = NULL;
++        c->cir_opa = NULL;
++        c->opa_start_on_y = NULL;
++        c->x_start_on_y = NULL;
++        return;
++    }
+     int32_t * cir_y = &cir_x[(radius + 1) * 2];
+ 
+     uint32_t y_8th_cnt = 0;
+@@ -1217,9 +1238,27 @@
+     lv_free(cir_x);
+ }
+ 
+-static lv_opa_t * get_next_line(lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t y, int32_t * len,
+-                                int32_t * x_start)
++static __attribute__((noinline, noclone)) lv_opa_t *
++get_next_line(lv_draw_sw_mask_radius_circle_dsc_t * c, int32_t y, int32_t * len,
++              int32_t * x_start)
  {
-+    /* TinkerTab #158 defensive bounds check.  LVGL 9.2.2's upstream
-+     * version indexes opa_start_on_y[y+1] without verifying y <= radius,
-+     * so callers that pass a y larger than the cached circle's radius
-+     * read past the end of the array and crash.  Seen on-device when a
-+     * rounded border (LV_RADIUS_CIRCLE + border_width>0) renders under
-+     * a clip rectangle whose height collapses to less than the radius
-+     * during a screen transition.  Return a degraded result (empty
-+     * line) rather than panicking the UI task. */
-+    if (y < 0 || y > c->radius) { *len = 0; *x_start = 0; return c->cir_opa; }
-+
++    /* TinkerTab #158 defensive bounds + NULL checks.  Upstream LVGL
++     * 9.2.2 indexes opa_start_on_y[y+1] and x_start_on_y[y] without
++     * verifying y <= radius or that the arrays are populated.  Under
++     * specific render conditions (LV_RADIUS_CIRCLE borders rendered
++     * while a clip rect's height collapses below the radius, or a
++     * partially-initialised cache entry being returned) we crash with
++     * an OOB read.  Forced noinline/noclone because the inlined version
++     * had its early-return optimised away in LVGL 9.2.2 GCC builds.
++     * Returning NULL with *len=0 is safe: callers of this function
++     * iterate `for (i = 0; i < aa_len; i++)` and never dereference the
++     * returned pointer when aa_len is zero. */
++    if (!c || !c->opa_start_on_y || !c->x_start_on_y || !c->cir_opa ||
++        y < 0 || y > c->radius) {
++        *len = 0;
++        *x_start = 0;
++        return NULL;
++    }
      *len = c->opa_start_on_y[y + 1] - c->opa_start_on_y[y];
      *x_start = c->x_start_on_y[y];
      return &c->cir_opa[c->opa_start_on_y[y]];


### PR DESCRIPTION
## Two stability fixes, validated on-device with the 30-min stress orchestrator

### Fix 1 — voice.c link-probe: skip zombie-reboot while WS alive (#159)
\`voice_lan_probe_task\` was rebooting Tab5 via \`esp_restart()\` after 6 consecutive TCP-probe failures (\`ZOMBIE_REBOOT = 6 × 30 s = 180 s\`, matches the 173-194 s inter-crash periodicity observed in the stress CSV exactly).  Under sustained LVGL/screenshot load the probes would transiently time out even with a perfectly healthy WiFi link.

**Change:** if \`voice_is_connected()\` is true, don't increment \`zombie_rounds\`.  A live WebSocket is the strongest possible "WiFi alive" signal — frames are actively in both directions.  If individual TCP probes time out while the WS is handling pings + text frames, that's transient back-pressure, not a wedged stack.

**Result:** zero \`reset=SW\` events across the post-fix stress run (previously 9 per 30 min).

### Fix 2 — LVGL mask-radius: noinline + widened NULL/alloc guards (#158 v2)
The #166 patch added a bounds check inside \`get_next_line()\` but GCC inlined the function into \`lv_draw_mask_radius\` and the early-return got optimised away.  Same crash kept firing at \`lv_draw_sw_mask.c:1249\`.

**Change:**
1. \`__attribute__((noinline, noclone))\` on \`get_next_line\` — keeps the bounds check at runtime.  ELF now contains \`get_next_line\` as a standalone symbol (\`riscv32-esp-elf-nm\` confirms: \`48082a32 t get_next_line\`).
2. Widened the guard to cover NULL arrays + return NULL + \`*len=0\` — safe because callers iterate \`for (i = 0; i < aa_len; i++)\` and never deref the pointer when \`aa_len == 0\`.
3. Added **alloc-failure guards** inside \`lv_draw_sw_mask_radius_init\`:
   - After \`c->buf = lv_malloc(radius*6+6)\`
   - After \`cir_x = lv_malloc_zeroed(cir_xy_size)\`
   
   Under LVGL-pool exhaustion these return NULL.  \`LV_ASSERT_MALLOC\` is a no-op in our build (\`CONFIG_LV_USE_ASSERT_MALLOC=n\`), so the code proceeded to store at NULL → Store access fault (\`MEPC 0x48083f66\`).  New guards clear the arrays to NULL and bail; downstream \`get_next_line\` picks up the NULL and skips the scanline.

**Result:** the \`lv_draw_sw_mask.c:1249\` crash is no longer in fresh coredumps.

### Patch delivery infra — survives fresh clones

\`managed_components/\` is gitignored, so a naked edit to LVGL's source wouldn't persist.  Infra:
- \`patches/lvgl-get-next-line-bounds.patch\` — unified diff in git
- \`tools/apply_patches.sh\` — idempotent applier (sentinel \`TinkerTab #158\` makes reapply a no-op)
- \`CMakeLists.txt\` — runs the script both at configure time (\`execute_process\`) and as a build-time \`add_custom_target\`, so fresh clones + \`idf.py reconfigure\` + plain \`idf.py build\` all land the patch

**Verified fresh-clone scenario:** \`rm -rf managed_components build && idf.py build\` → patch applied, sentinel count = 3 (one per guard).

## Test plan
- [x] Build clean: \`get_next_line\` exists as standalone symbol in ELF, 3 sentinel hits in source, alloc-failure branches visible in disassembly (\`beqz a0\` after each lv_malloc)
- [x] Flash + boot: \`reset_reason=USB\`, all 8 selftest PASS
- [x] 4-min idle: monotonic uptime, zero crashes
- [x] 30-min stress: zero \`reset=SW\` events (was 9 per 30 min pre-fix), zero \`lv_draw_sw_mask\` panics (was every 175 s pre-fix)

## Follow-up
A separate crash surfaced under the same stress once the SW/mask-radius paths were closed: \`ui_notes.c:1861 add_note_card\` NULL-derefs \`lv_label_create()\` during rapid list refresh.  Filing as a new issue — not blocking this PR.