### PR TITLE
fix(ui-memory): guard render_hits_cb on overlay visibility (closes #171)

### DIFF
--- a/main/ui_memory.c
+++ b/main/ui_memory.c
@@ -151,7 +151,14 @@ static void build_hit(lv_obj_t *parent,
 static void render_hits_cb(void *arg)
 {
     (void)arg;
-    if (!s_hits_root) return;
+    /* #171: the fetch_task on Core 1 queues this callback via
+     * lv_async_call after the HTTP response arrives.  Between queuing
+     * and execution the user may have hidden the overlay, so there's
+     * no visual reason to rebuild the list — and a future refactor
+     * that migrates this overlay to a destroy/create lifecycle would
+     * see s_hits_root / s_stats_lbl dangling.  Cheap guard: just bail
+     * if we're not currently visible. */
+    if (!s_visible || !s_hits_root) return;
     lv_obj_clean(s_hits_root);
 
     if (s_loading) {


### PR DESCRIPTION
## Background
LVGL stability audit flagged \`ui_memory.c:render_hits_cb\` as Class C — async callback accessing state without a visibility guard.  One-liner defensive fix.

## Change
\`fetch_task\` (Core 1, background) calls \`lv_async_call(render_hits_cb, NULL)\` after the HTTP memory fetch from Dragon completes. Between queuing and the LVGL timer firing the callback, the user may have hidden the overlay — the current callback rebuilds the list anyway (wasted work) and would hit dangling pointers if the overlay ever gets refactored to destroy/create semantics.

Guard:
\`\`\`c
if (!s_visible || !s_hits_root) return;
\`\`\`

Pattern matches \`ui_wifi.c\` / \`ui_settings.c\` / the \`ui_notes.c\` fix in #170.

## Test plan
- [x] Build clean
- [ ] Flash + verify memory overlay still fetches + renders normally (no regression)
- [ ] Cumulative stress test after all 4 audit PRs land