### PR TITLE
fix(ui-camera): idempotent create to prevent double-instantiation leak (closes #172)

### DIFF
--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -155,6 +155,18 @@ static void cb_back_btn(lv_event_t *e)
  * ================================================================ */
 lv_obj_t *ui_camera_create(void)
 {
+    /* #172: idempotent re-entry.  Camera owns a ~1.8 MB PSRAM canvas
+     * buffer + a preview timer + a full LVGL screen tree.  If the
+     * create path is hit twice without an intervening destroy (debug
+     * /navigate racing with a tile tap, duplicate async navigation
+     * during screen churn), we'd overwrite \`scr_camera\` / \`canvas_buf\`
+     * and leak the previous instance + leave its preview timer firing
+     * on a dangling canvas.  Short-circuit when we're already live. */
+    if (scr_camera) {
+        lv_screen_load(scr_camera);
+        return scr_camera;
+    }
+
     bool cam_ok = tab5_camera_initialized();
 
     /* Find highest existing IMG_NNNN.jpg to avoid overwriting */


### PR DESCRIPTION
## Background
LVGL stability audit Class D.  \`ui_camera_create()\` was non-idempotent — a duplicate call (debug \`/navigate?screen=camera\` racing with a nav-sheet tile tap, rapid async nav during screen churn) would overwrite the static \`scr_camera\` pointer and leak:
- the previous full LVGL screen tree
- the previous **1.84 MB PSRAM canvas buffer** (overwritten before \`free_canvas_buffer()\` runs)
- the previous preview timer (still firing on an orphaned canvas)

Create-side twin of #167 (fixed destroy-side: nav-away didn't tear camera down).

## Change
Early-return at the top of \`ui_camera_create()\`:
\`\`\`c
if (scr_camera) {
    lv_screen_load(scr_camera);
    return scr_camera;
}
\`\`\`
Matches the pattern already used by \`ui_files.c\` and \`ui_notes.c\`.

## Test plan
- [x] Build clean
- [ ] Cumulative stress test after all 4 audit PRs land