### PR TITLE
fix(ui-home): idempotent create as defensive hardening (closes #173)

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -316,6 +316,18 @@ static void pos_centered(lv_obj_t *obj, int y, int w, int h)
 
 lv_obj_t *ui_home_create(void)
 {
+    /* #173: defensive idempotent check.  Today's boot path only calls
+     * ui_home_create() once, but if a future refactor ever adds a
+     * second create (theme reload, locale switch, crash recovery that
+     * re-calls boot sequence) the unguarded overwrite of s_screen
+     * would silently leak the old home tree + every static object
+     * pointer below.  Matches pattern already used by ui_notes,
+     * ui_files, ui_camera (post-#172). */
+    if (s_screen) {
+        lv_screen_load(s_screen);
+        return s_screen;
+    }
+
     s_screen = lv_obj_create(NULL);
     lv_obj_remove_style_all(s_screen);
     lv_obj_set_size(s_screen, SW, SH);


### PR DESCRIPTION
## Background
LVGL stability audit Class D — lowest severity.  \`ui_home_create()\` has never been a crash source in practice because today's boot path calls it exactly once.  Defensive hardening for consistency with the sibling screens (\`ui_notes\`, \`ui_files\`, \`ui_camera\` post-#172): if a future refactor adds a second-create call (theme reload, locale switch, crash-recovery boot loop), the current unguarded overwrite of \`s_screen\` would silently leak the entire home tree + every static pointer at the top of the file.

## Change
Early-return at the top of \`ui_home_create()\`:
\`\`\`c
if (s_screen) {
    lv_screen_load(s_screen);
    return s_screen;
}
\`\`\`

Zero runtime cost.

## Test plan
- [x] Build clean
- [ ] Verify boot still lands on home correctly (no regression)