### PR TITLE
fix(heap_wd): SRAM exhaustion detector — converts silent SW reset to clean PANIC+coredump

### DIFF
--- a/main/heap_watchdog.c
+++ b/main/heap_watchdog.c
@@ -72,6 +72,24 @@ static const char *TAG = "heap_wd";
 #define HEAP_WD_INT_FRAG_TOTAL_MIN     (16 * 1024)  /* 16KB — must have enough free for it to be fragmentation, not exhaustion */
 #define HEAP_WD_INT_FRAG_REBOOT_COUNT  3        /* 3 consecutive checks (3 minutes) */
 
+/* #182 Phase 3-d: internal SRAM EXHAUSTION detector (not fragmentation).
+ * The frag check above only fires when `free > 16 KB` — it's designed for
+ * the case "lots of free but small largest block".  That deliberately
+ * excludes the case we observed in #182: `free` and `largest` both shrink
+ * together until largest drops below the ESP-Hosted SDIO driver's per-
+ * packet DMA-alloc demand (~14 KB).  When that happens, SDIO silently
+ * drops RX packets, WS starves, and we get the voice.c:1528 hard-kick
+ * reboot (reset_reason=SW, no coredump).
+ *
+ * This detector fires when `internal_largest < 20 KB` sustained for
+ * 2 consecutive checks (2 min).  20 KB gives ~6 KB of margin above the
+ * observed 14 KB SDIO demand.  2-min sustained avoids false positives
+ * from transient dips during a single screen transition.  The abort
+ * path saves a coredump so future regressions are diagnosable; the
+ * current silent cascade just leaves the user with a reboot. */
+#define HEAP_WD_INT_EXHAUST_BLOCK_MIN    (20 * 1024)  /* 20KB largest block */
+#define HEAP_WD_INT_EXHAUST_REBOOT_COUNT 2             /* 2 consecutive = 2 min */
+
 /* DMA pool exhaustion thresholds (audit #80):
  * WiFi driver + TLS need DMA-capable buffers for RX/TX descriptors. When
  * free DMA pool drops too low the driver silently fails — packets never
@@ -111,6 +129,7 @@ static void heap_watchdog_task(void *arg)
     int frag_count = 0;
     int internal_frag_count = 0;
     int dma_critical_count = 0;
+    int internal_exhaust_count = 0;  /* #182 Phase 3-d: SRAM exhaustion (largest block too small for SDIO) */
 
     ESP_LOGI(TAG, "Heap watchdog started (check every %ds, reboot after %d consecutive fragmentation events)",
              HEAP_WD_CHECK_INTERVAL_MS / 1000, HEAP_WD_FRAG_REBOOT_COUNT);
@@ -177,6 +196,58 @@ static void heap_watchdog_task(void *arg)
                          internal_frag_count, HEAP_WD_INT_FRAG_REBOOT_COUNT);
             }
             internal_frag_count = 0;
+        }
+
+        /* #182 Phase 3-d: SRAM EXHAUSTION detector.  Fires when the
+         * largest free internal-SRAM block shrinks below the ESP-Hosted
+         * SDIO driver's per-packet DMA-alloc peak demand, sustained for
+         * 2 consecutive minutes.  This is the observed failure mode of
+         * the SW-reset cascade in #182: largest drops to ~11 KB, SDIO
+         * tries a 14 KB heap_caps_aligned_alloc, fails silently, packets
+         * drop, WS starves, and we get the voice.c:1528 hard-kick reboot
+         * with no coredump.
+         *
+         * Triggering here converts the silent cascade into a clean
+         * esp_system_abort with "sram_exhausted" reason, which saves a
+         * coredump to the 0x620000 partition.  The fix is strictly
+         * observability — the user still loses the session, but future
+         * regressions are diagnosable.
+         *
+         * Excluded from triggering here (to avoid double-counting with
+         * the fragmentation check above): cases where free > 16 KB and
+         * largest < 4 KB — that's a genuine fragmentation pattern and
+         * the existing check handles it. */
+        if (internal_largest < HEAP_WD_INT_EXHAUST_BLOCK_MIN
+            && !(internal_largest < HEAP_WD_INT_FRAG_BLOCK_MIN
+                 && internal_free > HEAP_WD_INT_FRAG_TOTAL_MIN)) {
+            internal_exhaust_count++;
+            ESP_LOGE(TAG, "Internal SRAM exhausted: largest=%uKB below %uKB threshold (count=%d/%d)",
+                     (unsigned)(internal_largest / 1024),
+                     (unsigned)(HEAP_WD_INT_EXHAUST_BLOCK_MIN / 1024),
+                     internal_exhaust_count, HEAP_WD_INT_EXHAUST_REBOOT_COUNT);
+
+            if (internal_exhaust_count >= HEAP_WD_INT_EXHAUST_REBOOT_COUNT) {
+                extern voice_state_t voice_get_state(void);
+                voice_state_t vs = voice_get_state();
+                if (vs == VOICE_STATE_LISTENING || vs == VOICE_STATE_SPEAKING
+                    || vs == VOICE_STATE_PROCESSING) {
+                    ESP_LOGW(TAG, "Heap watchdog: deferring exhaustion reboot, voice active (state=%d)", vs);
+                } else {
+                    ESP_LOGE(TAG, "Heap watchdog: SRAM exhausted %d min; internal free=%uKB largest=%uKB DMA free=%uKB PSRAM free=%uKB",
+                             HEAP_WD_INT_EXHAUST_REBOOT_COUNT,
+                             (unsigned)(internal_free / 1024),
+                             (unsigned)(internal_largest / 1024),
+                             (unsigned)(dma_free / 1024),
+                             (unsigned)(psram_free / 1024));
+                    hw_restart_with_coredump("sram_exhausted");
+                }
+            }
+        } else {
+            if (internal_exhaust_count > 0) {
+                ESP_LOGI(TAG, "Internal SRAM headroom recovered (was %d/%d)",
+                         internal_exhaust_count, HEAP_WD_INT_EXHAUST_REBOOT_COUNT);
+            }
+            internal_exhaust_count = 0;
         }
 
         /* Audit #80 + W15-C05: DMA exhaustion reboot path.  Soft warn at


### PR DESCRIPTION
## Summary

- Adds a third internal-SRAM watchdog path to `heap_watchdog.c`: fires when `internal_largest_free_block < 20 KB` for 2 consecutive 60-s checks, triggers `esp_system_abort("sram_exhausted")` for a coredump reboot.
- Addresses the `reset_reason=SW` cascade class from #182 by **beating the silent reboot** (voice.c:1528 hard-kick path) to the reboot with a named PANIC + coredump instead.
- Does **not** fix the underlying SRAM pressure — cadence is unchanged. This is the observability half of the fix (P3-d in the investigation doc).

## Why P3-d not P3-a

The ideal direct fix (P3-a) would be to bump `CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL` from 128 KB → 192 KB, giving the SDIO driver headroom for its variable-size DMA allocations. I tried it: the firmware boot-loops with `main_task` abort, same class as the Phase 3-A LV_MEM 192 KB boot abort (#181's preceding investigation). 160 KB also boot-loops. The firmware layout can't absorb more reserve without giving back elsewhere (task stacks, LV_MEM base, etc.). P3-d converts the silent cascade into a diagnosable PANIC so the next pass can be surgical.

## What this PR changes

- `main/heap_watchdog.c`: two new `#define`s (`HEAP_WD_INT_EXHAUST_BLOCK_MIN = 20 KB`, `HEAP_WD_INT_EXHAUST_REBOOT_COUNT = 2`) + one new `if` block in the 60-s watchdog loop with the same voice-active grace list as the existing fragmentation check.
- No sdkconfig changes. No third-party component touched.

## Validation

15-min stress run on this branch:

| | Baseline (pre-PR) | This PR |
|---|---|---|
| Total resets | 2 in ~15 min | 2 in ~15 min (unchanged cadence — expected) |
| `reset_reason` | SW (silent) | **PANIC (coredump + named reason)** |
| Reboot reason captured | none | `sram_exhausted` |
| Hard-kick race | detector beat voice.c:1528 by ~500 ms on the first reset; detector fired alone on the second |

Serial excerpt (first reset):
```
E (74235) heap_wd: Internal SRAM exhausted: largest=10KB below 20KB threshold (count=1/2)
E (134235) heap_wd: Internal SRAM exhausted: largest=10KB below 20KB threshold (count=2/2)
E (134235) heap_wd: Heap watchdog: SRAM exhausted 2 min; internal free=20KB largest=10KB DMA free=19KB PSRAM free=19053KB
E (134236) heap_wd: reboot reason=sram_exhausted — aborting for coredump
```

`/info` confirms `reset_reason = PANIC` after the detector fires — the coredump partition at 0x620000 is written so post-mortem is `esptool read_flash 0x620000 0x40000 cd.bin + espcoredump.py info_corefile`.

## Test plan

- [x] Builds clean (`idf.py build`)
- [x] Boots cleanly (no regression from heap_wd change itself)
- [x] Detector fires under stress in the expected 2-check / 2-minute window
- [x] Detector's abort wins the race against voice.c:1528's `esp_restart` (observed 500 ms margin on a real cascade; tight but reliable in the observed run)
- [x] `reset_reason = PANIC` with reason `heap_wd: sram_exhausted`
- [x] Idle boot after the PANIC reset looks healthy (`internal_free` back at ~53 KB)

## What's NOT in this PR (explicitly)

- **The actual leak / pressure fix.** The underlying DMA-alloc failure under stress still happens. This PR ships observability so the next iteration can be data-driven rather than guesswork.
- **Trying smaller reserve bumps** (e.g., 136 KB, 144 KB).  Marked as a separate follow-up — those weren't tested in this PR's scope.
- **Moving other consumers out of internal SRAM.** Larger surface; filed for later if a hard fix is needed.

## References

- #182 (tracking issue — stays open; this PR partially closes it by making the cascade diagnosable but doesn't eliminate it)
- Investigation branch with full Phase 1 + Phase 2 findings: `investigate/182-sram-leak` @ commit 1efd40b
- `docs/STABILITY-INVESTIGATION.md` on that branch — "#182 Phase 1" + "#182 Phase 2 pivoted" log entries

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)