### PR TITLE
fix(lvgl): drop LV_MEM 96→64 KB to free 32 KB BSS, relieving SDIO pressure

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -108,12 +108,16 @@ CONFIG_LV_USE_LOG=y
 CONFIG_LV_LOG_LEVEL_WARN=y
 CONFIG_LV_THEME_DEFAULT_DARK=y
 CONFIG_LV_DRAW_SW_CIRCLE_CACHE_SIZE=32
-# LVGL memory — 64KB base + 1024KB expand = 1088KB total capacity.
-# 2026-04-17: tuned from the historical 96KB down to 64KB to leave headroom for
-# FreeRTOS idle+timer static stacks in internal SRAM on fresh toolchain builds
-# (xPortcheckValidStackMem assert at 96KB, keyboard-init store fault at 32KB).
-# Expand uses system heap (PSRAM) on demand.
-CONFIG_LV_MEM_SIZE_KILOBYTES=96
+# LVGL memory.  Base pool is 64 KB statically in BSS; the real working
+# heap comes from a 2 MB PSRAM-backed lv_mem_add_pool() at boot in main.c
+# (see #183 + docs/STABILITY-INVESTIGATION.md).  History: 2026-04-17 had
+# 64 KB (xPortcheckValidStackMem assert at 96 KB on some builds), later
+# bumped to 96 in a prior cycle when the PSRAM pool wasn't yet in place;
+# now that main.c adds 2 MB from PSRAM at boot the 64 KB base is plenty
+# and restoring 64 KB here frees 32 KB of BSS for internal-SRAM pressure
+# relief (#182).  The POOL_EXPAND_SIZE number below is only a TLSF
+# per-pool max-size ceiling, not an auto-expand trigger — see CLAUDE.md.
+CONFIG_LV_MEM_SIZE_KILOBYTES=64
 CONFIG_LV_MEM_POOL_EXPAND_SIZE_KILOBYTES=4096
 # Disable LVGL assert on malloc failure — default while(1) hangs 60s then WDT kills device
 CONFIG_LV_USE_ASSERT_NULL=n


### PR DESCRIPTION
## Summary

- Drops `CONFIG_LV_MEM_SIZE_KILOBYTES` from 96 KB → 64 KB. Frees 32 KB of BSS-allocated internal SRAM.
- Since #183 the real LVGL working heap is a 2 MB PSRAM pool via `lv_mem_add_pool()` — the BSS base pool is oversized. Under stress it's only ~37-63 KB used; 64 KB is plenty.
- The freed SRAM directly relieves the ESP-Hosted SDIO RX peak-alloc pressure that's been driving the #182 SW-reset cascade.

## Validation — user-story stress orchestrator, not the metronome

Built a richer stress tool `/tmp/stress_user_stories.sh` that runs **11 realistic user-flow scenarios**: morning chat, web search storm (tool use in cloud mode), code explorer (rich-media JPEG saturation), mode tour through all 4 voice modes, memory drill (TinkerClaw), multi-turn marathons, UI thrash, screenshot bursts, concurrent chaos, settings drill, idle drift. Each scenario has its own pacing and waits for real LLM responses rather than firing on a metronome.

| Metric | Baseline (96 KB) | This PR (64 KB) |
|---|---|---|
| Run duration before stopping | 18 min (early stop on crash) | **23 min (all 11 scenarios ran)** |
| Scenarios completed | 8 of 11 | **11 of 11** |
| Total resets | 3 | **1** |
| Silent SW cascade resets | 1 | **0** |
| TASK_WDT resets | 1 | **0** |
| PANIC (clean coredump) resets | 1 | 1 (the only reset) |
| `internal_largest` idle baseline | ~54-62 KB | **~84 KB (+30 KB)** |
| `internal_largest` under stress | dips to 11 KB | **stable ~26 KB** (2× SDIO's 14 KB demand) |
| First crash at | ~7 min | **~13 min (~2× cadence)** |

## What's NOT in this PR

- **The combo LV_MEM=64 + reserve=160 KB.** Tested during this PR's development: it now boots (previously boot-looped without the BSS freed), but counter-intuitively fragments internal SRAM early (largest=15 KB at boot vs 84 KB with reserve=128). **Combo performs WORSE** than LV_MEM=64 alone. Reserve stays at 128 KB.
- **The slow drift.** Under extended stress `internal_largest` still creeps 26 → 17 KB over ~15 min. The remaining PANIC reset in this PR's validation run is #184's detector catching that drift. Worth a separate investigation; now that the detector produces a coredump with a named reason, that follow-up has real data to work with.

## References

- #183 — 2 MB PSRAM LVGL pool (merged) — this PR's prerequisite for safely dropping the BSS base
- #184 — heap_wd SRAM exhaustion detector (merged) — still catches the remaining slow drift
- #182 — tracking issue for the SW-reset class; this PR closes a major chunk but leaves the slow-drift root cause open
- Full Phase 1+2 investigation: `investigate/182-sram-leak` branch @ commit `1efd40b` (`docs/STABILITY-INVESTIGATION.md`)

## Test plan

- [x] Clean build
- [x] Boots (the comment in sdkconfig.defaults noted 64 was the pre-96 value that worked — verified still holds)
- [x] 23-min user-story stress: 11/11 scenarios ran, 1 reset (PANIC coredump), 0 silent SW cascades
- [x] `internal_largest` baseline at idle: 84 KB (was 54-62 KB)
- [x] `internal_largest` steady state under stress: ~26 KB (was dipping to 11 KB)

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)