### PR TITLE
fix(chat): clear CLICKABLE on msg bubbles so scroll gesture fires (refs #187)

### DIFF
--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -228,6 +228,10 @@ static void slot_ensure_breakout(msg_slot_t *slot, lv_obj_t *parent, uint32_t ac
     lv_obj_set_style_pad_hor(slot->breakout, SIDE_PAD, 0);
     lv_obj_set_style_pad_ver(slot->breakout, 20, 0);
     lv_obj_clear_flag(slot->breakout, LV_OBJ_FLAG_SCROLLABLE);
+    /* #187: breakouts must be NON-CLICKABLE so a press on one doesn't
+     * capture the touch stream; otherwise the swipe-to-scroll gesture
+     * on the parent scroll container never fires. */
+    lv_obj_clear_flag(slot->breakout, LV_OBJ_FLAG_CLICKABLE);
 
     slot->brk_accent = lv_obj_create(slot->breakout);
     lv_obj_remove_style_all(slot->brk_accent);
@@ -553,6 +557,11 @@ chat_msg_view_t *chat_msg_view_create(lv_obj_t *parent, int x, int y, int w, int
         lv_obj_remove_style_all(slot->bubble);
         lv_obj_set_size(slot->bubble, BUBBLE_MAX_W, LV_SIZE_CONTENT);
         lv_obj_clear_flag(slot->bubble, LV_OBJ_FLAG_SCROLLABLE);
+        /* #187: bubbles must be NON-CLICKABLE so a press on a message
+         * doesn't capture the touch stream and starve the parent
+         * scroll container of its drag gesture.  Without this,
+         * swipe-up/down on the chat area silently no-ops. */
+        lv_obj_clear_flag(slot->bubble, LV_OBJ_FLAG_CLICKABLE);
         lv_obj_add_flag(slot->bubble, LV_OBJ_FLAG_HIDDEN);
 
         slot->body = lv_label_create(slot->bubble);


### PR DESCRIPTION
## Summary

Chat message list didn't respond to swipe because every \`slot->bubble\` (and \`slot->breakout\`) was \`LV_OBJ_FLAG_CLICKABLE\` by default (LVGL's default for \`lv_obj_create\`).  Presses were consumed as click candidates on the bubble before the parent scroll container could dispatch a scroll-drag.  Net effect: swipe-up / swipe-down silently no-op'd.

Clearing \`LV_OBJ_FLAG_CLICKABLE\` on bubble + breakout restores the scroll gesture.  Verified on-device via injected \`/touch action=swipe\` — screenshots now change after a swipe (md5 differs); before the fix they were byte-identical.

Refs #187.  **Does not fully close** #187 — see below.

## Verified on-device

| State | Before swipe md5 | After swipe md5 |
|---|---|---|
| Pre-fix firmware | ea59c3fd… | ea59c3fd… (identical — no scroll) |
| Post-fix firmware | ea59c3fd… | 6c462297… (scrolled — different) |
| Second swipe     | 6c462297… | af1d7d15… (scrolled again) |

Also fixed the companion symptom where the last bubble visibly rendered below the input pill in a typical session: \`scroll_y\` was stuck at 0 so content at \`content_y > visible_h\` rendered below the scroll container's bounds.  With scroll now working, autopin-to-bottom (#117/#136/#137/#142) places the tail correctly inside the msg view.

## Explicitly NOT fixed in this PR

A second symptom still visible after this fix: when a single assistant bubble's height approaches or exceeds the msg-view's visible height (long reply), the bubble's bottom still bleeds past the scroll container's draw rect into the input-pill area.  That's a **clipping** issue (the scroll is scrolling correctly but the container isn't confining its children to its bounds).

Likely caused by \`lv_obj_remove_style_all(v->scroll)\` stripping the default clip-children-to-rect behavior, or by something in the theme chain resolving to \`LV_OBJ_FLAG_OVERFLOW_VISIBLE\` equivalent.

Kept out of this PR to keep the diff minimal (9 LOC) + bisectable — the scroll-gesture half is a big UX win on its own.  Follow-up will address the clip by either skipping \`remove_style_all\` + overriding specific properties, or by an explicit \`lv_obj_set_style_clip_corner\` + clip-corner flag.

## Test plan

- [x] Clean build
- [x] Flash to Tab5
- [x] Before-fix screenshots: swipe no-ops (md5 identical) — **confirmed**
- [x] Post-fix screenshots: swipe scrolls (md5 differs) — **confirmed**
- [x] Autopin-to-bottom on new message still works (latest turn visible at bottom of the scroll area, above the pill)
- [x] No regression on orb tap / pill tap / keyboard tap — each is on its own clickable object (ball, pill, kb_btn), not on the bubbles

## References

- Issue: #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)