### PR TITLE
fix(chat): scroll container sizing bug that bled bubbles past input pill (closes #187)

### DIFF
--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -517,15 +517,17 @@ static void ev_scroll(lv_event_t *e)
 {
     chat_msg_view_t *v = lv_event_get_user_data(e);
     if (!v || !v->scroll) return;
-    /* #142: decide whether the user is trying to read history or is
-     * pinned at the bottom.  `content_height - visible_h - scroll_y`
-     * is the distance from the current top-of-viewport to the last
-     * bubble; > AUTOPIN_PX means they've dragged up and we should
-     * stop auto-jumping to the tail on subsequent refreshes. */
-    int32_t scroll_y  = lv_obj_get_scroll_y(v->scroll);
-    int32_t content_h = lv_obj_get_content_height(v->scroll);
-    int32_t visible_h = lv_obj_get_height(v->scroll);
-    int32_t distance_from_bottom = content_h - visible_h - scroll_y;
+    /* #142 + #187: decide whether the user is reading history or pinned
+     * at the bottom.  `lv_obj_get_scroll_bottom` returns the *remaining
+     * scroll distance below the viewport* — 0 when pinned, >0 when the
+     * user has dragged up.  Previously we derived this from
+     * `get_content_height - visible_h - scroll_y`, but get_content_height
+     * is (outer - padding - border*2), not the scrollable extent — so
+     * after #187's fix dropped the manual set_content_height override it
+     * silently returned 918 and stranded user_scrolled_up at false,
+     * which made the refresh snap the view straight back to the tail on
+     * every swipe. */
+    int32_t distance_from_bottom = lv_obj_get_scroll_bottom(v->scroll);
     if (distance_from_bottom < 0) distance_from_bottom = 0;
     v->user_scrolled_up = (distance_from_bottom > AUTOPIN_PX);
     chat_msg_view_refresh(v);
@@ -607,7 +609,6 @@ void chat_msg_view_refresh(chat_msg_view_t *v)
     int total = chat_store_count();
     if (total == 0) {
         hide_all_slots(v);
-        lv_obj_set_content_height(v->scroll, 0);
         return;
     }
 
@@ -622,7 +623,18 @@ void chat_msg_view_refresh(chat_msg_view_t *v)
          * current bubble's ts has room to render. */
         running += estimate_height(m) + BUBBLE_TS_H + BUBBLE_GAP;
     }
-    lv_obj_set_content_height(v->scroll, running);
+    /* closes #187: DO NOT call lv_obj_set_content_height here.  In
+     * LVGL 9 that function is shorthand for
+     *   lv_obj_set_height(obj, h + pad_top + pad_bottom + 2*border_width)
+     * — i.e., it resizes the OUTER height of v->scroll, not a reported
+     * content size.  With pad=0/border=0 the scroll container grew to
+     * `running` pixels every refresh, which pushed child bubbles past
+     * the intended viewport (bleed past the input pill) and collapsed
+     * autopin math: `target_y = running - lv_obj_get_height(v->scroll)
+     * = running - running = 0`, so scroll_to_y never left the top.
+     * LVGL's scroll container auto-computes scrollable extent from the
+     * children we position via lv_obj_set_pos, so no manual set is
+     * needed — v->scroll stays at (w × h) set in chat_msg_view_create. */
 
     /* #142: only force-jump to bottom when the user is pinned there
      * (new session, or they've already scrolled all the way down).


### PR DESCRIPTION
## Summary
- Drop `lv_obj_set_content_height(v->scroll, …)` calls in `chat_msg_view_refresh` — that LVGL-9 API resizes the OUTER height of v->scroll, not a reported content size, so v->scroll grew to fit its content every refresh and bubbles spilled past the intended viewport.
- Switch `ev_scroll`'s autopin latch from hand-rolled math against `lv_obj_get_content_height` (which is `outer - padding - border*2`, i.e. just 918 after the fix) to `lv_obj_get_scroll_bottom`, which is the actual distance from the viewport to the scrollable content end.

## Closes
Closes #187 (the clip half — PR #188 shipped the gesture-capture half).

## Background
`lv_obj_set_content_height` was being called defensively to "tell LVGL the scroll extent", but in LVGL 9 it's shorthand for `lv_obj_set_height(obj, h + pad_top + pad_bottom + 2*border_width)`. With pad=0 and border=0 it literally resized v->scroll to `running` pixels tall every refresh, which both (a) pushed children past y=1036 under the input pill, and (b) made `target_y = running - lv_obj_get_height(v->scroll) = 0` — so autopin-to-bottom was a silent no-op and the view stayed stuck at scroll_y=0.

Followed the three-step instrumentation plan from [#187 (comment)](https://github.com/lorcan35/TinkerTab/issues/187#issuecomment-4313183191) before touching the fix:
1. **debug/187-scroll-border** — 2 px red border on v->scroll showed children rendering outside the container's intended bounds on an 8-turn conversation.
2. **debug/187-scroll-logs** — per-refresh log of `running` / `lv_obj_get_height` / `target_y` captured the smoking gun: visible_h tracks running exactly (318, 458, 598, 738, 878, 1018, 1158) with target_y pinned at 0.
3. **debug/187-parent-check** — grep-confirmed `lv_obj_set_parent` is never called in chat_msg_view.c, so bubbles are always children of v->scroll (ruled out the "overflow bubble got reparented" alternate hypothesis).

The failed clip_corner=true attempt from the issue comment is correctly avoided — that would have been a symptom patch on top of a still-mis-sized container.

## Test plan
- [x] Build + flash onto Tab5 at 192.168.1.90 via `idf.py -p /dev/ttyACM0 flash`
- [x] Navigate to chat, drive 8 turns via `POST /chat` — conversation overflows viewport
- [x] Autopin-to-bottom screenshot: T3 fragment clipped at top, T4–T8 + AI reply visible above the pill, no bleed past "Hold to speak" pill
- [x] Swipe-down via `POST /touch` (y1=300 → y2=950, 400 ms) in READY state: view scrolls to reveal T1–T7 at top, md5 differs (`c86fc902…` → `879828ae…`)
- [x] Swipe-up in READY state: view returns to tail cleanly, autopin-resume works
- [x] `/voice` state stays READY throughout; serial log shows no LVGL asserts, no PANIC, no SW reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)