### PR TITLE
fix(voice): ignore late llm tokens + handle cancel_ack (closes #193)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -735,6 +735,29 @@ static void handle_text_message(const char *data, int len)
         s_tts_done = true;
         if (s_play_sem) xSemaphoreGive(s_play_sem);
     } else if (strcmp(type_str, "llm") == 0) {
+        /* TinkerBox #91 follow-up (#193): ignore late llm tokens that
+         * arrive after a cancel.  Tab5 transitions to READY locally on
+         * cancel-send (see voice_cancel below); Dragon now actually
+         * interrupts the LLM stream within ~1 ms (was ~65 s pre-#91),
+         * but tokens already in TCP flight at cancel-time still arrive
+         * a few hundred ms later.  Without this guard, the unconditional
+         * voice_set_state below pulls the orb back into PROCESSING with
+         * the partial cancelled response text — the cancel APPEARS to
+         * not have worked from the user's perspective.
+         *
+         * Honor llm tokens only when the user is actively waiting for a
+         * turn (PROCESSING or SPEAKING).  All other states (READY after
+         * cancel, IDLE on disconnect, LISTENING when a new mic recording
+         * already started) mean the previous turn is no longer the user's
+         * focus and any late tokens belong to a turn they cancelled.
+         */
+        voice_state_t cur_for_llm = voice_get_state();
+        if (cur_for_llm != VOICE_STATE_PROCESSING && cur_for_llm != VOICE_STATE_SPEAKING) {
+            ESP_LOGD(TAG, "llm token ignored — state=%d (post-cancel late arrival)",
+                     cur_for_llm);
+            cJSON_Delete(root);
+            return;
+        }
         cJSON *text = cJSON_GetObjectItem(root, "text");
         if (cJSON_IsString(text) && text->valuestring) {
             if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
@@ -751,6 +774,16 @@ static void handle_text_message(const char *data, int len)
             ESP_LOGD(TAG, "LLM token: \"%s\"", text->valuestring);
             voice_set_state(VOICE_STATE_PROCESSING, s_llm_text);
         }
+    } else if (strcmp(type_str, "cancel_ack") == 0) {
+        /* TinkerBox #91: server-side confirmation that cancel landed.
+         * Today we just log it — the state machine already transitioned
+         * to READY when voice_cancel was called, and the llm-token
+         * guard above handles the late-arrival grace window.
+         * If we ever add a "definitely no more late tokens, safe to
+         * resume" semantic, this is where it would slot in. */
+        cJSON *cancelled = cJSON_GetObjectItem(root, "cancelled");
+        int n = cJSON_IsArray(cancelled) ? cJSON_GetArraySize(cancelled) : 0;
+        ESP_LOGI(TAG, "cancel_ack: cancelled=%d slot(s)", n);
     } else if (strcmp(type_str, "error") == 0) {
         cJSON *msg = cJSON_GetObjectItem(root, "message");
         const char *err_src = cJSON_IsString(msg) ? msg->valuestring : "unknown";


### PR DESCRIPTION
Closes #193.  Companion to TinkerBox#91 / [TinkerBox PR #92](https://github.com/lorcan35/TinkerBox/pull/92) (Phase 1 of the UX-gap remediation).

## What's broken today

After the matching TinkerBox PR lands, cancel actually interrupts in-flight LLM streams within ~1 ms (was ~65 s).  But \`llm\` tokens already in TCP flight at the moment cancel was processed will arrive at Tab5 a few hundred ms later — and the unconditional \`voice_set_state(VOICE_STATE_PROCESSING, s_llm_text)\` at \`voice.c:752\` pulls the orb back into PROCESSING with the partial cancelled-response text.  Cancel APPEARS not to have worked from the user's perspective.

## What's in here

| File | Change |
|---|---|
| \`main/voice.c\` | Top of \`llm\` event handler: early-return if state is not PROCESSING/SPEAKING.  Late tokens after a cancel are silently dropped with a debug log.  Also added a \`cancel_ack\` handler — TinkerBox now sends this with the list of slots cancelled; today we just log it. |

~33 LOC including comments.

## Real-device acceptance

\`\`\`
$ idf.py build      # 17.1 s incremental
$ idf.py -p /dev/ttyACM0 flash  # OK, hard reset
$ curl http://192.168.1.90:8080/info
{voice_connected: true, dragon_connected: true, heap_free: 19.5MB, lvgl_fps: 27}
\`\`\`

Built clean, flashed clean, boots clean, WS to Dragon comes back up, heap healthy, UI rendering normally.

## Honest test limit

The specific late-token race only manifests when paired with the matching TinkerBox PR.  Today Tab5's voice WS connects to live Dragon (port 3502) which doesn't have the Phase 1 fix yet.  True E2E demonstration of \"cancel + late tokens\" requires either:
  - The TinkerBox PR merged into prod, then user cancels a real text turn
  - OR Tab5 reconfigured to point at sandbox port 3513 (requires debug-server auth token)

The fix's correctness is verified by:
  - Build success (firmware compiled cleanly)
  - Boot verification (Tab5 alive 100+ s post-flash, WS connecting + reconnecting normally)
  - Logical reasoning (early-return for !PROCESSING && !SPEAKING is the standard guard pattern; cJSON ownership matches the existing line 666 early-return)

One caveat: during testing, Tab5 reset_reason flipped from USB → WDT → PANIC across the test session.  Tab5 has known stability issues per the existing LVGL stability investigation; could not reproduce or attribute to this firmware change.  Worth monitoring on the next live deploy of Phase 1.

## Future scope (not in this PR)

\`tts_start\`, \`tts_end\`, \`tool_call\`, \`tool_result\`, binary TTS chunks have the same unconditional-state-set pattern.  All have the same potential late-event race after a cancel.  Fix them in a Phase 2/3 follow-up once we have telemetry confirming the gap is real for those paths too.

## Test plan
- [x] Build succeeds (17 s incremental)
- [x] Flashes cleanly via /dev/ttyACM0
- [x] Boots cleanly, voice + dragon connected
- [x] WS reconnect cycles work (observed normal reconnect after a transient WiFi drop)
- [ ] E2E cancel+late-token race — pending TinkerBox PR #92 merge to prod (deferred)

## Refs
- Closes #193
- Refs lorcan35/TinkerBox#91 (audit master tracker)
- Refs lorcan35/TinkerBox#92 (matching Dragon-side fix)