### PR TITLE
feat(voice): handle dictation post-process events (Phase 2 H4)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -845,6 +845,34 @@ static void handle_text_message(const char *data, int len)
                 ui_chat_push_message(role, content);
             }
         }
+    } else if (strcmp(type_str, "dictation_postprocessing") == 0) {
+        /* TinkerBox#94 H4: Dragon spawned the title+summary LLM call after
+         * `stt`.  Pre-fix the user stared at the bare transcript for
+         * 10-20 s with no signal that more was coming.  Show a status
+         * caption so the wait feels intentional. */
+        ESP_LOGI(TAG, "Dictation post-process started");
+        voice_set_state(VOICE_STATE_PROCESSING, "Generating summary...");
+    } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
+        /* TinkerBox#94 H4: LLM failed or wasn't available.  Note already
+         * saved (the transcript landed via the prior `stt` event); user
+         * just doesn't get an auto-generated title/summary.  Clear the
+         * "Generating summary..." caption and toast the friendly
+         * message. */
+        cJSON *msg = cJSON_GetObjectItem(root, "message");
+        const char *m = cJSON_IsString(msg) ? msg->valuestring
+                                            : "Note saved — summary unavailable";
+        ESP_LOGW(TAG, "Dictation post-process error: %s", m);
+        char buf[160];
+        strncpy(buf, m, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        voice_async_toast(strdup(buf));
+        voice_set_state(VOICE_STATE_READY, "dictation_done");
+    } else if (strcmp(type_str, "dictation_postprocessing_cancelled") == 0) {
+        /* TinkerBox#94 H4: a NEW dictation superseded the prior in-flight
+         * post-process.  The new dictation will emit its own
+         * `dictation_postprocessing` event a few ms later — silently log
+         * here so we don't fight the new caption. */
+        ESP_LOGI(TAG, "Dictation post-process cancelled (superseded by new dictation)");
     } else if (strcmp(type_str, "dictation_summary") == 0) {
         cJSON *title = cJSON_GetObjectItem(root, "title");
         cJSON *summary = cJSON_GetObjectItem(root, "summary");


### PR DESCRIPTION
Companion to [TinkerBox PR #95](https://github.com/lorcan35/TinkerBox/pull/95) (TinkerBox#94 / Phase 2 H4 of the UX-gap remediation).

## Problem

Pre-fix, Tab5 sat for 10-20 s on the bare transcript caption between \`stt\` and \`dictation_summary\` because Dragon emitted no events while the LLM wrote the title + summary in the background.  Failure paths (no LLM, LLM crash) emitted nothing at all — UI stuck forever on "dictation_done".

## Fix

Three new event handlers in \`main/voice.c\`:

| Event | Tab5 behavior |
|---|---|
| \`dictation_postprocessing\` | Set state caption to "Generating summary..." so the wait feels intentional |
| \`dictation_postprocessing_error\` | Toast Dragon's friendly message ("Note saved — summary unavailable (LLM offline)" / "Note saved — summary generation failed"), drop state to READY/dictation_done.  Note already saved on Dragon; user just doesn't get the auto-generated title. |
| \`dictation_postprocessing_cancelled\` | Silent log; the superseding dictation's own \`dictation_postprocessing\` event will set the new caption a few ms later |

Both error/info paths route through the existing \`voice_async_toast()\` helper which uses \`lv_async_call\` to dispatch to the LVGL thread — matches the established pattern at voice.c:2640.

## Real-device acceptance

\`\`\`
$ idf.py build       # 16.1 s incremental
$ idf.py -p /dev/ttyACM0 flash  # clean
$ curl http://192.168.1.90:8080/info
{uptime: 35s, voice_connected: true, dragon_connected: true,
 reset_reason: USB, heap_free: 19.5 MB, lvgl_fps: tracking}
\`\`\`

Built clean, flashed clean, booted clean.  No PANIC.

## Honest test limit

The full E2E demo (dictate → see "Generating summary..." → summary lands OR error toast) requires both PRs merged AND Tab5 pointing at the Phase-2 Dragon.  Pre-merge proof: build+flash+boot succeeds + the Dragon-side unit tests confirm event emission shape.

refs lorcan35/TinkerBox#94