### PR TITLE
fix: voice caption bounded length + ellipsis on truncation (closes #200)

### DIFF
--- a/main/md_strip.c
+++ b/main/md_strip.c
@@ -59,3 +59,39 @@ void md_strip_inline(const char *in, char *out, size_t out_cap)
     }
     out[oi] = 0;
 }
+
+/* Audit C10 (TinkerBox #137 / TinkerTab #200): same as md_strip_inline
+ * but appends a UTF-8 ellipsis ("…", 3 bytes) when the source was
+ * truncated by `out_cap`.  Reserves 4 trailing bytes for the
+ * ellipsis + NUL on the truncation path.  Falls through to the
+ * vanilla strip when the source fits comfortably. */
+void md_strip_inline_with_ellipsis(const char *in, char *out, size_t out_cap)
+{
+    if (!out || out_cap == 0) return;
+    if (!in) { out[0] = 0; return; }
+
+    /* Reserve room for "…" (3 bytes) + NUL.  If out_cap is too small
+     * for the marker, fall back to the unmarked strip — better to
+     * lose the ellipsis than to refuse a render. */
+    if (out_cap < 8) {
+        md_strip_inline(in, out, out_cap);
+        return;
+    }
+    size_t reserved = 3;  /* UTF-8 ellipsis */
+    md_strip_inline(in, out, out_cap - reserved);
+    /* Detect truncation: source had more bytes than we wrote (and we
+     * filled to capacity).  md_strip_inline NUL-terminates at the
+     * stopping point regardless. */
+    size_t written = 0;
+    while (written < out_cap - reserved && out[written]) written++;
+    /* Use input length as a lower bound — markdown stripping shrinks
+     * the input, so source-len > written-cap implies truncation. */
+    size_t in_len = 0;
+    while (in[in_len]) in_len++;
+    if (in_len > written) {
+        out[written++] = (char)0xE2;
+        out[written++] = (char)0x80;
+        out[written++] = (char)0xA6;
+        out[written]   = 0;
+    }
+}

--- a/main/md_strip.h
+++ b/main/md_strip.h
@@ -16,3 +16,17 @@
  * (always NUL-terminated).  Safe for empty / NULL input.
  */
 void md_strip_inline(const char *in, char *out, size_t out_cap);
+
+/* Audit C10 (TinkerBox #137 / TinkerTab #200): voice-overlay caption
+ * formatter.  Same as md_strip_inline but appends a UTF-8 ellipsis
+ * "…" (3 bytes) when the source text was truncated by `out_cap`.
+ *
+ * The voice overlay caption is a small bubble in the LVGL voice
+ * overlay; rendering hundreds of characters there overflows the
+ * visual bubble + thrashes LVGL.  The full reply is always available
+ * in the chat screen below — the voice caption only needs enough
+ * to indicate progress.
+ *
+ * Always NUL-terminated.  Safe for empty / NULL input.
+ */
+void md_strip_inline_with_ellipsis(const char *in, char *out, size_t out_cap);

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -550,7 +550,7 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
         } else {
             const char *llm_txt2 = voice_get_llm_text();
             if (llm_txt2 && llm_txt2[0] && s_ai_label) {
-                { char _m[1024]; md_strip_inline(llm_txt2, _m, sizeof(_m));
+                { char _m[256]; md_strip_inline_with_ellipsis(llm_txt2, _m, sizeof(_m));
                   lv_label_set_text(s_ai_label, _m); }
                 if (s_ai_bubble) lv_obj_clear_flag(s_ai_bubble, LV_OBJ_FLAG_HIDDEN);
             }
@@ -566,7 +566,7 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
             lv_obj_scroll_to_y(s_chat_cont, LV_COORD_MAX, LV_ANIM_OFF);
             /* #115: drive the fixed-position response label. */
             if (llm_txt2 && llm_txt2[0] && s_response_label) {
-                { char _m[1024]; md_strip_inline(llm_txt2, _m, sizeof(_m));
+                { char _m[256]; md_strip_inline_with_ellipsis(llm_txt2, _m, sizeof(_m));
                   lv_label_set_text(s_response_label, _m); }
                 lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
                 lv_obj_move_foreground(s_response_label);
@@ -1295,7 +1295,7 @@ static void show_state_processing(const char *detail)
             lv_obj_add_flag(s_lbl_status, LV_OBJ_FLAG_HIDDEN);
         }
 
-        { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+        { char _m[256]; md_strip_inline_with_ellipsis(llm, _m, sizeof(_m));
           lv_label_set_text(s_ai_label, _m); }
         lv_obj_clear_flag(s_ai_bubble, LV_OBJ_FLAG_HIDDEN);
         /* closes #115: lift above orb z-order, same as SPEAKING. */
@@ -1306,7 +1306,7 @@ static void show_state_processing(const char *detail)
 
         /* #115: drive the fixed-position response label too. */
         if (s_response_label) {
-            { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+            { char _m[256]; md_strip_inline_with_ellipsis(llm, _m, sizeof(_m));
               lv_label_set_text(s_response_label, _m); }
             lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
             lv_obj_move_foreground(s_response_label);
@@ -1375,7 +1375,7 @@ static void show_state_speaking(void)
         lv_obj_clear_flag(s_user_bubble, LV_OBJ_FLAG_HIDDEN);
     }
     if (llm && llm[0]) {
-        { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+        { char _m[256]; md_strip_inline_with_ellipsis(llm, _m, sizeof(_m));
           lv_label_set_text(s_ai_label, _m); }
         lv_obj_set_width(s_ai_label, CHAT_BUBBLE_MAX_W - 2 * CHAT_BUBBLE_PAD);
         lv_label_set_long_mode(s_ai_label, LV_LABEL_LONG_WRAP);
@@ -1385,7 +1385,7 @@ static void show_state_speaking(void)
         /* #115: drive the fixed-position response label — this is the
          * reliable path when the flex chat_cont doesn't render. */
         if (s_response_label) {
-            { char _m[1024]; md_strip_inline(llm, _m, sizeof(_m));
+            { char _m[256]; md_strip_inline_with_ellipsis(llm, _m, sizeof(_m));
               lv_label_set_text(s_response_label, _m); }
             lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
             lv_obj_move_foreground(s_response_label);


### PR DESCRIPTION
## Summary

Voice overlay caption rendered up to ~1000 chars, overflowing the visual bubble + thrashing LVGL.  Added \`md_strip_inline_with_ellipsis\` and migrated 6 call sites in \`ui_voice.c\` to a 256-byte buffer.

## Test plan

- [x] Clean idf.py build on esp32p4
- [ ] Live smoke after merge: long LLM response → voice overlay caption shows ~250 chars + "…", chat screen shows full text