### PR TITLE
fix: chat-ring + widget-store eviction counters via /info (closes #202)

### DIFF
--- a/main/chat_msg_store.c
+++ b/main/chat_msg_store.c
@@ -19,6 +19,8 @@ static chat_session_t s_active   = { .valid = false };
 static chat_msg_t    *s_msgs     = NULL;   /* PSRAM-backed */
 static int            s_count    = 0;
 static int            s_write_idx = 0;
+/* Audit B2 (#202): ring-buffer eviction counter for /info exposure. */
+static uint32_t       s_evictions_total = 0;
 static bool           s_inited   = false;
 
 static void copy_str(char *dst, size_t dst_sz, const char *src)
@@ -111,14 +113,27 @@ int chat_store_add(const chat_msg_t *msg)
         s_write_idx = (s_write_idx + 1) % BSP_CHAT_MAX_MESSAGES;
         s_count++;
     } else {
-        /* Ring is full — overwrite oldest (which is at s_write_idx). */
+        /* Ring is full — overwrite oldest (which is at s_write_idx).
+         * Audit B2 (TinkerBox #137 / TinkerTab #202): pre-fix the
+         * eviction was completely silent — no log, no metric.  A
+         * skill emitting >BSP_CHAT_MAX_MESSAGES bubbles per turn
+         * (or any session that scrolled past the ring cap) silently
+         * lost the oldest messages with no operator visibility.
+         * Counter exposed via chat_store_evictions_total(). */
         real = s_write_idx;
         s_write_idx = (s_write_idx + 1) % BSP_CHAT_MAX_MESSAGES;
+        s_evictions_total++;
     }
     s_msgs[real] = *msg;
     s_msgs[real].active = true;
     if (s_msgs[real].height_px == 0) s_msgs[real].height_px = -1;
     return s_count - 1;
+}
+
+/* Audit B2 (#202): observability accessor for ring-buffer evictions. */
+uint32_t chat_store_evictions_total(void)
+{
+    return s_evictions_total;
 }
 
 int chat_store_count(void) { return s_count; }

--- a/main/chat_msg_store.h
+++ b/main/chat_msg_store.h
@@ -82,6 +82,12 @@ int chat_store_add(const chat_msg_t *msg);
 /** Current message count (0..BSP_CHAT_MAX_MESSAGES). */
 int chat_store_count(void);
 
+/** Audit B2 (TinkerBox #137 / TinkerTab #202): how many oldest-message
+ *  evictions have happened since boot.  Pre-fix the ring overwrote
+ *  silently; this counter lets the debug server / dashboard surface
+ *  whether a session ever scrolled past BSP_CHAT_MAX_MESSAGES. */
+uint32_t chat_store_evictions_total(void);
+
 /** Get message by logical index (0 = oldest, count-1 = newest). */
 const chat_msg_t *chat_store_get(int index);
 

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -28,6 +28,8 @@
 #include "ui_home.h"
 #include "ui_chat.h"
 #include "ui_keyboard.h"
+#include "widget.h"           /* Audit C4 (#202): widget_store_evictions_total */
+#include "chat_msg_store.h"   /* Audit B2 (#202): chat_store_evictions_total */
 #include "wifi.h"
 #include "battery.h"
 
@@ -353,6 +355,18 @@ static esp_err_t info_handler(httpd_req_t *req)
     cJSON_AddStringToObject(root, "reset_reason", reason < sizeof(reset_reasons)/sizeof(reset_reasons[0]) ? reset_reasons[reason] : "UNKNOWN");
 
     cJSON_AddBoolToObject(root, "auth_required", true);
+
+    /* Audit B2 + C4 (#202): expose ring/store eviction counters so the
+     * dashboard can spot a skill storm or chat-burst overflow without
+     * grep'ing serial logs.  Both are monotonic counters since boot. */
+    cJSON_AddNumberToObject(root, "chat_evictions_total",
+                            (double)chat_store_evictions_total());
+    cJSON_AddNumberToObject(root, "widget_evictions_total",
+                            (double)widget_store_evictions_total());
+    const char *last_evicted = widget_store_last_evicted_id();
+    if (last_evicted && last_evicted[0]) {
+        cJSON_AddStringToObject(root, "widget_last_evicted_id", last_evicted);
+    }
 
     char *json = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);

--- a/main/widget.h
+++ b/main/widget.h
@@ -172,3 +172,13 @@ widget_tone_t widget_tone_from_str(const char *s);
 
 /** Convert a type string like "live" to the enum. Returns NONE on unknown. */
 widget_type_t widget_type_from_str(const char *s);
+
+/* Audit C4 (TinkerBox #137 / TinkerTab #202): pre-fix the priority-
+ * weighted eviction at slot_for_new() was a silent ESP_LOGW —
+ * operators couldn't tell from /info whether a skill storm was
+ * thrashing the store.  These accessors expose total-evictions +
+ * the most recently evicted card_id so the debug server can surface
+ * the metric and the dashboard can chart it.
+ */
+uint32_t    widget_store_evictions_total(void);
+const char *widget_store_last_evicted_id(void);

--- a/main/widget_store.c
+++ b/main/widget_store.c
@@ -23,6 +23,9 @@ static const char *TAG = "widget_store";
 /* PSRAM-backed store. One static pointer; allocated once at init. */
 static widget_t *s_widgets = NULL;
 static int       s_capacity = 0;
+/* Audit C4 (#202): observability for priority-weighted eviction. */
+static uint32_t  s_evictions_total = 0;
+static char      s_last_evicted_id[WIDGET_ID_LEN] = {0};
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -78,11 +81,21 @@ static widget_t *slot_for_new(void)
     }
 
     if (best_inactive) return best_inactive;
+    /* Audit C4 (#202): record the eviction for /info exposure so a
+     * skill-storm causing churn can be diagnosed without grep'ing
+     * serial logs. */
+    s_evictions_total++;
+    if (best_active) {
+        size_t n = sizeof(s_last_evicted_id) - 1;
+        strncpy(s_last_evicted_id, best_active->card_id, n);
+        s_last_evicted_id[n] = '\0';
+    }
     ESP_LOGW(TAG,
-             "store full -- evicting id=%s (priority=%u, score=%lu)",
+             "store full -- evicting id=%s (priority=%u, score=%lu, total_evictions=%lu)",
              best_active ? best_active->card_id : "?",
              best_active ? best_active->priority : 0,
-             (unsigned long)best_active_score);
+             (unsigned long)best_active_score,
+             (unsigned long)s_evictions_total);
     return best_active;
 }
 
@@ -290,4 +303,15 @@ widget_type_t widget_type_from_str(const char *s)
     if (!strcmp(s, "media"))  return WIDGET_TYPE_MEDIA;
     if (!strcmp(s, "prompt")) return WIDGET_TYPE_PROMPT;
     return WIDGET_TYPE_NONE;
+}
+
+/* Audit C4 (#202): observability accessors. */
+uint32_t widget_store_evictions_total(void)
+{
+    return s_evictions_total;
+}
+
+const char *widget_store_last_evicted_id(void)
+{
+    return s_last_evicted_id;
 }


### PR DESCRIPTION
## Summary

Surface two silently-evicting buffers via \`/api/v1/info\`:
- \`chat_evictions_total\` (B2)
- \`widget_evictions_total\` + \`widget_last_evicted_id\` (C4)

Pre-fix the chat ring overwrote silently; the widget store logged per-event but had no running counter.  Operators / dashboard now have a single field to chart for "is this thrashing".

## Test plan

- [x] Clean idf.py build
- [ ] After OTA: \`curl http://192.168.1.90:8080/info\` → fields present, counters at 0
- [ ] Force a widget storm + verify counter ticks up