### PR TITLE
fix(ui): auto-rotate actually rotates display + persists (closes U2, refs #206)

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -417,6 +417,10 @@ void app_main(void)
         // (258) so every widget_media / chat image decode fell through
         // to the caption fallback path.  Audit B5 root cause (2026-04-20).
         ui_home_create();
+        /* Audit U2 (TinkerTab #206): if auto-rotate was persisted on,
+         * start the IMU poll timer + apply current orientation now so
+         * the user doesn't have to re-toggle after every reboot. */
+        ui_core_init_auto_rotation_from_nvs();
         /* Audit G (2026-04-20): first-boot onboarding carousel. Gated on
          * NVS onboard=0; once finished, subsequent boots skip. */
         extern void ui_onboarding_show_if_needed(void);

--- a/main/settings.c
+++ b/main/settings.c
@@ -421,6 +421,10 @@ esp_err_t tab5_settings_set_quiet_end(uint8_t h)
     return set_u8("quiet_end", h);
 }
 
+/* ── Auto-rotate (audit U2 / TinkerTab #206) ─────────────────────────── */
+uint8_t tab5_settings_get_auto_rotate(void) { return get_u8("auto_rot", 0); }
+esp_err_t tab5_settings_set_auto_rotate(uint8_t on) { return set_u8("auto_rot", on ? 1 : 0); }
+
 bool tab5_settings_quiet_active(int hour_local)
 {
     if (!tab5_settings_get_quiet_on()) return false;

--- a/main/settings.h
+++ b/main/settings.h
@@ -150,6 +150,14 @@ esp_err_t tab5_settings_set_quiet_end(uint8_t hour);
  *  Convenience — does the wrap-past-midnight math for you. */
 bool      tab5_settings_quiet_active(int hour_local);
 
+/* ── Auto-rotate (audit U2 / TinkerTab #206) ─────────────────────────── */
+
+/** Auto-rotate the display 180° when held upside-down (USB up).  IMU
+ *  polled at ~1 Hz from the LVGL thread; toggling persists to NVS so
+ *  the preference survives reboot.  0 = disabled (default), 1 = enabled. */
+uint8_t   tab5_settings_get_auto_rotate(void);
+esp_err_t tab5_settings_set_auto_rotate(uint8_t on);
+
 /* ── Auth token (debug server bearer auth) ───────────────────────────── */
 
 /** Read auth token from NVS. Returns ESP_OK if found and non-empty. */

--- a/main/ui_core.c
+++ b/main/ui_core.c
@@ -17,6 +17,8 @@
 #include "config.h"
 #include "touch.h"
 #include "debug_server.h"
+#include "imu.h"
+#include "settings.h"
 
 #include <string.h>
 #include "esp_log.h"
@@ -127,6 +129,19 @@ static void flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map)
 /* ========================================================================= */
 static uint32_t s_touch_debug_counter = 0;
 
+/* Audit U2 (#206): touch coords need to flip when display is rotated 180°.
+ * /touch debug injection is in display-space (the user thinks of the
+ * panel as rotated) so it does NOT flip. */
+static void touch_apply_rotation(int32_t *x, int32_t *y)
+{
+    if (!s_display) return;
+    lv_display_rotation_t rot = lv_display_get_rotation(s_display);
+    if (rot == LV_DISPLAY_ROTATION_180) {
+        *x = TAB5_DISPLAY_WIDTH  - 1 - *x;
+        *y = TAB5_DISPLAY_HEIGHT - 1 - *y;
+    }
+}
+
 static void touch_read_cb(lv_indev_t *indev, lv_indev_data_t *data)
 {
     (void)indev;
@@ -146,8 +161,11 @@ static void touch_read_cb(lv_indev_t *indev, lv_indev_data_t *data)
 
     bool touched = tab5_touch_read(points, &count);
     if (touched && count > 0) {
-        data->point.x = points[0].x;
-        data->point.y = points[0].y;
+        int32_t x = points[0].x;
+        int32_t y = points[0].y;
+        touch_apply_rotation(&x, &y);
+        data->point.x = x;
+        data->point.y = y;
         data->state = LV_INDEV_STATE_PRESSED;
         /* Log first 20 touches for debug */
         if (s_touch_debug_counter < 20) {
@@ -157,6 +175,66 @@ static void touch_read_cb(lv_indev_t *indev, lv_indev_data_t *data)
     } else {
         data->state = LV_INDEV_STATE_RELEASED;
     }
+}
+
+/* ========================================================================= */
+/*  Auto-rotate (audit U2 / #206)                                            */
+/* ========================================================================= */
+static lv_timer_t *s_autorot_timer = NULL;
+static lv_display_rotation_t s_last_applied_rot = LV_DISPLAY_ROTATION_0;
+
+static lv_display_rotation_t orient_to_rotation(tab5_orientation_t o)
+{
+    /* Tab5's UI is portrait-first; we only flip 180° for upside-down.
+     * Landscape orientations are reported by the IMU but we keep the
+     * UI in portrait — flipping to landscape here would break every
+     * absolute-positioned overlay (Settings, Voice, Mode sheet, ...). */
+    return (o == TAB5_ORIENT_PORTRAIT_INV)
+           ? LV_DISPLAY_ROTATION_180
+           : LV_DISPLAY_ROTATION_0;
+}
+
+static void autorot_timer_cb(lv_timer_t *t)
+{
+    (void)t;
+    if (!s_display) return;
+    if (!tab5_settings_get_auto_rotate()) return;
+    tab5_orientation_t o = tab5_imu_get_orientation();
+    lv_display_rotation_t want = orient_to_rotation(o);
+    if (want == s_last_applied_rot) return;
+    ESP_LOGI(TAG, "Auto-rotate: orientation=%d → applying rotation=%d",
+             (int)o, (int)want);
+    lv_display_set_rotation(s_display, want);
+    s_last_applied_rot = want;
+    lv_obj_invalidate(lv_screen_active());
+}
+
+void ui_core_apply_auto_rotation(bool enabled)
+{
+    if (enabled) {
+        if (!s_autorot_timer) {
+            /* 1 Hz poll — IMU read is cheap (~1 ms) and orientation
+             * doesn't change faster than that in normal use. */
+            s_autorot_timer = lv_timer_create(autorot_timer_cb, 1000, NULL);
+        }
+        /* Apply current orientation immediately so the user sees the
+         * effect of toggling the switch. */
+        autorot_timer_cb(NULL);
+    } else if (s_display) {
+        /* Switch off: snap back to portrait so the UI is always
+         * usable when re-entering Settings. */
+        lv_display_set_rotation(s_display, LV_DISPLAY_ROTATION_0);
+        s_last_applied_rot = LV_DISPLAY_ROTATION_0;
+        lv_obj_invalidate(lv_screen_active());
+    }
+}
+
+void ui_core_init_auto_rotation_from_nvs(void)
+{
+    /* Called once after the display is alive so the persisted toggle
+     * state takes effect at boot. */
+    bool on = tab5_settings_get_auto_rotate() != 0;
+    ui_core_apply_auto_rotation(on);
 }
 
 /* ========================================================================= */

--- a/main/ui_core.h
+++ b/main/ui_core.h
@@ -39,3 +39,20 @@ void tab5_ui_unlock(void);
 
 /** Get LVGL rendering FPS (flush callbacks per second). Updated every 1s. */
 uint32_t ui_core_get_fps(void);
+
+/* Audit U2 (TinkerTab #206): auto-rotate plumbing.
+ *
+ *   ui_core_apply_auto_rotation(true) — start the IMU poll timer (1 Hz) +
+ *      apply current orientation immediately.  Persisted toggle state
+ *      lives in NVS key "auto_rot" (settings.h).
+ *   ui_core_apply_auto_rotation(false) — snap back to portrait + leave
+ *      the timer running idle (cheap; checks NVS each tick).
+ *   ui_core_init_auto_rotation_from_nvs() — call once after the display
+ *      is alive so the persisted preference takes effect at boot.
+ *
+ * Touch coordinates are flipped automatically inside touch_read_cb when
+ * the display rotation is 180°; debug-server /touch injection is in
+ * display-space (post-rotation) and is NOT flipped.
+ */
+void ui_core_apply_auto_rotation(bool enabled);
+void ui_core_init_auto_rotation_from_nvs(void);

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -347,6 +347,14 @@ static void cb_autorotate(lv_event_t *e)
     lv_obj_t *sw = lv_event_get_target(e);
     bool on = lv_obj_has_state(sw, LV_STATE_CHECKED);
     ESP_LOGI(TAG, "Auto-rotate %s", on ? "enabled" : "disabled");
+
+    /* Audit U2 (#206): persist the toggle to NVS + immediately apply
+     * the current IMU-detected orientation.  ui_core's poll timer
+     * picks up the new setting and starts/stops applying rotation. */
+    tab5_settings_set_auto_rotate(on ? 1 : 0);
+    extern void ui_core_apply_auto_rotation(bool enabled);
+    ui_core_apply_auto_rotation(on);
+
     if (s_lbl_orient) {
         if (on) {
             tab5_orientation_t o = tab5_imu_get_orientation();
@@ -1295,7 +1303,11 @@ lv_obj_t *ui_settings_create(void)
     /* Auto-rotate */
     mk_row_label(s_scroll, "Auto-rotate", y);
     s_lbl_orient = mk_row_value(s_scroll, "Off", lv_color_hex(TEXT_DIM), y);
-    s_sw_autorot = mk_switch(s_scroll, acc_display, 660, y, false, cb_autorotate, NULL);
+    /* Audit U2 (#206): switch initial state mirrors NVS so the toggle
+     * survives reboot. */
+    s_sw_autorot = mk_switch(s_scroll, acc_display, 660, y,
+                             tab5_settings_get_auto_rotate() != 0,
+                             cb_autorotate, NULL);
     y += ROW_H + 16;
 
     /* ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes audit U2.  Toggle now:
- persists to new NVS key \`auto_rot\`
- starts a 1Hz IMU poll timer that calls \`lv_display_set_rotation\` for 180° flip
- flips touch coords in display-space so taps land where the user expects
- restores at boot from NVS

Landscape kept as portrait (would break absolute-positioned overlays).