### PR TITLE
fix(chat): audio_clip rows are tap-to-play (closes #213, refs #206)

### DIFF
--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -15,6 +15,7 @@
  */
 #include "chat_msg_view.h"
 #include "chat_msg_store.h"
+#include "ui_chat.h"                  /* U5: ui_chat_play_audio_clip */
 #include "ui_theme.h"
 #include "config.h"
 #include "bsp_config.h"
@@ -211,6 +212,9 @@ static void slot_reset(msg_slot_t *slot)
     if (slot->breakout)  lv_obj_add_flag(slot->breakout, LV_OBJ_FLAG_HIDDEN);
 }
 
+/* U5 (#206): forward decl — defined below with the AUDIO_CLIP wiring. */
+static void brk_body_clicked_cb(lv_event_t *e);
+
 static void slot_ensure_breakout(msg_slot_t *slot, lv_obj_t *parent, uint32_t accent)
 {
     if (!slot) return;
@@ -253,6 +257,14 @@ static void slot_ensure_breakout(msg_slot_t *slot, lv_obj_t *parent, uint32_t ac
     lv_obj_set_style_text_font(slot->brk_body, FONT_CHAT_MONO, 0);
     lv_obj_set_style_text_line_space(slot->brk_body, 4, 0);
     lv_label_set_text(slot->brk_body, "");
+
+    /* Audit U5 (#206): brk_body is the tap target for AUDIO_CLIP rows
+     * (the breakout itself stays non-clickable to preserve scroll —
+     * see #187).  Clickable flag is added on bind only when the slot
+     * holds an audio clip; the event_cb is registered once here and
+     * dispatches by reading the slot's currently-bound message. */
+    lv_obj_add_event_cb(slot->brk_body, brk_body_clicked_cb,
+                        LV_EVENT_CLICKED, slot);
 }
 
 /* ── Bind slot to a message ────────────────────────────────────── */
@@ -289,6 +301,11 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
             lv_obj_set_style_bg_color(slot->brk_accent, lv_color_hex(v->mode_color), 0);
         if (slot->brk_kicker)
             lv_obj_set_style_text_color(slot->brk_kicker, lv_color_hex(v->mode_color), 0);
+        /* U5 (#206): clear clickable-on-rebind so a slot recycled from
+         * AUDIO_CLIP -> IMAGE/CARD doesn't keep its tap target.  The
+         * AUDIO_CLIP branch below re-adds the flag. */
+        if (slot->brk_body)
+            lv_obj_clear_flag(slot->brk_body, LV_OBJ_FLAG_CLICKABLE);
 
         char kicker[64];
         switch (msg->type) {
@@ -380,6 +397,10 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
             lv_label_set_text(slot->brk_body, body);
             lv_obj_set_pos(slot->brk_body, SIDE_PAD, 40);
             lv_obj_set_size(slot->breakout, 720, 96);
+            /* U5 (#206): make this row tappable. brk_body_clicked_cb
+             * dispatches by reading the slot's currently-bound message
+             * (data_idx -> chat_store_get -> media_url). */
+            lv_obj_add_flag(slot->brk_body, LV_OBJ_FLAG_CLICKABLE);
         }
 
         /* Measure + cache. */
@@ -792,4 +813,21 @@ bool chat_msg_view_is_streaming(chat_msg_view_t *v)
 lv_obj_t *chat_msg_view_get_scroll(chat_msg_view_t *v)
 {
     return v ? v->scroll : NULL;
+}
+
+/* U5 (#206): brk_body tap dispatcher.  Reads the slot's currently-bound
+ * message from the store and, if it's an audio clip with a URL, hands
+ * it off to ui_chat_play_audio_clip (which downloads + opens the audio
+ * player overlay on the UI thread).  No-ops for IMAGE / CARD even
+ * though they share the same label widget — those rows aren't marked
+ * clickable so the cb doesn't fire there in practice; the type check
+ * is belt-and-braces for slot recycle races. */
+static void brk_body_clicked_cb(lv_event_t *e)
+{
+    msg_slot_t *slot = (msg_slot_t *)lv_event_get_user_data(e);
+    if (!slot || slot->data_idx < 0) return;
+    const chat_msg_t *msg = chat_store_get(slot->data_idx);
+    if (!msg || msg->type != MSG_AUDIO_CLIP) return;
+    if (!msg->media_url[0]) return;
+    ui_chat_play_audio_clip(msg->media_url);
 }

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2601,6 +2601,59 @@ static esp_err_t chat_messages_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
+/* ── POST /chat/audio_clip?url=<>&label=<> ─────────────────────────
+ * U5 (#206) verification helper: pushes an audio_clip into the chat
+ * store so the tap-to-play path can be exercised without a live Dragon
+ * audio_clip producer.  url= is required and is passed verbatim to
+ * ui_chat_push_audio_clip (relative paths are resolved against the
+ * configured Dragon host on tap).  Note: the chat overlay must be open
+ * for the row to render — POST /navigate?screen=chat first. */
+static void url_pct_decode_inplace(char *s)
+{
+    char *r = s, *w = s;
+    while (*r) {
+        if (*r == '%' && r[1] && r[2]) {
+            char hi = r[1], lo = r[2];
+            int hv = (hi >= '0' && hi <= '9') ? hi - '0'
+                   : (hi >= 'a' && hi <= 'f') ? hi - 'a' + 10
+                   : (hi >= 'A' && hi <= 'F') ? hi - 'A' + 10 : -1;
+            int lv = (lo >= '0' && lo <= '9') ? lo - '0'
+                   : (lo >= 'a' && lo <= 'f') ? lo - 'a' + 10
+                   : (lo >= 'A' && lo <= 'F') ? lo - 'A' + 10 : -1;
+            if (hv >= 0 && lv >= 0) {
+                *w++ = (char)((hv << 4) | lv);
+                r += 3;
+                continue;
+            }
+        }
+        if (*r == '+') { *w++ = ' '; r++; continue; }
+        *w++ = *r++;
+    }
+    *w = 0;
+}
+
+static esp_err_t chat_audio_clip_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[512] = {0}, url[256] = {0}, label[96] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "url",   url,   sizeof(url));
+    httpd_query_key_value(q, "label", label, sizeof(label));
+    url_pct_decode_inplace(url);
+    url_pct_decode_inplace(label);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!url[0]) {
+        cJSON_AddStringToObject(root, "error", "need ?url=<dragon-relative or absolute>");
+        return send_json_resp(req, root);
+    }
+    ui_chat_push_audio_clip(url, 0.0f, label[0] ? label : "test clip");
+    cJSON_AddBoolToObject(root, "ok", true);
+    cJSON_AddStringToObject(root, "url", url);
+    cJSON_AddStringToObject(root, "label", label[0] ? label : "test clip");
+    return send_json_resp(req, root);
+}
+
 /* ── GET /net/ping?host=<>&port=<> ──────────────────────────────── */
 /* Re-implements the non-blocking probe locally so we don't leak
  * voice.c internals.  Matches the fix from #146. */
@@ -2866,6 +2919,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_heap_history   = { .uri = "/heap/history",   .method = HTTP_GET,  .handler = heap_history_handler };
     const httpd_uri_t uri_heap_probe     = { .uri = "/heap/probe-csv", .method = HTTP_GET,  .handler = tab5_pool_probe_http_handler };
     const httpd_uri_t uri_chat_msgs      = { .uri = "/chat/messages",  .method = HTTP_GET,  .handler = chat_messages_handler };
+    const httpd_uri_t uri_chat_audio     = { .uri = "/chat/audio_clip",.method = HTTP_POST, .handler = chat_audio_clip_handler };
     const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
     const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
 
@@ -2913,6 +2967,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_heap_history);
     httpd_register_uri_handler(server, &uri_heap_probe);
     httpd_register_uri_handler(server, &uri_chat_msgs);
+    httpd_register_uri_handler(server, &uri_chat_audio);
     httpd_register_uri_handler(server, &uri_net_ping);
     httpd_register_uri_handler(server, &uri_nvs_erase);
 

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -20,22 +20,28 @@
 #include "chat_suggestions.h"
 #include "chat_session_drawer.h"
 
+#include "ui_audio.h"
 #include "ui_theme.h"
 #include "ui_keyboard.h"
 #include "config.h"
 #include "settings.h"
+#include "task_worker.h"
 #include "voice.h"
 #include "tab5_rtc.h"
 
+#include "esp_http_client.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "lvgl.h"
 
+#include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <strings.h>
 
 extern lv_obj_t *ui_home_get_screen(void);
 extern void      ui_home_show_toast(const char *text);
@@ -840,6 +846,145 @@ void ui_chat_push_audio_clip(const char *url, float duration_s, const char *labe
     safe_copy(a->label, sizeof(a->label), label);
     a->dur = duration_s;
     lv_async_call(async_push_audio_cb, a);
+}
+
+/* Audit U5 (#206): tap-to-play for inline audio_clip rows.
+ *
+ * Flow:
+ *   tap on chat row → ui_chat_play_audio_clip(url) (LVGL/voice thread)
+ *      → tab5_worker_enqueue(audio_clip_dl_job)
+ *         → HTTP GET into /sdcard/.audio_clip.wav (chunked, max 4 MB)
+ *         → lv_async_call(async_open_audio_player_cb, path)
+ *            → ui_audio_create("/sdcard/.audio_clip.wav") on UI thread.
+ *
+ * Cap chosen to bound SD-card writes — typical TTS clips are 30-300 KB.
+ * If the URL is relative ("/api/media/..."), the configured Dragon
+ * host:port is prepended (mirrors media_cache_fetch). */
+#define AUDIO_CLIP_MAX_BYTES   (4 * 1024 * 1024)
+/* Tab5's FATFS is built with CONFIG_FATFS_LFN_NONE — only 8.3 names are
+ * accepted (longer basenames trip EINVAL inside f_open).  "ACLIP.WAV"
+ * is 5+3 chars which is well within limits. */
+#define AUDIO_CLIP_TMP_PATH    "/sdcard/ACLIP.WAV"
+
+static void async_open_audio_player_cb(void *arg)
+{
+    char *path = (char *)arg;
+    if (!path) return;
+    /* ui_audio_create takes the WAV path and overlays the player on the
+     * current screen.  It internally calls ui_audio_destroy() if a
+     * previous player is open, so back-to-back taps Just Work. */
+    ui_audio_create(path);
+    free(path);
+}
+
+typedef struct {
+    char url[384];
+} audio_clip_job_t;
+
+static void audio_clip_dl_job(void *arg)
+{
+    audio_clip_job_t *j = (audio_clip_job_t *)arg;
+    if (!j) return;
+
+    /* Resolve relative URLs against the configured Dragon host. */
+    char full_url[512];
+    if (strncasecmp(j->url, "http://", 7) == 0 ||
+        strncasecmp(j->url, "https://", 8) == 0) {
+        snprintf(full_url, sizeof(full_url), "%s", j->url);
+    } else {
+        char host[64];
+        tab5_settings_get_dragon_host(host, sizeof(host));
+        uint16_t port = tab5_settings_get_dragon_port();
+        snprintf(full_url, sizeof(full_url), "http://%s:%u%s",
+                 host, port, j->url[0] == '/' ? j->url : "/");
+        if (j->url[0] != '/') {
+            /* unusual — fall back to verbatim */
+            snprintf(full_url, sizeof(full_url), "%s", j->url);
+        }
+    }
+    free(j);
+    j = NULL;
+
+    ESP_LOGI(TAG, "audio_clip: GET %s", full_url);
+
+    esp_http_client_config_t cfg = {
+        .url        = full_url,
+        .method     = HTTP_METHOD_GET,
+        .timeout_ms = 10000,
+        .buffer_size = 2048,
+    };
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) {
+        ESP_LOGW(TAG, "audio_clip: http_client_init OOM");
+        return;
+    }
+
+    bool ok = false;
+    FILE *fp = NULL;
+    do {
+        if (esp_http_client_open(client, 0) != ESP_OK) {
+            ESP_LOGW(TAG, "audio_clip: http_client_open failed");
+            break;
+        }
+        int cl = (int)esp_http_client_fetch_headers(client);
+        if (cl > AUDIO_CLIP_MAX_BYTES) {
+            ESP_LOGW(TAG, "audio_clip: too large (%d bytes)", cl);
+            break;
+        }
+        fp = fopen(AUDIO_CLIP_TMP_PATH, "wb");
+        if (!fp) {
+            ESP_LOGW(TAG, "audio_clip: fopen %s failed errno=%d (%s)",
+                     AUDIO_CLIP_TMP_PATH, errno, strerror(errno));
+            break;
+        }
+        char chunk[2048];
+        int total = 0;
+        while (total < AUDIO_CLIP_MAX_BYTES) {
+            int r = esp_http_client_read(client, chunk, sizeof(chunk));
+            if (r <= 0) break;
+            if (fwrite(chunk, 1, (size_t)r, fp) != (size_t)r) {
+                ESP_LOGW(TAG, "audio_clip: short fwrite");
+                break;
+            }
+            total += r;
+            /* Yield so voice WS / LVGL keep ticking on long downloads. */
+            vTaskDelay(pdMS_TO_TICKS(2));
+        }
+        int status = esp_http_client_get_status_code(client);
+        if (status == 200 && total > 64) {
+            ESP_LOGI(TAG, "audio_clip: saved %d bytes to %s",
+                     total, AUDIO_CLIP_TMP_PATH);
+            ok = true;
+        } else {
+            ESP_LOGW(TAG, "audio_clip: status=%d total=%d", status, total);
+        }
+    } while (0);
+
+    if (fp) fclose(fp);
+    esp_http_client_close(client);
+    esp_http_client_cleanup(client);
+
+    if (ok) {
+        char *path = strdup(AUDIO_CLIP_TMP_PATH);
+        if (path) lv_async_call(async_open_audio_player_cb, path);
+    } else {
+        /* Soft-fail: a single toast is friendlier than silently doing
+         * nothing.  ui_home_show_toast is the global toast surface. */
+        extern void ui_home_show_toast(const char *text);
+        ui_home_show_toast("Couldn't fetch audio");
+    }
+}
+
+void ui_chat_play_audio_clip(const char *url)
+{
+    if (!url || !url[0]) return;
+    audio_clip_job_t *j = calloc(1, sizeof(*j));
+    if (!j) return;
+    snprintf(j->url, sizeof(j->url), "%s", url);
+    if (tab5_worker_enqueue(audio_clip_dl_job, j, "audio_clip_dl") != ESP_OK) {
+        ESP_LOGW(TAG, "audio_clip: worker queue full, dropping");
+        free(j);
+    }
 }
 
 static void async_update_last_cb(void *arg)

--- a/main/ui_chat.h
+++ b/main/ui_chat.h
@@ -27,6 +27,16 @@ void ui_chat_push_card(const char *title, const char *subtitle,
 void ui_chat_push_audio_clip(const char *url, float duration_s, const char *label);
 
 /**
+ * Audit U5 (#206): tap-to-play handler for inline audio_clip rows.
+ * Downloads the URL (Dragon-relative or absolute) to a tmp WAV on the
+ * SD card and hands the path to ui_audio_create() so the user gets the
+ * standard audio-player overlay (play/pause/stop, volume).  Safe from
+ * any task — internally enqueues to the shared task_worker so the
+ * download doesn't block voice WS or LVGL.
+ */
+void ui_chat_play_audio_clip(const char *url);
+
+/**
  * Thread-safe: push a system/status bubble (e.g. "Searching the web…",
  * "Memory saved"). Renders centered + dim per chat_msg_view MSG_SYSTEM
  * treatment. Safe from any task; uses lv_async_call internally.


### PR DESCRIPTION
## Summary
- Wires inline audio_clip chat rows so a tap fetches the URL and opens the audio-player overlay, instead of being render-only.
- New \`ui_chat_play_audio_clip(url)\` worker-queued path (resolve→GET→/sdcard/ACLIP.WAV→ui_audio_create).
- chat_msg_view: tap dispatcher reads the slot's bound message and only acts on MSG_AUDIO_CLIP. Slot-recycle clears CLICKABLE on non-AUDIO rebinds. Breakout band stays non-clickable (#187).
- Closes audit U5 from \`docs/UI-COMPLETENESS.md\`.

## Test plan
- [x] Flashed via USB, served test 32 KB WAV from Dragon nginx
- [x] Injected via \`POST /chat/audio_clip?url=...\`, row renders
- [x] Tapped row → serial confirms GET → save → \`Audio player overlay created\`
- [x] Screenshot confirms player overlay (play button, volume slider, filename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)