### PR TITLE
fix(sessions): wire to nav sheet + live REST fetch (closes #217, refs #206)

### DIFF
--- a/main/ui_nav_sheet.c
+++ b/main/ui_nav_sheet.c
@@ -18,6 +18,7 @@
 #include "ui_memory.h"
 #include "ui_focus.h"
 #include "ui_agents.h"
+#include "ui_sessions.h"
 #include "config.h"
 #include "esp_log.h"
 #include <string.h>
@@ -56,7 +57,13 @@ static void go_notes(void)    { extern lv_obj_t *ui_notes_create(void); ui_notes
 static void go_settings(void) { extern lv_obj_t *ui_settings_create(void); ui_settings_create(); }
 static void go_camera(void)   { extern lv_obj_t *ui_camera_create(void); ui_camera_create(); }
 static void go_files(void)    { extern lv_obj_t *ui_files_create(void);  ui_files_create();  }
-static void go_memory(void)   { extern void ui_memory_show(void);        ui_memory_show();   }
+static void go_memory(void)   { ui_memory_show();   }
+/* U1 (#206): Sessions / Agents / Focus were reachable only via the
+ * /navigate debug endpoint — no on-device entry point.  Wire them into
+ * the nav sheet's tile grid so users can actually open them. */
+static void go_sessions(void) { ui_sessions_show(); }
+static void go_agents(void)   { ui_agents_show();   }
+static void go_focus(void)    { ui_focus_show();    }
 
 static const nav_tile_t s_tiles[] = {
     { "Chat",     "Threads \xE2\x80\xA2 history",  go_chat     },
@@ -65,6 +72,9 @@ static const nav_tile_t s_tiles[] = {
     { "Camera",   "Viewfinder",                    go_camera   },
     { "Files",    "SD card",                       go_files    },
     { "Memory",   "Facts \xE2\x80\xA2 recall",      go_memory   },
+    { "Sessions", "Past conversations",            go_sessions },
+    { "Agents",   "TinkerClaw status",             go_agents   },
+    { "Focus",    "Pomodoro \xE2\x80\xA2 timers",   go_focus    },
 };
 #define NAV_TILE_COUNT (sizeof(s_tiles) / sizeof(s_tiles[0]))
 
@@ -173,13 +183,15 @@ static void build_sheet(void)
     lv_obj_set_style_text_color(xl, lv_color_hex(SHEET_TEXT2), 0);
     lv_obj_center(xl);
 
-    /* 2x3 grid of tiles.  Tile = 304 x 184, gap = 16.
-     * Grid starts at x=40, y=168. */
-    const int TW = 304, TH = 184, GAP = 16;
-    const int GRID_X = 40, GRID_Y = 170;
+    /* U1 (#206): 3x3 grid (was 2x3).  Tile = 218 x 184, gap = 16,
+     * starts at x=24, y=170 — fits 720 wide and 820 tall sheet:
+     *   3 cols * 218 + 2 * 16 = 686 + 24 px side margins.
+     *   3 rows * 184 + 2 * 16 + 170 = 754 < 820. */
+    const int TW = 218, TH = 184, GAP = 16;
+    const int GRID_X = 24, GRID_Y = 170;
     for (int i = 0; i < (int)NAV_TILE_COUNT; i++) {
-        int col = i % 2;
-        int row = i / 2;
+        int col = i % 3;
+        int row = i / 3;
         lv_obj_t *tile = lv_obj_create(s_sheet);
         lv_obj_remove_style_all(tile);
         lv_obj_set_size(tile, TW, TH);

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -11,8 +11,17 @@
 #include "ui_home.h"
 #include "ui_core.h"
 #include "config.h"
+#include "settings.h"
+#include "task_worker.h"
 #include "esp_log.h"
+#include "esp_http_client.h"
+#include "cJSON.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 static const char *TAG = "ui_sessions";
 
@@ -22,41 +31,48 @@ static const char *TAG = "ui_sessions";
 
 static lv_obj_t *s_overlay  = NULL;
 static lv_obj_t *s_back_btn = NULL;
+static lv_obj_t *s_count_lbl = NULL;
+static lv_obj_t *s_rows_root = NULL;   /* container for fetched rows */
+static lv_obj_t *s_status    = NULL;   /* "Loading..." / "Dragon unreachable" */
 static bool      s_visible  = false;
+static volatile bool s_fetch_inflight = false;
 
+/* U1 (#206): runtime row, populated from Dragon /api/v1/sessions.
+ * The static-string fields in the legacy `session_row_t` are now owned
+ * char[]s so the parser can write into them. */
+#define MAX_ROWS 12
 typedef struct {
-    const char *time_top;    /* "10:15" or "YEST" */
-    const char *time_bot;    /* optional second line e.g. "19:04" */
-    const char *subject;     /* amber, the user's question */
-    const char *preview;     /* dim, last AI reply */
-    int         msg_count;
-    const char *mode_tag;    /* "CLAW" / "SONNET" / "LOCAL" / "HYBRID" */
-    uint32_t    mode_color;  /* TH_MODE_* */
+    char        time_top[12];   /* "10:15" or "YEST" */
+    char        time_bot[12];   /* optional second line "19:04" */
+    char        subject[80];    /* title (truncated) */
+    char        preview[128];   /* model name when no preview is sent */
+    int         msg_count;      /* -1 if unknown — Dragon doesn't ship it */
+    char        mode_tag[10];   /* "CLAW" / "CLOUD" / "LOCAL" / "HYBRID" */
+    uint32_t    mode_color;     /* TH_MODE_* */
 } session_row_t;
 
-static const session_row_t s_sessions[] = {
-    { "10:15", NULL,
-      "AirPods vs XM5",
-      "Both excellent, but the XM5 wins for calls -- its dual-beamforming mic reads vocals about 3dB cleaner in wind.",
-      8, "SONNET", TH_MODE_CLOUD },
-    { "YEST", "19:04",
-      "Debug LVGL crash",
-      "Circle cache overflow -- try CACHE_SIZE=32 in sdkconfig.defaults and a full rebuild.",
-      14, "CLAW", TH_MODE_CLAW },
-    { "YEST", "11:20",
-      "Lunch ideas (no rice)",
-      "How about a protein bowl with roasted chickpeas, tahini, pickled onions, and a soft egg on top?",
-      3, "LOCAL", TH_MODE_LOCAL },
-    { "APR 14", "16:02",
-      "Meeting prep -- OKR review",
-      "Here's what I'd bring up: Q2 carry-overs, the hiring freeze, and a proposal to split the ingest workstream.",
-      22, "CLAW", TH_MODE_CLAW },
-    { "APR 14", "08:11",
-      "Morning digest",
-      "3 items: Ollama 0.6, LocalAI hot-swap, and a WWDC rumor worth a second glance.",
-      4, "HYBRID", TH_MODE_HYBRID },
-};
-#define N_SESSIONS (int)(sizeof(s_sessions)/sizeof(s_sessions[0]))
+typedef struct {
+    session_row_t items[MAX_ROWS];
+    int           count;
+    bool          ok;
+} sessions_fetch_t;
+/* PSRAM-backed — putting a 3 KB struct in BSS tipped the internal-SRAM
+ * budget past the FreeRTOS timer-task stack alloc and we boot-looped
+ * with `vApplicationGetTimerTaskMemory: pxStackBufferTemp != NULL`.
+ * Lazy-allocate on first use via heap_caps_malloc(MALLOC_CAP_SPIRAM). */
+static sessions_fetch_t *s_fetch = NULL;
+
+static bool ensure_fetch_buf(void)
+{
+    if (s_fetch) return true;
+    s_fetch = heap_caps_calloc(1, sizeof(*s_fetch),
+                               MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!s_fetch) {
+        ESP_LOGW(TAG, "PSRAM alloc for sessions buffer failed");
+        return false;
+    }
+    return true;
+}
 
 static void back_click_cb(lv_event_t *e)
 {
@@ -70,6 +86,64 @@ static void overlay_gesture_cb(lv_event_t *e)
     lv_dir_t dir = lv_indev_get_gesture_dir(lv_indev_active());
     if (dir == LV_DIR_RIGHT || dir == LV_DIR_BOTTOM) {
         ui_sessions_hide();
+    }
+}
+
+/* U1 (#206): voice_mode → tag/color mapping (matches chat header tints). */
+static void mode_to_tag(uint8_t vm, char *out, size_t n, uint32_t *color_out)
+{
+    const char *tag;
+    uint32_t    col;
+    switch (vm) {
+        case 0: tag = "LOCAL";  col = TH_MODE_LOCAL;  break;
+        case 1: tag = "HYBRID"; col = TH_MODE_HYBRID; break;
+        case 2: tag = "CLOUD";  col = TH_MODE_CLOUD;  break;
+        case 3: tag = "CLAW";   col = TH_MODE_CLAW;   break;
+        default: tag = "?";     col = 0x5C5C68;       break;
+    }
+    snprintf(out, n, "%s", tag);
+    if (color_out) *color_out = col;
+}
+
+/* U1 (#206): unix-epoch updated_at → time_top + optional time_bot.
+ * Today  → "HH:MM"
+ * Yest.  → "YEST" + "HH:MM"
+ * Older  → "MMM DD" + "HH:MM" */
+static void format_when(uint32_t updated_at,
+                        char *t_top, size_t n_top,
+                        char *t_bot, size_t n_bot)
+{
+    t_top[0] = 0; t_bot[0] = 0;
+    if (updated_at == 0) {
+        snprintf(t_top, n_top, "--:--");
+        return;
+    }
+    time_t now = time(NULL);
+    time_t ts  = (time_t)updated_at;
+    struct tm now_tm, ts_tm;
+    localtime_r(&now, &now_tm);
+    localtime_r(&ts,  &ts_tm);
+
+    char hhmm[8];
+    strftime(hhmm, sizeof(hhmm), "%H:%M", &ts_tm);
+
+    bool same_day = (now_tm.tm_year == ts_tm.tm_year &&
+                     now_tm.tm_yday == ts_tm.tm_yday);
+    bool yest = (now - ts < 48 * 3600 && !same_day);
+
+    if (same_day) {
+        snprintf(t_top, n_top, "%s", hhmm);
+    } else if (yest) {
+        snprintf(t_top, n_top, "YEST");
+        snprintf(t_bot, n_bot, "%s", hhmm);
+    } else {
+        char md[12];
+        strftime(md, sizeof(md), "%b %d", &ts_tm);
+        for (char *p = md; *p; p++) {
+            if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
+        }
+        snprintf(t_top, n_top, "%s", md);
+        snprintf(t_bot, n_bot, "%s", hhmm);
     }
 }
 
@@ -96,7 +170,7 @@ static int build_session_row(lv_obj_t *parent, int y, const session_row_t *r)
     lv_obj_set_style_text_letter_space(tt, 2, 0);
     lv_obj_set_pos(tt, 0, 0);
 
-    if (r->time_bot) {
+    if (r->time_bot[0]) {
         lv_obj_t *tb = lv_label_create(c);
         lv_label_set_text(tb, r->time_bot);
         lv_obj_set_style_text_font(tb, FONT_CAPTION, 0);
@@ -124,25 +198,187 @@ static int build_session_row(lv_obj_t *parent, int y, const session_row_t *r)
     lv_obj_set_style_text_line_space(pv, 3, 0);
     lv_obj_set_pos(pv, 120, 28);
 
-    /* Right meta: msg count + mode tag */
-    char msgbuf[16];
-    snprintf(msgbuf, sizeof(msgbuf), "%d MSG", r->msg_count);
-    lv_obj_t *mc = lv_label_create(c);
-    lv_label_set_text(mc, msgbuf);
-    lv_obj_set_style_text_font(mc, FONT_CAPTION, 0);
-    lv_obj_set_style_text_color(mc, lv_color_hex(0x5C5C68), 0);
-    lv_obj_set_style_text_letter_space(mc, 2, 0);
-    lv_obj_align(mc, LV_ALIGN_TOP_RIGHT, 0, 0);
+    /* Right meta: msg count + mode tag.  msg_count == -1 means
+     * "Dragon's /api/v1/sessions doesn't ship message counts" — we
+     * just hide the count line in that case so the row reads cleanly. */
+    if (r->msg_count >= 0) {
+        char msgbuf[16];
+        snprintf(msgbuf, sizeof(msgbuf), "%d MSG", r->msg_count);
+        lv_obj_t *mc = lv_label_create(c);
+        lv_label_set_text(mc, msgbuf);
+        lv_obj_set_style_text_font(mc, FONT_CAPTION, 0);
+        lv_obj_set_style_text_color(mc, lv_color_hex(0x5C5C68), 0);
+        lv_obj_set_style_text_letter_space(mc, 2, 0);
+        lv_obj_align(mc, LV_ALIGN_TOP_RIGHT, 0, 0);
+    }
 
     lv_obj_t *mt = lv_label_create(c);
     lv_label_set_text(mt, r->mode_tag);
     lv_obj_set_style_text_font(mt, FONT_CAPTION, 0);
     lv_obj_set_style_text_color(mt, lv_color_hex(r->mode_color), 0);
     lv_obj_set_style_text_letter_space(mt, 3, 0);
-    lv_obj_align(mt, LV_ALIGN_TOP_RIGHT, 0, 22);
+    lv_obj_align(mt, LV_ALIGN_TOP_RIGHT, 0, r->msg_count >= 0 ? 22 : 0);
 
     /* Return the content height so caller can advance y cleanly. */
     return 72;
+}
+
+/* U1 (#206): hop to the LVGL thread to (re)build the row list from
+ * s_fetch->  Called by the worker via lv_async_call. */
+static void render_rows_cb(void *arg)
+{
+    (void)arg;
+    if (!s_overlay || !s_rows_root || !s_fetch) return;
+
+    /* Wipe previous rows. */
+    lv_obj_clean(s_rows_root);
+
+    if (s_status) {
+        if (!s_fetch->ok) {
+            lv_label_set_text(s_status,
+                "Dragon unreachable. Check Settings \xe2\x80\xa2 Network.");
+            lv_obj_set_style_text_color(s_status, lv_color_hex(0xFF6464), 0);
+            lv_obj_remove_flag(s_status, LV_OBJ_FLAG_HIDDEN);
+        } else if (s_fetch->count == 0) {
+            lv_label_set_text(s_status, "No conversations yet.");
+            lv_obj_set_style_text_color(s_status,
+                lv_color_hex(TH_TEXT_DIM), 0);
+            lv_obj_remove_flag(s_status, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_add_flag(s_status, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+
+    if (s_count_lbl) {
+        char buf[40];
+        snprintf(buf, sizeof(buf), "%d \xe2\x80\xa2 RECENT", s_fetch->count);
+        lv_label_set_text(s_count_lbl, buf);
+    }
+
+    int y = 0;
+    for (int i = 0; i < s_fetch->count; i++) {
+        int h = build_session_row(s_rows_root, y, &s_fetch->items[i]);
+        y += h + 14;
+    }
+    /* Force the container to size to its content so the scroll works. */
+    lv_obj_set_height(s_rows_root, y > 0 ? y : LV_SIZE_CONTENT);
+}
+
+/* U1 (#206): runs on tab5_worker — single-threaded HTTP GET against
+ * /api/v1/sessions, parse JSON, populate s_fetch, hop back to LVGL. */
+static void fetch_sessions_job(void *arg)
+{
+    (void)arg;
+    if (!ensure_fetch_buf()) {
+        s_fetch_inflight = false;
+        return;
+    }
+    char host[64] = {0};
+    tab5_settings_get_dragon_host(host, sizeof(host));
+    if (!host[0]) snprintf(host, sizeof(host), "192.168.1.91");
+    uint16_t port = tab5_settings_get_dragon_port();
+    if (port == 0) port = 3502;
+
+    char url[160];
+    snprintf(url, sizeof(url),
+             "http://%s:%u/api/v1/sessions?limit=%d", host, port, MAX_ROWS);
+
+    s_fetch->count = 0;
+    s_fetch->ok    = false;
+
+    esp_http_client_config_t cfg = {
+        .url = url, .timeout_ms = 4000, .buffer_size = 4096,
+    };
+    esp_http_client_handle_t cli = esp_http_client_init(&cfg);
+    if (!cli) goto done;
+
+    esp_err_t err = esp_http_client_open(cli, 0);
+    int status = 0, content_len = 0, total = 0;
+    char *body = NULL;
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "http_client_open failed: %s", esp_err_to_name(err));
+        goto cleanup;
+    }
+    content_len = esp_http_client_fetch_headers(cli);
+    if (content_len <= 0)        content_len = 16384;
+    if (content_len > 32 * 1024) content_len = 32 * 1024;
+    body = malloc(content_len + 1);
+    if (!body) goto cleanup;
+    while (total < content_len) {
+        int r = esp_http_client_read(cli, body + total, content_len - total);
+        if (r <= 0) break;
+        total += r;
+    }
+    body[total > 0 ? total : 0] = 0;
+    status = esp_http_client_get_status_code(cli);
+    ESP_LOGI(TAG, "GET %s -> %d (%d bytes)", url, status, total);
+    if (status != 200 || total <= 0) goto cleanup;
+
+    cJSON *root = cJSON_ParseWithLength(body, total);
+    if (!root) goto cleanup;
+    cJSON *arr = cJSON_GetObjectItem(root, "sessions");
+    if (!cJSON_IsArray(arr)) arr = root;
+    if (!cJSON_IsArray(arr)) { cJSON_Delete(root); goto cleanup; }
+
+    int n = cJSON_GetArraySize(arr);
+    if (n > MAX_ROWS) n = MAX_ROWS;
+    for (int i = 0; i < n; i++) {
+        cJSON *o = cJSON_GetArrayItem(arr, i);
+        if (!cJSON_IsObject(o)) continue;
+        session_row_t *r = &s_fetch->items[s_fetch->count];
+        memset(r, 0, sizeof(*r));
+
+        const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(o, "title"));
+        snprintf(r->subject, sizeof(r->subject), "%s",
+                 title && title[0] ? title : "(untitled)");
+
+        const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(o, "llm_model"));
+        if (model && model[0]) {
+            snprintf(r->preview, sizeof(r->preview), "%s", model);
+        }
+
+        cJSON *vm = cJSON_GetObjectItem(o, "voice_mode");
+        uint8_t v = cJSON_IsNumber(vm) ? (uint8_t)vm->valueint : 0;
+        mode_to_tag(v, r->mode_tag, sizeof(r->mode_tag), &r->mode_color);
+
+        /* Dragon's /api/v1/sessions doesn't include msg counts in the
+         * default index payload — flag as unknown so build_session_row
+         * skips the count line cleanly. */
+        cJSON *mc = cJSON_GetObjectItem(o, "message_count");
+        r->msg_count = cJSON_IsNumber(mc) ? mc->valueint : -1;
+
+        uint32_t ts = 0;
+        cJSON *u = cJSON_GetObjectItem(o, "updated_at");
+        if (cJSON_IsNumber(u)) ts = (uint32_t)u->valuedouble;
+        else {
+            u = cJSON_GetObjectItem(o, "created_at");
+            if (cJSON_IsNumber(u)) ts = (uint32_t)u->valuedouble;
+        }
+        format_when(ts, r->time_top, sizeof(r->time_top),
+                       r->time_bot, sizeof(r->time_bot));
+
+        s_fetch->count++;
+    }
+    s_fetch->ok = true;
+    cJSON_Delete(root);
+
+cleanup:
+    if (body) free(body);
+    esp_http_client_close(cli);
+    esp_http_client_cleanup(cli);
+done:
+    s_fetch_inflight = false;
+    lv_async_call(render_rows_cb, NULL);
+}
+
+static void kick_sessions_fetch(void)
+{
+    if (s_fetch_inflight) return;
+    s_fetch_inflight = true;
+    if (tab5_worker_enqueue(fetch_sessions_job, NULL, "sessions") != ESP_OK) {
+        ESP_LOGW(TAG, "worker queue full — dropping sessions fetch");
+        s_fetch_inflight = false;
+    }
 }
 
 void ui_sessions_show(void)
@@ -158,6 +394,8 @@ void ui_sessions_show(void)
         lv_obj_remove_flag(s_overlay, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(s_overlay);
         s_visible = true;
+        /* Refresh on every re-show so the list stays current. */
+        kick_sessions_fetch();
         return;
     }
 
@@ -198,24 +436,31 @@ void ui_sessions_show(void)
     lv_obj_set_style_text_color(head, lv_color_hex(TH_AMBER), 0);
     lv_obj_set_pos(head, SIDE_PAD, 110);
 
-    char count_buf[40];
-    snprintf(count_buf, sizeof(count_buf), "%d  \xe2\x80\xa2  %s",
-             N_SESSIONS, "THIS WEEK");
-    lv_obj_t *count = lv_label_create(s_overlay);
-    lv_label_set_text(count, count_buf);
-    lv_obj_set_style_text_font(count, FONT_CAPTION, 0);
-    lv_obj_set_style_text_color(count, lv_color_hex(TH_TEXT_SECONDARY), 0);
-    lv_obj_set_style_text_letter_space(count, 3, 0);
-    lv_obj_set_pos(count, SIDE_PAD, 190);
+    s_count_lbl = lv_label_create(s_overlay);
+    lv_label_set_text(s_count_lbl, "LOADING \xe2\x80\xa2 SESSIONS");
+    lv_obj_set_style_text_font(s_count_lbl, FONT_CAPTION, 0);
+    lv_obj_set_style_text_color(s_count_lbl, lv_color_hex(TH_TEXT_SECONDARY), 0);
+    lv_obj_set_style_text_letter_space(s_count_lbl, 3, 0);
+    lv_obj_set_pos(s_count_lbl, SIDE_PAD, 190);
 
-    int y = 250;
-    for (int i = 0; i < N_SESSIONS; i++) {
-        int h = build_session_row(s_overlay, y, &s_sessions[i]);
-        y += h + 14;
-    }
+    /* Status line — empty/error message; hidden once we have rows. */
+    s_status = lv_label_create(s_overlay);
+    lv_label_set_text(s_status, "Loading conversations...");
+    lv_obj_set_style_text_font(s_status, FONT_BODY, 0);
+    lv_obj_set_style_text_color(s_status, lv_color_hex(TH_TEXT_DIM), 0);
+    lv_obj_set_pos(s_status, SIDE_PAD, 250);
+
+    /* Row container — render_rows_cb populates it.  Rows render at
+     * y=0+ within this container; the container itself sits at y=290. */
+    s_rows_root = lv_obj_create(s_overlay);
+    lv_obj_remove_style_all(s_rows_root);
+    lv_obj_set_size(s_rows_root, SW, LV_SIZE_CONTENT);
+    lv_obj_set_pos(s_rows_root, 0, 290);
+    lv_obj_clear_flag(s_rows_root, LV_OBJ_FLAG_SCROLLABLE);
 
     s_visible = true;
-    ESP_LOGI(TAG, "sessions overlay shown (%d rows)", N_SESSIONS);
+    kick_sessions_fetch();
+    ESP_LOGI(TAG, "sessions overlay shown (fetching from Dragon)");
 }
 
 void ui_sessions_hide(void)


### PR DESCRIPTION
## Summary
- Add Sessions / Agents / Focus tiles to nav sheet (3x3 grid replacing 2x3).
- Replace ui_sessions hardcoded mock rows with live GET /api/v1/sessions?limit=12.
- cJSON parser → row fields; voice_mode → tag/color; updated_at → relative time.
- PSRAM-backed buffer (BSS placement boot-looped with FreeRTOS timer-task alloc).
- Loading / error / empty state lines above the row container.
- Closes audit U1 from \`docs/UI-COMPLETENESS.md\`.

## Test plan
- [x] Flashed via USB; 9-tile nav grid renders with Sessions / Agents / Focus
- [x] Tapped Sessions → overlay opens, serial logs the live GET
- [x] Dragon returns 401 (pre-existing auth gap, same as U6) → error state renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)