### PR TITLE
feat(agents/focus): live tool activity from voice WS (closes #219, refs #206)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
              "settings.c" "ota.c" "media_cache.c"
              "widget_store.c"
              "task_worker.c"
+             "tool_log.c"
         EMBED_TXTFILES "debug_ui.html"
         INCLUDE_DIRS "."
         REQUIRES tab5

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2601,6 +2601,52 @@ static esp_err_t chat_messages_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
+/* ── POST /tool_log/push?name=&detail=&ms= ──────────────────────
+ * U7+U8 (#206) verification helper: forge a tool_log event so the
+ * agents/focus surfaces can be exercised without a live Dragon LLM
+ * tool_call producer.  When `ms` is provided, push a "done" entry;
+ * otherwise push a "running" entry.  Also accepts mode=both to push
+ * a paired call+result. */
+extern void tool_log_push_call(const char *name, const char *detail);
+extern void tool_log_push_result(const char *name, uint32_t exec_ms);
+static void url_pct_decode_inplace(char *s);   /* defined just below */
+
+static esp_err_t tool_log_push_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[256] = {0}, name[32] = {0}, detail[96] = {0}, ms_s[12] = {0}, mode[12] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "name",   name,   sizeof(name));
+    httpd_query_key_value(q, "detail", detail, sizeof(detail));
+    httpd_query_key_value(q, "ms",     ms_s,   sizeof(ms_s));
+    httpd_query_key_value(q, "mode",   mode,   sizeof(mode));
+    url_pct_decode_inplace(name);
+    url_pct_decode_inplace(detail);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!name[0]) {
+        cJSON_AddStringToObject(root, "error", "need ?name=<tool>");
+        return send_json_resp(req, root);
+    }
+    uint32_t ms = (uint32_t)atoi(ms_s);
+    bool both = (strcmp(mode, "both") == 0);
+
+    if (both) {
+        tool_log_push_call(name, detail);
+        tool_log_push_result(name, ms);
+    } else if (ms_s[0]) {
+        tool_log_push_result(name, ms);
+    } else {
+        tool_log_push_call(name, detail);
+    }
+
+    cJSON_AddBoolToObject(root, "ok", true);
+    cJSON_AddStringToObject(root, "name", name);
+    cJSON_AddStringToObject(root, "mode", both ? "both" : (ms_s[0] ? "result" : "call"));
+    cJSON_AddNumberToObject(root, "ms", ms);
+    return send_json_resp(req, root);
+}
+
 /* ── POST /chat/audio_clip?url=<>&label=<> ─────────────────────────
  * U5 (#206) verification helper: pushes an audio_clip into the chat
  * store so the tap-to-play path can be exercised without a live Dragon
@@ -2920,6 +2966,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_heap_probe     = { .uri = "/heap/probe-csv", .method = HTTP_GET,  .handler = tab5_pool_probe_http_handler };
     const httpd_uri_t uri_chat_msgs      = { .uri = "/chat/messages",  .method = HTTP_GET,  .handler = chat_messages_handler };
     const httpd_uri_t uri_chat_audio     = { .uri = "/chat/audio_clip",.method = HTTP_POST, .handler = chat_audio_clip_handler };
+    const httpd_uri_t uri_tool_push      = { .uri = "/tool_log/push",  .method = HTTP_POST, .handler = tool_log_push_handler };
     const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
     const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
 
@@ -2968,6 +3015,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_heap_probe);
     httpd_register_uri_handler(server, &uri_chat_msgs);
     httpd_register_uri_handler(server, &uri_chat_audio);
+    httpd_register_uri_handler(server, &uri_tool_push);
     httpd_register_uri_handler(server, &uri_net_ping);
     httpd_register_uri_handler(server, &uri_nvs_erase);
 

--- a/main/tool_log.c
+++ b/main/tool_log.c
@@ -1,0 +1,112 @@
+/*
+ * tool_log.c — see tool_log.h.
+ */
+
+#include "tool_log.h"
+
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static const char *TAG = "tool_log";
+
+/* Ring storage — lazy-allocated in PSRAM on first push (see header
+ * for the BSS-budget reasoning).  s_head is the next write index;
+ * s_count saturates at TOOL_LOG_CAP. */
+static tool_log_event_t *s_ring  = NULL;
+static int               s_head  = 0;
+static int               s_count = 0;
+static SemaphoreHandle_t s_mutex = NULL;
+
+static bool ensure_ring(void)
+{
+    if (s_ring) return true;
+    if (!s_mutex) {
+        s_mutex = xSemaphoreCreateMutex();
+        if (!s_mutex) return false;
+    }
+    s_ring = heap_caps_calloc(TOOL_LOG_CAP, sizeof(*s_ring),
+                              MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!s_ring) {
+        ESP_LOGW(TAG, "PSRAM alloc failed for tool_log ring");
+        return false;
+    }
+    return true;
+}
+
+static void copy_in(tool_log_event_t *dst, const char *name,
+                    const char *detail)
+{
+    memset(dst, 0, sizeof(*dst));
+    snprintf(dst->name, sizeof(dst->name), "%s",
+             name && name[0] ? name : "tool");
+    snprintf(dst->detail, sizeof(dst->detail), "%s",
+             detail && detail[0] ? detail : dst->name);
+    dst->started_at = time(NULL);
+}
+
+void tool_log_push_call(const char *name, const char *detail)
+{
+    if (!ensure_ring()) return;
+    if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(50)) != pdTRUE) return;
+
+    tool_log_event_t *slot = &s_ring[s_head];
+    copy_in(slot, name, detail);
+    slot->status  = TOOL_LOG_RUNNING;
+    slot->exec_ms = 0;
+
+    s_head = (s_head + 1) % TOOL_LOG_CAP;
+    if (s_count < TOOL_LOG_CAP) s_count++;
+
+    xSemaphoreGive(s_mutex);
+}
+
+void tool_log_push_result(const char *name, uint32_t exec_ms)
+{
+    if (!ensure_ring()) return;
+    if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(50)) != pdTRUE) return;
+
+    /* Walk newest → oldest and complete the first matching RUNNING. */
+    bool matched = false;
+    for (int i = 0; i < s_count && !matched; i++) {
+        int idx = (s_head - 1 - i + TOOL_LOG_CAP) % TOOL_LOG_CAP;
+        tool_log_event_t *e = &s_ring[idx];
+        if (e->status == TOOL_LOG_RUNNING &&
+            name && strncmp(e->name, name, sizeof(e->name)) == 0) {
+            e->status  = TOOL_LOG_DONE;
+            e->exec_ms = exec_ms;
+            matched = true;
+        }
+    }
+    if (!matched) {
+        /* No matching RUNNING entry — synthesize a DONE row so the
+         * surface still shows what just ran. */
+        tool_log_event_t *slot = &s_ring[s_head];
+        copy_in(slot, name, NULL);
+        slot->status  = TOOL_LOG_DONE;
+        slot->exec_ms = exec_ms;
+        s_head = (s_head + 1) % TOOL_LOG_CAP;
+        if (s_count < TOOL_LOG_CAP) s_count++;
+    }
+
+    xSemaphoreGive(s_mutex);
+}
+
+int tool_log_count(void)
+{
+    return s_count;
+}
+
+bool tool_log_get(int idx_back, tool_log_event_t *out)
+{
+    if (!s_ring || !out || idx_back < 0 || idx_back >= s_count) return false;
+    if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(50)) != pdTRUE) return false;
+    int idx = (s_head - 1 - idx_back + TOOL_LOG_CAP) % TOOL_LOG_CAP;
+    *out = s_ring[idx];
+    xSemaphoreGive(s_mutex);
+    return true;
+}

--- a/main/tool_log.h
+++ b/main/tool_log.h
@@ -1,0 +1,57 @@
+/*
+ * tool_log.{c,h} — Audit U7+U8 (#206)
+ *
+ * Single-process ring buffer of the last 16 tool_call / tool_result
+ * events received from Dragon over the voice WS.  Lets ui_agents +
+ * ui_focus render live activity instead of hand-curated demo rows.
+ *
+ * Producer: voice.c, on every "tool_call" / "tool_result" frame.
+ * Consumers: ui_agents + ui_focus, on overlay show.
+ *
+ * Storage: PSRAM (lazy-allocated on first push) — the ring is ~3 KB,
+ * which would tip the internal-SRAM budget if we put it in BSS (same
+ * class of fault as ui_sessions per docs/STABILITY-INVESTIGATION.md
+ * #185).  Reads from any task — single-writer, single-reader-per-call,
+ * fields are read atomically per slot under a short FreeRTOS mutex.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+#define TOOL_LOG_CAP        16
+#define TOOL_LOG_NAME_LEN   24
+#define TOOL_LOG_DETAIL_LEN 80
+
+typedef enum {
+    TOOL_LOG_RUNNING = 0,   /* tool_call seen, no result yet */
+    TOOL_LOG_DONE    = 1,   /* tool_result seen */
+} tool_log_status_t;
+
+typedef struct {
+    char              name[TOOL_LOG_NAME_LEN];
+    char              detail[TOOL_LOG_DETAIL_LEN];
+    tool_log_status_t status;
+    uint32_t          exec_ms;   /* 0 while running */
+    time_t            started_at;
+} tool_log_event_t;
+
+/* Push a "tool started" event.  detail is a one-line human-readable
+ * description (e.g. "Searching the web…") — pass NULL or "" to use
+ * tool name verbatim. */
+void tool_log_push_call(const char *name, const char *detail);
+
+/* Mark the most-recent matching name as DONE with execution_ms.
+ * If no matching RUNNING entry is found, append a synthetic DONE
+ * row so the surface still shows what happened. */
+void tool_log_push_result(const char *name, uint32_t exec_ms);
+
+/* How many events are currently stored (0..TOOL_LOG_CAP). */
+int  tool_log_count(void);
+
+/* Snapshot copy of the event at index `idx_back` from newest:
+ *  idx_back=0 → most recent, idx_back=count-1 → oldest.
+ * Returns false if idx_back is out of range. */
+bool tool_log_get(int idx_back, tool_log_event_t *out);

--- a/main/ui_agents.c
+++ b/main/ui_agents.c
@@ -11,8 +11,11 @@
 #include "ui_home.h"
 #include "ui_core.h"
 #include "config.h"
+#include "tool_log.h"
 #include "esp_log.h"
+#include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 static const char *TAG = "ui_agents";
 
@@ -22,7 +25,11 @@ static const char *TAG = "ui_agents";
 
 static lv_obj_t *s_overlay       = NULL;
 static lv_obj_t *s_back_btn      = NULL;
+static lv_obj_t *s_count_lbl     = NULL;   /* U7 (#206): refreshed on each show */
+static lv_obj_t *s_entry_root    = NULL;   /* container for the live activity entry */
 static bool      s_visible       = false;
+
+static void render_live_content(void);
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -144,6 +151,10 @@ void ui_agents_show(void)
         lv_obj_remove_flag(s_overlay, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(s_overlay);
         s_visible = true;
+        /* U7 (#206): live content was built from a snapshot of
+         * tool_log on first show — refresh on every re-show so new
+         * tool activity appears. */
+        render_live_content();
         return;
     }
 
@@ -187,40 +198,116 @@ void ui_agents_show(void)
     lv_obj_set_style_text_color(head, lv_color_hex(TH_AMBER), 0);
     lv_obj_set_pos(head, SIDE_PAD, 110);
 
-    lv_obj_t *count = lv_label_create(s_overlay);
-    lv_label_set_text(count, "1 LIVE  •  1 DONE");
-    lv_obj_set_style_text_font(count, FONT_CAPTION, 0);
-    lv_obj_set_style_text_color(count, lv_color_hex(TH_TEXT_SECONDARY), 0);
-    lv_obj_set_style_text_letter_space(count, 3, 0);
-    lv_obj_set_pos(count, SIDE_PAD, 190);
-
-    /* Two hand-curated entries so the surface is demonstrable. */
-    const char *heartbeat_tasks[] = {
-        "Inbox scanned  •  3 found  •  234 ms",
-        "Drafting reply to Aisha  •  70%  •  1.2 KB",
-        "News digest  •  queued  •  ETA 60 s",
-    };
-    build_agent_entry(s_overlay, 250,
-                      "HEARTBEAT",
-                      "2 MIN LIVE",
-                      TH_MODE_CLAW,
-                      "I scanned your inbox -- three replies were waiting. "
-                      "Drafting one to Aisha now; the digest is queued.",
-                      heartbeat_tasks, 3);
-
-    const char *browser_tasks[] = {
-        "Fetched Hacker News  •  240 ms",
-        "Summarised 4 articles  •  2.1 s",
-    };
-    build_agent_entry(s_overlay, 560,
-                      "BROWSER",
-                      "YESTERDAY",
-                      TH_STATUS_GREEN,
-                      "Pulled Hacker News and saved four articles for you.",
-                      browser_tasks, 2);
-
+    render_live_content();
     s_visible = true;
     ESP_LOGI(TAG, "agents overlay shown");
+}
+
+/* U7+U8 (#206): rebuild the count label + entry container from the
+ * current tool_log ring snapshot.  Idempotent — called on every show
+ * (first or re-show).  Hide/show pattern is preserved (we don't
+ * destroy s_overlay), so the LV pool isn't churned. */
+static void render_live_content(void)
+{
+    if (!s_overlay) return;
+
+    int total = tool_log_count();
+    int running = 0, done = 0;
+    for (int i = 0; i < total; i++) {
+        tool_log_event_t e;
+        if (tool_log_get(i, &e)) {
+            if (e.status == TOOL_LOG_RUNNING) running++;
+            else                              done++;
+        }
+    }
+
+    /* Count label — create-once, update text in place on re-renders. */
+    if (!s_count_lbl) {
+        s_count_lbl = lv_label_create(s_overlay);
+        lv_obj_set_style_text_font(s_count_lbl, FONT_CAPTION, 0);
+        lv_obj_set_style_text_color(s_count_lbl,
+            lv_color_hex(TH_TEXT_SECONDARY), 0);
+        lv_obj_set_style_text_letter_space(s_count_lbl, 3, 0);
+        lv_obj_set_pos(s_count_lbl, SIDE_PAD, 190);
+    }
+    char count_buf[40];
+    snprintf(count_buf, sizeof(count_buf), "%d LIVE  \xe2\x80\xa2  %d DONE",
+             running, done);
+    lv_label_set_text(s_count_lbl, count_buf);
+
+    /* Entry container — wipe + rebuild children on each render.  The
+     * container itself persists across re-shows so the LV pool isn't
+     * thrashed; only the cheap label/dot widgets are recycled. */
+    if (!s_entry_root) {
+        s_entry_root = lv_obj_create(s_overlay);
+        lv_obj_remove_style_all(s_entry_root);
+        lv_obj_set_size(s_entry_root, SW, LV_SIZE_CONTENT);
+        lv_obj_set_pos(s_entry_root, 0, 250);
+        lv_obj_clear_flag(s_entry_root, LV_OBJ_FLAG_SCROLLABLE);
+    } else {
+        lv_obj_clean(s_entry_root);
+    }
+
+    if (total == 0) {
+        lv_obj_t *empty = lv_label_create(s_entry_root);
+        lv_label_set_long_mode(empty, LV_LABEL_LONG_WRAP);
+        lv_label_set_text(empty,
+            "No tool activity yet.\n\n"
+            "Talk to TinkerClaw -- when it searches the web, recalls a "
+            "memory, or runs any other tool, it'll show up here.");
+        lv_obj_set_width(empty, SW - 2 * SIDE_PAD);
+        lv_obj_set_style_text_font(empty, FONT_BODY, 0);
+        lv_obj_set_style_text_color(empty, lv_color_hex(TH_TEXT_DIM), 0);
+        lv_obj_set_style_text_line_space(empty, 4, 0);
+        lv_obj_set_pos(empty, SIDE_PAD, 0);
+        return;
+    }
+
+    int n_show = total > 6 ? 6 : total;
+    const char *task_lines[6] = {0};
+    static char  task_storage[6][96];
+
+    tool_log_event_t newest;
+    tool_log_get(0, &newest);
+
+    char narrative[160];
+    if (running > 0) {
+        snprintf(narrative, sizeof(narrative),
+            "Running %s now. %d completed in this session.",
+            newest.detail[0] ? newest.detail : newest.name, done);
+    } else {
+        snprintf(narrative, sizeof(narrative),
+            "Last action: %s. %d completed in this session.",
+            newest.detail[0] ? newest.detail : newest.name, done);
+    }
+
+    for (int i = 0; i < n_show; i++) {
+        tool_log_event_t e;
+        if (!tool_log_get(i, &e)) continue;
+        if (e.status == TOOL_LOG_DONE) {
+            snprintf(task_storage[i], sizeof(task_storage[0]),
+                     "%s  \xe2\x80\xa2  done  \xe2\x80\xa2  %u ms",
+                     e.name, (unsigned)e.exec_ms);
+        } else {
+            snprintf(task_storage[i], sizeof(task_storage[0]),
+                     "%s  \xe2\x80\xa2  running",
+                     e.name);
+        }
+        task_lines[i] = task_storage[i];
+    }
+
+    char ts_label[24] = "JUST NOW";
+    time_t now = time(NULL);
+    long secs = (long)(now - newest.started_at);
+    if      (secs < 60)    snprintf(ts_label, sizeof(ts_label), "JUST NOW");
+    else if (secs < 3600)  snprintf(ts_label, sizeof(ts_label), "%ld MIN AGO", secs / 60);
+    else if (secs < 86400) snprintf(ts_label, sizeof(ts_label), "%ld H AGO",   secs / 3600);
+    else                   snprintf(ts_label, sizeof(ts_label), "%ld D AGO",   secs / 86400);
+
+    build_agent_entry(s_entry_root, 0,
+                      "AGENT ACTIVITY", ts_label,
+                      running > 0 ? TH_MODE_CLAW : TH_STATUS_GREEN,
+                      narrative, task_lines, n_show);
 }
 
 void ui_agents_hide(void)

--- a/main/ui_focus.c
+++ b/main/ui_focus.c
@@ -18,7 +18,10 @@
 #include "ui_home.h"
 #include "ui_core.h"
 #include "config.h"
+#include "tool_log.h"
 #include "esp_log.h"
+#include <stdio.h>
+#include <time.h>
 
 static const char *TAG = "ui_focus";
 
@@ -29,9 +32,13 @@ static const char *TAG = "ui_focus";
 #define ORB_CORNER_X   (SW - ORB_CORNER_SZ - 56)
 #define ORB_CORNER_Y   64
 
-static lv_obj_t *s_overlay  = NULL;
-static lv_obj_t *s_back_btn = NULL;
-static bool      s_visible  = false;
+static lv_obj_t *s_overlay   = NULL;
+static lv_obj_t *s_back_btn  = NULL;
+static lv_obj_t *s_narrative = NULL;     /* U8 (#206): refreshed on each show */
+static lv_obj_t *s_tasks     = NULL;
+static bool      s_visible   = false;
+
+static void render_live_focus(void);
 
 static void back_click_cb(lv_event_t *e)
 {
@@ -134,6 +141,7 @@ void ui_focus_show(void)
         lv_obj_remove_flag(s_overlay, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(s_overlay);
         s_visible = true;
+        render_live_focus();
         return;
     }
 
@@ -193,30 +201,23 @@ void ui_focus_show(void)
     lv_obj_set_style_text_color(h, lv_color_hex(TH_AMBER), 0);
     lv_obj_set_style_text_letter_space(h, 3, 0);
 
-    lv_obj_t *narrative = lv_label_create(sec1);
-    lv_label_set_long_mode(narrative, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(narrative,
-        "I scanned your inbox -- three replies were waiting. "
-        "Drafting one to Aisha now; the digest is queued.");
-    lv_obj_set_style_text_font(narrative, &lv_font_montserrat_28, 0);
-    lv_obj_set_style_text_color(narrative, lv_color_hex(TH_TEXT_PRIMARY), 0);
-    lv_obj_set_style_text_line_space(narrative, 4, 0);
+    s_narrative = lv_label_create(sec1);
+    lv_label_set_long_mode(s_narrative, LV_LABEL_LONG_WRAP);
+    lv_obj_set_style_text_font(s_narrative, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(s_narrative, lv_color_hex(TH_TEXT_PRIMARY), 0);
+    lv_obj_set_style_text_line_space(s_narrative, 4, 0);
     /* Reserve the top-right corner for the orb (140 px) so the narrative
      * can't collide with it. Spec shot-01 right pane. */
-    lv_obj_set_width(narrative, SW - 2 * SIDE_PAD - 160);
+    lv_obj_set_width(s_narrative, SW - 2 * SIDE_PAD - 160);
 
-    /* Task stream below the narrative */
-    lv_obj_t *tasks = lv_obj_create(s_overlay);
-    lv_obj_remove_style_all(tasks);
-    lv_obj_set_size(tasks, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
-    lv_obj_set_pos(tasks, SIDE_PAD, 480);
-    lv_obj_set_flex_flow(tasks, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_style_pad_row(tasks, 2, 0);
-    lv_obj_clear_flag(tasks, LV_OBJ_FLAG_SCROLLABLE);
-
-    build_task_row(tasks, "Inbox scanned",            "3 FOUND  •  234MS",   TH_STATUS_GREEN);
-    build_task_row(tasks, "Drafting reply to Aisha",  "70%  •  1.2KB",       TH_AMBER);
-    build_task_row(tasks, "News digest",              "QUEUED  •  ETA 60S",  0x2D2D35);
+    /* Task stream below the narrative — populated by render_live_focus. */
+    s_tasks = lv_obj_create(s_overlay);
+    lv_obj_remove_style_all(s_tasks);
+    lv_obj_set_size(s_tasks, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
+    lv_obj_set_pos(s_tasks, SIDE_PAD, 480);
+    lv_obj_set_flex_flow(s_tasks, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_row(s_tasks, 2, 0);
+    lv_obj_clear_flag(s_tasks, LV_OBJ_FLAG_SCROLLABLE);
 
     /* Section 2 — EARLIER TODAY */
     lv_obj_t *sec2h = lv_label_create(s_overlay);
@@ -251,7 +252,65 @@ void ui_focus_show(void)
     lv_obj_set_pos(ask_lbl, SIDE_PAD + 14, SH - 114);
 
     s_visible = true;
+    render_live_focus();
     ESP_LOGI(TAG, "focus overlay shown");
+}
+
+/* U8 (#206): rebuild narrative + task rows from the live tool_log
+ * snapshot.  Idempotent on re-show; preserves the hide/show pattern by
+ * recycling s_narrative (text update) and s_tasks (clean + rebuild). */
+static void render_live_focus(void)
+{
+    if (!s_overlay || !s_narrative || !s_tasks) return;
+
+    int total = tool_log_count();
+    int running = 0, done = 0;
+    for (int i = 0; i < total; i++) {
+        tool_log_event_t e;
+        if (tool_log_get(i, &e)) {
+            if (e.status == TOOL_LOG_RUNNING) running++;
+            else                              done++;
+        }
+    }
+
+    if (total == 0) {
+        lv_label_set_text(s_narrative,
+            "Nothing running. Talk to TinkerClaw and your live "
+            "activity will land here.");
+    } else {
+        tool_log_event_t newest;
+        tool_log_get(0, &newest);
+        char narr[200];
+        if (running > 0) {
+            snprintf(narr, sizeof(narr),
+                "Running %s now. %d completed in this session.",
+                newest.detail[0] ? newest.detail : newest.name, done);
+        } else {
+            snprintf(narr, sizeof(narr),
+                "Last action: %s. %d completed in this session.",
+                newest.detail[0] ? newest.detail : newest.name, done);
+        }
+        lv_label_set_text(s_narrative, narr);
+    }
+
+    /* Wipe + repopulate the task rows. */
+    lv_obj_clean(s_tasks);
+    int n_show = total > 6 ? 6 : total;
+    for (int i = 0; i < n_show; i++) {
+        tool_log_event_t e;
+        if (!tool_log_get(i, &e)) continue;
+        char meta[48];
+        if (e.status == TOOL_LOG_DONE) {
+            snprintf(meta, sizeof(meta), "DONE  \xe2\x80\xa2  %u MS",
+                     (unsigned)e.exec_ms);
+        } else {
+            snprintf(meta, sizeof(meta), "RUNNING");
+        }
+        uint32_t color = (e.status == TOOL_LOG_DONE) ? TH_STATUS_GREEN : TH_AMBER;
+        build_task_row(s_tasks,
+                       e.detail[0] ? e.detail : e.name,
+                       meta, color);
+    }
 }
 
 void ui_focus_hide(void)

--- a/main/voice.c
+++ b/main/voice.c
@@ -23,6 +23,7 @@
 
 #include "voice.h"
 #include "task_worker.h"   /* #133: defer queue-drain to avoid stack blow */
+#include "tool_log.h"      /* U7+U8 (#206): record tool activity for ui_agents/ui_focus */
 #include <limits.h>  /* W14-L02: INT_MAX for WS size_t->int bound */
 #include "widget.h"
 #include "ui_voice.h"
@@ -1232,6 +1233,9 @@ static void handle_text_message(const char *data, int len)
          * CLAUDE.md's "thinking + tool indicator bubbles" claim was wired
          * only to the overlay-state string previously. */
         ui_chat_push_system(status_text);
+        /* U7+U8 (#206): record activity so the agents/focus surfaces
+         * can render real history instead of the v5 demo rows. */
+        tool_log_push_call(tool_name, status_text);
     } else if (strcmp(type_str, "tool_result") == 0) {
         cJSON *tool = cJSON_GetObjectItem(root, "tool");
         cJSON *exec_ms = cJSON_GetObjectItem(root, "execution_ms");
@@ -1245,6 +1249,9 @@ static void handle_text_message(const char *data, int len)
         snprintf(done_buf, sizeof(done_buf), "%s done (%.0fms)",
                  tool_name, ms);
         ui_chat_push_system(done_buf);
+        /* U7+U8 (#206): mark the tool_log entry done so the
+         * agents/focus surfaces can show "DONE  •  234 ms". */
+        tool_log_push_result(tool_name, (uint32_t)ms);
     } else if (strcmp(type_str, "media") == 0) {
         const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
         const char *mtype = cJSON_GetStringValue(cJSON_GetObjectItem(root, "media_type"));


### PR DESCRIPTION
## Summary
- New \`tool_log.{c,h}\` — 16-slot PSRAM ring of tool_call/tool_result events (mutex-protected).
- voice.c writes to the ring on every tool_call/tool_result frame.
- ui_agents and ui_focus rebuilt to render live tool activity (was 100% mock).
- Hide/show pattern preserved; empty state when log is empty.
- Debug helper \`POST /tool_log/push\` for verification without a live Dragon producer.
- Closes audits U7 + U8 from \`docs/UI-COMPLETENESS.md\`.

## Test plan
- [x] Flashed via USB; empty state renders ("0 LIVE · 0 DONE" + placeholder)
- [x] Pushed 4 fake events via debug helper; Agents shows "1 LIVE · 3 DONE" + 4 task rows
- [x] Focus shows the same data as narrative + task stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)