### PR TITLE
fix(chat): camera button + STT-partial caption (closes #221, refs #206)

### DIFF
--- a/main/chat_input_bar.c
+++ b/main/chat_input_bar.c
@@ -33,6 +33,7 @@ struct chat_input_bar {
     lv_obj_t *ghost;          /* placeholder text */
     lv_obj_t *cursor;          /* blinking caret */
     lv_obj_t *kb_btn;          /* 56×56 keyboard affordance */
+    lv_obj_t *cam_btn;         /* U11 (#206): 56×56 camera affordance */
     lv_obj_t *textarea;        /* hidden textarea used by ui_keyboard_show */
     lv_obj_t *partial;         /* optional STT partial line above the pill */
     lv_timer_t *cursor_blink;
@@ -47,6 +48,7 @@ struct chat_input_bar {
 
     chat_input_evt_cb_t   ball_cb;     void *ball_ud;
     chat_input_evt_cb_t   kb_cb;       void *kb_ud;
+    chat_input_evt_cb_t   cam_cb;      void *cam_ud;     /* U11 (#206) */
     chat_input_submit_cb_t submit_cb;   void *submit_ud;
     chat_input_evt_cb_t   pill_cb;     void *pill_ud;
 };
@@ -140,6 +142,11 @@ static void ev_kb_tap(lv_event_t *e)
     chat_input_bar_t *b = lv_event_get_user_data(e);
     if (b && b->kb_cb) b->kb_cb(b->kb_ud);
 }
+static void ev_cam_tap(lv_event_t *e)
+{
+    chat_input_bar_t *b = lv_event_get_user_data(e);
+    if (b && b->cam_cb) b->cam_cb(b->cam_ud);
+}
 static void ev_pill_tap(lv_event_t *e)
 {
     chat_input_bar_t *b = lv_event_get_user_data(e);
@@ -218,7 +225,10 @@ chat_input_bar_t *chat_input_bar_create(lv_obj_t *parent, int parent_h)
      * the ghost label + blinking cursor. */
     b->textarea = lv_textarea_create(b->pill);
     lv_obj_remove_style_all(b->textarea);
-    lv_obj_set_size(b->textarea, PILL_W - PILL_TEXT_X - PILL_KB_SZ - 20, 48);
+    /* U11 (#206): textarea shrinks by another (PILL_KB_SZ + 12) to make
+     * room for the camera button next to the keyboard button. */
+    lv_obj_set_size(b->textarea,
+        PILL_W - PILL_TEXT_X - 2 * PILL_KB_SZ - 32, 48);
     lv_obj_set_pos(b->textarea, PILL_TEXT_X, (PILL_H - 48) / 2);
     lv_textarea_set_one_line(b->textarea, true);
     lv_textarea_set_placeholder_text(b->textarea, "");
@@ -264,6 +274,29 @@ chat_input_bar_t *chat_input_bar_create(lv_obj_t *parent, int parent_h)
     lv_obj_set_style_text_font(kb_lbl, FONT_BODY, 0);
     lv_obj_set_style_text_color(kb_lbl, lv_color_hex(TH_TEXT_BODY), 0);
     lv_obj_center(kb_lbl);
+
+    /* U11 (#206): camera affordance — 56x56 elevated card just left of
+     * the keyboard button.  Tap routes to the cam_cb (typically opens
+     * the camera screen). */
+    b->cam_btn = lv_obj_create(b->pill);
+    lv_obj_remove_style_all(b->cam_btn);
+    lv_obj_set_size(b->cam_btn, PILL_KB_SZ, PILL_KB_SZ);
+    lv_obj_set_pos(b->cam_btn,
+                   PILL_W - 2 * PILL_KB_SZ - 12 - 12,
+                   (PILL_H - PILL_KB_SZ) / 2);
+    lv_obj_set_style_bg_color(b->cam_btn, lv_color_hex(TH_CARD_ELEVATED), 0);
+    lv_obj_set_style_bg_opa(b->cam_btn, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(b->cam_btn, 18, 0);
+    lv_obj_set_style_border_width(b->cam_btn, 1, 0);
+    lv_obj_set_style_border_color(b->cam_btn, lv_color_hex(0x1E1E2A), 0);
+    lv_obj_add_flag(b->cam_btn, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_clear_flag(b->cam_btn, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_event_cb(b->cam_btn, ev_cam_tap, LV_EVENT_CLICKED, b);
+    lv_obj_t *cam_lbl = lv_label_create(b->cam_btn);
+    lv_label_set_text(cam_lbl, LV_SYMBOL_IMAGE);
+    lv_obj_set_style_text_font(cam_lbl, FONT_BODY, 0);
+    lv_obj_set_style_text_color(cam_lbl, lv_color_hex(TH_TEXT_BODY), 0);
+    lv_obj_center(cam_lbl);
 
     /* Partial-caption label above the pill, hidden by default. */
     b->partial = lv_label_create(parent);
@@ -368,6 +401,8 @@ void chat_input_bar_on_keyboard(chat_input_bar_t *b, chat_input_evt_cb_t cb, voi
 
 void chat_input_bar_on_text_submit(chat_input_bar_t *b, chat_input_submit_cb_t cb, void *ud)
 { if (b) { b->submit_cb = cb; b->submit_ud = ud; } }
+void chat_input_bar_on_camera(chat_input_bar_t *b, chat_input_evt_cb_t cb, void *ud)
+{ if (b) { b->cam_cb = cb; b->cam_ud = ud; } }
 
 void chat_input_bar_on_pill_tap(chat_input_bar_t *b, chat_input_evt_cb_t cb, void *ud)
 { if (b) { b->pill_cb = cb; b->pill_ud = ud; } }

--- a/main/chat_input_bar.h
+++ b/main/chat_input_bar.h
@@ -58,6 +58,9 @@ void chat_input_bar_clear(chat_input_bar_t *b);
 /* Event wiring */
 void chat_input_bar_on_ball_tap(chat_input_bar_t *b, chat_input_evt_cb_t cb, void *ud);
 void chat_input_bar_on_keyboard(chat_input_bar_t *b, chat_input_evt_cb_t cb, void *ud);
+/** U11 (#206): tap on the camera affordance in the pill.  Caller
+ *  decides what to do (typically open the camera screen). */
+void chat_input_bar_on_camera(chat_input_bar_t *b, chat_input_evt_cb_t cb, void *ud);
 /** Fires on keyboard "Done" or equivalent. Text pointer is LVGL-owned;
  *  callback must copy if it needs it beyond the call. */
 void chat_input_bar_on_text_submit(chat_input_bar_t *b, chat_input_submit_cb_t cb, void *ud);

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2601,6 +2601,25 @@ static esp_err_t chat_messages_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
+/* ── POST /chat/partial?text=<> ─────────────────────────────────
+ * U12 (#206) verification helper: shove a string into the live
+ * STT-partial caption above the chat input pill.  Empty text hides. */
+extern void ui_chat_show_partial(const char *partial);
+static void url_pct_decode_inplace(char *s);   /* defined further below */
+static esp_err_t chat_partial_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[256] = {0}, text[160] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "text", text, sizeof(text));
+    url_pct_decode_inplace(text);
+    ui_chat_show_partial(text[0] ? text : NULL);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    cJSON_AddStringToObject(root, "text", text);
+    return send_json_resp(req, root);
+}
+
 /* ── POST /tool_log/push?name=&detail=&ms= ──────────────────────
  * U7+U8 (#206) verification helper: forge a tool_log event so the
  * agents/focus surfaces can be exercised without a live Dragon LLM
@@ -2609,7 +2628,6 @@ static esp_err_t chat_messages_handler(httpd_req_t *req)
  * a paired call+result. */
 extern void tool_log_push_call(const char *name, const char *detail);
 extern void tool_log_push_result(const char *name, uint32_t exec_ms);
-static void url_pct_decode_inplace(char *s);   /* defined just below */
 
 static esp_err_t tool_log_push_handler(httpd_req_t *req)
 {
@@ -2967,6 +2985,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_chat_msgs      = { .uri = "/chat/messages",  .method = HTTP_GET,  .handler = chat_messages_handler };
     const httpd_uri_t uri_chat_audio     = { .uri = "/chat/audio_clip",.method = HTTP_POST, .handler = chat_audio_clip_handler };
     const httpd_uri_t uri_tool_push      = { .uri = "/tool_log/push",  .method = HTTP_POST, .handler = tool_log_push_handler };
+    const httpd_uri_t uri_chat_partial   = { .uri = "/chat/partial",   .method = HTTP_POST, .handler = chat_partial_handler };
     const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
     const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
 
@@ -3016,6 +3035,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_chat_msgs);
     httpd_register_uri_handler(server, &uri_chat_audio);
     httpd_register_uri_handler(server, &uri_tool_push);
+    httpd_register_uri_handler(server, &uri_chat_partial);
     httpd_register_uri_handler(server, &uri_net_ping);
     httpd_register_uri_handler(server, &uri_nvs_erase);
 

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -252,6 +252,21 @@ static void on_pill_tap(void *ud)
     if (s_input) ui_keyboard_show(chat_input_bar_get_textarea(s_input));
 }
 
+/* U11 (#206): camera affordance in the chat composer.  No
+ * photo-upload protocol exists yet, so the simplest useful
+ * behaviour is to navigate to the camera screen — capture there
+ * already saves to /sdcard/IMG_NNNN.jpg, and the file browser
+ * preview (U4) lets the user open the result.  When the upload
+ * protocol lands this stays the entry point. */
+static void on_camera_tap(void *ud)
+{
+    (void)ud;
+    extern lv_obj_t *ui_camera_create(void);
+    /* Hide chat first so the camera viewfinder owns the screen. */
+    ui_chat_hide();
+    ui_camera_create();
+}
+
 static void on_text_submit(const char *text, void *ud)
 {
     (void)ud;
@@ -503,6 +518,7 @@ lv_obj_t *ui_chat_create(void)
     chat_input_bar_on_keyboard(s_input, on_keyboard, NULL);
     chat_input_bar_on_pill_tap(s_input, on_pill_tap, NULL);
     chat_input_bar_on_text_submit(s_input, on_text_submit, NULL);
+    chat_input_bar_on_camera(s_input, on_camera_tap, NULL);
 
     s_sugg = chat_suggestions_create(s_overlay);
     chat_suggestions_on_pick(s_sugg, on_sugg_pick, NULL);
@@ -973,6 +989,29 @@ static void audio_clip_dl_job(void *arg)
         extern void ui_home_show_toast(const char *text);
         ui_home_show_toast("Couldn't fetch audio");
     }
+}
+
+/* U12 (#206): live STT-partial caption above the chat pill.
+ * Thread-safe — voice.c calls it from the WS task on every stt_partial
+ * frame.  We strdup so the WS buffer is free to be reused, then
+ * lv_async_call hops to the LVGL thread for the actual label update. */
+static void async_set_partial_cb(void *arg)
+{
+    char *txt = (char *)arg;
+    if (s_input) chat_input_bar_show_partial(s_input, txt);
+    free(txt);
+}
+
+void ui_chat_show_partial(const char *partial)
+{
+    /* NULL/empty → hide.  Skip the strdup hop — pass NULL through. */
+    if (!partial || !*partial) {
+        lv_async_call(async_set_partial_cb, NULL);
+        return;
+    }
+    char *copy = strdup(partial);
+    if (!copy) return;
+    lv_async_call(async_set_partial_cb, copy);
 }
 
 void ui_chat_play_audio_clip(const char *url)

--- a/main/ui_chat.h
+++ b/main/ui_chat.h
@@ -60,3 +60,10 @@ void ui_chat_update_last_message(const char *text);
  * if the view is not mounted.
  */
 void ui_chat_refresh_receipts(void);
+
+/**
+ * U12 (#206): show/hide the live STT partial caption above the input
+ * pill.  Pass NULL or "" to hide.  Thread-safe (lv_async_call hop) so
+ * voice.c can call it from the WS task on every stt_partial frame.
+ */
+void ui_chat_show_partial(const char *partial);

--- a/main/voice.c
+++ b/main/voice.c
@@ -717,6 +717,12 @@ static void handle_text_message(const char *data, int len)
 
     if (strcmp(type_str, "stt_partial") == 0) {
         cJSON *text = cJSON_GetObjectItem(root, "text");
+        /* U12 (#206): regardless of dictation mode, surface the partial
+         * as a live caption above the chat input pill.  No-op when chat
+         * is closed (s_input is NULL inside ui_chat). */
+        if (cJSON_IsString(text) && text->valuestring) {
+            ui_chat_show_partial(text->valuestring);
+        }
         if (cJSON_IsString(text) && text->valuestring && s_voice_mode == VOICE_MODE_DICTATE
             && s_dictation_text) {
             /* v4·D audit P1 fix: use bounded copy instead of unchecked
@@ -741,6 +747,9 @@ static void handle_text_message(const char *data, int len)
         }
     } else if (strcmp(type_str, "stt") == 0) {
         cJSON *text = cJSON_GetObjectItem(root, "text");
+        /* U12 (#206): final STT result lands as a real chat bubble — clear
+         * the live partial caption so it doesn't linger above the pill. */
+        ui_chat_show_partial(NULL);
         if (cJSON_IsString(text) && text->valuestring) {
             if (s_voice_mode == VOICE_MODE_DICTATE) {
                 if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);


### PR DESCRIPTION
## Summary
- U11: 56×56 camera button in chat composer, taps open the camera screen.
- U12: \`ui_chat_show_partial\` thread-safe bridge; voice.c feeds it from \`stt_partial\`, clears on \`stt\` final.
- Debug helper \`POST /chat/partial?text=...\` for verification.
- Closes audits U11 + U12.

## Test plan
- [x] Flashed via USB; camera button visible in chat composer
- [x] Tap camera button → camera screen opens
- [x] Pushed partial via debug helper → amber caption above pill
- [x] Empty text hides caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)