### PR TITLE
fix(voice): conn_mode change re-targets the live WS URI (closes #225, refs #206)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1287,6 +1287,11 @@ static esp_err_t settings_set_handler(httpd_req_t *req)
         if (m >= 0 && m <= 2) {
             if (tab5_settings_set_connection_mode((uint8_t)m) == ESP_OK) {
                 cJSON_AddItemToArray(updated, cJSON_CreateString("conn_mode"));
+                /* U21 (#206): re-target the live WS URI so a remote
+                 * change to "Internet Only"/"Local Only" lands without
+                 * waiting for the user to power-cycle. */
+                extern void voice_reapply_connection_mode(void);
+                voice_reapply_connection_mode();
             }
         }
     }

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -531,6 +531,11 @@ static void cb_conn_mode(lv_event_t *e)
     tab5_settings_set_connection_mode((uint8_t)sel);
     ESP_LOGI(TAG, "Connection mode: %d (%s)",
              (int)sel, sel == 0 ? "auto" : sel == 1 ? "local" : "remote");
+    /* U21 (#206): re-target the live WS URI so the new mode (esp.
+     * "Internet Only") takes effect immediately.  Without this, the
+     * existing WS stays on whatever URI was picked at boot and the
+     * dropdown change is purely cosmetic until next power-cycle. */
+    voice_reapply_connection_mode();
 }
 
 /* ── Dragon host ────────────────────────────────────────────────────── */

--- a/main/voice.c
+++ b/main/voice.c
@@ -3234,6 +3234,31 @@ void voice_force_reconnect(void)
     s_started = true;
 }
 
+/* U21 (#206): re-pick the WebSocket URI from the current conn_m
+ * setting.  Without this, switching "Internet Only" in Settings only
+ * lands on the next manual power-cycle -- the live WS stays on whatever
+ * URI it was started with (LAN if conn_m used to be 0/1).
+ *
+ * voice_ws_start_client reads conn_m fresh and picks ngrok vs LAN, so
+ * we just hand it the configured Dragon host/port and let it do the
+ * stop-set_uri-start dance. */
+void voice_reapply_connection_mode(void)
+{
+    if (!s_initialized || !s_ws) {
+        ESP_LOGW(TAG, "reapply_connection_mode: client not ready");
+        return;
+    }
+    char host[64] = {0};
+    tab5_settings_get_dragon_host(host, sizeof(host));
+    if (!host[0]) {
+        snprintf(host, sizeof(host), "%s", TAB5_DRAGON_HOST);
+    }
+    uint16_t port = tab5_settings_get_dragon_port();
+    if (port == 0) port = TAB5_DRAGON_PORT;
+    ESP_LOGI(TAG, "Re-applying connection mode (LAN target=%s:%u)", host, port);
+    voice_ws_start_client(host, port);
+}
+
 bool voice_is_connected(void)
 {
     return s_ws && esp_websocket_client_is_connected(s_ws);

--- a/main/voice.h
+++ b/main/voice.h
@@ -177,3 +177,9 @@ bool voice_is_connected(void);
  *  Call when the user actively interacts (e.g., taps the orb) while disconnected.
  *  This bypasses the watchdog delay so the user doesn't wait up to 60s. */
 void voice_force_reconnect(void);
+
+/** U21 (#206): re-evaluate the NVS conn_m setting and re-target the
+ *  WebSocket URI accordingly.  Call after \c tab5_settings_set_connection_mode()
+ *  so an Internet-Only / LAN-Only switch takes effect immediately
+ *  instead of waiting for the user to power-cycle. */
+void voice_reapply_connection_mode(void);


### PR DESCRIPTION
## Summary
- New \`voice_reapply_connection_mode()\` re-runs URI selection based on current \`conn_m\`.
- Settings dropdown + debug \`/settings\` JSON handler call it after writing NVS.
- Closes audit U21.

## Test plan
- [x] Flashed via USB; \`conn_mode=2\` re-targets to ngrok immediately
- [x] \`conn_mode=1\` re-targets back to LAN (ngrok fallback disabled)
- [x] Serial logs the swap with the new URI

🤖 Generated with [Claude Code](https://claude.com/claude-code)