### PR TITLE
fix(rest): send bearer auth on Dragon /api/v1 fetches (closes #227)

### DIFF
--- a/main/chat_session_drawer.c
+++ b/main/chat_session_drawer.c
@@ -307,8 +307,10 @@ static void parse_sessions_json(const char *json_txt, size_t len,
     if (!json_txt || len == 0) return;
     cJSON *root = cJSON_ParseWithLength(json_txt, len);
     if (!root) return;
-    /* Accept either {"sessions":[...]} or raw array. */
-    cJSON *arr = cJSON_GetObjectItem(root, "sessions");
+    /* Dragon ships {"items":[...]}; older mocks shipped {"sessions":[...]}
+     * or a raw array.  Accept all three. */
+    cJSON *arr = cJSON_GetObjectItem(root, "items");
+    if (!cJSON_IsArray(arr)) arr = cJSON_GetObjectItem(root, "sessions");
     if (!cJSON_IsArray(arr)) arr = root;
     if (!cJSON_IsArray(arr)) { cJSON_Delete(root); return; }
 
@@ -362,6 +364,13 @@ static void drawer_fetch_task(void *arg)
     };
     esp_http_client_handle_t client = esp_http_client_init(&cfg);
     if (client) {
+        /* Dragon's /api/v1 routes require Authorization: Bearer <token>. */
+        if (TAB5_DRAGON_TOKEN && TAB5_DRAGON_TOKEN[0] &&
+            strcmp(TAB5_DRAGON_TOKEN, "CHANGEME_SET_IN_SDKCONFIG_LOCAL") != 0) {
+            char auth[96];
+            snprintf(auth, sizeof(auth), "Bearer %s", TAB5_DRAGON_TOKEN);
+            esp_http_client_set_header(client, "Authorization", auth);
+        }
         esp_err_t err = esp_http_client_open(client, 0);
         if (err == ESP_OK) {
             int cl = (int)esp_http_client_fetch_headers(client);

--- a/main/ui_memory.c
+++ b/main/ui_memory.c
@@ -285,6 +285,15 @@ static void fetch_task(void *pv)
     s_last_fetch.ok    = false;
     if (!cli) goto done;
 
+    /* Dragon's /api/v1 routes require Authorization: Bearer <token>.
+     * Token is the same one voice.c sends on the WS upgrade. */
+    if (TAB5_DRAGON_TOKEN && TAB5_DRAGON_TOKEN[0] &&
+        strcmp(TAB5_DRAGON_TOKEN, "CHANGEME_SET_IN_SDKCONFIG_LOCAL") != 0) {
+        char auth[96];
+        snprintf(auth, sizeof(auth), "Bearer %s", TAB5_DRAGON_TOKEN);
+        esp_http_client_set_header(cli, "Authorization", auth);
+    }
+
     esp_err_t err = esp_http_client_open(cli, 0);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "http_client_open failed: %s", esp_err_to_name(err));

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -292,6 +292,15 @@ static void fetch_sessions_job(void *arg)
     esp_http_client_handle_t cli = esp_http_client_init(&cfg);
     if (!cli) goto done;
 
+    /* Dragon's /api/v1 routes need Authorization: Bearer <token>
+     * (same one voice.c uses on the WS upgrade). */
+    if (TAB5_DRAGON_TOKEN && TAB5_DRAGON_TOKEN[0] &&
+        strcmp(TAB5_DRAGON_TOKEN, "CHANGEME_SET_IN_SDKCONFIG_LOCAL") != 0) {
+        char auth[96];
+        snprintf(auth, sizeof(auth), "Bearer %s", TAB5_DRAGON_TOKEN);
+        esp_http_client_set_header(cli, "Authorization", auth);
+    }
+
     esp_err_t err = esp_http_client_open(cli, 0);
     int status = 0, content_len = 0, total = 0;
     char *body = NULL;
@@ -316,7 +325,10 @@ static void fetch_sessions_job(void *arg)
 
     cJSON *root = cJSON_ParseWithLength(body, total);
     if (!root) goto cleanup;
-    cJSON *arr = cJSON_GetObjectItem(root, "sessions");
+    /* Dragon ships {"items":[...]} on /api/v1/sessions; older mocks
+     * shipped {"sessions":[...]} or a raw array.  Accept all three. */
+    cJSON *arr = cJSON_GetObjectItem(root, "items");
+    if (!cJSON_IsArray(arr)) arr = cJSON_GetObjectItem(root, "sessions");
     if (!cJSON_IsArray(arr)) arr = root;
     if (!cJSON_IsArray(arr)) { cJSON_Delete(root); goto cleanup; }
 
@@ -341,19 +353,19 @@ static void fetch_sessions_job(void *arg)
         uint8_t v = cJSON_IsNumber(vm) ? (uint8_t)vm->valueint : 0;
         mode_to_tag(v, r->mode_tag, sizeof(r->mode_tag), &r->mode_color);
 
-        /* Dragon's /api/v1/sessions doesn't include msg counts in the
-         * default index payload — flag as unknown so build_session_row
-         * skips the count line cleanly. */
+        /* Dragon ships message_count on /api/v1/sessions; -1 means
+         * "not present" so build_session_row hides the count line. */
         cJSON *mc = cJSON_GetObjectItem(o, "message_count");
         r->msg_count = cJSON_IsNumber(mc) ? mc->valueint : -1;
 
+        /* Recency timestamp — Dragon uses "last_active_at" (touched on
+         * every turn).  Fall back to updated_at then created_at for
+         * older payloads / stripped responses. */
         uint32_t ts = 0;
-        cJSON *u = cJSON_GetObjectItem(o, "updated_at");
+        cJSON *u = cJSON_GetObjectItem(o, "last_active_at");
+        if (!cJSON_IsNumber(u)) u = cJSON_GetObjectItem(o, "updated_at");
+        if (!cJSON_IsNumber(u)) u = cJSON_GetObjectItem(o, "created_at");
         if (cJSON_IsNumber(u)) ts = (uint32_t)u->valuedouble;
-        else {
-            u = cJSON_GetObjectItem(o, "created_at");
-            if (cJSON_IsNumber(u)) ts = (uint32_t)u->valuedouble;
-        }
         format_when(ts, r->time_top, sizeof(r->time_top),
                        r->time_bot, sizeof(r->time_bot));
 


### PR DESCRIPTION
## Summary
- Inject \`Authorization: Bearer <TAB5_DRAGON_TOKEN>\` on three Dragon REST clients (ui_memory, ui_sessions, chat_session_drawer).
- Accept Dragon's \`{"items":[...]}\` payload shape.
- Fall through \`last_active_at\` → \`updated_at\` → \`created_at\` for session timestamps.
- Closes follow-up surfaced after #216 + #218.

## Test plan
- [x] Flashed via USB; serial logs \`GET .../api/v1/sessions -> 200\`
- [x] Sessions screen renders 12 real conversations with timestamps + models + modes + counts
- [x] Memory screen renders 6 real facts with real timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)