### PR TITLE
fix(chat): lv_screen_load(home) guard fixes #229 PANIC after camera

### DIFF
--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -468,6 +468,22 @@ static void poll_voice(lv_timer_t *t)
 
 lv_obj_t *ui_chat_create(void)
 {
+    /* #229 fix: when the user navigates "camera -> chat", the
+     * navigate handler tears down the camera screen (lv_obj_delete on
+     * the active screen) before calling us.  If we don't ensure home
+     * is loaded as the active screen, our overlay (parented to home)
+     * hangs in a tree whose root isn't on any display.  LVGL's render
+     * timer then walks a stale screen list and calls
+     * lv_obj_update_layout(NULL), exploding inside lv_obj_pos.c:304.
+     * Mirrors the guard ui_memory / ui_focus / ui_agents / ui_sessions
+     * already have. */
+    {
+        lv_obj_t *home = ui_home_get_screen();
+        if (home && lv_screen_active() != home) {
+            lv_screen_load(home);
+        }
+    }
+
     if (s_overlay) {
         lv_obj_clear_flag(s_overlay, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(s_overlay);


### PR DESCRIPTION
## Summary
- Add the missing \`lv_screen_load(home)\` guard at the top of \`ui_chat_create()\`.
- Mirrors the guard ui_memory / ui_focus / ui_agents / ui_sessions already had.
- Closes #229.

## Root cause
\`ui_camera_destroy()\` deletes the active screen on the navigate-from-camera path. \`ui_chat_create()\` only unhid its overlay (parented to home) without ensuring home was the active screen. LVGL's render timer then walked a stale screen list and called \`lv_obj_update_layout(NULL)\` → crash in \`lv_obj_pos.c:304\`.

Coredump backtrace pinpointed the call as coming from \`lv_display_refr_timer\` rather than from chat_msg_view itself, which is what made this look like a media-render bug at first.

## Test plan
- [x] Flashed via USB
- [x] Open chat → camera button → capture → upload pipeline runs
- [x] /navigate?screen=chat → chat re-opens cleanly (was the panic trigger)
- [x] IMAGE · INLINE bubble renders the actual decoded JPEG from Dragon
- [x] Uptime continues unbroken; reset_reason stays "USB" (no PANIC)
- [x] /chat/messages shows 1 image bubble in store

🤖 Generated with [Claude Code](https://claude.com/claude-code)