### PR TITLE
cleanup(ux): U15 + U17 + U18 small UX bundle (closes #234, refs #206)

### DIFF
--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <dirent.h>
 
 static const char *TAG = "ui_camera";
 
@@ -180,19 +181,54 @@ lv_obj_t *ui_camera_create(void)
 
     bool cam_ok = tab5_camera_initialized();
 
-    /* Find highest existing IMG_NNNN.jpg to avoid overwriting */
-    if (!capture_counter_init && tab5_sdcard_mounted()) {
-        char path[32];
-        for (uint32_t i = 9999; i > 0; i--) {
-            snprintf(path, sizeof(path), "/sdcard/IMG_%04"PRIu32".jpg", i);
-            struct stat st;
-            if (stat(path, &st) == 0) {
-                capture_counter = i + 1;
-                ESP_LOGI(TAG, "Resuming capture counter at %"PRIu32, capture_counter);
-                break;
+    /* U18 (#206): resume the capture counter from existing IMG_NNNN.jpg
+     * filenames on the SD card.
+     *
+     * Pre-fix: 9999 stat() calls in a loop, run once on first camera
+     * open.  Two failure modes:
+     *   - Slow SD or large card → 9999 stats can take seconds and
+     *     trip the LVGL/IDLE WDT before the screen is even built.
+     *   - SD inserted AFTER first camera open → the init flag was
+     *     set permanently when the previous open ran with no SD,
+     *     so the counter stayed at 0 and the next capture overwrote
+     *     IMG_0000.jpg (or worse, clobbered an existing photo).
+     *
+     * Post-fix: single opendir+readdir scan (one pass over directory
+     * entries, not a 0..9999 brute force), and gate on actual SD mount
+     * state so a late insert re-scans on the next ui_camera_create. */
+    if (tab5_sdcard_mounted()) {
+        if (!capture_counter_init) {
+            DIR *d = opendir("/sdcard");
+            uint32_t highest = 0;
+            if (d) {
+                struct dirent *de;
+                while ((de = readdir(d)) != NULL) {
+                    /* Match IMG_NNNN.jpg / IMG_NNNN.JPG (case-insensitive
+                     * because FATFS short-name mode upcases everything). */
+                    if (strncasecmp(de->d_name, "IMG_", 4) != 0) continue;
+                    const char *dot = strrchr(de->d_name, '.');
+                    if (!dot || strcasecmp(dot, ".jpg") != 0) continue;
+                    /* Parse the 4-digit number between IMG_ and .jpg. */
+                    char num_buf[8] = {0};
+                    size_t num_len = (size_t)(dot - (de->d_name + 4));
+                    if (num_len == 0 || num_len >= sizeof(num_buf)) continue;
+                    memcpy(num_buf, de->d_name + 4, num_len);
+                    char *end = NULL;
+                    unsigned long n = strtoul(num_buf, &end, 10);
+                    if (end != num_buf + num_len) continue;
+                    if (n > highest) highest = (uint32_t)n;
+                }
+                closedir(d);
             }
+            capture_counter = highest + 1;
+            capture_counter_init = true;
+            ESP_LOGI(TAG, "Capture counter resumed at %"PRIu32 " (scanned existing IMG_*.jpg)",
+                     capture_counter);
         }
-        capture_counter_init = true;
+    } else {
+        /* SD not mounted (yet).  Don't latch capture_counter_init —
+         * next open after the user inserts the card will re-scan. */
+        capture_counter_init = false;
     }
 
     /* ── Screen ──────────────────────────────────────────────── */

--- a/main/ui_files.c
+++ b/main/ui_files.c
@@ -163,6 +163,11 @@ static void cb_retry_sd(lv_event_t *e)
     }
     if (tab5_sdcard_mounted()) {
         rebuild_list();
+        /* U15 (#206): show_no_sd hid the bottombar (the "X GB free of Y"
+         * row) while the panel was up.  rebuild_list re-populates the
+         * file list but used to leave the bottom row hidden, so the
+         * surface looked stripped after a successful retry. */
+        if (bottombar) lv_obj_remove_flag(bottombar, LV_OBJ_FLAG_HIDDEN);
     } else {
         show_no_sd();
     }

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -1015,14 +1015,19 @@ static void phase2_timer_cb(lv_timer_t *t)
     }
     y += ROW_H + 8;
 
-    /* Wave 4: "Show intro again" row — re-triggers the onboarding
-     * carousel without requiring an NVS erase.  Useful after a factory
-     * reset-like setup or when demoing the product. */
+    /* "Show intro again" row — re-triggers the onboarding carousel
+     * without requiring an NVS erase.  Useful after a factory-reset-
+     * like setup or when demoing the product.
+     *
+     * U17 (#206): was rendered in dim grey on dim grey ("buried"
+     * per the audit).  Promoted to the section-accent color (amber)
+     * so users can find it without scanning every row in About. */
     {
         extern void cb_replay_intro(lv_event_t *e);
-        lv_obj_t *intro_btn = mk_pill_btn(s_scroll, "Show intro again",
-                                          lv_color_hex(0x2A2A3A),
-                                          lv_color_hex(TEXT_DIM),
+        lv_obj_t *intro_btn = mk_pill_btn(s_scroll,
+                                          LV_SYMBOL_REFRESH " Show intro again",
+                                          acc_about,
+                                          lv_color_hex(TEXT_PRIMARY),
                                           SIDE_PAD, y + 3, CONTENT_W, 42, 8,
                                           cb_replay_intro);
         (void)intro_btn;


### PR DESCRIPTION
## Summary
- **U15**: \`cb_retry_sd\` restores the bottom storage bar after a successful Retry.
- **U17**: "Show intro again" promoted from buried-grey to amber-accent pill with refresh icon.
- **U18**: capture counter resumption — single \`opendir\` scan + don't latch init flag when SD isn't mounted.
- Closes audits U15 + U17 + U18.

## Test plan
- [x] U18: flashed; serial logs \`Capture counter resumed at 10 (scanned existing IMG_*.jpg)\`; FPS healthy
- [x] U17: screenshot of Settings → About shows amber-tinted button
- [x] U15: code-reviewed (live SD eject not tested — needs physical access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)