### PR TITLE
fix(home): hide floating keyboard trigger on home (closes #236, refs #206)

### DIFF
--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -613,7 +613,10 @@ void ui_chat_hide(void)
     if (!s_overlay) return;
     ui_keyboard_set_layout_cb(NULL);
     ui_keyboard_hide();
-    ui_keyboard_set_trigger_visible(true);  /* restore for home / notes / wifi */
+    /* U16 (#206): don't auto-restore the floating keyboard trigger on
+     * chat hide.  Home explicitly hides it (its menu chip lives in the
+     * trigger's hitbox).  Other screens that actually want it (notes /
+     * wifi text fields) call set_trigger_visible(true) themselves. */
     if (s_poll) lv_timer_pause(s_poll);
     if (s_drawer) chat_session_drawer_hide(s_drawer);
     lv_obj_add_flag(s_overlay, LV_OBJ_FLAG_HIDDEN);

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -694,6 +694,12 @@ lv_obj_t *ui_home_create(void)
      * content in subsequent strips is visible via /screenshot. */
     lv_refr_now(lv_display_get_default());
 
+    /* U16 (#206): boot-time hide of the floating keyboard trigger so
+     * its (640, 1136) hitbox doesn't shadow the home menu chip at
+     * (612..668, 1160..1216).  See ui_home_go_home for the rationale. */
+    extern void ui_keyboard_set_trigger_visible(bool);
+    ui_keyboard_set_trigger_visible(false);
+
     ESP_LOGI(TAG, "v4 Ambient Canvas home created (orb %dpx, mode %d)",
              ORB_SIZE, s_badge_mode);
     return s_screen;
@@ -1625,6 +1631,15 @@ void ui_home_go_home(void)
     /* Wave 4 UX: drop a stale idle voice overlay so the user sees home. */
     extern void ui_voice_dismiss_if_idle(void);
     ui_voice_dismiss_if_idle();
+    /* U16 (#206): the floating keyboard trigger sits on lv_layer_top()
+     * at (640, 1136) — directly on top of home's menu chip
+     * (612..668, 1160..1216).  Home has no text-input use case (the
+     * menu chip + orb-mic are the only affordances), so the trigger
+     * eats taps that should open the nav sheet.  Hide it on home;
+     * other screens (notes, wifi, settings textareas, etc.) restore
+     * it via ui_keyboard_set_trigger_visible(true). */
+    extern void ui_keyboard_set_trigger_visible(bool);
+    ui_keyboard_set_trigger_visible(false);
 }
 
 lv_obj_t *ui_home_get_tileview(void) { return NULL; }


### PR DESCRIPTION
## Summary
- ui_home_create + ui_home_go_home call \`ui_keyboard_set_trigger_visible(false)\`.
- ui_chat_hide no longer auto-restores the trigger.
- Closes audit U16 — the last LOW-priority audit item.

## Test plan
- [x] Flashed via USB; home renders without the floating-trigger glyph
- [x] Tap (640, 1188) → \`ui_nav_sheet: nav sheet shown\` in serial (not the keyboard)
- [x] Nav-sheet 9-tile grid rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)