### PR TITLE
fix(chat): scrub <tool>/<args> XML from streamed LLM text (closes #160, closes #78)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2606,6 +2606,36 @@ static esp_err_t chat_messages_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
+/* ── POST /chat/llm_done?text=<> ────────────────────────────────
+ * #78 + #160 verification: feed `text` through the same
+ * md_strip_tool_markers + ui_chat_push_message path voice.c's
+ * llm_done handler runs.  Verifies the Tab5-side defensive scrub
+ * without needing Dragon to actually emit a tool-call. */
+extern void md_strip_tool_markers(const char *in, char *out, size_t out_cap);
+static void url_pct_decode_inplace(char *s);   /* defined further below */
+static esp_err_t chat_llm_done_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    char q[1024] = {0}, text[800] = {0};
+    httpd_req_get_url_query_str(req, q, sizeof(q));
+    httpd_query_key_value(q, "text", text, sizeof(text));
+    url_pct_decode_inplace(text);
+    cJSON *root = cJSON_CreateObject();
+    if (!text[0]) {
+        cJSON_AddStringToObject(root, "error", "need ?text=<llm response>");
+        return send_json_resp(req, root);
+    }
+    char clean[800];
+    md_strip_tool_markers(text, clean, sizeof(clean));
+    if (clean[0]) {
+        ui_chat_push_message("assistant", clean);
+    }
+    cJSON_AddBoolToObject(root, "ok", true);
+    cJSON_AddStringToObject(root, "raw", text);
+    cJSON_AddStringToObject(root, "after_strip", clean);
+    return send_json_resp(req, root);
+}
+
 /* ── POST /chat/partial?text=<> ─────────────────────────────────
  * U12 (#206) verification helper: shove a string into the live
  * STT-partial caption above the chat input pill.  Empty text hides. */
@@ -2991,6 +3021,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_chat_audio     = { .uri = "/chat/audio_clip",.method = HTTP_POST, .handler = chat_audio_clip_handler };
     const httpd_uri_t uri_tool_push      = { .uri = "/tool_log/push",  .method = HTTP_POST, .handler = tool_log_push_handler };
     const httpd_uri_t uri_chat_partial   = { .uri = "/chat/partial",   .method = HTTP_POST, .handler = chat_partial_handler };
+    const httpd_uri_t uri_chat_llm_done  = { .uri = "/chat/llm_done",  .method = HTTP_POST, .handler = chat_llm_done_handler };
     const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
     const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
 
@@ -3041,6 +3072,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_chat_audio);
     httpd_register_uri_handler(server, &uri_tool_push);
     httpd_register_uri_handler(server, &uri_chat_partial);
+    httpd_register_uri_handler(server, &uri_chat_llm_done);
     httpd_register_uri_handler(server, &uri_net_ping);
     httpd_register_uri_handler(server, &uri_nvs_erase);
 

--- a/main/md_strip.c
+++ b/main/md_strip.c
@@ -2,7 +2,10 @@
 #include "md_strip.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <string.h>
+#include <strings.h>
+#include <stdint.h>
 #include <ctype.h>
 
 static bool is_line_start(const char *buf, const char *p)
@@ -94,4 +97,99 @@ void md_strip_inline_with_ellipsis(const char *in, char *out, size_t out_cap)
         out[written++] = (char)0xA6;
         out[written]   = 0;
     }
+}
+
+/* Issues #78 + #160 — see md_strip.h.
+ *
+ * State-machine scrub of `<tag>...</tag>` regions for the well-known
+ * Dragon tool-call markers.  We deliberately only strip these two tags
+ * — a generic "remove all XML" would mangle legitimate prose like
+ * "<3" or "x<5".  Case-insensitive on the tag name, content between
+ * tags is dropped, surrounding whitespace is collapsed.
+ */
+
+static bool tag_match_at(const char *s, size_t n, size_t at,
+                         const char *tag, size_t tag_len)
+{
+    if (at + tag_len + 2 > n) return false;
+    if (s[at] != '<') return false;
+    if (strncasecmp(s + at + 1, tag, tag_len) != 0) return false;
+    char terminator = s[at + 1 + tag_len];
+    /* Accept "<tool>" or "<tool ".  Reject "<tools" / "<tooling". */
+    return terminator == '>' || terminator == ' ' || terminator == '\t';
+}
+
+static bool close_tag_match_at(const char *s, size_t n, size_t at,
+                               const char *tag, size_t tag_len)
+{
+    if (at + tag_len + 3 > n) return false;
+    if (s[at] != '<' || s[at + 1] != '/') return false;
+    if (strncasecmp(s + at + 2, tag, tag_len) != 0) return false;
+    return s[at + 2 + tag_len] == '>';
+}
+
+static size_t skip_to_close(const char *s, size_t n, size_t from,
+                            const char *tag, size_t tag_len)
+{
+    /* Walk forward past the open tag's '>' first. */
+    size_t i = from;
+    while (i < n && s[i] != '>') i++;
+    if (i < n) i++;  /* past '>' */
+    /* Scan for </tag>.  If unbalanced, give up at end of string. */
+    while (i < n) {
+        if (close_tag_match_at(s, n, i, tag, tag_len)) {
+            return i + tag_len + 3;  /* past </tag> */
+        }
+        i++;
+    }
+    return n;
+}
+
+void md_strip_tool_markers(const char *in, char *out, size_t out_cap)
+{
+    if (!out || out_cap == 0) return;
+    if (!in) { out[0] = 0; return; }
+
+    static const char *kTags[] = { "tool", "args" };
+    static const size_t kTagLens[] = { 4, 4 };
+    const size_t kNumTags = sizeof(kTags) / sizeof(kTags[0]);
+
+    size_t n = strlen(in);
+    size_t oi = 0;
+    size_t i = 0;
+    while (i < n && oi + 1 < out_cap) {
+        bool stripped = false;
+        for (size_t t = 0; t < kNumTags; t++) {
+            if (tag_match_at(in, n, i, kTags[t], kTagLens[t])) {
+                i = skip_to_close(in, n, i, kTags[t], kTagLens[t]);
+                /* Emit a sentinel space so "Sure.<tool>...</args>Here"
+                 * collapses to "Sure. Here" instead of "Sure.Here".
+                 * The whitespace-collapse pass below normalises adjacent
+                 * spaces, so we don't have to worry about doubles. */
+                if (oi + 1 < out_cap) out[oi++] = ' ';
+                stripped = true;
+                break;
+            }
+        }
+        if (stripped) continue;
+        out[oi++] = in[i++];
+    }
+    out[oi] = 0;
+
+    /* Collapse runs of whitespace introduced by the strip + trim leading/
+     * trailing space.  In-place compaction. */
+    size_t r = 0, w = 0;
+    bool in_ws = true;  /* start in trim-leading mode */
+    while (r < oi) {
+        unsigned char c = (unsigned char)out[r++];
+        bool ws = (c == ' ' || c == '\t' || c == '\n' || c == '\r');
+        if (ws) {
+            if (!in_ws) { out[w++] = ' '; in_ws = true; }
+        } else {
+            out[w++] = (char)c;
+            in_ws = false;
+        }
+    }
+    while (w > 0 && out[w - 1] == ' ') w--;
+    out[w] = 0;
 }

--- a/main/md_strip.h
+++ b/main/md_strip.h
@@ -30,3 +30,17 @@ void md_strip_inline(const char *in, char *out, size_t out_cap);
  * Always NUL-terminated.  Safe for empty / NULL input.
  */
 void md_strip_inline_with_ellipsis(const char *in, char *out, size_t out_cap);
+
+/* Issues #78 + #160: strip Dragon's tool-call XML markers from a
+ * streamed LLM response so the user doesn't see raw
+ *   <tool>recall</tool><args>{"query":"..."}</args>
+ * land as a chat bubble.  Tab5-side defensive scrub — Dragon may also
+ * strip server-side, but a token-stream timing race can still leak the
+ * markers (the audit issue caught this in a real screenshot).
+ *
+ * Removes any well-formed `<tool>...</tool>` and `<args>...</args>`
+ * sub-strings (case-insensitive, span newlines), collapses the
+ * resulting double-spaces, and trims leading/trailing whitespace.
+ * Works in-place when out == in.  Always NUL-terminated.
+ */
+void md_strip_tool_markers(const char *in, char *out, size_t out_cap);

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -545,7 +545,11 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
         if (has_conversation) {
             const char *llm_txt2 = voice_get_llm_text();
             if (llm_txt2 && llm_txt2[0] && s_response_label) {
-                { char _m[256]; md_strip_inline_with_ellipsis(llm_txt2, _m, sizeof(_m));
+                /* #78 + #160: tool-marker scrub before the markdown
+                 * pass so raw <tool>...</tool> never flashes in the
+                 * voice overlay caption either. */
+                { char _m[256]; md_strip_tool_markers(llm_txt2, _m, sizeof(_m));
+                  md_strip_inline_with_ellipsis(_m, _m, sizeof(_m));
                   lv_label_set_text(s_response_label, _m); }
                 lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
                 lv_obj_move_foreground(s_response_label);
@@ -1190,9 +1194,12 @@ static void show_state_processing(const char *detail)
             lv_obj_add_flag(s_lbl_status, LV_OBJ_FLAG_HIDDEN);
         }
 
-        /* #115: drive the fixed-position response label. */
+        /* #115: drive the fixed-position response label.
+         * #78 + #160: scrub tool markers first so streamed <tool>...
+         * never flashes in the caption. */
         if (s_response_label) {
-            { char _m[256]; md_strip_inline_with_ellipsis(llm, _m, sizeof(_m));
+            { char _m[256]; md_strip_tool_markers(llm, _m, sizeof(_m));
+              md_strip_inline_with_ellipsis(_m, _m, sizeof(_m));
               lv_label_set_text(s_response_label, _m); }
             lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
             lv_obj_move_foreground(s_response_label);
@@ -1253,10 +1260,12 @@ static void show_state_speaking(void)
     /* Keep chat area visible with both bubbles */
     const char *llm = voice_get_llm_text();
     /* U20 (#206): bubble paths removed.  STT is reflected by the
-     * status string from voice.c; LLM tokens drive s_response_label. */
+     * status string from voice.c; LLM tokens drive s_response_label.
+     * #78 + #160: scrub tool markers before the markdown pass. */
     if (llm && llm[0] && s_response_label) {
         char _m[256];
-        md_strip_inline_with_ellipsis(llm, _m, sizeof(_m));
+        md_strip_tool_markers(llm, _m, sizeof(_m));
+        md_strip_inline_with_ellipsis(_m, _m, sizeof(_m));
         lv_label_set_text(s_response_label, _m);
         lv_obj_clear_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
         lv_obj_move_foreground(s_response_label);

--- a/main/voice.c
+++ b/main/voice.c
@@ -24,6 +24,7 @@
 #include "voice.h"
 #include "task_worker.h"   /* #133: defer queue-drain to avoid stack blow */
 #include "tool_log.h"      /* U7+U8 (#206): record tool activity for ui_agents/ui_focus */
+#include "md_strip.h"     /* #78 + #160: scrub <tool>...</tool> markers from streamed LLM text */
 #include <limits.h>  /* W14-L02: INT_MAX for WS size_t->int bound */
 #include "widget.h"
 #include "ui_voice.h"
@@ -1027,7 +1028,19 @@ static void handle_text_message(const char *data, int len)
             bubble_text = full->valuestring;
         }
         if (bubble_text && bubble_text[0]) {
-            ui_chat_push_message("assistant", bubble_text);
+            /* #78 + #160: defensive Tab5-side scrub of any <tool>...</tool>
+             * + <args>...</args> markers that survived Dragon's
+             * server-side stripper.  Without this the user sometimes
+             * sees raw "<tool>recall</tool><args>{\"query\":...}</args>"
+             * land as a chat bubble (caught by the audit screenshot in
+             * #160).  The strip handles the bubble destined for chat;
+             * s_llm_text continues to hold the raw text in case other
+             * paths need it. */
+            char clean[MAX_TRANSCRIPT_LEN];
+            md_strip_tool_markers(bubble_text, clean, sizeof(clean));
+            if (clean[0]) {
+                ui_chat_push_message("assistant", clean);
+            }
         }
         /* v4·D TC polish: if no TTS is coming (TC bypass never sends
          * tts_start -- gateway is text-only), transition to READY


### PR DESCRIPTION
## Summary
- New \`md_strip_tool_markers()\` — state-machine scrub of \`<tool>...</tool>\` + \`<args>...</args>\` regions.
- voice.c \`llm_done\` + ui_voice's three render sites now scrub before push.
- Debug helper \`POST /chat/llm_done?text=...\` for verification.
- Closes #160 + #78 in one shot.

## Test plan
- [x] 5 strip cases verified via debug endpoint (canonical / marker-only / no-markers / "<3" prose / multiline tags)
- [x] Fresh-boot screenshot of chat shows the cleaned bubble after the canonical XML payload was pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)