### PR TITLE
fix(chat): rebind slot on in-place message edits (closes #239)

### DIFF
--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -791,6 +791,10 @@ void chat_msg_view_append_stream(chat_msg_view_t *v, const char *text)
 
     /* Push into the store so the view refresh picks it up. */
     chat_store_update_last_text(v->stream_buf);
+    /* Streaming mutates the last message's text in place; invalidate
+     * the bound slot so refresh runs slot_bind again instead of
+     * skipping with the "already bound" optimisation. */
+    chat_msg_view_invalidate_index(v, chat_store_count() - 1);
     chat_msg_view_refresh(v);
     chat_msg_view_scroll_to_bottom(v);
 }
@@ -813,6 +817,25 @@ bool chat_msg_view_is_streaming(chat_msg_view_t *v)
 lv_obj_t *chat_msg_view_get_scroll(chat_msg_view_t *v)
 {
     return v ? v->scroll : NULL;
+}
+
+void chat_msg_view_invalidate_index(chat_msg_view_t *v, int idx)
+{
+    /* Walk the pool and unbind any slot that was bound to `idx`.  The
+     * next refresh will treat the slot as free, find idx unbound, and
+     * call slot_bind — which is what re-renders msg->text into the
+     * label.  Without this, refresh's "already bound, skip" pass at
+     * line ~702 leaves the label stale after an in-place edit
+     * (chat_store_update_last_text or the assistant-bubble dedup
+     * path in async_push_msg_cb).
+     *
+     * No-op when the index isn't currently bound to any slot. */
+    if (!v || idx < 0) return;
+    for (int s = 0; s < BSP_CHAT_POOL_SIZE; s++) {
+        if (v->pool[s].data_idx == idx) {
+            slot_reset(&v->pool[s]);
+        }
+    }
 }
 
 /* U5 (#206): brk_body tap dispatcher.  Reads the slot's currently-bound

--- a/main/chat_msg_view.h
+++ b/main/chat_msg_view.h
@@ -28,6 +28,14 @@ void chat_msg_view_set_mode_color(chat_msg_view_t *v, uint32_t hex);
 void chat_msg_view_refresh(chat_msg_view_t *v);
 void chat_msg_view_scroll_to_bottom(chat_msg_view_t *v);
 
+/** Invalidate any pool slot currently bound to message `idx` so the
+ *  next refresh re-binds (re-runs slot_bind, picking up the latest
+ *  msg->text and styles).  Used by in-place edits — the
+ *  chat_store_update_last_text path and the assistant-bubble dedup
+ *  path mutate a message's text in place; without this kick, refresh's
+ *  "already bound, skip" optimisation leaves the visible label stale. */
+void chat_msg_view_invalidate_index(chat_msg_view_t *v, int idx);
+
 /** Begin a streaming AI message: pin the last slot, buffer tokens. */
 void chat_msg_view_begin_streaming(chat_msg_view_t *v);
 void chat_msg_view_append_stream(chat_msg_view_t *v, const char *text);

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -733,6 +733,11 @@ static void async_push_msg_cb(void *arg)
                 m->height_px = -1;
             }
             if (s_view) {
+                /* Invalidate the existing slot so refresh re-runs
+                 * slot_bind and picks up the new text — without this,
+                 * refresh sees data_idx==merge_idx already bound and
+                 * skips, leaving the visible label stale. */
+                chat_msg_view_invalidate_index(s_view, merge_idx);
                 chat_msg_view_refresh(s_view);
                 chat_msg_view_scroll_to_bottom(s_view);   /* closes #107 */
             }


### PR DESCRIPTION
## Summary
- New \`chat_msg_view_invalidate_index(v, idx)\` un-binds any pool slot for an updated message so refresh re-runs \`slot_bind\`.
- Wired into the dedup path (#129) + streaming append path.
- Fixes both the dedup and streaming stale-label classes in one change.

## Test plan
- [x] Flashed via USB; pushed AAAA → BBBB → CCCC sequence
- [x] Each push correctly updates the visible bubble (was stuck on AAAA before)
- [x] Store + view stay in sync end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)