### PR TITLE
fix(heap): route cJSON + REST bodies to PSRAM (closes #241, refs #182)

### DIFF
--- a/main/chat_session_drawer.c
+++ b/main/chat_session_drawer.c
@@ -376,7 +376,11 @@ static void drawer_fetch_task(void *arg)
             int cl = (int)esp_http_client_fetch_headers(client);
             if (cl <= 0) cl = 16384;                         /* safety */
             if (cl > 32 * 1024) cl = 32 * 1024;              /* upper bound */
-            char *buf = malloc(cl + 1);
+            /* PSRAM-backed: see ui_sessions.c for the rationale (up
+             * to 32 KB body was carving the tight internal heap on
+             * every drawer open). */
+            char *buf = heap_caps_malloc((size_t)cl + 1,
+                                         MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
             if (buf) {
                 int total = 0;
                 while (total < cl) {
@@ -388,7 +392,7 @@ static void drawer_fetch_task(void *arg)
                 if (total > 0) {
                     parse_sessions_json(buf, total, res->sessions, &res->count);
                 }
-                free(buf);
+                heap_caps_free(buf);
             }
         }
         esp_http_client_close(client);

--- a/main/main.c
+++ b/main/main.c
@@ -21,6 +21,7 @@
 #include "esp_task_wdt.h"
 #include "nvs_flash.h"
 #include "esp_heap_caps.h"
+#include "cJSON.h"   /* #182 follow-up: route cJSON allocs to PSRAM */
 #include "esp_timer.h"
 #include "driver/i2c_master.h"
 
@@ -194,8 +195,42 @@ done:
     vTaskSuspend(NULL);  /* P4 TLSP workaround (#20) */
 }
 
+/* #182 follow-up: every cJSON_Parse/AddString/etc allocates per-node
+ * objects via the default malloc, which on ESP-IDF lands in internal
+ * SRAM.  voice.c hits cJSON dozens of times per minute (every WS frame
+ * — llm token, tool_call, ping, config_update, …) plus REST handlers
+ * fire it on every fetch.  At ~50 B/node × hundreds of allocs/min the
+ * tight 512 KB internal heap fragments slowly until heap_watchdog's
+ * SRAM-exhaustion detector trips a controlled reboot.
+ *
+ * Routing cJSON's allocator to PSRAM (via cJSON_InitHooks) makes ALL
+ * cJSON node allocations land in the spacious 32 MB PSRAM heap
+ * instead.  PSRAM is ~3-5× slower per access than internal SRAM, but
+ * cJSON nodes are touched once at parse + once at delete; the marginal
+ * latency is invisible against 60-90 s LLM turns and 250 ms REST
+ * round-trips.  In return we eliminate the steady internal-SRAM drift
+ * that was the proximate cause of the periodic safety reboots. */
+static void *cjson_psram_malloc(size_t sz) {
+    return heap_caps_malloc(sz, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+}
+static void cjson_psram_free(void *p) {
+    heap_caps_free(p);
+}
+static void install_cjson_psram_hooks(void) {
+    cJSON_Hooks hooks = {
+        .malloc_fn = cjson_psram_malloc,
+        .free_fn   = cjson_psram_free,
+    };
+    cJSON_InitHooks(&hooks);
+}
+
 void app_main(void)
 {
+    /* Install cJSON PSRAM hooks IMMEDIATELY — before any subsystem
+     * gets a chance to call cJSON_Parse and cache nodes via the
+     * default malloc.  PSRAM is already up at this point (the bootloader
+     * brought it up before app_main). */
+    install_cjson_psram_hooks();
     printf("\n\n");
     printf("========================================\n");
     printf("  TinkerTab v1.0.0 — Full Hardware\n");

--- a/main/ui_memory.c
+++ b/main/ui_memory.c
@@ -301,7 +301,11 @@ static void fetch_task(void *pv)
     }
     int content_len = esp_http_client_fetch_headers(cli);
     if (content_len < 0) content_len = 8192;
-    char *body = malloc(content_len + 1);
+    /* PSRAM-backed: see ui_sessions.c for the rationale (REST body
+     * up to 32 KB was malloc'd to internal SRAM and slowly fragmented
+     * the tight internal heap on every fetch). */
+    char *body = heap_caps_malloc((size_t)content_len + 1,
+                                  MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (!body) goto cleanup;
     int got = 0;
     while (got < content_len) {
@@ -314,12 +318,12 @@ static void fetch_task(void *pv)
     int status = esp_http_client_get_status_code(cli);
     ESP_LOGI(TAG, "GET %s -> %d (%d bytes)", url, status, got);
     if (status != 200) {
-        free(body);
+        heap_caps_free(body);
         goto cleanup;
     }
 
     cJSON *root = cJSON_Parse(body);
-    free(body);
+    heap_caps_free(body);
     if (!root) {
         ESP_LOGW(TAG, "cJSON parse failed");
         goto cleanup;

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -311,7 +311,12 @@ static void fetch_sessions_job(void *arg)
     content_len = esp_http_client_fetch_headers(cli);
     if (content_len <= 0)        content_len = 16384;
     if (content_len > 32 * 1024) content_len = 32 * 1024;
-    body = malloc(content_len + 1);
+    /* PSRAM-backed: prevents internal-SRAM fragmentation on every
+     * fetch (#182 follow-up — the REST body could be 6-32 KB and was
+     * carving the tight internal heap in plain malloc, contributing
+     * to the slow drift the SRAM-exhaustion watchdog catches). */
+    body = heap_caps_malloc((size_t)content_len + 1,
+                            MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (!body) goto cleanup;
     while (total < content_len) {
         int r = esp_http_client_read(cli, body + total, content_len - total);
@@ -375,7 +380,7 @@ static void fetch_sessions_job(void *arg)
     cJSON_Delete(root);
 
 cleanup:
-    if (body) free(body);
+    if (body) heap_caps_free(body);
     esp_http_client_close(cli);
     esp_http_client_cleanup(cli);
 done:


### PR DESCRIPTION
## Summary
- \`cJSON_InitHooks\` at boot routes ALL cJSON node allocations (242 sites firmware-wide) to PSRAM.
- REST body buffers in ui_sessions/ui_memory/chat_session_drawer switched to \`heap_caps_malloc(SPIRAM)\`.
- Closes #241; meaningful relief for #182 (residual SW-reset under stress).

## Test plan
- [x] Flashed via USB
- [x] 20 mixed cycles (sessions x10 + chat x5 + camera x5) — internal SRAM held flat at \`largest=68 KB\` (was dropping into the 30 KB reboot zone in 5-8 cycles before)
- [x] No watchdog-triggered reboot during stress

🤖 Generated with [Claude Code](https://claude.com/claude-code)