### PR TITLE
fix(keyboard): live /keyboard/layout endpoint kills coord drift (closes #161)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2606,6 +2606,43 @@ static esp_err_t chat_messages_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
+/* ── GET /keyboard/layout ───────────────────────────────────────
+ * Issue #161: returns the live keyboard key positions so tests can
+ * derive tap coords instead of hardcoding them in a memory file that
+ * rots on layout drift.  Empty array when keyboard isn't built yet. */
+#include "ui_keyboard.h"
+static esp_err_t keyboard_layout_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    cJSON *root = cJSON_CreateObject();
+    cJSON *keys = cJSON_AddArrayToObject(root, "keys");
+    cJSON_AddBoolToObject(root, "visible", ui_keyboard_is_visible());
+    /* Cap matches the busiest layer (letters has ~33 keys). */
+    enum { CAP = 48 };
+    static ui_keyboard_key_info_t buf[CAP];
+    int n = ui_keyboard_dump_layout(buf, CAP);
+    cJSON_AddNumberToObject(root, "count", n);
+    static const char *kTypeName[] = {
+        "char", "backspace", "shift", "enter", "space", "layer",
+    };
+    for (int i = 0; i < n && i < CAP; i++) {
+        cJSON *k = cJSON_CreateObject();
+        cJSON_AddStringToObject(k, "label", buf[i].label);
+        cJSON_AddNumberToObject(k, "x",  buf[i].x);
+        cJSON_AddNumberToObject(k, "y",  buf[i].y);
+        cJSON_AddNumberToObject(k, "w",  buf[i].w);
+        cJSON_AddNumberToObject(k, "h",  buf[i].h);
+        /* center-of-key tap targets — most useful for scripts */
+        cJSON_AddNumberToObject(k, "cx", buf[i].x + buf[i].w / 2);
+        cJSON_AddNumberToObject(k, "cy", buf[i].y + buf[i].h / 2);
+        const char *tn = (buf[i].type < (sizeof(kTypeName) / sizeof(*kTypeName)))
+                       ? kTypeName[buf[i].type] : "unknown";
+        cJSON_AddStringToObject(k, "type", tn);
+        cJSON_AddItemToArray(keys, k);
+    }
+    return send_json_resp(req, root);
+}
+
 /* ── POST /chat/llm_done?text=<> ────────────────────────────────
  * #78 + #160 verification: feed `text` through the same
  * md_strip_tool_markers + ui_chat_push_message path voice.c's
@@ -3022,6 +3059,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_tool_push      = { .uri = "/tool_log/push",  .method = HTTP_POST, .handler = tool_log_push_handler };
     const httpd_uri_t uri_chat_partial   = { .uri = "/chat/partial",   .method = HTTP_POST, .handler = chat_partial_handler };
     const httpd_uri_t uri_chat_llm_done  = { .uri = "/chat/llm_done",  .method = HTTP_POST, .handler = chat_llm_done_handler };
+    const httpd_uri_t uri_kb_layout      = { .uri = "/keyboard/layout",.method = HTTP_GET,  .handler = keyboard_layout_handler };
     const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
     const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
 
@@ -3073,6 +3111,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_tool_push);
     httpd_register_uri_handler(server, &uri_chat_partial);
     httpd_register_uri_handler(server, &uri_chat_llm_done);
+    httpd_register_uri_handler(server, &uri_kb_layout);
     httpd_register_uri_handler(server, &uri_net_ping);
     httpd_register_uri_handler(server, &uri_nvs_erase);
 

--- a/main/ui_keyboard.c
+++ b/main/ui_keyboard.c
@@ -280,6 +280,49 @@ void ui_keyboard_set_trigger_visible(bool visible)
     else         lv_obj_add_flag(s_trigger_btn, LV_OBJ_FLAG_HIDDEN);
 }
 
+/* Issue #161: walk the active row tree and dump live key geometry +
+ * label so automated tests can derive tap coords instead of hardcoding
+ * them in a memory file that rots whenever the layout changes. */
+int ui_keyboard_dump_layout(ui_keyboard_key_info_t *out_keys, int cap)
+{
+    if (!s_kb_panel) return 0;
+
+    /* Force a layout refresh so reported coords match the rendered
+     * frame (LVGL otherwise lazily computes them on the next draw). */
+    lv_obj_update_layout(s_kb_panel);
+
+    lv_obj_t **rows = s_num_layer ? s_num_rows : s_letter_rows;
+    int found = 0;
+    for (int r = 0; r < 4; r++) {
+        lv_obj_t *row = rows[r];
+        if (!row) continue;
+        uint32_t n = lv_obj_get_child_count(row);
+        for (uint32_t i = 0; i < n; i++) {
+            lv_obj_t *key = lv_obj_get_child(row, i);
+            if (!key) continue;
+            if (out_keys && found < cap) {
+                ui_keyboard_key_info_t *e = &out_keys[found];
+                memset(e, 0, sizeof(*e));
+                /* Absolute screen coords via lv_area_t. */
+                lv_area_t a; lv_obj_get_coords(key, &a);
+                e->x = a.x1;
+                e->y = a.y1;
+                e->w = a.x2 - a.x1 + 1;
+                e->h = a.y2 - a.y1 + 1;
+                e->type = (uint8_t)(uintptr_t)lv_obj_get_user_data(key);
+                /* Label is the first child created via lv_label_create. */
+                if (lv_obj_get_child_count(key) > 0) {
+                    lv_obj_t *lbl = lv_obj_get_child(key, 0);
+                    const char *txt = lv_label_get_text(lbl);
+                    if (txt) snprintf(e->label, sizeof(e->label), "%s", txt);
+                }
+            }
+            found++;
+        }
+    }
+    return found;
+}
+
 /* ========================================================================= */
 /*  Build keyboard panel                                                      */
 /* ========================================================================= */

--- a/main/ui_keyboard.h
+++ b/main/ui_keyboard.h
@@ -57,3 +57,24 @@ void ui_keyboard_set_trigger_visible(bool visible);
 // Only one callback active at a time (last registration wins).
 // Pass NULL to unregister.
 void ui_keyboard_set_layout_cb(ui_keyboard_cb_t cb);
+
+/* Issue #161: programmatic layout dump for tests.
+ *
+ * Returns the live (label, x, y, w, h, type) of every key currently
+ * built in the active keyboard layer, so automated tests can derive
+ * tap coordinates instead of hardcoding them in a memory file that
+ * silently rots whenever the layout changes (the original concrete
+ * pain — touch-map memory said y=1078 for the Send/Done row but the
+ * actual key sat at y=1204, so test taps landed in empty space).
+ *
+ * Call after ui_keyboard_show() or while is_visible(); returns 0 if
+ * the panel isn't built yet.  out_keys may be NULL; pass cap=0 to
+ * just query the count. */
+typedef struct {
+    char     label[16];
+    int16_t  x, y;
+    int16_t  w, h;
+    uint8_t  type;       /* key_type_t cast — char/space/back/shift/layer/enter */
+} ui_keyboard_key_info_t;
+
+int ui_keyboard_dump_layout(ui_keyboard_key_info_t *out_keys, int cap);


### PR DESCRIPTION
## Summary
- New \`ui_keyboard_dump_layout()\` walks the live LVGL row tree and returns per-key (label, x, y, w, h, type).
- Debug \`GET /keyboard/layout\` exposes it as JSON with center-of-key tap targets (\`cx\`, \`cy\`).
- Tests/memory files no longer need to hardcode coords that rot every layout change.

## Test plan
- [x] Flashed via USB; \`/keyboard/layout\` returns 33 keys when KB is up
- [x] Send/Done key center at \`(664, 1204)\` matches rendered frame
- [x] Q row centers at \`cy=964\` matching the audit issue's observed coords

🤖 Generated with [Claude Code](https://claude.com/claude-code)