### PR TITLE
fix(memory): NULL s_loading before lv_obj_clean to kill render_hits_cb UAF (closes #245)

### DIFF
--- a/main/ui_memory.c
+++ b/main/ui_memory.c
@@ -172,11 +172,18 @@ static void render_hits_cb(void *arg)
      * see s_hits_root / s_stats_lbl dangling.  Cheap guard: just bail
      * if we're not currently visible. */
     if (!s_visible || !s_hits_root) return;
+    /* lv_obj_clean frees ALL children of s_hits_root, including
+     * s_loading (which was created as a child).  After this, s_loading
+     * is a freed pointer — the original code then called
+     * lv_obj_add_flag(s_loading, …) on freed memory, and under stress
+     * the LV pool reuses that slot for some other widget, corrupting
+     * its state until a later lv_obj_invalidate finds a NULL parent
+     * and crashes ui_task.  Caught via stress repro of #80; same
+     * class as the Wave 2 #229 chat-render bug.  NULL the pointer
+     * before the clean call so the (now-redundant) guard below stays
+     * truthful. */
+    s_loading = NULL;
     lv_obj_clean(s_hits_root);
-
-    if (s_loading) {
-        lv_obj_add_flag(s_loading, LV_OBJ_FLAG_HIDDEN);
-    }
 
     if (!s_last_fetch.ok) {
         lv_obj_t *err = lv_label_create(s_hits_root);


### PR DESCRIPTION
## Summary
- One-line fix to a real use-after-free in \`ui_memory.c::render_hits_cb\`.
- \`s_loading\` is a child of \`s_hits_root\` and gets freed by \`lv_obj_clean\` — the next line dereferenced the dangling pointer.
- Surfaced while investigating #80 stress pattern.

## Test plan
- [x] 5-min mixed-screen stress (8 nav targets × 0.5s each + /screenshot per cycle), 360s of \`ping -i 1\` running concurrently
- [x] **BEFORE:** 50.5% ping uptime (multiple long reboots)
- [x] **AFTER:** 92.4% ping uptime (3 brief reboots from a separate, deeper LVGL-pool bug)

## Related
- Same UAF class as Wave 2's #229 (chat re-render PANIC)
- Stress also revealed remaining LVGL-pool corruption from camera destroy/recreate — filed separately for a future wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)