### PR TITLE
fix(stability): mutex around lv_async_call in mem_fetch — closes TWDT race

### DIFF
--- a/main/ui_core.c
+++ b/main/ui_core.c
@@ -49,14 +49,18 @@ static const char *TAG = "ui_core";
  *      Uses portMAX_DELAY but never acquires s_lvgl_mutex while held.
  *
  * ABBA deadlock analysis:
- *   - Voice tasks NEVER call tab5_ui_lock(). They use lv_async_call()
- *     (which is thread-safe without mutex) to schedule LVGL work.
  *   - Debug server (httpd, Core 1) uses tab5_ui_try_lock(2000) with
  *     bounded timeout for screenshots only. Never holds s_ws_mutex.
  *   - No code path holds both s_lvgl_mutex and s_ws_mutex simultaneously.
  *
- * Rule: voice/network code must use lv_async_call() for LVGL updates,
- *       NEVER acquire s_lvgl_mutex directly. This eliminates ABBA risk. */
+ * Rule: voice/network/worker code must use lv_async_call() to hop work
+ *       to the LVGL thread.  IMPORTANT (#256): lv_async_call is NOT
+ *       thread-safe in LVGL 9.x — it calls lv_malloc + lv_timer_create
+ *       on the unprotected TLSF heap.  Callers from a non-LVGL thread
+ *       MUST take tab5_ui_lock around the lv_async_call.  Without it,
+ *       a worker enqueueing while ui_task is allocating draw tasks will
+ *       eventually corrupt a TLSF free-list pointer and TWDT in
+ *       search_suitable_block. */
 static esp_lcd_panel_handle_t s_panel = NULL;
 static lv_display_t          *s_display = NULL;
 static lv_indev_t            *s_indev = NULL;

--- a/main/ui_memory.c
+++ b/main/ui_memory.c
@@ -369,8 +369,17 @@ cleanup:
     esp_http_client_close(cli);
     esp_http_client_cleanup(cli);
 done:
-    /* Hop to LVGL thread to rebuild the UI. */
+    /* Hop to LVGL thread to rebuild the UI.
+     *
+     * #256: lv_async_call internally calls lv_malloc + lv_timer_create
+     * — both unprotected TLSF allocator operations.  Calling it from
+     * tab5_worker (Core 1) while ui_task is allocating draw tasks on
+     * Core 0 races the LVGL TLSF heap, eventually corrupting a free
+     * block-list pointer → search_suitable_block infinite loop →
+     * TASK_WDT.  Take the LVGL mutex around it. */
+    tab5_ui_lock();
     lv_async_call(render_hits_cb, NULL);
+    tab5_ui_unlock();
     s_fetch_inflight = false;
     /* #252: was xTaskCreate + vTaskSuspend(NULL) — accumulated one
      * suspended TCB+bookkeeping (~870 B internal SRAM each) per


### PR DESCRIPTION
## Summary
- Discover root cause of residual TWDT under mixed nav+screenshot stress: \`lv_async_call\` in LVGL 9.x is NOT thread-safe (does \`lv_malloc\` + \`lv_timer_create\` without locking). The codebase comment claiming it was thread-safe was wrong.
- Targeted fix: take tab5_ui_lock around the mem_fetch -> lv_async_call site.
- Closes #256

## Coredump signature (worker TWDT)
\`\`\`
Crashed task: tab5_worker
PC: lv_tlsf.c:774 block_locate_free (search_suitable_block looped)
Caller chain: fetch_task -> lv_async_call -> lv_malloc(8)
\`\`\`
Worker thread allocating from TLSF on Core 1 races with ui_task allocating draw tasks on Core 0; the unprotected free-list eventually corrupts.

## Test plan
- [x] Build clean
- [x] 5-min mixed stress (camera→notes→chat→memory→home + screenshot per cycle, 92 iterations)
- [x] **0 reboots, 100% ping uptime** (pre-fix: ~6 reboots, ~15-iter cadence)
- [x] Coredump backtrace matched the hypothesis exactly
- [x] Updated misleading thread-safety comment in ui_core.c

## Stress benchmark progression this session
| Stage | Ping uptime | Reboots / 5 min |
|---|---|---|
| Pre-session | ~50 % | many |
| After #246 (UAF fix) | 92.4 % | 3 |
| After #249 (screenshot WithCaps) | 96 % | 1 |
| After #251+#253+#255 (nav guard, worker conversion) | 97.6 % | 1 PANIC + 1 TWDT |
| **After this PR** | **100 %** | **0** |

## Follow-up
The other 45 \`lv_async_call\` sites in this codebase have the same theoretical race. Most are rarely hit (event-driven, not in stress hot paths) but still need the wrap for correctness. I'll file the systematic-wrap PR separately so this targeted, validated fix can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)