### PR TITLE
feat(camera): rotation 0/90/180/270 + Settings dropdown

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1182,6 +1182,8 @@ static esp_err_t settings_get_handler(httpd_req_t *req)
 
     /* Audit U2 (#206): auto-rotate persisted preference. */
     cJSON_AddNumberToObject(root, "auto_rot",    tab5_settings_get_auto_rotate());
+    /* #260: camera rotation persisted preference. */
+    cJSON_AddNumberToObject(root, "cam_rot",     tab5_settings_get_cam_rotation());
 
     /* Budget */
     cJSON_AddNumberToObject(root, "spent_mils", (double)tab5_budget_get_today_mils());
@@ -1350,6 +1352,16 @@ static esp_err_t settings_set_handler(httpd_req_t *req)
             extern void ui_core_apply_auto_rotation(bool enabled);
             ui_core_apply_auto_rotation(v != 0);
             cJSON_AddItemToArray(updated, cJSON_CreateString("auto_rot"));
+        }
+    }
+
+    /* #260: camera rotation POST setter for testability. */
+    cJSON *cr = cJSON_GetObjectItem(req_json, "cam_rot");
+    if (cJSON_IsNumber(cr)) {
+        int v = (int)cr->valuedouble;
+        if (v >= 0 && v <= 3 &&
+            tab5_settings_set_cam_rotation((uint8_t)v) == ESP_OK) {
+            cJSON_AddItemToArray(updated, cJSON_CreateString("cam_rot"));
         }
     }
 

--- a/main/settings.c
+++ b/main/settings.c
@@ -425,6 +425,10 @@ esp_err_t tab5_settings_set_quiet_end(uint8_t h)
 uint8_t tab5_settings_get_auto_rotate(void) { return get_u8("auto_rot", 0); }
 esp_err_t tab5_settings_set_auto_rotate(uint8_t on) { return set_u8("auto_rot", on ? 1 : 0); }
 
+/* ── Camera rotation (#260) ───────────────────────────────────────────── */
+uint8_t tab5_settings_get_cam_rotation(void) { return get_u8("cam_rot", 0); }
+esp_err_t tab5_settings_set_cam_rotation(uint8_t rot) { return set_u8("cam_rot", rot & 0x03); }
+
 bool tab5_settings_quiet_active(int hour_local)
 {
     if (!tab5_settings_get_quiet_on()) return false;

--- a/main/settings.h
+++ b/main/settings.h
@@ -158,6 +158,15 @@ bool      tab5_settings_quiet_active(int hour_local);
 uint8_t   tab5_settings_get_auto_rotate(void);
 esp_err_t tab5_settings_set_auto_rotate(uint8_t on);
 
+/** Camera frame rotation, applied to the preview + saved photo. The
+ *  SC2336 sensor is fixed-orientation 1280x720 landscape; this knob
+ *  rotates the captured frame in software so the user can hold the
+ *  device portrait, upside-down, or either landscape and see a
+ *  natural viewfinder.  0 = 0deg (no rotation, default), 1 = 90 CW,
+ *  2 = 180, 3 = 270 CW (= 90 CCW).  See issue #260. */
+uint8_t   tab5_settings_get_cam_rotation(void);
+esp_err_t tab5_settings_set_cam_rotation(uint8_t rot);
+
 /* ── Auth token (debug server bearer auth) ───────────────────────────── */
 
 /** Read auth token from NVS. Returns ESP_OK if found and non-empty. */

--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -14,6 +14,7 @@
 #include "camera.h"
 #include "sdcard.h"
 #include "voice.h"      /* U11 follow-up: voice_upload_chat_image() */
+#include "settings.h"   /* #260: cam_rot NVS key */
 #include "config.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
@@ -75,6 +76,12 @@ static uint32_t    canvas_buf_size = 0;
 
 static uint16_t    canvas_w        = 0;
 static uint16_t    canvas_h        = 0;
+
+/* #260: snapshot of NVS cam_rot at screen-create time.
+ * 0 = 0deg (raw memcpy, fastest path), 1 = 90 CW, 2 = 180, 3 = 270 CW.
+ * Snapshotted (not re-read each frame) so the buffer dimensions stay
+ * consistent for the lifetime of the canvas widget. */
+static uint8_t     s_cam_rot       = 0;
 
 static uint32_t    capture_counter = 0;
 static bool        capture_counter_init = false;
@@ -142,6 +149,51 @@ static void free_canvas_buffer(void)
         canvas_buf_size = 0;
         canvas_w = 0;
         canvas_h = 0;
+    }
+}
+
+/* ================================================================
+ * #260: RGB565 in-place rotation helpers.
+ *
+ * Source frame is sw x sh.  Destination is the canvas buffer,
+ * sized appropriately by the caller (90/270 = sh x sw, 180 = sw x sh).
+ *
+ * Naive transpose loops; ~30-40 ms per 1280x720 frame on PSRAM.
+ * Acceptable for the 10 FPS preview (100 ms budget).  If we ever
+ * raise preview FPS, swap in tile-based rotation (32x32 cache lines)
+ * or the ESP32-P4 PPA hardware path.
+ * ================================================================ */
+static void rotate_rgb565_180(const uint16_t *src, uint16_t *dst,
+                              int sw, int sh)
+{
+    /* dst[(sh-1-y), (sw-1-x)] = src[y, x] */
+    int npix = sw * sh;
+    for (int i = 0; i < npix; i++) {
+        dst[npix - 1 - i] = src[i];
+    }
+}
+
+static void rotate_rgb565_90cw(const uint16_t *src, uint16_t *dst,
+                               int sw, int sh)
+{
+    /* dst is sh wide, sw tall.  dst[(sh-1-y) + x*sh] = src[x + y*sw] */
+    for (int y = 0; y < sh; y++) {
+        const uint16_t *srow = src + y * sw;
+        for (int x = 0; x < sw; x++) {
+            dst[(sh - 1 - y) + x * sh] = srow[x];
+        }
+    }
+}
+
+static void rotate_rgb565_270cw(const uint16_t *src, uint16_t *dst,
+                                int sw, int sh)
+{
+    /* dst is sh wide, sw tall.  dst[y + (sw-1-x)*sh] = src[x + y*sw] */
+    for (int y = 0; y < sh; y++) {
+        const uint16_t *srow = src + y * sw;
+        for (int x = 0; x < sw; x++) {
+            dst[y + (sw - 1 - x) * sh] = srow[x];
+        }
     }
 }
 
@@ -331,7 +383,14 @@ lv_obj_t *ui_camera_create(void)
         uint16_t w, h;
         res_to_dimensions(current_res, &w, &h);
         esp_task_wdt_reset();
-        alloc_canvas_buffer(w, h);
+        /* #260: snapshot rotation pref + allocate canvas with the post-
+         * rotation dimensions so 90/270 give a portrait-fit viewfinder. */
+        s_cam_rot = tab5_settings_get_cam_rotation() & 0x03;
+        if (s_cam_rot == 1 || s_cam_rot == 3) {
+            alloc_canvas_buffer(h, w);  /* dimensions swapped */
+        } else {
+            alloc_canvas_buffer(w, h);
+        }
 
         if (canvas_buf) {
             canvas_preview = lv_canvas_create(vf_area);
@@ -483,14 +542,38 @@ static void preview_timer_cb(lv_timer_t *t)
     esp_err_t err = tab5_camera_capture(&frame);
     if (err != ESP_OK) return;
 
-    /* Only blit if the frame matches our canvas dimensions and is RGB565 */
     if (frame.format != TAB5_CAM_FMT_RGB565) return;
-    if (frame.width != canvas_w || frame.height != canvas_h) return;
 
-    /* Copy frame data into the canvas buffer */
-    uint32_t copy_size = (uint32_t)frame.width * frame.height * 2;
-    if (copy_size > canvas_buf_size) copy_size = canvas_buf_size;
-    memcpy(canvas_buf, frame.data, copy_size);
+    /* #260: rotate the captured frame into the canvas buffer.
+     * For rotation 0/180 the frame and canvas share dimensions
+     * (sw x sh).  For 90/270 the canvas is allocated swapped
+     * (sh x sw) — see alloc_canvas_buffer in ui_camera_create. */
+    const uint16_t *src = (const uint16_t *)frame.data;
+    uint16_t *dst = (uint16_t *)canvas_buf;
+    int sw = frame.width;
+    int sh = frame.height;
+    uint32_t expected = (uint32_t)sw * sh * 2;
+    if (expected > canvas_buf_size) return;
+
+    switch (s_cam_rot) {
+    case 1:  /* 90 CW: source w/h swapped on output */
+        if (canvas_w != sh || canvas_h != sw) return;
+        rotate_rgb565_90cw(src, dst, sw, sh);
+        break;
+    case 2:  /* 180: same dimensions */
+        if (canvas_w != sw || canvas_h != sh) return;
+        rotate_rgb565_180(src, dst, sw, sh);
+        break;
+    case 3:  /* 270 CW (= 90 CCW): swapped */
+        if (canvas_w != sh || canvas_h != sw) return;
+        rotate_rgb565_270cw(src, dst, sw, sh);
+        break;
+    case 0:
+    default:
+        if (canvas_w != sw || canvas_h != sh) return;
+        memcpy(dst, src, expected);
+        break;
+    }
 
     /* Tell LVGL the canvas content changed */
     lv_obj_invalidate(canvas_preview);
@@ -520,12 +603,44 @@ static void capture_btn_cb(lv_event_t *e)
         return;
     }
 
+    /* #260: rotate the saved photo to match what the user saw on the
+     * viewfinder.  Allocate a temp PSRAM buffer; for 0deg we just save
+     * the frame as-is (skip the alloc). */
+    tab5_cam_frame_t saved = frame;
+    uint8_t *rot_buf = NULL;
+    if (s_cam_rot != 0 && frame.format == TAB5_CAM_FMT_RGB565) {
+        size_t bytes = (size_t)frame.width * frame.height * 2;
+        rot_buf = heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM);
+        if (rot_buf) {
+            const uint16_t *src = (const uint16_t *)frame.data;
+            uint16_t *dst = (uint16_t *)rot_buf;
+            switch (s_cam_rot) {
+            case 1:
+                rotate_rgb565_90cw(src, dst, frame.width, frame.height);
+                saved.width  = frame.height;
+                saved.height = frame.width;
+                break;
+            case 2:
+                rotate_rgb565_180(src, dst, frame.width, frame.height);
+                break;
+            case 3:
+                rotate_rgb565_270cw(src, dst, frame.width, frame.height);
+                saved.width  = frame.height;
+                saved.height = frame.width;
+                break;
+            }
+            saved.data = rot_buf;
+            saved.size = bytes;
+        }
+    }
+
     /* Build filename with incrementing counter */
     char path[64];
     snprintf(path, sizeof(path), "/sdcard/IMG_%04"PRIu32".jpg",
              capture_counter);
 
-    err = tab5_camera_save_jpeg(&frame, path);
+    err = tab5_camera_save_jpeg(&saved, path);
+    if (rot_buf) heap_caps_free(rot_buf);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Save failed: %s", esp_err_to_name(err));
         toast_show("Save failed");

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -351,6 +351,19 @@ static void cb_volume_released(lv_event_t *e)
     tab5_audio_test_tone(440, 200);  /* 440Hz A4 for 200ms */
 }
 
+/* #260: camera rotation dropdown — persists to NVS.  ui_camera reads
+ * the value at screen-create time, so the new setting applies the next
+ * time the user opens the camera (or right away if they're not on it). */
+static void cb_cam_rotation(lv_event_t *e)
+{
+    lv_obj_t *dd = lv_event_get_target(e);
+    uint16_t sel = lv_dropdown_get_selected(dd);
+    if (sel > 3) sel = 0;
+    ESP_LOGI(TAG, "Camera rotation -> %u (%u deg)",
+             (unsigned)sel, (unsigned)(sel * 90));
+    tab5_settings_set_cam_rotation((uint8_t)sel);
+}
+
 static void cb_autorotate(lv_event_t *e)
 {
     lv_obj_t *sw = lv_event_get_target(e);
@@ -1402,6 +1415,30 @@ lv_obj_t *ui_settings_create(void)
     s_sw_autorot = mk_switch(s_scroll, acc_display, 660, y,
                              tab5_settings_get_auto_rotate() != 0,
                              cb_autorotate, NULL);
+    y += ROW_H + 4;
+
+    /* #260: Camera rotation dropdown.  Sensor is fixed-orientation
+     * landscape; this rotates the captured frame in software. */
+    mk_row_label(s_scroll, "Camera rotation", y);
+    {
+        lv_obj_t *dd = lv_dropdown_create(s_scroll);
+        lv_dropdown_set_options(dd, "0\xc2\xb0\n90\xc2\xb0 CW\n180\xc2\xb0\n270\xc2\xb0 CW");
+        uint8_t cur = tab5_settings_get_cam_rotation();
+        if (cur > 3) cur = 0;
+        lv_dropdown_set_selected(dd, cur);
+        lv_obj_set_pos(dd, 340, y);
+        lv_obj_set_size(dd, 340, 36);
+        lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), 0);
+        lv_obj_set_style_bg_opa(dd, LV_OPA_COVER, 0);
+        lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), 0);
+        lv_obj_set_style_text_font(dd, FONT_SECONDARY, 0);
+        lv_obj_set_style_border_width(dd, 1, 0);
+        lv_obj_set_style_border_color(dd, lv_color_hex(0x1A1A24), 0);
+        lv_obj_set_style_radius(dd, 6, 0);
+        lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), LV_PART_ITEMS);
+        lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
+        lv_obj_add_event_cb(dd, cb_cam_rotation, LV_EVENT_VALUE_CHANGED, NULL);
+    }
     y += ROW_H + 16;
 
     /* ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- New NVS key \`cam_rot\` (u8, 0..3 for 0deg / 90 CW / 180 / 270 CW) — default 0 preserves current behavior.
- \`ui_camera.c\` rotates the captured RGB565 frame before blitting to the canvas; canvas is sized post-rotation so 90/270 give a portrait-fit viewfinder.
- Same rotation applied to the captured-still path so the saved photo matches the viewfinder.
- Settings dropdown in the Display section, persists to NVS.
- \`/settings\` debug endpoint accepts \`cam_rot\` for testability.
- Closes #260.

## Test plan
- [x] Build clean
- [x] Flash + smoke each rotation (0, 1, 2, 3) — all four orientations render correctly in screenshots
- [x] Persistence (NVS round-trip via /settings POST → re-enter camera → screenshot)
- [x] Default 0 preserves the current view (raw memcpy path; no perf impact when off)

## Visual confirmation
Screenshots captured for each rotation show:
- rot=0: landscape frame, letterboxed top/bottom (current behavior)
- rot=1: portrait, fills the viewfinder vertically (the natural "hold Tab5 upright" view)
- rot=2: landscape inverted
- rot=3: portrait flipped vs rot=1

## Out of scope
- IMU-driven auto-rotate for the camera (display already has it; could follow later).
- Hardware-accelerated rotation via ESP32-P4 PPA. The naive software rotate is ~30-40 ms / frame at 1280x720, fits the 100 ms preview budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)