### PR TITLE
feat(voice): OPUS codec wrapper + capability negotiation

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "mode_manager.c"
+             "voice.c" "voice_codec.c" "mode_manager.c"
              "debug_server.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"
@@ -48,5 +48,6 @@ else()
                  esp_wifi esp_netif esp_event esp_http_client esp_http_server tcp_transport
                  espcoredump app_update esp_https_ota
                  esp_driver_isp esp_video esp_cam_sensor
+                 espressif__esp_audio_codec
     )
 endif()

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -13,3 +13,7 @@ dependencies:
   # machine — see issue #76. Event-driven with built-in auto-reconnect,
   # ping/pong, and TLS. Eliminates the register-before-receive-task race.
   espressif/esp_websocket_client: ^1.6.1
+  # esp_audio_codec (#262): OPUS encoder/decoder for the voice WS path.
+  # 16 kHz mono PCM <-> ~24 kbps OPUS = ~10x bandwidth cut on the mic
+  # uplink and TTS downlink.
+  espressif/esp_audio_codec: ^2.4.1

--- a/main/voice.c
+++ b/main/voice.c
@@ -22,6 +22,7 @@
  */
 
 #include "voice.h"
+#include "voice_codec.h"   /* #262: OPUS encode/decode wrapper */
 #include "task_worker.h"   /* #133: defer queue-drain to avoid stack blow */
 #include "tool_log.h"      /* U7+U8 (#206): record tool activity for ui_agents/ui_focus */
 #include "md_strip.h"     /* #78 + #160: scrub <tool>...</tool> markers from streamed LLM text */
@@ -558,6 +559,12 @@ static esp_err_t voice_ws_send_register(void)
     cJSON_AddBoolToObject(caps, "camera", true);
     cJSON_AddBoolToObject(caps, "sd_card", true);
     cJSON_AddBoolToObject(caps, "touch", true);
+    /* #262: advertise audio codec support.  Dragon picks one and replies
+     * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
+     * until Dragon switches it. */
+    cJSON *acodecs = cJSON_AddArrayToObject(caps, "audio_codec");
+    cJSON_AddItemToArray(acodecs, cJSON_CreateString("pcm"));
+    cJSON_AddItemToArray(acodecs, cJSON_CreateString("opus"));
     /* v4·D audit P0 fix: widget_capability was spec-only -- now wired.
      * Skills can downgrade widget content for low-end clients (smaller
      * list, lower image res).  Match the actual Tab5 limits we've
@@ -1222,6 +1229,27 @@ static void handle_text_message(const char *data, int len)
                 }
             }
         }
+        /* #262: codec negotiation reply.  Dragon picks one of the
+         * codecs Tab5 advertised in `register` and tells us via
+         * config_update.audio_codec.  Two flavours so it can choose
+         * uplink (mic) and downlink (TTS) independently:
+         *   - audio_codec        : applies to both (legacy / shorthand)
+         *   - audio_uplink_codec : mic only
+         *   - audio_downlink_codec: TTS only
+         * Unrecognized strings fall back to PCM. */
+        cJSON *acu = cJSON_GetObjectItem(root, "audio_uplink_codec");
+        cJSON *acd = cJSON_GetObjectItem(root, "audio_downlink_codec");
+        cJSON *ac  = cJSON_GetObjectItem(root, "audio_codec");
+        if (cJSON_IsString(acu)) {
+            voice_codec_set_uplink(voice_codec_from_name(acu->valuestring));
+        } else if (cJSON_IsString(ac)) {
+            voice_codec_set_uplink(voice_codec_from_name(ac->valuestring));
+        }
+        if (cJSON_IsString(acd)) {
+            voice_codec_set_downlink(voice_codec_from_name(acd->valuestring));
+        } else if (cJSON_IsString(ac)) {
+            voice_codec_set_downlink(voice_codec_from_name(ac->valuestring));
+        }
         /* Wave 14 W14-L03: if neither voice_mode nor cloud_mode was
          * present, the handler used to exit silently and Tab5 would
          * disagree with Dragon about the active mode with no trace.
@@ -1595,27 +1623,36 @@ static void handle_binary_message(const char *data, int len)
         voice_set_state(VOICE_STATE_SPEAKING, NULL);
     }
 
-    /* Upsample into a stack-adjacent but reasonably-sized temp buffer. A single
-     * Dragon TTS chunk is typically 640–1024 B (320–512 samples), so
-     * worst-case output is 512 × 3 = 1536 samples = 3072 B. Cap at 2048
-     * input samples to stay well under the managed-client buffer. */
-    const size_t in_samples   = len / sizeof(int16_t);
-    if (in_samples == 0) return;
-    size_t max_out = in_samples * UPSAMPLE_RATIO;
-    /* Wave 9 audit #80 + stability P0: use the pre-allocated upsample
-     * buffer from voice_init instead of malloc/free on every chunk. */
+    /* #262: decode through voice_codec.  PCM is a memcpy-shaped passthrough
+     * (out_samples == in_samples), keeping the existing upsample 16k->48k
+     * path unchanged.  OPUS produces variable-length PCM (typ 320 samples
+     * per 20 ms packet) which then upsamples the same way. */
     if (!s_upsample_buf) {
         ESP_LOGW(TAG, "handle_binary: upsample_buf not initialized");
         return;
     }
-    if (max_out > UPSAMPLE_BUF_CAPACITY) {
-        ESP_LOGW(TAG, "handle_binary: chunk too large (in=%zu out=%zu cap=%d) — truncating",
-                 in_samples, max_out, UPSAMPLE_BUF_CAPACITY);
-        max_out = UPSAMPLE_BUF_CAPACITY;
+
+    /* Decode straight into a temp area in s_upsample_buf, low half;
+     * upsample reads from there and writes to the high half.
+     * Splitting avoids an extra malloc per chunk. */
+    int16_t *dec_pcm = s_upsample_buf;                          /* low half */
+    int16_t *up_out  = s_upsample_buf + (UPSAMPLE_BUF_CAPACITY / 2);  /* high half */
+    size_t dec_cap   = UPSAMPLE_BUF_CAPACITY / 2;
+    size_t in_samples = 0;
+    if (voice_codec_decode_downlink((const uint8_t *)data, (size_t)len,
+                                    dec_pcm, dec_cap, &in_samples) != ESP_OK ||
+        in_samples == 0) {
+        ESP_LOGW(TAG, "handle_binary: codec decode failed (len=%d)", len);
+        return;
     }
-    size_t out_samples = upsample_16k_to_48k((const int16_t *)data, in_samples,
-                                              s_upsample_buf, max_out);
-    playback_buf_write(s_upsample_buf, out_samples);
+    size_t max_out = in_samples * UPSAMPLE_RATIO;
+    if (max_out > dec_cap) {
+        ESP_LOGW(TAG, "handle_binary: upsample would exceed half-buf — truncating");
+        max_out = dec_cap;
+    }
+    size_t out_samples = upsample_16k_to_48k(dec_pcm, in_samples,
+                                              up_out, max_out);
+    playback_buf_write(up_out, out_samples);
 }
 
 // ---------------------------------------------------------------------------
@@ -1936,10 +1973,17 @@ static void mic_capture_task(void *arg)
         MIC_TDM_SAMPLES * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     int16_t *mono_buf = (int16_t *)heap_caps_malloc(
         VOICE_CHUNK_SAMPLES * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-    if (!tdm_buf || !mono_buf) {
+    /* #262: encoded uplink buffer.  640 B is enough for either raw PCM
+     * (320 samples * 2 B) or an OPUS frame at the 24 kbps target — a
+     * 20 ms OPUS packet is ~60 B but the API recommends much more
+     * headroom; 640 B comfortably fits the worst-case bitrate ceiling. */
+    uint8_t  *enc_buf  = (uint8_t  *)heap_caps_malloc(
+        VOICE_CHUNK_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!tdm_buf || !mono_buf || !enc_buf) {
         ESP_LOGE(TAG, "Failed to allocate mic buffers");
         heap_caps_free(tdm_buf);
         heap_caps_free(mono_buf);
+        heap_caps_free(enc_buf);
         s_mic_task = NULL;
         vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
         return;
@@ -2017,12 +2061,23 @@ static void mic_capture_task(void *arg)
 
         ui_notes_write_audio(mono_buf, out_idx);
 
-        size_t send_bytes = out_idx * sizeof(int16_t);
         if (ws_live) {
-            err = voice_ws_send_binary(mono_buf, send_bytes);
-            if (err != ESP_OK) {
-                ESP_LOGW(TAG, "WS send failed — continuing SD recording");
-                if (s_voice_mode == VOICE_MODE_ASK) break;
+            /* #262: encode through voice_codec (PCM = memcpy passthrough,
+             * OPUS = ~60 B variable-length packet).  Dragon decodes per
+             * the active uplink codec it picked in config_update. */
+            size_t send_bytes = 0;
+            esp_err_t cerr = voice_codec_encode_uplink(mono_buf, out_idx,
+                                                       enc_buf, VOICE_CHUNK_BYTES,
+                                                       &send_bytes);
+            if (cerr == ESP_OK && send_bytes > 0) {
+                err = voice_ws_send_binary(enc_buf, send_bytes);
+                if (err != ESP_OK) {
+                    ESP_LOGW(TAG, "WS send failed — continuing SD recording");
+                    if (s_voice_mode == VOICE_MODE_ASK) break;
+                }
+            } else {
+                ESP_LOGW(TAG, "voice_codec_encode_uplink failed (%d) — dropping chunk",
+                         (int)cerr);
             }
         }
         frames_sent++;
@@ -2103,6 +2158,7 @@ static void mic_capture_task(void *arg)
     s_current_rms = 0;
     heap_caps_free(tdm_buf);
     heap_caps_free(mono_buf);
+    heap_caps_free(enc_buf);
 
     if (s_voice_mode == VOICE_MODE_DICTATE && had_speech
         && total_silence_frames >= DICTATION_AUTO_STOP_FRAMES
@@ -2179,6 +2235,9 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
     s_using_ngrok = false;
 
     s_state_cb = state_cb;
+
+    /* #262: codec module is independent of WS lifecycle — init once. */
+    voice_codec_init();
 
     s_state_mutex = xSemaphoreCreateMutex();
     if (!s_state_mutex) {
@@ -2907,6 +2966,11 @@ esp_err_t voice_disconnect(void)
     s_session_gen++;
 
     s_disconnecting = true;
+
+    /* #262: reset codec to PCM so a stale OPUS state doesn't outlive
+     * the reconnect.  Dragon will re-negotiate on the new register. */
+    voice_codec_set_uplink(VOICE_CODEC_PCM);
+    voice_codec_set_downlink(VOICE_CODEC_PCM);
 
     tab5_audio_speaker_enable(false);
 

--- a/main/voice_codec.c
+++ b/main/voice_codec.c
@@ -1,0 +1,248 @@
+/*
+ * voice_codec.c — see header.
+ *
+ * The 20 ms / 320-sample frame size matches both:
+ *   - voice.c's existing mic chunk size (VOICE_CHUNK_SAMPLES)
+ *   - the typical OPUS frame the gateway is expected to send back
+ * so encode/decode is a 1:1 chunk mapping with no buffering needed.
+ */
+#include "voice_codec.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+
+#include "encoder/impl/esp_opus_enc.h"
+#include "decoder/impl/esp_opus_dec.h"
+
+static const char *TAG = "voice_codec";
+
+/* Wire format constants — see voice.c: 16 kHz mono, 16-bit PCM. */
+#define VC_SAMPLE_RATE  16000
+#define VC_CHANNELS     1
+#define VC_BITS         16
+#define VC_FRAME_MS     20
+#define VC_FRAME_SAMPS  ((VC_SAMPLE_RATE / 1000) * VC_FRAME_MS)  /* 320 */
+
+/* OPUS bitrate target.  24 kbps @ 16 kHz mono with VOIP application
+ * mode is comfortably above the cliff for intelligibility while still
+ * giving ~10x bandwidth reduction over raw PCM (256 kbps). */
+#define VC_OPUS_BITRATE 24000
+
+static voice_codec_t s_uplink   = VOICE_CODEC_PCM;
+static voice_codec_t s_downlink = VOICE_CODEC_PCM;
+
+static void *s_enc = NULL;   /* opaque OPUS encoder handle */
+static void *s_dec = NULL;   /* opaque OPUS decoder handle */
+static int   s_enc_in_size  = 0;   /* bytes per input frame (== 640) */
+static int   s_enc_out_size = 0;   /* recommended output buffer size */
+
+static bool  s_inited = false;
+
+esp_err_t voice_codec_init(void)
+{
+    if (s_inited) return ESP_OK;
+    s_inited = true;
+    ESP_LOGI(TAG, "init (default uplink=PCM downlink=PCM)");
+    return ESP_OK;
+}
+
+static esp_err_t ensure_encoder(void)
+{
+    if (s_enc) return ESP_OK;
+    esp_opus_enc_config_t cfg = ESP_OPUS_ENC_CONFIG_DEFAULT();
+    cfg.sample_rate      = VC_SAMPLE_RATE;
+    cfg.channel          = VC_CHANNELS;
+    cfg.bits_per_sample  = VC_BITS;
+    cfg.bitrate          = VC_OPUS_BITRATE;
+    cfg.frame_duration   = ESP_OPUS_ENC_FRAME_DURATION_20_MS;
+    cfg.application_mode = ESP_OPUS_ENC_APPLICATION_VOIP;
+    cfg.complexity       = 5;     /* mid — keeps CPU below ~10% on a P4 core */
+    cfg.enable_fec       = false;
+    cfg.enable_dtx       = false;
+    cfg.enable_vbr       = true;
+    if (esp_opus_enc_open(&cfg, sizeof(cfg), &s_enc) != ESP_AUDIO_ERR_OK || !s_enc) {
+        ESP_LOGE(TAG, "esp_opus_enc_open failed");
+        s_enc = NULL;
+        return ESP_FAIL;
+    }
+    if (esp_opus_enc_get_frame_size(s_enc, &s_enc_in_size, &s_enc_out_size) != ESP_AUDIO_ERR_OK) {
+        ESP_LOGE(TAG, "esp_opus_enc_get_frame_size failed");
+        esp_opus_enc_close(s_enc);
+        s_enc = NULL;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "OPUS encoder ready (in=%d B/frame, out_recommend=%d B, bitrate=%d bps)",
+             s_enc_in_size, s_enc_out_size, VC_OPUS_BITRATE);
+    return ESP_OK;
+}
+
+static esp_err_t ensure_decoder(void)
+{
+    if (s_dec) return ESP_OK;
+    esp_opus_dec_cfg_t cfg = ESP_OPUS_DEC_CONFIG_DEFAULT();
+    cfg.sample_rate    = VC_SAMPLE_RATE;
+    cfg.channel        = VC_CHANNELS;
+    cfg.frame_duration = ESP_OPUS_DEC_FRAME_DURATION_20_MS;
+    cfg.self_delimited = false;
+    if (esp_opus_dec_open(&cfg, sizeof(cfg), &s_dec) != ESP_AUDIO_ERR_OK || !s_dec) {
+        ESP_LOGE(TAG, "esp_opus_dec_open failed");
+        s_dec = NULL;
+        return ESP_FAIL;
+    }
+    ESP_LOGI(TAG, "OPUS decoder ready");
+    return ESP_OK;
+}
+
+void voice_codec_deinit(void)
+{
+    if (s_enc) { esp_opus_enc_close(s_enc); s_enc = NULL; }
+    if (s_dec) { esp_opus_dec_close(s_dec); s_dec = NULL; }
+    s_uplink   = VOICE_CODEC_PCM;
+    s_downlink = VOICE_CODEC_PCM;
+    s_inited   = false;
+    ESP_LOGI(TAG, "deinit");
+}
+
+void voice_codec_set_uplink(voice_codec_t c)
+{
+    if (c == s_uplink) return;
+    ESP_LOGI(TAG, "uplink: %s -> %s", voice_codec_to_name(s_uplink), voice_codec_to_name(c));
+    s_uplink = c;
+    if (c == VOICE_CODEC_OPUS) {
+        if (ensure_encoder() != ESP_OK) {
+            ESP_LOGW(TAG, "OPUS encoder init failed; falling back to PCM uplink");
+            s_uplink = VOICE_CODEC_PCM;
+        }
+    }
+}
+
+void voice_codec_set_downlink(voice_codec_t c)
+{
+    if (c == s_downlink) return;
+    ESP_LOGI(TAG, "downlink: %s -> %s", voice_codec_to_name(s_downlink), voice_codec_to_name(c));
+    s_downlink = c;
+    if (c == VOICE_CODEC_OPUS) {
+        if (ensure_decoder() != ESP_OK) {
+            ESP_LOGW(TAG, "OPUS decoder init failed; falling back to PCM downlink");
+            s_downlink = VOICE_CODEC_PCM;
+        }
+    }
+}
+
+voice_codec_t voice_codec_get_uplink(void)   { return s_uplink; }
+voice_codec_t voice_codec_get_downlink(void) { return s_downlink; }
+
+esp_err_t voice_codec_encode_uplink(const int16_t *pcm_samples,
+                                    size_t n_samples,
+                                    uint8_t *out, size_t out_cap,
+                                    size_t *out_len)
+{
+    if (!pcm_samples || !out || !out_len) return ESP_ERR_INVALID_ARG;
+
+    if (s_uplink == VOICE_CODEC_PCM) {
+        size_t bytes = n_samples * sizeof(int16_t);
+        if (bytes > out_cap) return ESP_ERR_INVALID_SIZE;
+        memcpy(out, pcm_samples, bytes);
+        *out_len = bytes;
+        return ESP_OK;
+    }
+
+    /* OPUS: expect exactly one 20 ms frame (320 samples). */
+    if (!s_enc) {
+        ESP_LOGW(TAG, "encode_uplink called with no encoder — falling back to PCM");
+        size_t bytes = n_samples * sizeof(int16_t);
+        if (bytes > out_cap) return ESP_ERR_INVALID_SIZE;
+        memcpy(out, pcm_samples, bytes);
+        *out_len = bytes;
+        return ESP_OK;
+    }
+    if ((int)(n_samples * sizeof(int16_t)) != s_enc_in_size) {
+        ESP_LOGW(TAG, "encode_uplink: bad frame size %u (want %d B)",
+                 (unsigned)(n_samples * sizeof(int16_t)), s_enc_in_size);
+        return ESP_ERR_INVALID_SIZE;
+    }
+    if ((int)out_cap < s_enc_out_size) {
+        ESP_LOGW(TAG, "encode_uplink: out_cap %u < recommended %d",
+                 (unsigned)out_cap, s_enc_out_size);
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    esp_audio_enc_in_frame_t  in  = {
+        .buffer = (uint8_t *)pcm_samples,
+        .len    = (uint32_t)(n_samples * sizeof(int16_t)),
+    };
+    esp_audio_enc_out_frame_t outf = {
+        .buffer = out,
+        .len    = (uint32_t)out_cap,
+    };
+    esp_audio_err_t er = esp_opus_enc_process(s_enc, &in, &outf);
+    if (er != ESP_AUDIO_ERR_OK) {
+        ESP_LOGW(TAG, "esp_opus_enc_process failed: %d", (int)er);
+        return ESP_FAIL;
+    }
+    *out_len = outf.encoded_bytes;
+    return ESP_OK;
+}
+
+esp_err_t voice_codec_decode_downlink(const uint8_t *data, size_t len,
+                                      int16_t *out_pcm, size_t out_cap,
+                                      size_t *out_n)
+{
+    if (!data || !out_pcm || !out_n) return ESP_ERR_INVALID_ARG;
+
+    if (s_downlink == VOICE_CODEC_PCM) {
+        size_t samples = len / sizeof(int16_t);
+        if (samples > out_cap) samples = out_cap;
+        memcpy(out_pcm, data, samples * sizeof(int16_t));
+        *out_n = samples;
+        return ESP_OK;
+    }
+
+    if (!s_dec) {
+        ESP_LOGW(TAG, "decode_downlink called with no decoder — treating as PCM");
+        size_t samples = len / sizeof(int16_t);
+        if (samples > out_cap) samples = out_cap;
+        memcpy(out_pcm, data, samples * sizeof(int16_t));
+        *out_n = samples;
+        return ESP_OK;
+    }
+
+    esp_audio_dec_in_raw_t raw = {
+        .buffer        = (uint8_t *)data,
+        .len           = (uint32_t)len,
+        .consumed      = 0,
+        .frame_recover = ESP_AUDIO_DEC_RECOVERY_NONE,
+    };
+    esp_audio_dec_out_frame_t outf = {
+        .buffer       = (uint8_t *)out_pcm,
+        .len          = (uint32_t)(out_cap * sizeof(int16_t)),
+        .needed_size  = 0,
+        .decoded_size = 0,
+    };
+    esp_audio_dec_info_t info = {0};
+    esp_audio_err_t er = esp_opus_dec_decode(s_dec, &raw, &outf, &info);
+    if (er != ESP_AUDIO_ERR_OK) {
+        ESP_LOGW(TAG, "esp_opus_dec_decode failed: %d", (int)er);
+        return ESP_FAIL;
+    }
+    *out_n = outf.decoded_size / sizeof(int16_t);
+    return ESP_OK;
+}
+
+voice_codec_t voice_codec_from_name(const char *name)
+{
+    if (!name) return VOICE_CODEC_PCM;
+    if (strcasecmp(name, "opus") == 0) return VOICE_CODEC_OPUS;
+    return VOICE_CODEC_PCM;
+}
+
+const char *voice_codec_to_name(voice_codec_t c)
+{
+    switch (c) {
+    case VOICE_CODEC_OPUS: return "opus";
+    case VOICE_CODEC_PCM:
+    default:               return "pcm";
+    }
+}

--- a/main/voice_codec.h
+++ b/main/voice_codec.h
@@ -1,0 +1,86 @@
+/*
+ * voice_codec.h — OPUS encode/decode for the Tab5 ↔ Dragon voice WS
+ * (#262 / #263).  Wraps the espressif/esp_audio_codec OPUS engine for
+ * the specific shape of our pipeline: 16 kHz mono, 16-bit PCM, 20 ms
+ * frames (320 samples = 640 bytes per chunk).
+ *
+ * Codec is negotiated via WS handshake:
+ *   - Tab5 advertises capabilities.audio_codec = ["pcm","opus"] in
+ *     `register`.
+ *   - Dragon picks one and replies with config_update.audio_codec.
+ *   - Tab5 calls voice_codec_set_uplink/downlink per the chosen codec
+ *     before sending mic / decoding TTS.
+ *
+ * Default uplink + downlink = PCM (current behavior).  When the WS
+ * connection drops the codec resets to PCM so a stale OPUS state
+ * doesn't outlive the reconnect.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include "esp_err.h"
+
+typedef enum {
+    VOICE_CODEC_PCM  = 0,   /* raw int16_t LE @ 16 kHz mono — default */
+    VOICE_CODEC_OPUS = 1,
+} voice_codec_t;
+
+/* Initialize the codec module.  Idempotent.  Allocates encoder +
+ * decoder lazily on first use; this function just makes the module
+ * usable.  Returns ESP_OK on success. */
+esp_err_t voice_codec_init(void);
+
+/* Tear down all encoder/decoder state.  Called on voice_disconnect or
+ * deinit.  Safe to call multiple times. */
+void voice_codec_deinit(void);
+
+/* Set the uplink codec (mic → Dragon).  Called by the WS RX handler
+ * after Dragon's config_update arrives. */
+void voice_codec_set_uplink(voice_codec_t c);
+
+/* Set the downlink codec (Dragon → Tab5 TTS audio). */
+void voice_codec_set_downlink(voice_codec_t c);
+
+/* Read current uplink/downlink codec. */
+voice_codec_t voice_codec_get_uplink(void);
+voice_codec_t voice_codec_get_downlink(void);
+
+/* Encode one 20 ms PCM chunk (16 kHz mono int16_t).
+ *
+ * @param pcm_samples  Pointer to PCM samples.
+ * @param n_samples    Number of int16_t samples.  Must be exactly 320
+ *                     (= 20 ms @ 16 kHz) when codec=OPUS.
+ * @param out          Output buffer (caller-owned).
+ * @param out_cap      Capacity of out in bytes.
+ * @param[out] out_len Bytes written.
+ *
+ * For PCM uplink this is just a memcpy.  For OPUS it produces a
+ * variable-length packet (~60 bytes typical at 24 kbps).
+ *
+ * Returns ESP_OK on success. */
+esp_err_t voice_codec_encode_uplink(const int16_t *pcm_samples,
+                                    size_t n_samples,
+                                    uint8_t *out, size_t out_cap,
+                                    size_t *out_len);
+
+/* Decode one downlink frame back to int16_t mono 16 kHz PCM.
+ *
+ * For PCM downlink this is just a memcpy / type-pun.  For OPUS this
+ * decodes the packet into PCM samples (typically 320 per frame for a
+ * 20 ms packet, but variable based on the encoder's choice).
+ *
+ * @param data         Encoded packet bytes (or PCM bytes if codec=PCM).
+ * @param len          Length of data in bytes.
+ * @param out_pcm      Output PCM buffer.
+ * @param out_cap      Capacity of out_pcm in samples (int16_t units).
+ * @param[out] out_n   Number of int16_t samples written.
+ *
+ * Returns ESP_OK on success. */
+esp_err_t voice_codec_decode_downlink(const uint8_t *data, size_t len,
+                                      int16_t *out_pcm, size_t out_cap,
+                                      size_t *out_n);
+
+/* Convenience: name → enum + enum → name. */
+voice_codec_t voice_codec_from_name(const char *name);
+const char *voice_codec_to_name(voice_codec_t c);


### PR DESCRIPTION
## Summary
- New \`main/voice_codec.{c,h}\` wrapping \`espressif/esp_audio_codec\`'s OPUS engine for our 16 kHz mono / 20 ms / 320-sample frame shape.
- \`register\` advertises \`capabilities.audio_codec = ["pcm", "opus"]\`.
- \`config_update\` RX accepts \`audio_codec\` (both directions), \`audio_uplink_codec\`, \`audio_downlink_codec\`.
- Mic capture loop encodes through the wrapper before WS send.
- Binary RX (TTS) decodes through the wrapper before the existing 16k→48k upsample.
- \`voice_disconnect\` resets both codecs back to PCM.
- Refs #262 (Dragon-side decoder lands in TinkerBox).

## Test plan
- [x] Build clean — esp_audio_codec resolves (and transitively pulls in esp_h264 which we'll use later for video).
- [x] Flash + default PCM smoke: /chat round-trip works (voice_connected=true, state transitions through PROCESSING → SPEAKING).
- [x] No regression in 5-min mixed nav+screenshot stress (still 100 % uptime).
- [ ] OPUS round-trip end-to-end — gated on TinkerBox PR landing the Dragon-side decoder.

## Why this is non-breaking
- Default codec stays PCM until Dragon's \`config_update\` switches it.
- Dragon today doesn't recognize the \`audio_codec\` capability — Tab5 advertises both, Dragon ignores the extra field, mic continues sending PCM as raw int16 binary frames as today.
- If the OPUS encoder fails to init at runtime, the wrapper falls back to PCM and logs a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)