### PR TITLE
fix(voice): gate OPUS uplink behind compile-time flag (encoder crashes on this build)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -122,8 +122,11 @@ static const char *TAG = "tab5_voice";
  * race on Dragon restart. */
 #define WS_AUTH_FAIL_THRESHOLD 3
 
-// Mic capture task — needs room for AFE feed buffer (960 int16 = 1.9KB) + TDM diagnostics
-#define MIC_TASK_STACK_SIZE    8192
+// Mic capture task — needs room for AFE feed buffer (960 int16 = 1.9KB)
+// + TDM diagnostics + OPUS encoder (silk_Encode is the heavy consumer,
+// ~4 KB of locals — 8 KB was insufficient and panicked in
+// silk_encode_frame_FIX, see #262 follow-up).
+#define MIC_TASK_STACK_SIZE    16384
 #define MIC_TASK_PRIORITY      5
 #define MIC_TASK_CORE          1
 
@@ -561,10 +564,18 @@ static esp_err_t voice_ws_send_register(void)
     cJSON_AddBoolToObject(caps, "touch", true);
     /* #262: advertise audio codec support.  Dragon picks one and replies
      * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
-     * until Dragon switches it. */
+     * until Dragon switches it.  Per-direction so the broken uplink
+     * encoder (#262 follow-up: silk_NSQ_c crashes on this build) doesn't
+     * starve the working downlink decoder; until the encoder ships,
+     * advertise opus only on the downlink. */
     cJSON *acodecs = cJSON_AddArrayToObject(caps, "audio_codec");
     cJSON_AddItemToArray(acodecs, cJSON_CreateString("pcm"));
+#if VOICE_CODEC_OPUS_UPLINK_ENABLED
     cJSON_AddItemToArray(acodecs, cJSON_CreateString("opus"));
+#endif
+    cJSON *acodecs_dl = cJSON_AddArrayToObject(caps, "audio_downlink_codec");
+    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("pcm"));
+    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("opus"));
     /* v4·D audit P0 fix: widget_capability was spec-only -- now wired.
      * Skills can downgrade widget content for low-end clients (smaller
      * list, lower image res).  Match the actual Tab5 limits we've
@@ -2800,9 +2811,12 @@ esp_err_t voice_start_listening(void)
     s_llm_text[0] = '\0';
 
     s_mic_running = true;
-    BaseType_t ret = xTaskCreatePinnedToCore(
+    /* #262 follow-up: 16 KB stack (was 8) for OPUS silk_Encode locals.
+     * WithCaps(SPIRAM) keeps the bump out of internal SRAM. */
+    BaseType_t ret = xTaskCreatePinnedToCoreWithCaps(
         mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
-        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE);
+        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
+        MALLOC_CAP_SPIRAM);
     if (ret != pdPASS) {
         ESP_LOGE(TAG, "Failed to create mic capture task");
         voice_ws_send_text("{\"type\":\"stop\"}");
@@ -2849,9 +2863,12 @@ esp_err_t voice_start_dictation(void)
     s_llm_text[0] = '\0';
 
     s_mic_running = true;
-    BaseType_t ret = xTaskCreatePinnedToCore(
+    /* #262 follow-up: 16 KB stack (was 8) for OPUS silk_Encode locals.
+     * WithCaps(SPIRAM) keeps the bump out of internal SRAM. */
+    BaseType_t ret = xTaskCreatePinnedToCoreWithCaps(
         mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
-        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE);
+        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
+        MALLOC_CAP_SPIRAM);
     if (ret != pdPASS) {
         ESP_LOGE(TAG, "Failed to create mic capture task");
         voice_ws_send_text("{\"type\":\"stop\"}");

--- a/main/voice_codec.c
+++ b/main/voice_codec.c
@@ -58,7 +58,11 @@ static esp_err_t ensure_encoder(void)
     cfg.bitrate          = VC_OPUS_BITRATE;
     cfg.frame_duration   = ESP_OPUS_ENC_FRAME_DURATION_20_MS;
     cfg.application_mode = ESP_OPUS_ENC_APPLICATION_VOIP;
-    cfg.complexity       = 5;     /* mid — keeps CPU below ~10% on a P4 core */
+    /* complexity=0 picks the simplest SILK code paths; higher levels
+     * crashed in silk_NSQ_del_dec_c on this build (likely a SIMD or
+     * working-buffer alignment issue in the esp_audio_codec port).
+     * Quality at 0 + 24 kbps is still good for VOIP. */
+    cfg.complexity       = 0;
     cfg.enable_fec       = false;
     cfg.enable_dtx       = false;
     cfg.enable_vbr       = true;
@@ -108,6 +112,13 @@ void voice_codec_deinit(void)
 void voice_codec_set_uplink(voice_codec_t c)
 {
     if (c == s_uplink) return;
+#if !VOICE_CODEC_OPUS_UPLINK_ENABLED
+    if (c == VOICE_CODEC_OPUS) {
+        ESP_LOGW(TAG, "uplink OPUS request ignored — encoder disabled at compile-time "
+                      "(VOICE_CODEC_OPUS_UPLINK_ENABLED=0); staying PCM");
+        return;
+    }
+#endif
     ESP_LOGI(TAG, "uplink: %s -> %s", voice_codec_to_name(s_uplink), voice_codec_to_name(c));
     s_uplink = c;
     if (c == VOICE_CODEC_OPUS) {

--- a/main/voice_codec.h
+++ b/main/voice_codec.h
@@ -21,6 +21,19 @@
 #include <stddef.h>
 #include "esp_err.h"
 
+/* Compile-time gate for the OPUS uplink (mic) path.  The
+ * espressif/esp_audio_codec OPUS encoder crashes reproducibly inside
+ * silk_NSQ_c / silk_NSQ_del_dec_c on this build (PSRAM-backed PCM
+ * input + complexity 0 or 5 both reproduce; suspect a SIMD alignment
+ * or working-buffer issue specific to the ESP32-P4 port).  Until that
+ * is root-caused we keep the encoder turned off — Tab5 only advertises
+ * PCM uplink in capabilities, the encode helper short-circuits to PCM
+ * even if voice_codec_set_uplink(OPUS) is called.
+ *
+ * Decoder is unaffected (different SILK / CELT code paths) so the
+ * downlink path is left enabled — Phase 2B will exercise it. */
+#define VOICE_CODEC_OPUS_UPLINK_ENABLED 0
+
 typedef enum {
     VOICE_CODEC_PCM  = 0,   /* raw int16_t LE @ 16 kHz mono — default */
     VOICE_CODEC_OPUS = 1,


### PR DESCRIPTION
## Summary
Disable the OPUS uplink encoder pending root-cause of SILK NSQ panic (#264). Gate is a single-line \`#define\` in \`voice_codec.h\` so re-enabling is trivial once fixed.

## Background
PR #263 wired \`espressif/esp_audio_codec\` 's OPUS encoder into the mic uplink. Every dictation cycle reproducibly PANICs inside SILK NSQ functions (3 different crash sites — \`silk_encode_frame_FIX\`, \`silk_NSQ_del_dec_c\`, \`silk_NSQ_c\` — across attempts to fix via stack bump and complexity drop). Decoder is unaffected.  Full investigation tracked in #264.

## Changes
- \`voice_codec.h\`: \`VOICE_CODEC_OPUS_UPLINK_ENABLED\` flag (default 0).
- \`voice_codec.c\`: \`voice_codec_set_uplink(OPUS)\` is a logged no-op when the flag is off.
- \`voice.c\` register: advertise \`audio_codec: ["pcm"]\` only when uplink is gated off; explicitly advertise \`audio_downlink_codec: ["pcm","opus"]\` so the working downlink remains exposed for Phase 2B.
- \`voice.c\` mic spawn: moved to \`xTaskCreatePinnedToCoreWithCaps\` with 16 KB PSRAM stack — diagnostic from the encoder bisect, harmless under PCM and ready for re-enable.

## Test plan
- [x] Build clean
- [x] Boot OK after flash, no PANIC
- [x] 8 s dictation: no crash; Dragon transcribes 4 segments end-to-end
- [x] Dragon negotiation: \`client=['pcm'] chosen=pcm applied=pcm\`
- [ ] (#264) — root-cause SILK crash, re-enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)