### PR TITLE
feat(video): live JPEG streaming Tab5 → Dragon (Phase 3A)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "voice_codec.c" "mode_manager.c"
+             "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2144,6 +2144,55 @@ static esp_err_t voice_reconnect_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
+/* ── #266: live video streaming control (POST /video/start, /video/stop,
+ *           GET /video) ─────────────────────────────────────────────── */
+#include "voice_video.h"
+static esp_err_t send_json_resp(httpd_req_t *req, cJSON *root);
+static esp_err_t video_start_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    int fps = VOICE_VIDEO_DEFAULT_FPS;
+    char q[64] = {0}, v[16] = {0};
+    if (httpd_req_get_url_query_str(req, q, sizeof(q)) == ESP_OK &&
+        httpd_query_key_value(q, "fps", v, sizeof(v)) == ESP_OK) {
+        int n = atoi(v);
+        if (n > 0 && n <= VOICE_VIDEO_MAX_FPS) fps = n;
+    }
+    esp_err_t err = voice_video_start_streaming(fps);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", err == ESP_OK);
+    cJSON_AddNumberToObject(root, "fps", fps);
+    if (err != ESP_OK) {
+        cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+    }
+    return send_json_resp(req, root);
+}
+
+static esp_err_t video_stop_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    voice_video_stop_streaming();
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    return send_json_resp(req, root);
+}
+
+static esp_err_t video_state_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    voice_video_stats_t s;
+    voice_video_get_stats(&s);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "active",          s.active);
+    cJSON_AddNumberToObject(root, "fps",           s.fps);
+    cJSON_AddNumberToObject(root, "frames_sent",   (double)s.frames_sent);
+    cJSON_AddNumberToObject(root, "frames_dropped",(double)s.frames_dropped);
+    cJSON_AddNumberToObject(root, "bytes_sent",    (double)s.bytes_sent);
+    cJSON_AddNumberToObject(root, "last_jpeg_bytes",(double)s.last_jpeg_bytes);
+    return send_json_resp(req, root);
+}
+
 /* ── Wave 12 observability: /heap endpoint ─────────────────────────────
  *
  * Exposes the per-pool heap state + last reboot reason in one call so
@@ -3138,6 +3187,16 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_voice_reconnect = {
         .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
     };
+    /* #266: live video streaming control. */
+    const httpd_uri_t uri_video_start = {
+        .uri = "/video/start", .method = HTTP_POST, .handler = video_start_handler
+    };
+    const httpd_uri_t uri_video_stop = {
+        .uri = "/video/stop",  .method = HTTP_POST, .handler = video_stop_handler
+    };
+    const httpd_uri_t uri_video_state = {
+        .uri = "/video",       .method = HTTP_GET,  .handler = video_state_handler
+    };
     const httpd_uri_t uri_dictation_post = {
         .uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler
     };
@@ -3202,6 +3261,9 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_chat);
     httpd_register_uri_handler(server, &uri_voice_state);
     httpd_register_uri_handler(server, &uri_voice_reconnect);
+    httpd_register_uri_handler(server, &uri_video_start);
+    httpd_register_uri_handler(server, &uri_video_stop);
+    httpd_register_uri_handler(server, &uri_video_state);
     httpd_register_uri_handler(server, &uri_dictation_post);
     httpd_register_uri_handler(server, &uri_dictation_get);
     httpd_register_uri_handler(server, &uri_wifi_kick);

--- a/main/voice.c
+++ b/main/voice.c
@@ -23,6 +23,7 @@
 
 #include "voice.h"
 #include "voice_codec.h"   /* #262: OPUS encode/decode wrapper */
+#include "voice_video.h"   /* #266: live JPEG streaming */
 #include "task_worker.h"   /* #133: defer queue-drain to avoid stack blow */
 #include "tool_log.h"      /* U7+U8 (#206): record tool activity for ui_agents/ui_focus */
 #include "md_strip.h"     /* #78 + #160: scrub <tool>...</tool> markers from streamed LLM text */
@@ -86,7 +87,14 @@ static const char *TAG = "tab5_voice";
 
 // esp_websocket_client tuning
 #define WS_CLIENT_TASK_STACK   10240   /* client event/receive task stack */
-#define WS_CLIENT_BUFFER_SIZE  4096    /* per-frame buffer; binary TTS comes in 640–1024 B chunks, headroom for text+media */
+/* per-frame buffer; binary TTS comes in 640–1024 B chunks, audio mic
+ * uplink is 640 B/PCM chunk.  #266: bumped from 4 KB to 32 KB so
+ * voice_video JPEG frames (paired with a low quality target) fit in
+ * a single WS binary frame.  TX + RX bufs ≈ 64 KB internal SRAM —
+ * acceptable since we have one WS client.  Larger values trade
+ * internal SRAM headroom for bigger JPEG frames; if 720p video gets
+ * blocky, raise this in tandem with VV_JPEG_QUALITY in voice_video.c. */
+#define WS_CLIENT_BUFFER_SIZE  (32 * 1024)
 #define WS_CLIENT_RECONNECT_MS 1000    /* base reconnect delay -- exponential ramp takes over from here */
 #define WS_CLIENT_NETWORK_MS   10000   /* blocking send deadline */
 #define WS_CLIENT_PING_SEC     15      /* built-in WS-level ping */
@@ -521,6 +529,14 @@ static esp_err_t voice_ws_send_binary(const void *data, size_t len)
     return ESP_OK;
 }
 
+/* #266: thin public wrapper for voice_video.c (and any future binary
+ * sender).  Behavior is identical to voice_ws_send_binary — same
+ * 100 ms send timeout, same drop accounting. */
+esp_err_t voice_ws_send_binary_public(const void *data, size_t len)
+{
+    return voice_ws_send_binary(data, len);
+}
+
 // ---------------------------------------------------------------------------
 // Device registration — sent as FIRST text frame from the CONNECTED handler.
 // This is the #76 fix: register is sent from inside the event handler, AFTER
@@ -562,6 +578,12 @@ static esp_err_t voice_ws_send_register(void)
     cJSON_AddBoolToObject(caps, "camera", true);
     cJSON_AddBoolToObject(caps, "sd_card", true);
     cJSON_AddBoolToObject(caps, "touch", true);
+    /* #266: live JPEG video uplink.  Tab5 sends per-frame binary WS
+     * frames prefixed with the "VID0" 4-byte magic + 4-byte length.
+     * Dragon detects the magic to route video vs audio. */
+    cJSON_AddBoolToObject(caps, "video_send", true);
+    cJSON_AddNumberToObject(caps, "video_max_fps", 10);
+    cJSON_AddNumberToObject(caps, "video_format", 0);  /* 0 = JPEG */
     /* #262: advertise audio codec support.  Dragon picks one and replies
      * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
      * until Dragon switches it.  Per-direction so the broken uplink
@@ -2249,6 +2271,8 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
 
     /* #262: codec module is independent of WS lifecycle — init once. */
     voice_codec_init();
+    /* #266: video streaming module.  Just allocates the JPEG engine. */
+    voice_video_init();
 
     s_state_mutex = xSemaphoreCreateMutex();
     if (!s_state_mutex) {
@@ -2988,6 +3012,10 @@ esp_err_t voice_disconnect(void)
      * the reconnect.  Dragon will re-negotiate on the new register. */
     voice_codec_set_uplink(VOICE_CODEC_PCM);
     voice_codec_set_downlink(VOICE_CODEC_PCM);
+
+    /* #266: stop any in-flight video stream — sending to a closing WS
+     * would just bleed dropped-frame log spam. */
+    voice_video_stop_streaming();
 
     tab5_audio_speaker_enable(false);
 

--- a/main/voice.h
+++ b/main/voice.h
@@ -101,6 +101,13 @@ esp_err_t voice_clear_history(void);
 /** Send a text message to Dragon, bypassing STT (goes straight to LLM). */
 esp_err_t voice_send_text(const char *text);
 
+/** Send a raw binary frame on the voice WS (#266: video frames + any
+ *  future non-audio binary payload).  Internally calls the same
+ *  esp_websocket_client_send_bin path as the mic uplink, with the same
+ *  send_lock + 1 s timeout.  Caller is responsible for any framing
+ *  (e.g. voice_video.c prefixes a 4-byte type magic). */
+esp_err_t voice_ws_send_binary_public(const void *data, size_t len);
+
 /** Send voice_mode (0-3) and LLM model string to Dragon as a config_update JSON frame. */
 esp_err_t voice_send_config_update(int voice_mode, const char *llm_model);
 

--- a/main/voice_video.c
+++ b/main/voice_video.c
@@ -1,0 +1,314 @@
+/*
+ * voice_video.c — see header.
+ */
+#include "voice_video.h"
+
+#include <string.h>
+#include <inttypes.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "driver/jpeg_encode.h"
+
+#include "camera.h"
+#include "settings.h"
+#include "voice.h"
+
+static const char *TAG = "voice_video";
+
+/* JPEG quality.  30 keeps frames in the 15-25 KB range so they fit
+ * inside the 32 KB WS_CLIENT_BUFFER_SIZE in one WS binary send.
+ * Quality 30 still looks fine for 1280x720 hand-held video — the
+ * artefacts are masked by motion.  Bump in tandem with the WS buffer
+ * if you need higher fidelity. */
+#define VV_JPEG_QUALITY        30
+#define VV_OUT_BUF_BYTES       (96 * 1024)    /* 96 KB safety ceiling */
+#define VV_TASK_STACK          16384
+#define VV_TASK_PRIO           4
+#define VV_TASK_CORE           1
+
+static jpeg_encoder_handle_t s_enc      = NULL;
+static SemaphoreHandle_t     s_enc_mux  = NULL;
+static TaskHandle_t          s_task     = NULL;
+
+static volatile bool s_running    = false;
+static volatile int  s_target_fps = VOICE_VIDEO_DEFAULT_FPS;
+
+static voice_video_stats_t s_stats = {0};
+
+/* Forward declarations for hooks we'll need from voice.c.  Kept as
+ * extern so we don't drag voice.h's full surface into this header. */
+extern esp_err_t voice_ws_send_binary_public(const void *data, size_t len);
+
+/* RGB565 rotation helpers — same shapes as ui_camera.c (#260).  Local
+ * copies so the streamer doesn't depend on the UI module. */
+static void rot180(const uint16_t *src, uint16_t *dst, int sw, int sh)
+{
+    int n = sw * sh;
+    for (int i = 0; i < n; i++) dst[n - 1 - i] = src[i];
+}
+static void rot90(const uint16_t *src, uint16_t *dst, int sw, int sh)
+{
+    for (int y = 0; y < sh; y++) {
+        const uint16_t *row = src + y * sw;
+        for (int x = 0; x < sw; x++) {
+            dst[(sh - 1 - y) + x * sh] = row[x];
+        }
+    }
+}
+static void rot270(const uint16_t *src, uint16_t *dst, int sw, int sh)
+{
+    for (int y = 0; y < sh; y++) {
+        const uint16_t *row = src + y * sw;
+        for (int x = 0; x < sw; x++) {
+            dst[y + (sw - 1 - x) * sh] = row[x];
+        }
+    }
+}
+
+esp_err_t voice_video_init(void)
+{
+    if (!s_enc_mux) {
+        s_enc_mux = xSemaphoreCreateMutex();
+        if (!s_enc_mux) return ESP_ERR_NO_MEM;
+    }
+    if (!s_enc) {
+        jpeg_encode_engine_cfg_t cfg = {
+            .intr_priority = 0,
+            .timeout_ms    = 5000,
+        };
+        esp_err_t r = jpeg_new_encoder_engine(&cfg, &s_enc);
+        if (r != ESP_OK) {
+            ESP_LOGE(TAG, "jpeg_new_encoder_engine failed: %s", esp_err_to_name(r));
+            s_enc = NULL;
+            return r;
+        }
+    }
+    ESP_LOGI(TAG, "init OK (jpeg engine ready)");
+    return ESP_OK;
+}
+
+bool voice_video_is_streaming(void)
+{
+    return s_running;
+}
+
+void voice_video_get_stats(voice_video_stats_t *out)
+{
+    if (!out) return;
+    *out = s_stats;
+}
+
+/* Encode one RGB565 frame to JPEG via the hardware engine.
+ * out_buf is caller-owned.  Returns ESP_OK + sets *out_size. */
+static esp_err_t encode_jpeg(const uint8_t *rgb565, int w, int h,
+                             uint8_t *out_buf, size_t out_cap,
+                             uint32_t *out_size)
+{
+    jpeg_encode_cfg_t cfg = {
+        .height        = h,
+        .width         = w,
+        .src_type      = JPEG_ENCODE_IN_FORMAT_RGB565,
+        .sub_sample    = JPEG_DOWN_SAMPLING_YUV420,
+        .image_quality = VV_JPEG_QUALITY,
+    };
+    if (xSemaphoreTake(s_enc_mux, pdMS_TO_TICKS(2000)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+    esp_err_t r = jpeg_encoder_process(s_enc, &cfg,
+                                       (uint8_t *)rgb565,
+                                       (size_t)w * h * 2,
+                                       out_buf, out_cap, out_size);
+    xSemaphoreGive(s_enc_mux);
+    return r;
+}
+
+/* Build the on-wire frame: 4-byte magic + 4-byte length + JPEG bytes.
+ * Caller-supplied wire_buf must be at least jpeg_len + 8 bytes. */
+static size_t pack_wire_frame(uint8_t *wire_buf,
+                              const uint8_t *jpeg, uint32_t jpeg_len)
+{
+    /* "VID0" big-endian magic. */
+    wire_buf[0] = 'V'; wire_buf[1] = 'I'; wire_buf[2] = 'D'; wire_buf[3] = '0';
+    wire_buf[4] = (uint8_t)((jpeg_len >> 24) & 0xff);
+    wire_buf[5] = (uint8_t)((jpeg_len >> 16) & 0xff);
+    wire_buf[6] = (uint8_t)((jpeg_len >> 8)  & 0xff);
+    wire_buf[7] = (uint8_t)( jpeg_len        & 0xff);
+    memcpy(wire_buf + 8, jpeg, jpeg_len);
+    return jpeg_len + 8;
+}
+
+static void streaming_task(void *arg)
+{
+    (void)arg;
+    ESP_LOGI(TAG, "streaming task started fps=%d core=%d",
+             s_target_fps, xPortGetCoreID());
+
+    /* HW JPEG encoder requires DMA-aligned buffers (the engine writes
+     * the bitstream via DMA).  Plain heap_caps_malloc fails with
+     * "bit stream is not aligned" — must use jpeg_alloc_encoder_mem
+     * with the OUTPUT direction for the destination buffer. */
+    jpeg_encode_memory_alloc_cfg_t out_alloc = {
+        .buffer_direction = JPEG_ENC_ALLOC_OUTPUT_BUFFER,
+    };
+    size_t jpeg_cap = 0;
+    uint8_t *jpeg_buf = jpeg_alloc_encoder_mem(VV_OUT_BUF_BYTES,
+                                               &out_alloc, &jpeg_cap);
+    /* Rotation scratch must also be DMA-aligned (the JPEG engine reads
+     * from it via DMA when rotation != 0).  Wire buffer can be plain
+     * PSRAM since it's only consumed by the WS-send path. */
+    jpeg_encode_memory_alloc_cfg_t in_alloc = {
+        .buffer_direction = JPEG_ENC_ALLOC_INPUT_BUFFER,
+    };
+    size_t rot_cap = 0;
+    uint16_t *rot_buf  = (uint16_t *)jpeg_alloc_encoder_mem(
+        1280 * 720 * 2, &in_alloc, &rot_cap);
+    uint8_t  *wire_buf = heap_caps_malloc(VV_OUT_BUF_BYTES + 8, MALLOC_CAP_SPIRAM);
+    if (!jpeg_buf || !rot_buf || !wire_buf) {
+        ESP_LOGE(TAG, "streaming alloc failed (jpeg=%p rot=%p wire=%p)",
+                 jpeg_buf, rot_buf, wire_buf);
+        if (jpeg_buf) free(jpeg_buf);    /* jpeg_alloc_encoder_mem path */
+        if (rot_buf)  free(rot_buf);
+        heap_caps_free(wire_buf);
+        s_running = false;
+        s_task    = NULL;
+        vTaskSuspend(NULL);
+        return;
+    }
+
+    int last_fps = s_target_fps;
+    TickType_t period = pdMS_TO_TICKS(1000 / last_fps);
+
+    while (s_running) {
+        if (s_target_fps != last_fps) {
+            last_fps = s_target_fps;
+            period = pdMS_TO_TICKS(1000 / last_fps);
+            ESP_LOGI(TAG, "fps changed -> %d (period=%u ms)",
+                     last_fps, (unsigned)(1000 / last_fps));
+        }
+
+        TickType_t t0 = xTaskGetTickCount();
+
+        if (!tab5_camera_initialized()) {
+            vTaskDelay(pdMS_TO_TICKS(200));
+            continue;
+        }
+
+        tab5_cam_frame_t frame;
+        esp_err_t cer = tab5_camera_capture(&frame);
+        if (cer != ESP_OK || frame.format != TAB5_CAM_FMT_RGB565) {
+            s_stats.frames_dropped++;
+            vTaskDelay(pdMS_TO_TICKS(20));
+            continue;
+        }
+
+        /* Apply rotation per cam_rot.  Match the viewfinder so the
+         * remote sees what the user sees. */
+        const uint8_t *jpeg_src = frame.data;
+        int sw = frame.width;
+        int sh = frame.height;
+        uint8_t rot = tab5_settings_get_cam_rotation() & 0x03;
+        if (rot != 0) {
+            const uint16_t *src = (const uint16_t *)frame.data;
+            switch (rot) {
+            case 1: rot90 (src, rot_buf, sw, sh); sw = frame.height; sh = frame.width; break;
+            case 2: rot180(src, rot_buf, sw, sh); break;
+            case 3: rot270(src, rot_buf, sw, sh); sw = frame.height; sh = frame.width; break;
+            }
+            jpeg_src = (const uint8_t *)rot_buf;
+        }
+
+        uint32_t jpeg_size = 0;
+        esp_err_t er = encode_jpeg(jpeg_src, sw, sh,
+                                   jpeg_buf, VV_OUT_BUF_BYTES, &jpeg_size);
+        if (er != ESP_OK || jpeg_size == 0) {
+            ESP_LOGW(TAG, "jpeg encode failed: %s sz=%" PRIu32,
+                     esp_err_to_name(er), jpeg_size);
+            s_stats.frames_dropped++;
+            goto wait;
+        }
+
+        size_t wire_len = pack_wire_frame(wire_buf, jpeg_buf, jpeg_size);
+        esp_err_t ser = voice_ws_send_binary_public(wire_buf, wire_len);
+        if (ser == ESP_OK) {
+            s_stats.frames_sent++;
+            s_stats.bytes_sent     += wire_len;
+            s_stats.last_jpeg_bytes = jpeg_size;
+        } else {
+            s_stats.frames_dropped++;
+        }
+
+wait:
+        ;  /* C: empty stmt after label */
+        TickType_t now = xTaskGetTickCount();
+        TickType_t spent = now - t0;
+        if (spent < period) {
+            vTaskDelay(period - spent);
+        } else {
+            taskYIELD();
+        }
+    }
+
+    free(jpeg_buf);                       /* jpeg_alloc_encoder_mem path */
+    free(rot_buf);                        /* same */
+    heap_caps_free(wire_buf);
+
+    ESP_LOGI(TAG, "streaming task exiting cleanly");
+    s_stats.active = false;
+    s_task = NULL;
+    /* P4 TLSP rule (#20): suspend, don't delete.  Worker stack lives
+     * in PSRAM (#262 follow-up) so the leak per stream is bounded
+     * PSRAM, not internal SRAM. */
+    vTaskSuspend(NULL);
+}
+
+esp_err_t voice_video_start_streaming(int fps)
+{
+    if (s_running || s_task) {
+        ESP_LOGW(TAG, "already streaming");
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (voice_video_init() != ESP_OK) return ESP_FAIL;
+
+    if (fps < 1) fps = 1;
+    if (fps > VOICE_VIDEO_MAX_FPS) fps = VOICE_VIDEO_MAX_FPS;
+    s_target_fps    = fps;
+    s_stats.active  = true;
+    s_stats.fps     = fps;
+    s_running       = true;
+
+    BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(
+        streaming_task, "voice_video", VV_TASK_STACK,
+        NULL, VV_TASK_PRIO, &s_task, VV_TASK_CORE,
+        MALLOC_CAP_SPIRAM);
+    if (ok != pdPASS) {
+        ESP_LOGE(TAG, "task spawn failed");
+        s_running      = false;
+        s_stats.active = false;
+        s_task         = NULL;
+        return ESP_ERR_NO_MEM;
+    }
+    ESP_LOGI(TAG, "streaming started fps=%d", fps);
+    return ESP_OK;
+}
+
+esp_err_t voice_video_stop_streaming(void)
+{
+    if (!s_running) return ESP_OK;
+    s_running = false;
+    /* Wait up to ~1.2 s for the task to drain its current frame and
+     * exit on its own.  We don't vTaskDelete (P4 TLSP rule). */
+    for (int i = 0; i < 60 && s_task != NULL; i++) {
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+    s_stats.active = false;
+    s_stats.fps    = 0;
+    ESP_LOGI(TAG, "streaming stopped (frames_sent=%" PRIu32
+                  " bytes=%" PRIu32 " dropped=%" PRIu32 ")",
+             s_stats.frames_sent, s_stats.bytes_sent, s_stats.frames_dropped);
+    return ESP_OK;
+}

--- a/main/voice_video.h
+++ b/main/voice_video.h
@@ -1,0 +1,65 @@
+/*
+ * voice_video.h — live JPEG streaming Tab5 → Dragon (#266 / Phase 3A
+ * of two-way video).
+ *
+ * Captures camera frames via the BSP V4L2 stack, applies the user's
+ * NVS cam_rot pref (matches the viewfinder), JPEG-encodes via the
+ * ESP32-P4 hardware engine, and ships each frame over the existing
+ * voice WS as a binary frame prefixed with a 4-byte type tag.
+ *
+ * Wire format (one binary WS frame per video frame):
+ *   bytes 0..3  : magic tag "VID0" (0x56 0x49 0x44 0x30)
+ *   bytes 4..7  : payload length (uint32_t big-endian, sanity check)
+ *   bytes 8..   : JPEG bytes
+ *
+ * Audio frames don't carry the magic tag — Dragon's binary handler
+ * checks for "VID0" and routes accordingly so existing PCM uplink is
+ * unchanged.
+ *
+ * Lifecycle:
+ *   voice_video_init() once at boot (idempotent).
+ *   voice_video_start_streaming(fps) starts a worker task that pumps
+ *     frames at ~fps Hz (capped at 10 to keep WS bandwidth sane).
+ *   voice_video_stop_streaming() stops the worker.  Idempotent.
+ *
+ * Threading: the streaming task runs on Core 1, owns the JPEG encoder
+ * engine (one per stream), and synchronises camera capture with
+ * tab5_camera_capture's internal busy flag.  Send goes through the
+ * existing voice_ws_send_binary().
+ */
+#pragma once
+
+#include <stdbool.h>
+#include "esp_err.h"
+
+#define VOICE_VIDEO_MAGIC      0x56494430u   /* "VID0" big-endian */
+#define VOICE_VIDEO_MAX_FPS    10
+#define VOICE_VIDEO_DEFAULT_FPS 5
+
+/* Idempotent.  Must be called once before start_streaming.  Allocates
+ * the JPEG encoder engine + mutex. */
+esp_err_t voice_video_init(void);
+
+/* Start the worker task at the requested fps (clamped to [1..MAX]).
+ * Returns ESP_OK on success, ESP_ERR_INVALID_STATE if already
+ * streaming, ESP_ERR_NO_MEM on alloc failure. */
+esp_err_t voice_video_start_streaming(int fps);
+
+/* Stop the worker task.  Blocks until the next frame finishes (max
+ * ~200 ms typical).  Idempotent. */
+esp_err_t voice_video_stop_streaming(void);
+
+/* True when the worker task is alive. */
+bool voice_video_is_streaming(void);
+
+/* Stats for /info / debug. */
+typedef struct {
+    bool     active;
+    int      fps;
+    uint32_t frames_sent;
+    uint32_t frames_dropped;
+    uint32_t bytes_sent;
+    uint32_t last_jpeg_bytes;
+} voice_video_stats_t;
+
+void voice_video_get_stats(voice_video_stats_t *out);


### PR DESCRIPTION
## Summary
- New \`voice_video.{c,h}\` module: long-running streaming task captures camera frames, applies the \`cam_rot\` from #260, JPEG-encodes via the ESP32-P4 hardware engine, ships each frame as a binary WS frame prefixed with \`b"VID0"\` + 4-byte length.
- \`register\` advertises \`capabilities.video_send=true\` + \`video_max_fps=10\`.
- \`POST /video/start?fps=N\` / \`POST /video/stop\` / \`GET /video\` (stats) for testing.
- WS client buffer 4 KB → 32 KB to fit ~30 KB JPEG frames.
- Closes #266.  Pairs with TinkerBox #176.

## Test plan
- [x] Build clean
- [x] Flash + 6 s @ 5 fps stream — Tab5 sends 30 frames, 0 dropped, ~30 KB each
- [x] Dragon receives frames (logs frame #1 + #20)
- [x] Pulled latest frame to workstation: valid 1280x720 JPEG of the room
- [x] No crash, audio path unchanged

## Critical fixes during validation
- JPEG encoder needs DMA-aligned buffers (\`jpeg_alloc_encoder_mem\`) for both INPUT and OUTPUT.  Plain \`heap_caps_malloc\` fails with "bit stream is not aligned".
- WS buffer needs to fit a complete frame in one send; 32 KB is the smallest power-of-two that works for q30 1280x720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)