### PR TITLE
feat(video): Tab5 video playback — receive + render Dragon JPEG (Phase 3B)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UI_SRCS
     "ui_theme.c"
     "ui_splash.c" "ui_home.c" "ui_settings.c"
     "ui_camera.c" "ui_files.c" "ui_audio.c" "ui_keyboard.c" "ui_voice.c" "ui_wifi.c"
+    "ui_video_pane.c"
     "ui_chat.c" "ui_notes.c" "ui_feedback.c" "ui_agents.c" "ui_memory.c" "ui_focus.c" "ui_sessions.c"
     "ui_mode_sheet.c"
     "ui_nav_sheet.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2145,9 +2145,35 @@ static esp_err_t voice_reconnect_handler(httpd_req_t *req)
 }
 
 /* ── #266: live video streaming control (POST /video/start, /video/stop,
- *           GET /video) ─────────────────────────────────────────────── */
+ *           GET /video).  #268 adds /video/show + /video/hide for the
+ *           downlink pane. ──────────────────────────────────────────── */
 #include "voice_video.h"
+#include "ui_video_pane.h"
+#include "ui_core.h"   /* tab5_lv_async_call (#258) */
 static esp_err_t send_json_resp(httpd_req_t *req, cJSON *root);
+
+/* The pane is an LVGL widget — must be opened on the LVGL thread. */
+static void show_pane_async(void *arg) { (void)arg; ui_video_pane_show(); }
+static void hide_pane_async(void *arg) { (void)arg; ui_video_pane_hide(); }
+
+static esp_err_t video_show_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    tab5_lv_async_call(show_pane_async, NULL);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    return send_json_resp(req, root);
+}
+
+static esp_err_t video_hide_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    tab5_lv_async_call(hide_pane_async, NULL);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    return send_json_resp(req, root);
+}
+
 static esp_err_t video_start_handler(httpd_req_t *req)
 {
     if (!check_auth(req)) return ESP_OK;
@@ -2190,6 +2216,12 @@ static esp_err_t video_state_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "frames_dropped",(double)s.frames_dropped);
     cJSON_AddNumberToObject(root, "bytes_sent",    (double)s.bytes_sent);
     cJSON_AddNumberToObject(root, "last_jpeg_bytes",(double)s.last_jpeg_bytes);
+    /* #268 downlink stats. */
+    cJSON_AddBoolToObject(root, "pane_visible",      ui_video_pane_is_visible());
+    cJSON_AddNumberToObject(root, "frames_recv",     (double)s.frames_recv);
+    cJSON_AddNumberToObject(root, "frames_recv_dropped", (double)s.frames_recv_dropped);
+    cJSON_AddNumberToObject(root, "bytes_recv",      (double)s.bytes_recv);
+    cJSON_AddNumberToObject(root, "last_recv_jpeg_bytes",(double)s.last_recv_jpeg_bytes);
     return send_json_resp(req, root);
 }
 
@@ -3187,7 +3219,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_voice_reconnect = {
         .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
     };
-    /* #266: live video streaming control. */
+    /* #266: live video streaming control.  #268 adds /video/show + hide. */
     const httpd_uri_t uri_video_start = {
         .uri = "/video/start", .method = HTTP_POST, .handler = video_start_handler
     };
@@ -3196,6 +3228,12 @@ esp_err_t tab5_debug_server_init(void)
     };
     const httpd_uri_t uri_video_state = {
         .uri = "/video",       .method = HTTP_GET,  .handler = video_state_handler
+    };
+    const httpd_uri_t uri_video_show = {
+        .uri = "/video/show",  .method = HTTP_POST, .handler = video_show_handler
+    };
+    const httpd_uri_t uri_video_hide = {
+        .uri = "/video/hide",  .method = HTTP_POST, .handler = video_hide_handler
     };
     const httpd_uri_t uri_dictation_post = {
         .uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler
@@ -3264,6 +3302,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_video_start);
     httpd_register_uri_handler(server, &uri_video_stop);
     httpd_register_uri_handler(server, &uri_video_state);
+    httpd_register_uri_handler(server, &uri_video_show);
+    httpd_register_uri_handler(server, &uri_video_hide);
     httpd_register_uri_handler(server, &uri_dictation_post);
     httpd_register_uri_handler(server, &uri_dictation_get);
     httpd_register_uri_handler(server, &uri_wifi_kick);

--- a/main/ui_video_pane.c
+++ b/main/ui_video_pane.c
@@ -1,0 +1,85 @@
+/*
+ * ui_video_pane.c — see header.
+ *
+ * Implementation: a single full-screen lv_image centred on a black
+ * lv_obj parented to ui_home's screen.  Tap-to-dismiss closes the
+ * pane.  No animations, no ornaments — keeps the LVGL pool footprint
+ * tiny so the pane is cheap to open/close mid-call.
+ */
+#include "ui_video_pane.h"
+
+#include "esp_log.h"
+#include "ui_home.h"
+
+static const char *TAG = "ui_video_pane";
+
+#define VP_W   720
+#define VP_H   1280
+
+static lv_obj_t *s_root  = NULL;
+static lv_obj_t *s_image = NULL;
+
+static void on_tap(lv_event_t *e)
+{
+    (void)e;
+    ui_video_pane_hide();
+}
+
+void ui_video_pane_show(void)
+{
+    if (s_root) {
+        lv_obj_remove_flag(s_root, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(s_root);
+        return;
+    }
+
+    lv_obj_t *parent = ui_home_get_screen();
+    if (!parent) parent = lv_screen_active();
+    if (!parent) return;
+
+    s_root = lv_obj_create(parent);
+    if (!s_root) {
+        ESP_LOGE(TAG, "OOM creating root");
+        return;
+    }
+    lv_obj_remove_style_all(s_root);
+    lv_obj_set_size(s_root, VP_W, VP_H);
+    lv_obj_set_pos(s_root, 0, 0);
+    lv_obj_set_style_bg_color(s_root, lv_color_hex(0x000000), 0);
+    lv_obj_set_style_bg_opa(s_root, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(s_root, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_root, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_event_cb(s_root, on_tap, LV_EVENT_CLICKED, NULL);
+    lv_obj_move_foreground(s_root);
+
+    s_image = lv_image_create(s_root);
+    lv_obj_center(s_image);
+    /* Camera native is 1280x720 landscape on a 720x1280 portrait pane.
+     * No rotation here — TJPGD-decoded RAW images don't compose well
+     * with lv_image rotation in LVGL 9 (renders blank).  The user can
+     * rotate via NVS cam_rot which already affects the encoded bytes
+     * upstream when the local Tab5 is the sender (Phase 3A); for
+     * downlink frames from a peer, just letterbox the landscape feed
+     * and let the user tilt the device. */
+    lv_obj_set_style_bg_color(s_root, lv_color_hex(0x000000), 0);
+}
+
+void ui_video_pane_hide(void)
+{
+    if (!s_root) return;
+    lv_obj_delete(s_root);
+    s_root  = NULL;
+    s_image = NULL;
+}
+
+bool ui_video_pane_is_visible(void)
+{
+    return s_root != NULL;
+}
+
+void ui_video_pane_set_dsc(const lv_image_dsc_t *dsc)
+{
+    if (!s_image || !dsc) return;
+    lv_image_set_src(s_image, dsc);
+    lv_obj_invalidate(s_image);
+}

--- a/main/ui_video_pane.h
+++ b/main/ui_video_pane.h
@@ -1,0 +1,29 @@
+/*
+ * ui_video_pane.h — full-screen video pane that displays the latest
+ * Dragon-sent JPEG frame (#268 / Phase 3B).
+ *
+ * Owned by voice_video.c::voice_video_on_downlink_frame which feeds
+ * fresh frames via ui_video_pane_set_dsc on the LVGL thread.
+ *
+ * The pane is an opt-in overlay — call ui_video_pane_show() to open
+ * it and ui_video_pane_hide() to close.  Phase 3C will hook these
+ * to the call-accept / call-end UI; for Phase 3B a debug endpoint is
+ * the only caller.
+ */
+#pragma once
+
+#include "lvgl.h"
+
+/* Open the full-screen video pane.  Idempotent. */
+void ui_video_pane_show(void);
+
+/* Hide + free the pane.  Safe even if not open. */
+void ui_video_pane_hide(void);
+
+/* True iff the pane is currently visible. */
+bool ui_video_pane_is_visible(void);
+
+/* Replace the image source with the supplied descriptor.  No-op if
+ * the pane is not visible (the call site doesn't need to track that).
+ * `dsc` must remain valid until the next call (LVGL doesn't copy). */
+void ui_video_pane_set_dsc(const lv_image_dsc_t *dsc);

--- a/main/voice.c
+++ b/main/voice.c
@@ -582,6 +582,7 @@ static esp_err_t voice_ws_send_register(void)
      * frames prefixed with the "VID0" 4-byte magic + 4-byte length.
      * Dragon detects the magic to route video vs audio. */
     cJSON_AddBoolToObject(caps, "video_send", true);
+    cJSON_AddBoolToObject(caps, "video_recv", true);   /* #268 Phase 3B */
     cJSON_AddNumberToObject(caps, "video_max_fps", 10);
     cJSON_AddNumberToObject(caps, "video_format", 0);  /* 0 = JPEG */
     /* #262: advertise audio codec support.  Dragon picks one and replies
@@ -1638,6 +1639,15 @@ static size_t upsample_16k_to_48k(const int16_t *in, size_t in_samples,
 
 static void handle_binary_message(const char *data, int len)
 {
+    /* #268: video frames carry the 4-byte "VID0" magic.  Route them
+     * to voice_video before any audio-state checks — video plays
+     * regardless of voice state (unlike TTS, which only plays in
+     * SPEAKING/PROCESSING).  Audio frames (no magic) fall through. */
+    if (voice_video_peek_downlink_magic(data, (size_t)len)) {
+        voice_video_on_downlink_frame((const uint8_t *)data, (size_t)len);
+        return;
+    }
+
     /* v4·D audit P0 fix: snapshot s_state under the mutex so we never
      * race with voice_set_state on another task.  The checks below
      * formerly read s_state twice without locking -- second read could
@@ -1880,7 +1890,46 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
                      data->data_len > 200 ? 200 : data->data_len, data->data_ptr);
             handle_text_message(data->data_ptr, data->data_len);
         } else if (data->op_code == WS_TRANSPORT_OPCODES_BINARY && data->data_len > 0) {
-            handle_binary_message(data->data_ptr, data->data_len);
+            /* #268: large binary frames (e.g. Phase 3B video JPEGs >32 KB)
+             * arrive in fragments — esp_websocket_client splits them at
+             * WS_CLIENT_BUFFER_SIZE.  Reassemble using payload_len +
+             * payload_offset before dispatching to handle_binary_message
+             * so the magic-byte sniff sees the whole frame.  Audio
+             * (PCM/OPUS) is single-fragment so the fast path skips
+             * reassembly. */
+            const int frag_total = data->payload_len;
+            const int frag_off   = data->payload_offset;
+            const int frag_len   = data->data_len;
+            if (frag_total <= 0 || frag_total == frag_len) {
+                /* Single-fragment frame — current behavior. */
+                handle_binary_message(data->data_ptr, frag_len);
+            } else {
+                /* Multi-fragment frame.  Lazy-init reassembly buffer
+                 * in PSRAM, sized to the same ceiling voice_video uses. */
+                static uint8_t *s_rx_reasm_buf = NULL;
+                static int      s_rx_reasm_cap = 96 * 1024;
+                if (!s_rx_reasm_buf) {
+                    s_rx_reasm_buf = heap_caps_malloc(
+                        s_rx_reasm_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                }
+                if (!s_rx_reasm_buf) {
+                    ESP_LOGW(TAG, "rx-reasm OOM (%d B); dropping frag", s_rx_reasm_cap);
+                    break;
+                }
+                if (frag_total > s_rx_reasm_cap) {
+                    ESP_LOGW(TAG, "rx-reasm: payload %d > cap %d; dropping", frag_total, s_rx_reasm_cap);
+                    break;
+                }
+                if (frag_off + frag_len > frag_total) {
+                    ESP_LOGW(TAG, "rx-reasm: bad frag off=%d len=%d total=%d",
+                             frag_off, frag_len, frag_total);
+                    break;
+                }
+                memcpy(s_rx_reasm_buf + frag_off, data->data_ptr, frag_len);
+                if (frag_off + frag_len == frag_total) {
+                    handle_binary_message((const char *)s_rx_reasm_buf, frag_total);
+                }
+            }
         } else if (data->op_code == WS_TRANSPORT_OPCODES_PING) {
             ESP_LOGD(TAG, "WS recv PING — client auto-pongs");
         } else if (data->op_code == WS_TRANSPORT_OPCODES_PONG) {

--- a/main/voice_video.c
+++ b/main/voice_video.c
@@ -17,6 +17,9 @@
 #include "camera.h"
 #include "settings.h"
 #include "voice.h"
+#include "ui_video_pane.h"
+#include "ui_core.h"          /* tab5_lv_async_call (#258) */
+#include "lvgl.h"
 
 static const char *TAG = "voice_video";
 
@@ -310,5 +313,111 @@ esp_err_t voice_video_stop_streaming(void)
     ESP_LOGI(TAG, "streaming stopped (frames_sent=%" PRIu32
                   " bytes=%" PRIu32 " dropped=%" PRIu32 ")",
              s_stats.frames_sent, s_stats.bytes_sent, s_stats.frames_dropped);
+    return ESP_OK;
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ *  #268 Phase 3B: downlink — receive video frames from Dragon, decode
+ *  via LVGL TJPGD, render via ui_video_pane.
+ *
+ *  Single PSRAM slot: voice.c hands us the wire bytes from inside the
+ *  WS event handler (binary RX path).  We copy the JPEG payload into
+ *  the slot, then hop to the LVGL thread to update the renderer's
+ *  image source.  The renderer holds onto the bytes via lv_image_dsc_t
+ *  with cf=LV_COLOR_FORMAT_RAW so TJPGD lazily decodes on draw.
+ * ──────────────────────────────────────────────────────────────────── */
+
+#define VV_RECV_SLOT_BYTES   (96 * 1024)   /* matches encoder ceiling */
+
+static uint8_t        *s_recv_slot       = NULL;
+static SemaphoreHandle_t s_recv_mux      = NULL;
+static lv_image_dsc_t   s_recv_dsc       = {0};
+
+bool voice_video_peek_downlink_magic(const void *data, size_t len)
+{
+    if (!data || len < 4) return false;
+    const uint8_t *b = (const uint8_t *)data;
+    return b[0] == 'V' && b[1] == 'I' && b[2] == 'D' && b[3] == '0';
+}
+
+/* JPEG SOF marker scan to extract w/h.  Same recipe as media_cache.c. */
+static void jpeg_dims(const uint8_t *jpeg, size_t len, uint16_t *w, uint16_t *h)
+{
+    *w = *h = 0;
+    for (size_t i = 0; i + 8 < len; i++) {
+        if (jpeg[i] == 0xFF && (jpeg[i+1] == 0xC0 || jpeg[i+1] == 0xC2)) {
+            *h = (jpeg[i+5] << 8) | jpeg[i+6];
+            *w = (jpeg[i+7] << 8) | jpeg[i+8];
+            return;
+        }
+    }
+}
+
+/* Runs on the LVGL thread (via tab5_lv_async_call). */
+static void downlink_render_async(void *arg)
+{
+    (void)arg;
+    /* The renderer is allowed to ignore the call (pane not open),
+     * which is fine — voice_video_on_downlink_frame already
+     * incremented frames_recv. */
+    ui_video_pane_set_dsc(&s_recv_dsc);
+}
+
+esp_err_t voice_video_on_downlink_frame(const uint8_t *wire_bytes, size_t len)
+{
+    if (!wire_bytes || len < 8 + 2) return ESP_ERR_INVALID_ARG;
+    if (!voice_video_peek_downlink_magic(wire_bytes, len)) return ESP_ERR_INVALID_ARG;
+
+    /* Lazy-init the slot + mutex on first frame so a connection that
+     * never receives video pays no PSRAM. */
+    if (!s_recv_mux) {
+        s_recv_mux = xSemaphoreCreateMutex();
+        if (!s_recv_mux) return ESP_ERR_NO_MEM;
+    }
+    if (!s_recv_slot) {
+        s_recv_slot = heap_caps_malloc(VV_RECV_SLOT_BYTES, MALLOC_CAP_SPIRAM);
+        if (!s_recv_slot) return ESP_ERR_NO_MEM;
+    }
+
+    /* Length sanity from the wire header. */
+    uint32_t payload_len = ((uint32_t)wire_bytes[4] << 24)
+                         | ((uint32_t)wire_bytes[5] << 16)
+                         | ((uint32_t)wire_bytes[6] <<  8)
+                         | ((uint32_t)wire_bytes[7]);
+    if (payload_len + 8 != len) {
+        ESP_LOGW(TAG, "downlink len mismatch hdr=%" PRIu32 " wire=%zu", payload_len, len);
+        s_stats.frames_recv_dropped++;
+        return ESP_ERR_INVALID_SIZE;
+    }
+    if (payload_len > VV_RECV_SLOT_BYTES) {
+        ESP_LOGW(TAG, "downlink frame %" PRIu32 " B exceeds slot %d B — dropping",
+                 payload_len, VV_RECV_SLOT_BYTES);
+        s_stats.frames_recv_dropped++;
+        return ESP_ERR_NO_MEM;
+    }
+
+    /* Copy JPEG payload into the slot under the mutex.  The renderer's
+     * dsc still references the slot bytes; LVGL TJPGD only touches
+     * them during draw on the LVGL thread, which we serialize via
+     * tab5_lv_async_call below. */
+    xSemaphoreTake(s_recv_mux, portMAX_DELAY);
+    memcpy(s_recv_slot, wire_bytes + 8, payload_len);
+    uint16_t jw = 0, jh = 0;
+    jpeg_dims(s_recv_slot, payload_len, &jw, &jh);
+    if (jw == 0 || jh == 0) {
+        /* Sensible default — keeps LVGL happy even if SOF parse missed. */
+        jw = 1280; jh = 720;
+    }
+    s_recv_dsc.header.w   = jw;
+    s_recv_dsc.header.h   = jh;
+    s_recv_dsc.header.cf  = LV_COLOR_FORMAT_RAW;
+    s_recv_dsc.data_size  = payload_len;
+    s_recv_dsc.data       = s_recv_slot;
+    s_stats.frames_recv++;
+    s_stats.bytes_recv          += len;
+    s_stats.last_recv_jpeg_bytes = payload_len;
+    xSemaphoreGive(s_recv_mux);
+
+    tab5_lv_async_call(downlink_render_async, NULL);
     return ESP_OK;
 }

--- a/main/voice_video.h
+++ b/main/voice_video.h
@@ -60,6 +60,24 @@ typedef struct {
     uint32_t frames_dropped;
     uint32_t bytes_sent;
     uint32_t last_jpeg_bytes;
+    /* #268 Phase 3B downlink stats */
+    uint32_t frames_recv;
+    uint32_t frames_recv_dropped;
+    uint32_t bytes_recv;
+    uint32_t last_recv_jpeg_bytes;
 } voice_video_stats_t;
 
 void voice_video_get_stats(voice_video_stats_t *out);
+
+/* #268 Phase 3B: feed one inbound video frame received from Dragon.
+ * `wire_bytes` MUST start with the "VID0" magic (caller should peek
+ * before invoking).  Copies the JPEG payload into an internal slot
+ * and asks the renderer to draw it on the LVGL thread.  Returns ESP_OK
+ * on a frame the renderer accepted, or ESP_ERR_NOT_FOUND when no
+ * video pane is open. */
+esp_err_t voice_video_on_downlink_frame(const uint8_t *wire_bytes, size_t len);
+
+/* #268: peek helper — returns true if `data` starts with the "VID0"
+ * magic.  Used by voice.c::handle_binary_message before deciding to
+ * route to the audio decode path or here. */
+bool voice_video_peek_downlink_magic(const void *data, size_t len);


### PR DESCRIPTION
## Summary
- voice_video.c gains a downlink path: \`voice_video_on_downlink_frame()\` decodes via LVGL TJPGD into an \`lv_image_dsc_t\` and renders through new \`ui_video_pane\`.
- voice.c WS handler now sniffs the \`VID0\` magic on inbound binary; routes to video instead of audio when matched.
- voice.c WS event handler: new fragmented-frame reassembly so the 30 KB JPEG (which arrives in 2-3 fragments because WS_CLIENT_BUFFER_SIZE=32 KB) reassembles before dispatch.
- New ui_video_pane.{c,h}: full-screen pane with single \`lv_image\` for the latest frame, tap-to-dismiss.
- Capability advertisement: \`video_recv: true\`.
- Debug endpoints: \`POST /video/show\` / \`/video/hide\`.
- Closes #268.  Pairs with TinkerBox #178.

## Test plan
- [x] Build clean
- [x] Open pane via /video/show
- [x] Inject the Phase 3A camera capture back through Dragon's /api/video/inject
- [x] Tab5 stats: frames_recv=1, dropped=0, bytes_recv=29851, last_jpeg=29843
- [x] /screenshot shows the JPEG rendered in the pane (visual confirmation)
- [x] Audio uplink unaffected (no magic = unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)