### PR TITLE
feat(call): in-call audio uplink + downlink (Phase 3E Tab5)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -1648,6 +1648,28 @@ static void handle_binary_message(const char *data, int len)
         return;
     }
 
+    /* #272 Phase 3E: call-audio frames carry the 4-byte "AUD0" magic.
+     * Strip the header + write the int16 PCM body straight to the
+     * playback buffer with the same upsample 16k->48k as TTS.  No
+     * state guards — call audio plays even when voice is READY. */
+    if (voice_codec_peek_call_audio_magic(data, (size_t)len)) {
+        const uint8_t *body = NULL;
+        size_t body_len = 0;
+        if (voice_codec_unpack_call_audio((const uint8_t *)data, (size_t)len,
+                                          &body, &body_len) && body_len >= 2 &&
+            s_upsample_buf) {
+            tab5_audio_speaker_enable(true);
+            const size_t in_samples = body_len / sizeof(int16_t);
+            const size_t max_out    = in_samples * UPSAMPLE_RATIO;
+            if (max_out <= UPSAMPLE_BUF_CAPACITY) {
+                size_t out_n = upsample_16k_to_48k((const int16_t *)body, in_samples,
+                                                    s_upsample_buf, max_out);
+                playback_buf_write(s_upsample_buf, out_n);
+            }
+        }
+        return;
+    }
+
     /* v4·D audit P0 fix: snapshot s_state under the mutex so we never
      * race with voice_set_state on another task.  The checks below
      * formerly read s_state twice without locking -- second read could
@@ -2086,7 +2108,7 @@ static void mic_capture_task(void *arg)
 
     bool ws_live = (s_ws != NULL) && esp_websocket_client_is_connected(s_ws);
 
-    while (s_mic_running && (ws_live || s_voice_mode == VOICE_MODE_DICTATE)) {
+    while (s_mic_running && (ws_live || s_voice_mode == VOICE_MODE_DICTATE || s_voice_mode == VOICE_MODE_CALL)) {
         esp_err_t err = tab5_mic_read(tdm_buf, MIC_TDM_SAMPLES, 100);
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "Mic read failed: %s", esp_err_to_name(err));
@@ -2152,7 +2174,22 @@ static void mic_capture_task(void *arg)
                                                        enc_buf, VOICE_CHUNK_BYTES,
                                                        &send_bytes);
             if (cerr == ESP_OK && send_bytes > 0) {
-                err = voice_ws_send_binary(enc_buf, send_bytes);
+                if (s_voice_mode == VOICE_MODE_CALL) {
+                    /* #272: wrap with AUD0 magic so Dragon broadcasts
+                     * to the call peer instead of feeding STT.  Stack-
+                     * allocated — mic task has 16 KB stack, plenty of
+                     * headroom for a 648 B packet. */
+                    uint8_t call_pkt[VOICE_CHUNK_BYTES + VOICE_CALL_AUDIO_HEADER_LEN];
+                    size_t wire_len = voice_codec_pack_call_audio(
+                        call_pkt, sizeof(call_pkt), enc_buf, send_bytes);
+                    if (wire_len > 0) {
+                        err = voice_ws_send_binary(call_pkt, wire_len);
+                    } else {
+                        err = ESP_ERR_NO_MEM;
+                    }
+                } else {
+                    err = voice_ws_send_binary(enc_buf, send_bytes);
+                }
                 if (err != ESP_OK) {
                     ESP_LOGW(TAG, "WS send failed — continuing SD recording");
                     if (s_voice_mode == VOICE_MODE_ASK) break;
@@ -2956,6 +2993,67 @@ esp_err_t voice_start_dictation(void)
 voice_mode_t voice_get_mode(void)
 {
     return s_voice_mode;
+}
+
+/* #272 Phase 3E: in-call audio.  Spawns the existing mic capture task
+ * in VOICE_MODE_CALL — the loop wraps each chunk with the AUD0 magic
+ * before voice_ws_send_binary so Dragon broadcasts to peers instead of
+ * feeding STT.  No start/stop messages, no state transitions — pure
+ * relay alongside whatever voice mode happens to be active.  In
+ * practice the user enters this from the nav-sheet "Call" tile via
+ * voice_video_start_call which calls us here. */
+esp_err_t voice_call_audio_start(void)
+{
+    bool ws_live = s_ws && esp_websocket_client_is_connected(s_ws);
+    if (!s_initialized || !ws_live) {
+        ESP_LOGE(TAG, "voice_call_audio_start: not connected");
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (s_mic_running || s_mic_task != NULL) {
+        ESP_LOGW(TAG, "voice_call_audio_start: mic already running (mode=%d)",
+                 s_voice_mode);
+        return ESP_OK;
+    }
+    if (tab5_settings_get_mic_mute()) {
+        ESP_LOGW(TAG, "voice_call_audio_start: mic muted — refusing");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "Starting call audio (VOICE_MODE_CALL)");
+    s_voice_mode = VOICE_MODE_CALL;
+    s_mic_running = true;
+    BaseType_t ret = xTaskCreatePinnedToCoreWithCaps(
+        mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
+        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
+        MALLOC_CAP_SPIRAM);
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to spawn call-audio mic task");
+        s_mic_running = false;
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+
+esp_err_t voice_call_audio_stop(void)
+{
+    if (s_voice_mode != VOICE_MODE_CALL || !s_mic_running) {
+        return ESP_OK;
+    }
+    ESP_LOGI(TAG, "Stopping call audio");
+    s_mic_running = false;
+
+    /* Same drain pattern as voice_stop_listening — wait for the mic
+     * task to exit cleanly, then re-enable I2S RX so a follow-up
+     * voice_start_listening / voice_start_dictation works. */
+    i2s_chan_handle_t rx_h = tab5_audio_get_i2s_rx();
+    if (rx_h) i2s_channel_disable(rx_h);
+    for (int i = 0; i < 120 && s_mic_task != NULL; i++) {
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+    if (rx_h) i2s_channel_enable(rx_h);
+
+    s_voice_mode = VOICE_MODE_ASK;   /* return to default for next listen */
+    return ESP_OK;
 }
 
 const char *voice_get_dictation_text(void)

--- a/main/voice.h
+++ b/main/voice.h
@@ -36,6 +36,10 @@ typedef enum {
 typedef enum {
     VOICE_MODE_ASK,      // Short-form: STT -> LLM -> TTS (30s max)
     VOICE_MODE_DICTATE,  // Long-form: STT only, unlimited, no LLM/TTS
+    VOICE_MODE_CALL,     // #272 Phase 3E: in-call audio.  Mic frames are
+                         // tagged with AUD0 magic so Dragon broadcasts to
+                         // the call peer instead of feeding STT.  No
+                         // start/stop messages, no LLM/TTS — pure relay.
 } voice_mode_t;
 
 // Callback for state changes (for UI updates)
@@ -107,6 +111,15 @@ esp_err_t voice_send_text(const char *text);
  *  send_lock + 1 s timeout.  Caller is responsible for any framing
  *  (e.g. voice_video.c prefixes a 4-byte type magic). */
 esp_err_t voice_ws_send_binary_public(const void *data, size_t len);
+
+/** #272 Phase 3E: start / stop in-call audio.  Spawns the mic capture
+ *  task in VOICE_MODE_CALL — chunks are wrapped with the AUD0 magic
+ *  prefix so Dragon broadcasts them to the call peer instead of
+ *  feeding STT.  No start/stop messages, no LLM/TTS — pure relay.
+ *  Called by voice_video_start_call / end_call alongside the video
+ *  streamer toggle.  Idempotent. */
+esp_err_t voice_call_audio_start(void);
+esp_err_t voice_call_audio_stop(void);
 
 /** Send voice_mode (0-3) and LLM model string to Dragon as a config_update JSON frame. */
 esp_err_t voice_send_config_update(int voice_mode, const char *llm_model);

--- a/main/voice_codec.c
+++ b/main/voice_codec.c
@@ -257,3 +257,42 @@ const char *voice_codec_to_name(voice_codec_t c)
     default:               return "pcm";
     }
 }
+
+/* #272 Phase 3E: call-audio framing helpers. */
+
+bool voice_codec_peek_call_audio_magic(const void *data, size_t len)
+{
+    if (!data || len < 4) return false;
+    const uint8_t *b = (const uint8_t *)data;
+    return b[0] == 'A' && b[1] == 'U' && b[2] == 'D' && b[3] == '0';
+}
+
+size_t voice_codec_pack_call_audio(uint8_t *out, size_t out_cap,
+                                   const void *body, size_t body_len)
+{
+    if (!out || !body) return 0;
+    if (out_cap < body_len + VOICE_CALL_AUDIO_HEADER_LEN) return 0;
+    out[0] = 'A'; out[1] = 'U'; out[2] = 'D'; out[3] = '0';
+    out[4] = (uint8_t)((body_len >> 24) & 0xff);
+    out[5] = (uint8_t)((body_len >> 16) & 0xff);
+    out[6] = (uint8_t)((body_len >>  8) & 0xff);
+    out[7] = (uint8_t)( body_len        & 0xff);
+    memcpy(out + VOICE_CALL_AUDIO_HEADER_LEN, body, body_len);
+    return body_len + VOICE_CALL_AUDIO_HEADER_LEN;
+}
+
+bool voice_codec_unpack_call_audio(const uint8_t *wire, size_t wire_len,
+                                   const uint8_t **out_body, size_t *out_body_len)
+{
+    if (!wire || !out_body || !out_body_len) return false;
+    if (wire_len < VOICE_CALL_AUDIO_HEADER_LEN) return false;
+    if (!voice_codec_peek_call_audio_magic(wire, wire_len)) return false;
+    uint32_t body_len = ((uint32_t)wire[4] << 24)
+                      | ((uint32_t)wire[5] << 16)
+                      | ((uint32_t)wire[6] <<  8)
+                      | ((uint32_t)wire[7]);
+    if (body_len + VOICE_CALL_AUDIO_HEADER_LEN != wire_len) return false;
+    *out_body     = wire + VOICE_CALL_AUDIO_HEADER_LEN;
+    *out_body_len = body_len;
+    return true;
+}

--- a/main/voice_codec.h
+++ b/main/voice_codec.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include "esp_err.h"
 
 /* Compile-time gate for the OPUS uplink (mic) path.  The
@@ -97,3 +98,35 @@ esp_err_t voice_codec_decode_downlink(const uint8_t *data, size_t len,
 /* Convenience: name → enum + enum → name. */
 voice_codec_t voice_codec_from_name(const char *name);
 const char *voice_codec_to_name(voice_codec_t c);
+
+/* #272 Phase 3E: call-audio framing.  When Tab5 is in a video call
+ * (voice_video_is_in_call() == true), mic uplink frames are tagged
+ * with the "AUD0" magic + 4-byte BE length so Dragon broadcasts them
+ * to the call peer instead of feeding STT.  Symmetric on the
+ * downlink — any AUD0-tagged frame from a peer plays through the
+ * existing TTS playback ring buffer.
+ *
+ * Wire format (one binary WS frame per audio chunk):
+ *   bytes 0..3 : magic "AUD0" (0x41 0x55 0x44 0x30)
+ *   bytes 4..7 : payload length (uint32_t big-endian)
+ *   bytes 8..  : raw int16 LE PCM @ 16 kHz mono (or OPUS — when uplink
+ *                codec is OPUS the payload is the encoded packet)
+ *
+ * No magic on regular voice-mode mic frames; existing STT path
+ * unaffected.
+ */
+#define VOICE_CALL_AUDIO_MAGIC      0x41554430u   /* "AUD0" big-endian */
+#define VOICE_CALL_AUDIO_HEADER_LEN 8
+
+/* Pack one audio chunk for call uplink: writes magic + length + body
+ * into out, returns the wire length.  out_cap must be >= body_len + 8. */
+size_t voice_codec_pack_call_audio(uint8_t *out, size_t out_cap,
+                                   const void *body, size_t body_len);
+
+/* True iff `data`'s first 4 bytes are the AUD0 magic. */
+bool voice_codec_peek_call_audio_magic(const void *data, size_t len);
+
+/* Strip the AUD0 magic + length header.  Returns the body pointer + len
+ * via out_body / out_body_len.  Returns false on malformed input. */
+bool voice_codec_unpack_call_audio(const uint8_t *wire, size_t wire_len,
+                                   const uint8_t **out_body, size_t *out_body_len);

--- a/main/voice_video.c
+++ b/main/voice_video.c
@@ -455,6 +455,11 @@ esp_err_t voice_video_start_call(int fps)
      * already streaming — that's fine, treat as success. */
     esp_err_t er = voice_video_start_streaming(fps);
     if (er != ESP_OK && er != ESP_ERR_INVALID_STATE) return er;
+    /* #272: in-call audio uplink.  Spawns the mic task in VOICE_MODE_CALL
+     * — chunks are wrapped with the AUD0 magic so Dragon broadcasts.
+     * Soft-fails (mic muted, already listening, etc.) — video still
+     * works without audio in that case. */
+    voice_call_audio_start();
     tab5_lv_async_call(open_call_pane_async, NULL);
     ESP_LOGI(TAG, "call start (fps=%d)", fps);
     return ESP_OK;
@@ -463,6 +468,7 @@ esp_err_t voice_video_start_call(int fps)
 esp_err_t voice_video_end_call(void)
 {
     voice_video_stop_streaming();
+    voice_call_audio_stop();
     tab5_lv_async_call(close_call_pane_async, NULL);
     ESP_LOGI(TAG, "call end");
     return ESP_OK;


### PR DESCRIPTION
## Summary
- New \`VOICE_MODE_CALL\`: mic task wraps each chunk with the AUD0 magic prefix so Dragon broadcasts to peers (TinkerBox #181) instead of feeding STT.
- handle_binary_message routes AUD0 frames straight to playback (no voice-state guard).
- voice_video_start_call / end_call now toggle audio alongside video.
- Closes #272.  Pairs with TinkerBox #181/#182.

## Test plan
- [x] Build clean
- [x] /video/call/start: Tab5 up, 18 video frames in 6 s, 0 dropped
- [x] /video/call/end: clean teardown
- [x] Standard voice mode unaffected (no AUD0 magic on regular mic frames)
- [ ] Phone web client end-to-end (needs both ends online)

🤖 Generated with [Claude Code](https://claude.com/claude-code)