### PR TITLE
fix(call): parent video pane to lv_layer_top (Wave-1 / 2)

### DIFF
--- a/main/ui_video_pane.c
+++ b/main/ui_video_pane.c
@@ -162,7 +162,12 @@ void ui_video_pane_show(void)
         return;
     }
 
-    lv_obj_t *parent = ui_home_get_screen();
+    /* #276: parent to lv_layer_top() instead of the home screen so the
+     * pane stays on top when the user navigates to Settings / Chat /
+     * Notes / etc.  Without this, the call keeps running while a new
+     * overlay covers the pane — privacy bug + UX confusion (user
+     * thinks they ended the call). */
+    lv_obj_t *parent = lv_layer_top();
     if (!parent) parent = lv_screen_active();
     if (!parent) return;
 


### PR DESCRIPTION
## Summary
- One-line fix: \`s_root\` now parents to \`lv_layer_top()\` instead of \`ui_home_get_screen()\`.  Pane sits on its own z-order island above every screen + overlay.
- Closes #276.

## Test plan
- [x] Build clean
- [x] Start call → /navigate?screen=settings → screenshot shows pane on top of Settings (was: Settings rendered full-screen, no pane)
- [x] /navigate?screen=chat → same — pane on top of Chat
- [x] End Call → underlying nav target visible, pane gone
- [x] /call/status now matches what's rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)