### PR TITLE
feat(call): auto-open pane on incoming peer video + Accept/Decline (Wave-1 / 2)

### DIFF
--- a/main/ui_video_pane.c
+++ b/main/ui_video_pane.c
@@ -44,13 +44,20 @@ static lv_obj_t *s_root      = NULL;
 static lv_obj_t *s_image     = NULL;
 static lv_obj_t *s_pip_canvas = NULL;
 static lv_obj_t *s_end_btn   = NULL;
+/* #278 incoming-call chrome */
+static lv_obj_t *s_accept_btn  = NULL;
+static lv_obj_t *s_decline_btn = NULL;
+static lv_obj_t *s_incoming_lbl = NULL;
 
 static uint8_t *s_pip_buf = NULL;   /* RGB565 PIP_W*PIP_H*2 bytes in PSRAM */
 
 static lv_timer_t *s_pip_timer = NULL;
-static bool s_in_call = false;
+static bool s_in_call    = false;
+static bool s_incoming   = false;     /* #278: ringing / awaiting accept */
 
-static ui_video_pane_end_call_cb_t s_end_cb = NULL;
+static ui_video_pane_end_call_cb_t s_end_cb     = NULL;
+static ui_video_pane_accept_cb_t   s_accept_cb  = NULL;
+static ui_video_pane_decline_cb_t  s_decline_cb = NULL;
 
 static void on_tap(lv_event_t *e)
 {
@@ -65,6 +72,28 @@ static void on_end_btn(lv_event_t *e)
     ui_video_pane_end_call_cb_t cb = s_end_cb;
     /* Hide first so the End Call cb can spawn another pane without
      * racing with our own teardown. */
+    ui_video_pane_hide();
+    if (cb) cb();
+}
+
+/* #278 incoming-call: tear down the incoming chrome and call the
+ * caller's accept hook (which typically upgrades to full call). */
+static void on_accept_btn(lv_event_t *e)
+{
+    (void)e;
+    ui_video_pane_accept_cb_t cb = s_accept_cb;
+    /* Don't hide — caller will upgrade us to call mode in place. */
+    s_incoming = false;
+    if (s_accept_btn)   { lv_obj_delete(s_accept_btn);   s_accept_btn   = NULL; }
+    if (s_decline_btn)  { lv_obj_delete(s_decline_btn);  s_decline_btn  = NULL; }
+    if (s_incoming_lbl) { lv_obj_delete(s_incoming_lbl); s_incoming_lbl = NULL; }
+    if (cb) cb();
+}
+
+static void on_decline_btn(lv_event_t *e)
+{
+    (void)e;
+    ui_video_pane_decline_cb_t cb = s_decline_cb;
     ui_video_pane_hide();
     if (cb) cb();
 }
@@ -194,7 +223,82 @@ void ui_video_pane_show_call(void)
 {
     if (!s_root) ui_video_pane_show();
     if (!s_root) return;
+    /* Coming from incoming-call mode? Tear that chrome down — the
+     * call-mode chrome (PIP + End Call) replaces it.  No-op if we
+     * weren't in incoming mode. */
+    if (s_incoming) {
+        s_incoming = false;
+        if (s_accept_btn)   { lv_obj_delete(s_accept_btn);   s_accept_btn   = NULL; }
+        if (s_decline_btn)  { lv_obj_delete(s_decline_btn);  s_decline_btn  = NULL; }
+        if (s_incoming_lbl) { lv_obj_delete(s_incoming_lbl); s_incoming_lbl = NULL; }
+    }
     build_call_chrome();
+}
+
+/* #278: build the incoming-call chrome (Accept + Decline buttons +
+ * "Incoming call" badge).  Idempotent. */
+static void build_incoming_chrome(void)
+{
+    if (s_incoming && s_accept_btn && s_decline_btn) return;
+    s_incoming = true;
+
+    /* "Incoming call" badge top-center */
+    if (!s_incoming_lbl) {
+        s_incoming_lbl = lv_label_create(s_root);
+        lv_label_set_text(s_incoming_lbl, "Incoming call");
+        lv_obj_set_style_text_color(s_incoming_lbl, lv_color_hex(0xF59E0B), 0);
+        lv_obj_align(s_incoming_lbl, LV_ALIGN_TOP_MID, 0, 32);
+    }
+
+    /* Accept (green) bottom-right where End Call would be in call mode. */
+    if (!s_accept_btn) {
+        s_accept_btn = lv_button_create(s_root);
+        lv_obj_remove_style_all(s_accept_btn);
+        lv_obj_set_size(s_accept_btn, END_W, END_H);
+        lv_obj_set_pos(s_accept_btn,
+                       VP_W - END_W - END_PAD,
+                       VP_H - END_H - END_PAD);
+        lv_obj_set_style_radius(s_accept_btn, END_H / 2, 0);
+        lv_obj_set_style_bg_color(s_accept_btn, lv_color_hex(0x22C55E), 0);
+        lv_obj_set_style_bg_opa(s_accept_btn, LV_OPA_COVER, 0);
+        lv_obj_add_event_cb(s_accept_btn, on_accept_btn, LV_EVENT_CLICKED, NULL);
+        lv_obj_t *lbl = lv_label_create(s_accept_btn);
+        lv_label_set_text(lbl, "Accept");
+        lv_obj_set_style_text_color(lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_center(lbl);
+    }
+
+    /* Decline (red) bottom-left */
+    if (!s_decline_btn) {
+        s_decline_btn = lv_button_create(s_root);
+        lv_obj_remove_style_all(s_decline_btn);
+        lv_obj_set_size(s_decline_btn, END_W, END_H);
+        lv_obj_set_pos(s_decline_btn, END_PAD, VP_H - END_H - END_PAD);
+        lv_obj_set_style_radius(s_decline_btn, END_H / 2, 0);
+        lv_obj_set_style_bg_color(s_decline_btn, lv_color_hex(0xEF4444), 0);
+        lv_obj_set_style_bg_opa(s_decline_btn, LV_OPA_COVER, 0);
+        lv_obj_add_event_cb(s_decline_btn, on_decline_btn, LV_EVENT_CLICKED, NULL);
+        lv_obj_t *lbl = lv_label_create(s_decline_btn);
+        lv_label_set_text(lbl, "Decline");
+        lv_obj_set_style_text_color(lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_center(lbl);
+    }
+}
+
+void ui_video_pane_show_incoming(void)
+{
+    if (!s_root) ui_video_pane_show();
+    if (!s_root) return;
+    /* If we're already in active-call mode, don't downgrade — the
+     * peer who triggered this is just streaming to an established
+     * call. */
+    if (s_in_call) return;
+    build_incoming_chrome();
+}
+
+bool ui_video_pane_is_incoming(void)
+{
+    return s_incoming;
 }
 
 void ui_video_pane_hide(void)
@@ -204,17 +308,24 @@ void ui_video_pane_hide(void)
         s_pip_timer = NULL;
     }
     if (s_root) {
+        /* lv_obj_delete recurses to children — no need to delete each
+         * child first.  Just NULL the static handles so we don't keep
+         * stale pointers. */
         lv_obj_delete(s_root);
-        s_root = NULL;
-        s_image = NULL;
-        s_pip_canvas = NULL;
-        s_end_btn = NULL;
+        s_root          = NULL;
+        s_image         = NULL;
+        s_pip_canvas    = NULL;
+        s_end_btn       = NULL;
+        s_accept_btn    = NULL;
+        s_decline_btn   = NULL;
+        s_incoming_lbl  = NULL;
     }
     if (s_pip_buf) {
         heap_caps_free(s_pip_buf);
         s_pip_buf = NULL;
     }
-    s_in_call = false;
+    s_in_call  = false;
+    s_incoming = false;
 }
 
 bool ui_video_pane_is_visible(void)
@@ -237,4 +348,14 @@ void ui_video_pane_set_dsc(const lv_image_dsc_t *dsc)
 void ui_video_pane_set_end_call_cb(ui_video_pane_end_call_cb_t cb)
 {
     s_end_cb = cb;
+}
+
+void ui_video_pane_set_accept_cb(ui_video_pane_accept_cb_t cb)
+{
+    s_accept_cb = cb;
+}
+
+void ui_video_pane_set_decline_cb(ui_video_pane_decline_cb_t cb)
+{
+    s_decline_cb = cb;
 }

--- a/main/ui_video_pane.h
+++ b/main/ui_video_pane.h
@@ -31,6 +31,17 @@ void ui_video_pane_show(void);
  * mode upgrades in place. */
 void ui_video_pane_show_call(void);
 
+/* #278 Incoming-call mode: full-screen remote feed + Accept/Decline
+ * buttons.  No local camera, no mic — those start only on Accept.
+ * Used by voice_video when downlink frames arrive while no call is
+ * active (peer-initiated). */
+void ui_video_pane_show_incoming(void);
+
+/* Whether the pane is currently in incoming-call mode (Accept/Decline
+ * buttons visible, no PIP).  False when in basic playback or active
+ * call mode. */
+bool ui_video_pane_is_incoming(void);
+
 /* Hide + free the pane.  Safe even if not open.  When in call mode
  * also kills the local-PIP timer.  Does NOT call voice_video_stop_*
  * — that's the caller's job (voice_video_end_call wraps both). */
@@ -51,3 +62,12 @@ void ui_video_pane_set_dsc(const lv_image_dsc_t *dsc);
  * Set NULL to clear.  Last registration wins. */
 typedef void (*ui_video_pane_end_call_cb_t)(void);
 void ui_video_pane_set_end_call_cb(ui_video_pane_end_call_cb_t cb);
+
+/* #278 Accept / Decline callbacks for the incoming-call mode.  Last
+ * registration wins; pass NULL to clear.  Tapping Accept calls
+ * accept_cb (caller upgrades to a full call).  Tapping Decline calls
+ * decline_cb + hides the pane. */
+typedef void (*ui_video_pane_accept_cb_t)(void);
+typedef void (*ui_video_pane_decline_cb_t)(void);
+void ui_video_pane_set_accept_cb (ui_video_pane_accept_cb_t cb);
+void ui_video_pane_set_decline_cb(ui_video_pane_decline_cb_t cb);

--- a/main/voice_video.c
+++ b/main/voice_video.c
@@ -12,6 +12,7 @@
 
 #include "esp_log.h"
 #include "esp_heap_caps.h"
+#include "esp_timer.h"     /* #278: cool-down clock for declined calls */
 #include "driver/jpeg_encode.h"
 
 #include "camera.h"
@@ -353,13 +354,55 @@ static void jpeg_dims(const uint8_t *jpeg, size_t len, uint16_t *w, uint16_t *h)
     }
 }
 
+/* #278: 30 s cool-down after Decline so a still-streaming peer
+ * doesn't immediately re-open the incoming-call modal.  Set by the
+ * decline cb; checked before auto-show. */
+static int64_t s_decline_cooldown_until_us = 0;
+#define VV_DECLINE_COOLDOWN_US (30LL * 1000LL * 1000LL)   /* 30 s */
+
+/* Decline callback: hide the pane (already done by the pane itself
+ * before this fires) + arm the cooldown.  Static so we can pass it
+ * directly via ui_video_pane_set_decline_cb. */
+static void downlink_decline_cb(void)
+{
+    s_decline_cooldown_until_us = esp_timer_get_time() + VV_DECLINE_COOLDOWN_US;
+    ESP_LOGI(TAG, "incoming declined, %d s cool-down armed",
+             (int)(VV_DECLINE_COOLDOWN_US / 1000000));
+}
+
+/* Accept callback: upgrade an incoming-call pane to a full active
+ * call (start outbound mic + camera).  The pane stays open and is
+ * upgraded to call mode by start_call's open_call_pane_async hop. */
+static void downlink_accept_cb(void)
+{
+    ESP_LOGI(TAG, "incoming accepted -> upgrading to active call");
+    voice_video_start_call(VOICE_VIDEO_DEFAULT_FPS);
+}
+
 /* Runs on the LVGL thread (via tab5_lv_async_call). */
 static void downlink_render_async(void *arg)
 {
     (void)arg;
-    /* The renderer is allowed to ignore the call (pane not open),
-     * which is fine — voice_video_on_downlink_frame already
-     * incremented frames_recv. */
+    /* If a call is already active, just paint the new frame and we're
+     * done — pane is up, image dsc binds straight in. */
+    if (ui_video_pane_is_visible()) {
+        ui_video_pane_set_dsc(&s_recv_dsc);
+        return;
+    }
+
+    /* No pane open + we got a frame from a peer.  Auto-show in
+     * incoming-call mode unless we're inside the post-decline cool-
+     * down — that way a peer who keeps streaming after the user
+     * declined doesn't immediately re-pop the modal. */
+    int64_t now = esp_timer_get_time();
+    if (now < s_decline_cooldown_until_us) {
+        return;
+    }
+    ui_video_pane_set_accept_cb(downlink_accept_cb);
+    ui_video_pane_set_decline_cb(downlink_decline_cb);
+    ui_video_pane_show_incoming();
+    /* Now bind the frame so the user sees the caller's preview behind
+     * the Accept/Decline buttons. */
     ui_video_pane_set_dsc(&s_recv_dsc);
 }
 


### PR DESCRIPTION
## Summary
- Inbound video frames now trigger an auto-show of the pane in incoming-call mode (Accept / Decline + "Incoming call" badge + peer preview).
- Accept upgrades in place to a full call (\`voice_video_start_call\`).
- Decline hides + arms a 30 s cool-down so a still-streaming peer doesn't immediately re-pop the modal.
- Closes #278.

## Test plan (all five passed via /touch + /screenshot)
- [x] Pane closed + inject → pane auto-opens with Accept/Decline + peer preview
- [x] Tap Accept → in_call=True, mode=CALL, mic + camera spawned, End Call replaces Accept/Decline
- [x] End Call → clean teardown, immediate re-inject re-opens incoming (no cool-down)
- [x] Tap Decline → pane closes, recv still increments (relay intact)
- [x] Inject within 30 s of Decline → pane stays closed (cool-down active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)