### PR TITLE
feat(call): mute pill + CALLING/CONNECTED status badge (Wave-2 / 2)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2210,6 +2210,7 @@ static esp_err_t call_status_handler(httpd_req_t *req)
     cJSON_AddStringToObject(aud, "voice_mode_name",
         (vmode < (sizeof(mode_names)/sizeof(mode_names[0]))) ? mode_names[vmode] : "?");
     cJSON_AddBoolToObject(aud, "call_audio_active", vmode == VOICE_MODE_CALL);
+    cJSON_AddBoolToObject(aud, "call_audio_muted",  voice_call_audio_is_muted());
 
     /* Heap snapshot — the heap_wd reset after start_call exhausted
      * SRAM, so always show internal-largest here for context. */
@@ -2254,6 +2255,27 @@ static esp_err_t video_call_end_handler(httpd_req_t *req)
     voice_video_end_call();
     cJSON *root = cJSON_CreateObject();
     cJSON_AddBoolToObject(root, "ok", true);
+    return send_json_resp(req, root);
+}
+
+/* #280: in-call mute toggle.  POST /call/mute or POST /call/unmute. */
+static esp_err_t call_mute_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    bool muted = voice_call_audio_set_muted(true);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    cJSON_AddBoolToObject(root, "muted", muted);
+    return send_json_resp(req, root);
+}
+
+static esp_err_t call_unmute_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    bool muted = voice_call_audio_set_muted(false);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    cJSON_AddBoolToObject(root, "muted", muted);
     return send_json_resp(req, root);
 }
 
@@ -3327,6 +3349,12 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_call_status = {
         .uri = "/call/status",      .method = HTTP_GET,  .handler = call_status_handler
     };
+    const httpd_uri_t uri_call_mute = {
+        .uri = "/call/mute",        .method = HTTP_POST, .handler = call_mute_handler
+    };
+    const httpd_uri_t uri_call_unmute = {
+        .uri = "/call/unmute",      .method = HTTP_POST, .handler = call_unmute_handler
+    };
     const httpd_uri_t uri_dictation_post = {
         .uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler
     };
@@ -3399,6 +3427,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_video_call_start);
     httpd_register_uri_handler(server, &uri_video_call_end);
     httpd_register_uri_handler(server, &uri_call_status);
+    httpd_register_uri_handler(server, &uri_call_mute);
+    httpd_register_uri_handler(server, &uri_call_unmute);
     httpd_register_uri_handler(server, &uri_dictation_post);
     httpd_register_uri_handler(server, &uri_dictation_get);
     httpd_register_uri_handler(server, &uri_wifi_kick);

--- a/main/ui_video_pane.c
+++ b/main/ui_video_pane.c
@@ -18,10 +18,13 @@
 
 #include "esp_log.h"
 #include "esp_heap_caps.h"
+#include "esp_timer.h"
 
 #include "ui_home.h"
 #include "camera.h"
 #include "settings.h"
+#include "voice.h"          /* #280: mute toggle */
+#include "voice_video.h"    /* #280: downlink frame stats for status */
 
 static const char *TAG = "ui_video_pane";
 
@@ -40,6 +43,12 @@ static const char *TAG = "ui_video_pane";
 
 #define PIP_FPS_MS 200   /* 5 fps */
 
+/* #280: mute pill top-right + status badge top-center. */
+#define MUTE_W      96
+#define MUTE_H      48
+#define MUTE_PAD    16
+#define STATUS_FPS_MS  1000  /* 1 Hz status refresh */
+
 static lv_obj_t *s_root      = NULL;
 static lv_obj_t *s_image     = NULL;
 static lv_obj_t *s_pip_canvas = NULL;
@@ -48,6 +57,13 @@ static lv_obj_t *s_end_btn   = NULL;
 static lv_obj_t *s_accept_btn  = NULL;
 static lv_obj_t *s_decline_btn = NULL;
 static lv_obj_t *s_incoming_lbl = NULL;
+/* #280 in-call chrome */
+static lv_obj_t *s_mute_btn   = NULL;
+static lv_obj_t *s_mute_lbl   = NULL;
+static lv_obj_t *s_status_lbl = NULL;
+static lv_timer_t *s_status_timer = NULL;
+static uint32_t s_last_recv_count_seen = 0;
+static int64_t  s_last_recv_change_us  = 0;
 
 static uint8_t *s_pip_buf = NULL;   /* RGB565 PIP_W*PIP_H*2 bytes in PSRAM */
 
@@ -96,6 +112,67 @@ static void on_decline_btn(lv_event_t *e)
     ui_video_pane_decline_cb_t cb = s_decline_cb;
     ui_video_pane_hide();
     if (cb) cb();
+}
+
+/* #280 mute toggle.  Flips voice's call-mute flag and updates the
+ * pill's label so the user gets immediate visual feedback. */
+static void on_mute_btn(lv_event_t *e)
+{
+    (void)e;
+    bool now = !voice_call_audio_is_muted();
+    voice_call_audio_set_muted(now);
+    if (s_mute_lbl) {
+        lv_label_set_text(s_mute_lbl, now ? "Unmute" : "Mute");
+    }
+    if (s_mute_btn) {
+        lv_obj_set_style_bg_color(s_mute_btn,
+            now ? lv_color_hex(0xEF4444) : lv_color_hex(0x1F2937), 0);
+    }
+}
+
+/* #280 status timer.  Picks one of CALLING / CONNECTED / PEER LEFT
+ * based on whether downlink frames are arriving, then appends MUTED
+ * if the local mic is suppressed.  Runs at 1 Hz. */
+static void status_timer_cb(lv_timer_t *t)
+{
+    (void)t;
+    if (!s_status_lbl) return;
+
+    voice_video_stats_t v;
+    voice_video_get_stats(&v);
+
+    if (v.frames_recv != s_last_recv_count_seen) {
+        s_last_recv_count_seen = v.frames_recv;
+        s_last_recv_change_us  = esp_timer_get_time();
+    }
+
+    int64_t now = esp_timer_get_time();
+    bool peer_active = v.frames_recv > 0 &&
+                       (now - s_last_recv_change_us) < (5LL * 1000 * 1000);
+
+    const char *label;
+    uint32_t    color;
+    if (peer_active) {
+        label = "CONNECTED";
+        color = 0x22C55E;          /* green */
+    } else if (v.frames_recv > 0) {
+        label = "PEER LEFT";
+        color = 0xF59E0B;          /* amber */
+    } else {
+        label = "CALLING...";   /* "CALLING…" */
+        color = 0xF59E0B;
+    }
+
+    /* Append MUTED when the local mic is suppressed. */
+    if (voice_call_audio_is_muted()) {
+        char buf[48];
+        snprintf(buf, sizeof(buf), "%s  \xE2\x80\xA2  MUTED", label);
+        lv_label_set_text(s_status_lbl, buf);
+        lv_obj_set_style_text_color(s_status_lbl, lv_color_hex(0xEF4444), 0);
+    } else {
+        lv_label_set_text(s_status_lbl, label);
+        lv_obj_set_style_text_color(s_status_lbl, lv_color_hex(color), 0);
+    }
 }
 
 /* Naive RGB565 nearest-neighbour downscale src(sw x sh) -> dst(dw x dh).
@@ -180,6 +257,38 @@ static void build_call_chrome(void)
 
     if (!s_pip_timer) {
         s_pip_timer = lv_timer_create(pip_timer_cb, PIP_FPS_MS, NULL);
+    }
+
+    /* #280: Mute pill (top-right) — toggles voice_call_audio_set_muted. */
+    if (!s_mute_btn) {
+        s_mute_btn = lv_button_create(s_root);
+        lv_obj_remove_style_all(s_mute_btn);
+        lv_obj_set_size(s_mute_btn, MUTE_W, MUTE_H);
+        lv_obj_set_pos(s_mute_btn, VP_W - MUTE_W - MUTE_PAD, MUTE_PAD);
+        lv_obj_set_style_radius(s_mute_btn, MUTE_H / 2, 0);
+        lv_obj_set_style_bg_color(s_mute_btn,
+            voice_call_audio_is_muted() ? lv_color_hex(0xEF4444) : lv_color_hex(0x1F2937), 0);
+        lv_obj_set_style_bg_opa(s_mute_btn, LV_OPA_COVER, 0);
+        lv_obj_add_event_cb(s_mute_btn, on_mute_btn, LV_EVENT_CLICKED, NULL);
+        s_mute_lbl = lv_label_create(s_mute_btn);
+        lv_label_set_text(s_mute_lbl, voice_call_audio_is_muted() ? "Unmute" : "Mute");
+        lv_obj_set_style_text_color(s_mute_lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_center(s_mute_lbl);
+    }
+
+    /* #280: status badge (top-center) — flips between CALLING…/CONNECTED/PEER LEFT
+     * driven by a 1 Hz lv_timer that polls voice_video_get_stats. */
+    if (!s_status_lbl) {
+        s_status_lbl = lv_label_create(s_root);
+        lv_label_set_text(s_status_lbl, "CALLING...");
+        lv_obj_set_style_text_color(s_status_lbl, lv_color_hex(0xF59E0B), 0);
+        lv_obj_align(s_status_lbl, LV_ALIGN_TOP_MID, 0, 32);
+    }
+    s_last_recv_count_seen = 0;
+    s_last_recv_change_us  = esp_timer_get_time();
+    if (!s_status_timer) {
+        s_status_timer = lv_timer_create(status_timer_cb, STATUS_FPS_MS, NULL);
+        status_timer_cb(NULL);   /* immediate first paint */
     }
 }
 
@@ -307,6 +416,10 @@ void ui_video_pane_hide(void)
         lv_timer_delete(s_pip_timer);
         s_pip_timer = NULL;
     }
+    if (s_status_timer) {
+        lv_timer_delete(s_status_timer);
+        s_status_timer = NULL;
+    }
     if (s_root) {
         /* lv_obj_delete recurses to children — no need to delete each
          * child first.  Just NULL the static handles so we don't keep
@@ -319,6 +432,9 @@ void ui_video_pane_hide(void)
         s_accept_btn    = NULL;
         s_decline_btn   = NULL;
         s_incoming_lbl  = NULL;
+        s_mute_btn      = NULL;
+        s_mute_lbl      = NULL;
+        s_status_lbl    = NULL;
     }
     if (s_pip_buf) {
         heap_caps_free(s_pip_buf);

--- a/main/voice.c
+++ b/main/voice.c
@@ -261,6 +261,9 @@ static char s_vision_model[64] = {0};
 
 // Dictation mode
 static voice_mode_t   s_voice_mode        = VOICE_MODE_ASK;
+/* #280: in-call mute flag (definition near other state; the body
+ * lives next to voice_call_audio_set_muted/_is_muted further down). */
+static volatile bool s_call_muted = false;
 static char          *s_dictation_text    = NULL;  /* PSRAM-allocated, DICTATION_TEXT_SIZE */
 static volatile float s_current_rms       = 0.0f;
 static char           s_dictation_title[128]   = {0};
@@ -2175,17 +2178,25 @@ static void mic_capture_task(void *arg)
                                                        &send_bytes);
             if (cerr == ESP_OK && send_bytes > 0) {
                 if (s_voice_mode == VOICE_MODE_CALL) {
-                    /* #272: wrap with AUD0 magic so Dragon broadcasts
-                     * to the call peer instead of feeding STT.  Stack-
-                     * allocated — mic task has 16 KB stack, plenty of
-                     * headroom for a 648 B packet. */
-                    uint8_t call_pkt[VOICE_CHUNK_BYTES + VOICE_CALL_AUDIO_HEADER_LEN];
-                    size_t wire_len = voice_codec_pack_call_audio(
-                        call_pkt, sizeof(call_pkt), enc_buf, send_bytes);
-                    if (wire_len > 0) {
-                        err = voice_ws_send_binary(call_pkt, wire_len);
+                    /* #280: drop the chunk silently when muted.  Mic
+                     * loop continues running so RMS / counters stay
+                     * fresh — only the WS send is suppressed.  Peer
+                     * hears silence; our state is preserved. */
+                    if (s_call_muted) {
+                        err = ESP_OK;
                     } else {
-                        err = ESP_ERR_NO_MEM;
+                        /* #272: wrap with AUD0 magic so Dragon broadcasts
+                         * to the call peer instead of feeding STT.  Stack-
+                         * allocated — mic task has 16 KB stack, plenty of
+                         * headroom for a 648 B packet. */
+                        uint8_t call_pkt[VOICE_CHUNK_BYTES + VOICE_CALL_AUDIO_HEADER_LEN];
+                        size_t wire_len = voice_codec_pack_call_audio(
+                            call_pkt, sizeof(call_pkt), enc_buf, send_bytes);
+                        if (wire_len > 0) {
+                            err = voice_ws_send_binary(call_pkt, wire_len);
+                        } else {
+                            err = ESP_ERR_NO_MEM;
+                        }
                     }
                 } else {
                     err = voice_ws_send_binary(enc_buf, send_bytes);
@@ -3034,6 +3045,26 @@ esp_err_t voice_call_audio_start(void)
     return ESP_OK;
 }
 
+/* #280: muted-but-running flag for the call audio uplink.  Read by
+ * mic_capture_task in the VOICE_MODE_CALL branch — when set, the
+ * encoded chunk is dropped instead of being wrapped + sent.  Storage
+ * lives with the other static state near the top of this file. */
+
+bool voice_call_audio_set_muted(bool muted)
+{
+    if (s_voice_mode != VOICE_MODE_CALL) {
+        return false;     /* no-op outside a call */
+    }
+    s_call_muted = muted;
+    ESP_LOGI(TAG, "Call audio %s", muted ? "MUTED" : "UNMUTED");
+    return s_call_muted;
+}
+
+bool voice_call_audio_is_muted(void)
+{
+    return s_call_muted;
+}
+
 esp_err_t voice_call_audio_stop(void)
 {
     if (s_voice_mode != VOICE_MODE_CALL || !s_mic_running) {
@@ -3041,6 +3072,9 @@ esp_err_t voice_call_audio_stop(void)
     }
     ESP_LOGI(TAG, "Stopping call audio");
     s_mic_running = false;
+    /* Leaving call mode resets mute state so the next call starts
+     * unmuted (sane default). */
+    s_call_muted = false;
 
     /* Same drain pattern as voice_stop_listening — wait for the mic
      * task to exit cleanly, then re-enable I2S RX so a follow-up

--- a/main/voice.h
+++ b/main/voice.h
@@ -121,6 +121,14 @@ esp_err_t voice_ws_send_binary_public(const void *data, size_t len);
 esp_err_t voice_call_audio_start(void);
 esp_err_t voice_call_audio_stop(void);
 
+/** #280: in-call mute toggle.  When muted, the mic loop still runs
+ *  (counters tick, RMS keeps updating) but PCM chunks are dropped
+ *  instead of being wrapped + sent — peer hears silence, our mic
+ *  state is preserved.  Idempotent.  No-op when not in
+ *  VOICE_MODE_CALL.  Returns the new muted state. */
+bool voice_call_audio_set_muted(bool muted);
+bool voice_call_audio_is_muted(void);
+
 /** Send voice_mode (0-3) and LLM model string to Dragon as a config_update JSON frame. */
 esp_err_t voice_send_config_update(int voice_mode, const char *llm_model);
 


### PR DESCRIPTION
## Summary
- Mute pill top-right + 1 Hz status badge top-center on the in-call pane.
- Status flips between CALLING... → CONNECTED → PEER LEFT based on downlink frame age (5 s window).  Appends "  ·  MUTED" when local mic is suppressed.
- Mute drops PCM chunks in the mic loop (peer hears silence; mic state + RMS preserved); video keeps flowing.
- New POST /call/mute / /call/unmute debug endpoints + /call/status exposes audio.call_audio_muted.
- Closes #280.

## Test plan (debug-driven via /touch + /screenshot)
- [x] start_call → status: CALLING... (amber)
- [x] inject peer frame → CONNECTED (green) within ~1 s
- [x] tap Mute pill → muted=true, pill red, label flips to "Unmute", status appends MUTED
- [x] 5 s after mute: uplink_frames keeps ticking 24 → 40 (mic alive, audio dropped, video flowing)
- [x] tap Unmute → MUTED tag drops; counters resume
- [x] end_call → clean teardown, mute flag reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)