### PR TITLE
feat(call): minimize pane + floating 'On call' chip (Wave-2 / 2)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -2186,6 +2186,7 @@ static esp_err_t call_status_handler(httpd_req_t *req)
     /* Top-level call state */
     cJSON_AddBoolToObject(root, "in_call", voice_video_is_in_call());
     cJSON_AddBoolToObject(root, "pane_visible", ui_video_pane_is_visible());
+    cJSON_AddBoolToObject(root, "pane_minimized", ui_video_pane_is_minimized());
 
     /* Video subsection (uplink + downlink stats) */
     voice_video_stats_t v;
@@ -2276,6 +2277,30 @@ static esp_err_t call_unmute_handler(httpd_req_t *req)
     cJSON *root = cJSON_CreateObject();
     cJSON_AddBoolToObject(root, "ok", true);
     cJSON_AddBoolToObject(root, "muted", muted);
+    return send_json_resp(req, root);
+}
+
+/* #282 minimize / restore: the call pane gets hidden but the call
+ * continues + a small "On call" chip on lv_layer_top lets the user
+ * re-show.  Both endpoints hop to the LVGL thread. */
+static void minimize_pane_async(void *arg) { (void)arg; ui_video_pane_minimize(); }
+static void restore_pane_async(void *arg)  { (void)arg; ui_video_pane_restore(); }
+
+static esp_err_t call_minimize_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    tab5_lv_async_call(minimize_pane_async, NULL);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
+    return send_json_resp(req, root);
+}
+
+static esp_err_t call_restore_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+    tab5_lv_async_call(restore_pane_async, NULL);
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", true);
     return send_json_resp(req, root);
 }
 
@@ -3355,6 +3380,12 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_call_unmute = {
         .uri = "/call/unmute",      .method = HTTP_POST, .handler = call_unmute_handler
     };
+    const httpd_uri_t uri_call_minimize = {
+        .uri = "/call/minimize",    .method = HTTP_POST, .handler = call_minimize_handler
+    };
+    const httpd_uri_t uri_call_restore = {
+        .uri = "/call/restore",     .method = HTTP_POST, .handler = call_restore_handler
+    };
     const httpd_uri_t uri_dictation_post = {
         .uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler
     };
@@ -3429,6 +3460,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_call_status);
     httpd_register_uri_handler(server, &uri_call_mute);
     httpd_register_uri_handler(server, &uri_call_unmute);
+    httpd_register_uri_handler(server, &uri_call_minimize);
+    httpd_register_uri_handler(server, &uri_call_restore);
     httpd_register_uri_handler(server, &uri_dictation_post);
     httpd_register_uri_handler(server, &uri_dictation_get);
     httpd_register_uri_handler(server, &uri_wifi_kick);

--- a/main/ui_video_pane.c
+++ b/main/ui_video_pane.c
@@ -49,6 +49,13 @@ static const char *TAG = "ui_video_pane";
 #define MUTE_PAD    16
 #define STATUS_FPS_MS  1000  /* 1 Hz status refresh */
 
+/* #282: minimize pill top-left + floating "On call" chip on lv_layer_top */
+#define MIN_W       96
+#define MIN_H       48
+#define CHIP_W      136
+#define CHIP_H      40
+#define CHIP_PAD    16
+
 static lv_obj_t *s_root      = NULL;
 static lv_obj_t *s_image     = NULL;
 static lv_obj_t *s_pip_canvas = NULL;
@@ -64,6 +71,12 @@ static lv_obj_t *s_status_lbl = NULL;
 static lv_timer_t *s_status_timer = NULL;
 static uint32_t s_last_recv_count_seen = 0;
 static int64_t  s_last_recv_change_us  = 0;
+/* #282 minimize chrome + floating "On call" chip on lv_layer_top */
+static lv_obj_t *s_min_btn       = NULL;
+static lv_obj_t *s_chip          = NULL;
+static lv_obj_t *s_chip_lbl      = NULL;
+static lv_timer_t *s_chip_timer  = NULL;
+static bool s_minimized = false;
 
 static uint8_t *s_pip_buf = NULL;   /* RGB565 PIP_W*PIP_H*2 bytes in PSRAM */
 
@@ -128,6 +141,55 @@ static void on_mute_btn(lv_event_t *e)
         lv_obj_set_style_bg_color(s_mute_btn,
             now ? lv_color_hex(0xEF4444) : lv_color_hex(0x1F2937), 0);
     }
+}
+
+/* #282: minimize handler — hide the pane (LV_OBJ_FLAG_HIDDEN) so the
+ * floating chip on lv_layer_top can show through.  Call keeps running. */
+static void on_min_btn(lv_event_t *e)
+{
+    (void)e;
+    ui_video_pane_minimize();
+}
+
+/* Tap the floating chip → restore the pane. */
+static void on_chip_click(lv_event_t *e)
+{
+    (void)e;
+    ui_video_pane_restore();
+}
+
+/* #282 chip timer.  1 Hz: show chip iff (in_call OR incoming) AND
+ * pane is currently hidden (minimized).  Lazy-creates the chip the
+ * first time it's needed, hides it via flag the rest of the time. */
+static void chip_timer_cb(lv_timer_t *t)
+{
+    (void)t;
+    bool want_chip = (s_in_call || s_incoming) && s_minimized;
+    if (!want_chip) {
+        if (s_chip) lv_obj_add_flag(s_chip, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+
+    if (!s_chip) {
+        lv_obj_t *layer = lv_layer_top();
+        if (!layer) return;
+        s_chip = lv_button_create(layer);
+        lv_obj_remove_style_all(s_chip);
+        lv_obj_set_size(s_chip, CHIP_W, CHIP_H);
+        /* Top-right corner of the screen, just below the status strip. */
+        lv_obj_set_pos(s_chip, VP_W - CHIP_W - CHIP_PAD, CHIP_PAD);
+        lv_obj_set_style_radius(s_chip, CHIP_H / 2, 0);
+        lv_obj_set_style_bg_color(s_chip, lv_color_hex(0xEF4444), 0);
+        lv_obj_set_style_bg_opa(s_chip, LV_OPA_COVER, 0);
+        lv_obj_add_event_cb(s_chip, on_chip_click, LV_EVENT_CLICKED, NULL);
+
+        s_chip_lbl = lv_label_create(s_chip);
+        lv_label_set_text(s_chip_lbl, "On call");
+        lv_obj_set_style_text_color(s_chip_lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_center(s_chip_lbl);
+    }
+    lv_obj_remove_flag(s_chip, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(s_chip);
 }
 
 /* #280 status timer.  Picks one of CALLING / CONNECTED / PEER LEFT
@@ -290,6 +352,29 @@ static void build_call_chrome(void)
         s_status_timer = lv_timer_create(status_timer_cb, STATUS_FPS_MS, NULL);
         status_timer_cb(NULL);   /* immediate first paint */
     }
+
+    /* #282: minimize pill (top-left) — hides the pane so the floating
+     * "On call" chip on lv_layer_top takes over.  Call keeps running. */
+    if (!s_min_btn) {
+        s_min_btn = lv_button_create(s_root);
+        lv_obj_remove_style_all(s_min_btn);
+        lv_obj_set_size(s_min_btn, MIN_W, MIN_H);
+        lv_obj_set_pos(s_min_btn, MUTE_PAD, MUTE_PAD);
+        lv_obj_set_style_radius(s_min_btn, MIN_H / 2, 0);
+        lv_obj_set_style_bg_color(s_min_btn, lv_color_hex(0x1F2937), 0);
+        lv_obj_set_style_bg_opa(s_min_btn, LV_OPA_COVER, 0);
+        lv_obj_add_event_cb(s_min_btn, on_min_btn, LV_EVENT_CLICKED, NULL);
+        lv_obj_t *lbl = lv_label_create(s_min_btn);
+        lv_label_set_text(lbl, "Hide");
+        lv_obj_set_style_text_color(lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_center(lbl);
+    }
+    if (!s_chip_timer) {
+        /* Long-lived timer — checks once a second whether to show the
+         * floating chip.  Killed in ui_video_pane_hide alongside the
+         * other timers. */
+        s_chip_timer = lv_timer_create(chip_timer_cb, 1000, NULL);
+    }
 }
 
 void ui_video_pane_show(void)
@@ -420,6 +505,18 @@ void ui_video_pane_hide(void)
         lv_timer_delete(s_status_timer);
         s_status_timer = NULL;
     }
+    if (s_chip_timer) {
+        lv_timer_delete(s_chip_timer);
+        s_chip_timer = NULL;
+    }
+    /* Floating chip lives on lv_layer_top, not s_root — delete it
+     * explicitly so it doesn't survive a hide(). */
+    if (s_chip) {
+        lv_obj_delete(s_chip);
+        s_chip = NULL;
+        s_chip_lbl = NULL;
+    }
+    s_minimized = false;
     if (s_root) {
         /* lv_obj_delete recurses to children — no need to delete each
          * child first.  Just NULL the static handles so we don't keep
@@ -435,6 +532,7 @@ void ui_video_pane_hide(void)
         s_mute_btn      = NULL;
         s_mute_lbl      = NULL;
         s_status_lbl    = NULL;
+        s_min_btn       = NULL;
     }
     if (s_pip_buf) {
         heap_caps_free(s_pip_buf);
@@ -446,7 +544,31 @@ void ui_video_pane_hide(void)
 
 bool ui_video_pane_is_visible(void)
 {
-    return s_root != NULL;
+    return s_root != NULL && !s_minimized;
+}
+
+void ui_video_pane_minimize(void)
+{
+    if (!s_root || s_minimized) return;
+    lv_obj_add_flag(s_root, LV_OBJ_FLAG_HIDDEN);
+    s_minimized = true;
+    /* Force chip timer to paint immediately so the chip pops without
+     * waiting for the next 1 s tick. */
+    if (s_chip_timer) chip_timer_cb(NULL);
+}
+
+void ui_video_pane_restore(void)
+{
+    if (!s_root || !s_minimized) return;
+    lv_obj_remove_flag(s_root, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(s_root);
+    s_minimized = false;
+    if (s_chip) lv_obj_add_flag(s_chip, LV_OBJ_FLAG_HIDDEN);
+}
+
+bool ui_video_pane_is_minimized(void)
+{
+    return s_minimized;
 }
 
 bool ui_video_pane_is_in_call(void)

--- a/main/ui_video_pane.h
+++ b/main/ui_video_pane.h
@@ -47,8 +47,16 @@ bool ui_video_pane_is_incoming(void);
  * — that's the caller's job (voice_video_end_call wraps both). */
 void ui_video_pane_hide(void);
 
-/* True iff the pane is currently visible. */
+/* True iff the pane is currently visible (not hidden via minimize). */
 bool ui_video_pane_is_visible(void);
+
+/* #282: minimize / restore.  Hides the pane (LV_OBJ_FLAG_HIDDEN)
+ * without tearing it down — call keeps running, child timers keep
+ * ticking, just not painted.  Restore re-shows + brings to front.
+ * Idempotent.  No-op if pane isn't open. */
+void ui_video_pane_minimize(void);
+void ui_video_pane_restore(void);
+bool ui_video_pane_is_minimized(void);
 
 /* True iff the pane is open in call mode (PIP + end-call button). */
 bool ui_video_pane_is_in_call(void);


### PR DESCRIPTION
## Summary
- New "Hide" pill top-left of the in-call pane → \`ui_video_pane_minimize\` flips \`LV_OBJ_FLAG_HIDDEN\`.  Call keeps running.
- Floating red "On call" chip top-right of every screen (parented to \`lv_layer_top\`) appears whenever \`(in_call || incoming) && minimized\`.  Tap → \`ui_video_pane_restore\`.
- \`/call/status\` now reports \`pane_minimized\`.  New \`POST /call/minimize\` / \`/call/restore\` debug endpoints.
- Closes #282.

## Test plan
- [x] start_call → Hide pill present
- [x] tap Hide → pane vanishes, in_call stays True
- [x] navigate to Home → "On call" chip visible top-right (visual confirmed)
- [x] tap chip → pane restores, chip auto-hides
- [x] end_call → clean teardown of pane + chip + timers + flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)