### PR TITLE
perf(call): persistent mic + video tasks (kills +2-tasks-per-call leak)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -210,6 +210,15 @@ static volatile bool s_using_ngrok        = false;  /* true once we've switched 
 // Mic capture task
 static TaskHandle_t  s_mic_task    = NULL;
 static volatile bool s_mic_running = false;
+/* #284: persistent mic task — created once at voice_init, idles on
+ * this binary semaphore between sessions instead of being spawned +
+ * suspended per-call.  Each start_listening / start_dictation /
+ * call_audio_start gives the semaphore; the task wakes, runs the
+ * capture loop until s_mic_running clears, then blocks again.
+ *
+ * Eliminates the +1-task-per-call zombie leak that #282/#284 audit
+ * flagged as the eventual heap_wd reset trigger. */
+static SemaphoreHandle_t s_mic_event_sem = NULL;
 
 // Playback drain task — pulls from ring buffer, blocks on i2s_channel_write
 static TaskHandle_t      s_play_task    = NULL;
@@ -2074,8 +2083,14 @@ static void voice_build_local_uri(char *out, size_t out_cap,
 // ---------------------------------------------------------------------------
 static void mic_capture_task(void *arg)
 {
-    ESP_LOGI(TAG, "Mic capture task started (core %d)", xPortGetCoreID());
+    ESP_LOGI(TAG, "Mic capture task started (core %d) — persistent",
+             xPortGetCoreID());
 
+    /* #284: buffers allocated once at task start, NEVER freed.  The
+     * persistent task pattern reuses them across every session
+     * (start_listening / start_dictation / call_audio_start).  640 B
+     * (enc_buf) + ~3.8 KB (mono_buf) + ~30 KB (tdm_buf) total — all
+     * in PSRAM. */
     int16_t *tdm_buf = (int16_t *)heap_caps_malloc(
         MIC_TDM_SAMPLES * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     int16_t *mono_buf = (int16_t *)heap_caps_malloc(
@@ -2087,16 +2102,24 @@ static void mic_capture_task(void *arg)
     uint8_t  *enc_buf  = (uint8_t  *)heap_caps_malloc(
         VOICE_CHUNK_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     if (!tdm_buf || !mono_buf || !enc_buf) {
-        ESP_LOGE(TAG, "Failed to allocate mic buffers");
+        ESP_LOGE(TAG, "Failed to allocate mic buffers — task idling forever");
         heap_caps_free(tdm_buf);
         heap_caps_free(mono_buf);
         heap_caps_free(enc_buf);
-        s_mic_task = NULL;
-        vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
-        return;
+        /* No buffers means we can't ever do useful work — block
+         * indefinitely on the never-given semaphore.  Don't suspend
+         * (P4 TLSP rule) and don't loop+spin. */
+        for (;;) vTaskDelay(portMAX_DELAY);
     }
 
-    s_mic_running = true;
+    /* #284: outer loop — block on the event semaphore between sessions. */
+    while (1) {
+        xSemaphoreTake(s_mic_event_sem, portMAX_DELAY);
+        if (!s_mic_running) {
+            /* Spurious wakeup — go back to sleep. */
+            continue;
+        }
+        ESP_LOGI(TAG, "Mic session start (mode=%d)", s_voice_mode);
     int frames_sent = 0;
 
     int silence_frames = 0;
@@ -2286,9 +2309,9 @@ static void mic_capture_task(void *arg)
 
     s_mic_running = false;
     s_current_rms = 0;
-    heap_caps_free(tdm_buf);
-    heap_caps_free(mono_buf);
-    heap_caps_free(enc_buf);
+    /* #284: do NOT free tdm_buf / mono_buf / enc_buf — persistent task
+     * reuses them across sessions.  They're freed only at process
+     * shutdown (which never happens on the firmware side). */
 
     if (s_voice_mode == VOICE_MODE_DICTATE && had_speech
         && total_silence_frames >= DICTATION_AUTO_STOP_FRAMES
@@ -2297,9 +2320,11 @@ static void mic_capture_task(void *arg)
         voice_set_state(VOICE_STATE_PROCESSING, NULL);
     }
 
-    ESP_LOGI(TAG, "Mic capture task exiting");
-    s_mic_task = NULL;
-    vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
+    ESP_LOGI(TAG, "Mic session end (frames=%d) — back to idle",
+             frames_sent);
+    /* #284: drop back to outer while(1) and wait for the next
+     * xSemaphoreGive in voice_*_start.  No vTaskSuspend, no leak. */
+    }   /* outer while(1) */
 }
 
 // ---------------------------------------------------------------------------
@@ -2370,6 +2395,25 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
     voice_codec_init();
     /* #266: video streaming module.  Just allocates the JPEG engine. */
     voice_video_init();
+
+    /* #284: persistent mic capture task — spawned once, idles on
+     * s_mic_event_sem between sessions.  Replaces the per-call
+     * xTaskCreate + vTaskSuspend zombie-leak pattern. */
+    s_mic_event_sem = xSemaphoreCreateBinary();
+    if (!s_mic_event_sem) {
+        ESP_LOGE(TAG, "Failed to create mic event semaphore");
+        return ESP_ERR_NO_MEM;
+    }
+    {
+        BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(
+            mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
+            NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
+            MALLOC_CAP_SPIRAM);
+        if (ok != pdPASS) {
+            ESP_LOGE(TAG, "Failed to spawn persistent mic task");
+            return ESP_ERR_NO_MEM;
+        }
+    }
 
     s_state_mutex = xSemaphoreCreateMutex();
     if (!s_state_mutex) {
@@ -2932,18 +2976,9 @@ esp_err_t voice_start_listening(void)
     s_llm_text[0] = '\0';
 
     s_mic_running = true;
-    /* #262 follow-up: 16 KB stack (was 8) for OPUS silk_Encode locals.
-     * WithCaps(SPIRAM) keeps the bump out of internal SRAM. */
-    BaseType_t ret = xTaskCreatePinnedToCoreWithCaps(
-        mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
-        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
-        MALLOC_CAP_SPIRAM);
-    if (ret != pdPASS) {
-        ESP_LOGE(TAG, "Failed to create mic capture task");
-        voice_ws_send_text("{\"type\":\"stop\"}");
-        s_mic_running = false;
-        return ESP_ERR_NO_MEM;
-    }
+    /* #284: signal the persistent mic task to start a session.  No
+     * per-call task spawn — task was created once at voice_init. */
+    if (s_mic_event_sem) xSemaphoreGive(s_mic_event_sem);
 
     voice_set_state(VOICE_STATE_LISTENING, NULL);
     return ESP_OK;
@@ -2984,18 +3019,8 @@ esp_err_t voice_start_dictation(void)
     s_llm_text[0] = '\0';
 
     s_mic_running = true;
-    /* #262 follow-up: 16 KB stack (was 8) for OPUS silk_Encode locals.
-     * WithCaps(SPIRAM) keeps the bump out of internal SRAM. */
-    BaseType_t ret = xTaskCreatePinnedToCoreWithCaps(
-        mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
-        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
-        MALLOC_CAP_SPIRAM);
-    if (ret != pdPASS) {
-        ESP_LOGE(TAG, "Failed to create mic capture task");
-        voice_ws_send_text("{\"type\":\"stop\"}");
-        s_mic_running = false;
-        return ESP_ERR_NO_MEM;
-    }
+    /* #284: signal persistent mic task. */
+    if (s_mic_event_sem) xSemaphoreGive(s_mic_event_sem);
 
     voice_set_state(VOICE_STATE_LISTENING, NULL);
     return ESP_OK;
@@ -3020,7 +3045,10 @@ esp_err_t voice_call_audio_start(void)
         ESP_LOGE(TAG, "voice_call_audio_start: not connected");
         return ESP_ERR_INVALID_STATE;
     }
-    if (s_mic_running || s_mic_task != NULL) {
+    /* #284: persistent task pattern — `s_mic_task != NULL` is now
+     * always true after voice_init (one task lives forever), so the
+     * old guard would always block.  Gate on s_mic_running only. */
+    if (s_mic_running) {
         ESP_LOGW(TAG, "voice_call_audio_start: mic already running (mode=%d)",
                  s_voice_mode);
         return ESP_OK;
@@ -3033,15 +3061,7 @@ esp_err_t voice_call_audio_start(void)
     ESP_LOGI(TAG, "Starting call audio (VOICE_MODE_CALL)");
     s_voice_mode = VOICE_MODE_CALL;
     s_mic_running = true;
-    BaseType_t ret = xTaskCreatePinnedToCoreWithCaps(
-        mic_capture_task, "voice_mic", MIC_TASK_STACK_SIZE,
-        NULL, MIC_TASK_PRIORITY, &s_mic_task, MIC_TASK_CORE,
-        MALLOC_CAP_SPIRAM);
-    if (ret != pdPASS) {
-        ESP_LOGE(TAG, "Failed to spawn call-audio mic task");
-        s_mic_running = false;
-        return ESP_ERR_NO_MEM;
-    }
+    if (s_mic_event_sem) xSemaphoreGive(s_mic_event_sem);
     return ESP_OK;
 }
 
@@ -3081,7 +3101,7 @@ esp_err_t voice_call_audio_stop(void)
      * voice_start_listening / voice_start_dictation works. */
     i2s_chan_handle_t rx_h = tab5_audio_get_i2s_rx();
     if (rx_h) i2s_channel_disable(rx_h);
-    for (int i = 0; i < 120 && s_mic_task != NULL; i++) {
+    for (int i = 0; i < 120 && s_mic_running; i++) {
         vTaskDelay(pdMS_TO_TICKS(10));
     }
     if (rx_h) i2s_channel_enable(rx_h);
@@ -3118,7 +3138,7 @@ esp_err_t voice_stop_listening(void)
         i2s_channel_disable(rx_h);
     }
 
-    for (int i = 0; i < 120 && s_mic_task != NULL; i++) {
+    for (int i = 0; i < 120 && s_mic_running; i++) {
         vTaskDelay(pdMS_TO_TICKS(10));
     }
 
@@ -3154,7 +3174,7 @@ esp_err_t voice_cancel(void)
         if (rx_h) {
             i2s_channel_disable(rx_h);
         }
-        for (int i = 0; i < 120 && s_mic_task != NULL; i++) {
+        for (int i = 0; i < 120 && s_mic_running; i++) {
             vTaskDelay(pdMS_TO_TICKS(10));
         }
         if (rx_h) {
@@ -3208,13 +3228,15 @@ esp_err_t voice_disconnect(void)
         i2s_channel_disable(rx_h);
     }
 
-    for (int i = 0; i < 120 && s_mic_task != NULL; i++) {
+    for (int i = 0; i < 120 && s_mic_running; i++) {
         vTaskDelay(pdMS_TO_TICKS(10));
     }
-    if (s_mic_task != NULL) {
-        ESP_LOGW(TAG, "Mic task did not exit in 1200ms — forcing handle NULL");
+    if (s_mic_running) {
+        ESP_LOGW(TAG, "Mic session did not stop in 1200ms — forcing flag");
+        s_mic_running = false;
     }
-    s_mic_task = NULL;
+    /* #284: don't NULL s_mic_task — the persistent task is still alive
+     * and waiting on its event semaphore for the next session. */
 
     if (rx_h) {
         i2s_channel_enable(rx_h);

--- a/main/voice_video.c
+++ b/main/voice_video.c
@@ -38,6 +38,10 @@ static const char *TAG = "voice_video";
 static jpeg_encoder_handle_t s_enc      = NULL;
 static SemaphoreHandle_t     s_enc_mux  = NULL;
 static TaskHandle_t          s_task     = NULL;
+/* #284: persistent streaming task — created once at voice_video_init,
+ * idles on this binary semaphore between sessions instead of being
+ * spawned + suspended per-call.  Same shape as voice.c's mic task. */
+static SemaphoreHandle_t     s_event_sem = NULL;
 
 static volatile bool s_running    = false;
 static volatile int  s_target_fps = VOICE_VIDEO_DEFAULT_FPS;
@@ -74,6 +78,9 @@ static void rot270(const uint16_t *src, uint16_t *dst, int sw, int sh)
     }
 }
 
+/* Forward declaration so voice_video_init can spawn it. */
+static void streaming_task(void *arg);
+
 esp_err_t voice_video_init(void)
 {
     if (!s_enc_mux) {
@@ -92,7 +99,27 @@ esp_err_t voice_video_init(void)
             return r;
         }
     }
-    ESP_LOGI(TAG, "init OK (jpeg engine ready)");
+    /* #284: spawn persistent streaming task ONCE.  Idles on
+     * s_event_sem; callers signal start_streaming -> sem give. */
+    if (!s_event_sem) {
+        s_event_sem = xSemaphoreCreateBinary();
+        if (!s_event_sem) {
+            ESP_LOGE(TAG, "Failed to create video event semaphore");
+            return ESP_ERR_NO_MEM;
+        }
+    }
+    if (!s_task) {
+        BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(
+            streaming_task, "voice_video", VV_TASK_STACK,
+            NULL, VV_TASK_PRIO, &s_task, VV_TASK_CORE,
+            MALLOC_CAP_SPIRAM);
+        if (ok != pdPASS) {
+            ESP_LOGE(TAG, "Failed to spawn persistent streaming task");
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    ESP_LOGI(TAG, "init OK (jpeg engine + persistent task ready)");
     return ESP_OK;
 }
 
@@ -149,10 +176,12 @@ static size_t pack_wire_frame(uint8_t *wire_buf,
 static void streaming_task(void *arg)
 {
     (void)arg;
-    ESP_LOGI(TAG, "streaming task started fps=%d core=%d",
-             s_target_fps, xPortGetCoreID());
+    ESP_LOGI(TAG, "streaming task started core=%d — persistent",
+             xPortGetCoreID());
 
-    /* HW JPEG encoder requires DMA-aligned buffers (the engine writes
+    /* #284: buffers allocated once, never freed — persistent task
+     * reuses them across every streaming session.
+     * HW JPEG encoder requires DMA-aligned buffers (the engine writes
      * the bitstream via DMA).  Plain heap_caps_malloc fails with
      * "bit stream is not aligned" — must use jpeg_alloc_encoder_mem
      * with the OUTPUT direction for the destination buffer. */
@@ -173,16 +202,21 @@ static void streaming_task(void *arg)
         1280 * 720 * 2, &in_alloc, &rot_cap);
     uint8_t  *wire_buf = heap_caps_malloc(VV_OUT_BUF_BYTES + 8, MALLOC_CAP_SPIRAM);
     if (!jpeg_buf || !rot_buf || !wire_buf) {
-        ESP_LOGE(TAG, "streaming alloc failed (jpeg=%p rot=%p wire=%p)",
+        ESP_LOGE(TAG, "streaming alloc failed (jpeg=%p rot=%p wire=%p) — task idling",
                  jpeg_buf, rot_buf, wire_buf);
         if (jpeg_buf) free(jpeg_buf);    /* jpeg_alloc_encoder_mem path */
         if (rot_buf)  free(rot_buf);
         heap_caps_free(wire_buf);
-        s_running = false;
-        s_task    = NULL;
-        vTaskSuspend(NULL);
-        return;
+        /* No buffers means we can never do useful work — block
+         * indefinitely.  Don't suspend (P4 TLSP rule), don't spin. */
+        for (;;) vTaskDelay(portMAX_DELAY);
     }
+
+    /* #284: outer loop — block on event semaphore between sessions. */
+    while (1) {
+        xSemaphoreTake(s_event_sem, portMAX_DELAY);
+        if (!s_running) continue;
+        ESP_LOGI(TAG, "streaming session start fps=%d", s_target_fps);
 
     int last_fps = s_target_fps;
     TickType_t period = pdMS_TO_TICKS(1000 / last_fps);
@@ -257,22 +291,20 @@ wait:
         }
     }
 
-    free(jpeg_buf);                       /* jpeg_alloc_encoder_mem path */
-    free(rot_buf);                        /* same */
-    heap_caps_free(wire_buf);
-
-    ESP_LOGI(TAG, "streaming task exiting cleanly");
+    /* #284: don't free buffers, don't NULL s_task — persistent task
+     * keeps them across sessions and drops back to the outer loop. */
     s_stats.active = false;
-    s_task = NULL;
-    /* P4 TLSP rule (#20): suspend, don't delete.  Worker stack lives
-     * in PSRAM (#262 follow-up) so the leak per stream is bounded
-     * PSRAM, not internal SRAM. */
-    vTaskSuspend(NULL);
+    ESP_LOGI(TAG, "streaming session end (frames_sent=%" PRIu32 ") — back to idle",
+             s_stats.frames_sent);
+    }   /* outer while(1) */
 }
 
 esp_err_t voice_video_start_streaming(int fps)
 {
-    if (s_running || s_task) {
+    /* #284: persistent task pattern — s_task is non-NULL after init,
+     * so the old `s_running || s_task` guard would always block.
+     * Gate on s_running only. */
+    if (s_running) {
         ESP_LOGW(TAG, "already streaming");
         return ESP_ERR_INVALID_STATE;
     }
@@ -285,17 +317,8 @@ esp_err_t voice_video_start_streaming(int fps)
     s_stats.fps     = fps;
     s_running       = true;
 
-    BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(
-        streaming_task, "voice_video", VV_TASK_STACK,
-        NULL, VV_TASK_PRIO, &s_task, VV_TASK_CORE,
-        MALLOC_CAP_SPIRAM);
-    if (ok != pdPASS) {
-        ESP_LOGE(TAG, "task spawn failed");
-        s_running      = false;
-        s_stats.active = false;
-        s_task         = NULL;
-        return ESP_ERR_NO_MEM;
-    }
+    /* Signal the persistent task to enter its inner loop. */
+    if (s_event_sem) xSemaphoreGive(s_event_sem);
     ESP_LOGI(TAG, "streaming started fps=%d", fps);
     return ESP_OK;
 }
@@ -305,10 +328,13 @@ esp_err_t voice_video_stop_streaming(void)
     if (!s_running) return ESP_OK;
     s_running = false;
     /* Wait up to ~1.2 s for the task to drain its current frame and
-     * exit on its own.  We don't vTaskDelete (P4 TLSP rule). */
-    for (int i = 0; i < 60 && s_task != NULL; i++) {
-        vTaskDelay(pdMS_TO_TICKS(20));
-    }
+     * exit on its own.  We don't vTaskDelete (P4 TLSP rule).
+     * #284: persistent task — short fixed wait for the current
+     * inner-loop frame to finish (the longest possible frame is
+     * ~250 ms at 4 fps + JPEG encode + WS send).  No tight handle
+     * to wait on; the task just drops back to the outer semaphore
+     * wait once s_running clears. */
+    vTaskDelay(pdMS_TO_TICKS(300));
     s_stats.active = false;
     s_stats.fps    = 0;
     ESP_LOGI(TAG, "streaming stopped (frames_sent=%" PRIu32


### PR DESCRIPTION
## Summary
- Mic capture task and video streaming task converted from per-call \`xTaskCreate + vTaskSuspend(NULL)\` to a single long-lived persistent task each, idling on a binary semaphore between sessions.
- Eliminates the +2-tasks-per-call zombie leak that #282/#284 audit flagged as the eventual heap_wd reset trigger.
- Buffers (tdm/mono/enc + jpeg/rot/wire) allocated once at task start, never freed — reused across every session.
- Closes #284.

## Test plan (debug-driven via /call/status)
- [x] 8 sequential start_call → end_call cycles: tasks stay at 28 (was: would be 44 with the old +2/cycle leak)
- [x] 5s session × 3 fps reliably sends 15-16 frames per cycle (same throughput as before)
- [x] Voice paths unaffected: dictation start/stop OK, /chat text round-trip OK (STT returns last_stt_text)
- [x] Tab5 healthy after 8 cycles: uptime 217s, no reset, internal SRAM largest 54 KB stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)