### PR TITLE
fix(camera): default cam_rot=3 — portrait viewfinder out of the box

### DIFF
--- a/main/settings.c
+++ b/main/settings.c
@@ -426,7 +426,14 @@ uint8_t tab5_settings_get_auto_rotate(void) { return get_u8("auto_rot", 0); }
 esp_err_t tab5_settings_set_auto_rotate(uint8_t on) { return set_u8("auto_rot", on ? 1 : 0); }
 
 /* ── Camera rotation (#260) ───────────────────────────────────────────── */
-uint8_t tab5_settings_get_cam_rotation(void) { return get_u8("cam_rot", 0); }
+/* #286: default 3 (270 CW = 90 CCW).  The sensor is mounted such that
+ * the natural-portrait orientation of the user (held with USB at the
+ * bottom, looking at the screen) requires a 270 CW rotation of the
+ * raw 1280x720 landscape frame to appear right-side-up in the
+ * viewfinder.  Empirically verified via screenshot: rot=1 puts the
+ * user upside-down, rot=3 puts head at top.  Users who want a
+ * different orientation flip it via Settings → Camera rotation. */
+uint8_t tab5_settings_get_cam_rotation(void) { return get_u8("cam_rot", 3); }
 esp_err_t tab5_settings_set_cam_rotation(uint8_t rot) { return set_u8("cam_rot", rot & 0x03); }
 
 bool tab5_settings_quiet_active(int hour_local)


### PR DESCRIPTION
## Summary
- One-line fix: \`cam_rot\` default 0 → 3 (270 CW = 90 CCW).
- Closes #286.

## Empirical validation
Tested all four rotations via /screenshot (image of room with monitor + person):
- rot=0 — landscape, sideways relative to portrait device ✗
- rot=1 — portrait, but head at bottom ✗
- rot=2 — landscape inverted ✗
- **rot=3 — portrait, head at top, monitor at top ✓**

Existing devices keep their preference (NVS load-or-default).  Users who want a different orientation flip it in Settings → Camera rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)