### PR TITLE
feat(camera): live Rotate button + PIP picks up cam_rot

### DIFF
--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -214,6 +214,24 @@ static void cb_back_btn(lv_event_t *e)
     lv_screen_load(ui_home_get_screen());
 }
 
+/* #286: live rotation cycle — 0→1→2→3→0.  Persists to NVS + tears
+ * down + recreates the camera screen so the new canvas dimensions
+ * are picked up.  Defined non-static so the topbar builder can
+ * forward-declare via extern. */
+void cb_rotate_btn(lv_event_t *e)
+{
+    (void)e;
+    uint8_t cur = tab5_settings_get_cam_rotation();
+    uint8_t nxt = (uint8_t)((cur + 1) & 0x03);
+    tab5_settings_set_cam_rotation(nxt);
+    ESP_LOGI(TAG, "cam_rot live cycle %u -> %u", cur, nxt);
+    /* Recreate the screen so alloc_canvas_buffer picks up the new
+     * dimensions.  Cheap — destroy+create round trip is ~50 ms. */
+    ui_camera_destroy();
+    extern lv_obj_t *ui_camera_create(void);
+    ui_camera_create();
+}
+
 /* ================================================================
  * ui_camera_create
  * ================================================================ */
@@ -319,6 +337,33 @@ lv_obj_t *ui_camera_create(void)
         lv_obj_set_style_text_color(arrow, lv_color_hex(COL_WHITE), 0);
         lv_obj_set_style_text_font(arrow, &lv_font_montserrat_24, 0);
         lv_obj_center(arrow);
+
+        /* #286: live rotate button — cycles cam_rot 0→1→2→3→0 in one
+         * tap and recreates the camera screen so the new rotation
+         * applies immediately.  Saves the user a trip to Settings. */
+        {
+            extern void cb_rotate_btn(lv_event_t *e);
+            lv_obj_t *btn_rot = lv_button_create(topbar);
+            lv_obj_remove_style_all(btn_rot);
+            lv_obj_set_size(btn_rot, 100, 48);
+            lv_obj_set_style_bg_color(btn_rot, lv_color_hex(0x1A1A24), 0);
+            lv_obj_set_style_bg_opa(btn_rot, LV_OPA_COVER, 0);
+            lv_obj_set_style_radius(btn_rot, 12, 0);
+            lv_obj_align(btn_rot, LV_ALIGN_LEFT_MID, 96, 0);
+            lv_obj_add_event_cb(btn_rot, cb_rotate_btn, LV_EVENT_CLICKED, NULL);
+            ui_fb_button(btn_rot);
+            lv_obj_t *rot_lbl = lv_label_create(btn_rot);
+            char buf[16];
+            /* Read NVS directly — s_cam_rot is snapshotted later in
+             * ui_camera_create's alloc_canvas_buffer step, so it's
+             * still stale at this point. */
+            snprintf(buf, sizeof(buf), "Rot %u",
+                     (unsigned)(tab5_settings_get_cam_rotation() & 0x03));
+            lv_label_set_text(rot_lbl, buf);
+            lv_obj_set_style_text_color(rot_lbl, lv_color_hex(COL_WHITE), 0);
+            lv_obj_set_style_text_font(rot_lbl, FONT_BODY, 0);
+            lv_obj_center(rot_lbl);
+        }
 
         /* v4·D Phase 4b vision chip — right-aligned violet pill that reads
          * "VISION · <MODEL>  READY" when Dragon has advertised a

--- a/main/ui_video_pane.c
+++ b/main/ui_video_pane.c
@@ -257,6 +257,12 @@ static void downscale_rgb565(const uint16_t *src, int sw, int sh,
     }
 }
 
+/* PIP rotation scratch — sized for the largest possible source frame
+ * (1280x720 RGB565 = 1.8 MB).  Allocated lazily on first rotated
+ * frame so PIP-disabled flow pays nothing.  Lives across pane
+ * sessions; freed in ui_video_pane_hide alongside the rest. */
+static uint16_t *s_pip_rot_scratch = NULL;
+
 static void pip_timer_cb(lv_timer_t *t)
 {
     (void)t;
@@ -267,11 +273,54 @@ static void pip_timer_cb(lv_timer_t *t)
     if (tab5_camera_capture(&frame) != ESP_OK) return;
     if (frame.format != TAB5_CAM_FMT_RGB565) return;
 
-    /* Downscale (no rotation in the PIP — keep it simple, the user
-     * already sees their feed.  cam_rot only matters for the remote
-     * who'll see Tab5's outbound stream rotated by voice_video). */
-    downscale_rgb565((const uint16_t *)frame.data, frame.width, frame.height,
-                     (uint16_t *)s_pip_buf, PIP_W, PIP_H);
+    /* #286 follow-up: apply cam_rot to the PIP source so the user's
+     * own preview matches the viewfinder + the outbound stream.
+     * Previously the PIP always showed the raw landscape sensor frame
+     * even after the user fixed cam_rot in Settings — confusing. */
+    const uint16_t *src = (const uint16_t *)frame.data;
+    int sw = frame.width;
+    int sh = frame.height;
+    uint8_t rot = tab5_settings_get_cam_rotation() & 0x03;
+    if (rot != 0) {
+        if (!s_pip_rot_scratch) {
+            s_pip_rot_scratch = (uint16_t *)heap_caps_malloc(
+                1280 * 720 * 2, MALLOC_CAP_SPIRAM);
+            if (!s_pip_rot_scratch) return;  /* OOM — skip frame */
+        }
+        switch (rot) {
+        case 1:
+            /* 90 CW: dst is sh x sw */
+            for (int y = 0; y < sh; y++) {
+                const uint16_t *row = src + y * sw;
+                for (int x = 0; x < sw; x++) {
+                    s_pip_rot_scratch[(sh - 1 - y) + x * sh] = row[x];
+                }
+            }
+            sw = frame.height;
+            sh = frame.width;
+            break;
+        case 2:
+            /* 180: same dims */
+            for (int i = 0, n = sw * sh; i < n; i++) {
+                s_pip_rot_scratch[n - 1 - i] = src[i];
+            }
+            break;
+        case 3:
+            /* 270 CW (= 90 CCW): dst is sh x sw */
+            for (int y = 0; y < sh; y++) {
+                const uint16_t *row = src + y * sw;
+                for (int x = 0; x < sw; x++) {
+                    s_pip_rot_scratch[y + (sw - 1 - x) * sh] = row[x];
+                }
+            }
+            sw = frame.height;
+            sh = frame.width;
+            break;
+        }
+        src = s_pip_rot_scratch;
+    }
+
+    downscale_rgb565(src, sw, sh, (uint16_t *)s_pip_buf, PIP_W, PIP_H);
     lv_obj_invalidate(s_pip_canvas);
 }
 
@@ -537,6 +586,10 @@ void ui_video_pane_hide(void)
     if (s_pip_buf) {
         heap_caps_free(s_pip_buf);
         s_pip_buf = NULL;
+    }
+    if (s_pip_rot_scratch) {
+        heap_caps_free(s_pip_rot_scratch);
+        s_pip_rot_scratch = NULL;
     }
     s_in_call  = false;
     s_incoming = false;


### PR DESCRIPTION
## Summary
- Camera screen: "Rot N" pill next to the back arrow.  Tap cycles 0→1→2→3→0, persists, recreates the screen instantly.  Two-tap discovery instead of trip to Settings.
- PIP in the call pane now applies cam_rot before downscaling — was previously always raw landscape regardless of user preference.
- Refs #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)