### PR TITLE
feat(debug): add GET /screen + wire obs events for e2e harness (closes #293)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1795,6 +1795,14 @@ static esp_err_t navigate_handler(httpd_req_t *req)
 
     httpd_query_key_value(query, "screen", s_nav_target, sizeof(s_nav_target));
 
+    /* #293: emit obs event for e2e harness BEFORE the async dispatch so
+     * the harness sees the navigation intent even if the dispatch is
+     * queued.  s_current_screen also gets updated on the LVGL side via
+     * async_navigate completion.  Forward-declared because debug_obs.h
+     * is included further down the file (after this handler). */
+    extern void tab5_debug_obs_event(const char *kind, const char *detail);
+    tab5_debug_obs_event("screen.navigate", s_nav_target);
+
     /* Schedule on LVGL thread (#258 helper takes the recursive LVGL
      * mutex internally — lv_async_call itself is NOT thread-safe). */
     tab5_lv_async_call(async_navigate, NULL);
@@ -2082,6 +2090,39 @@ static esp_err_t dictation_handler(httpd_req_t *req)
 }
 
 /* ── Voice state endpoint ─────────────────────────────────────────────── */
+
+/* #293: GET /screen — current screen + overlay visibility for the e2e
+ * harness.  s_nav_target is the last-requested screen via /navigate;
+ * overlay state comes from the per-module ui_*_is_visible() / is_active()
+ * helpers. */
+static esp_err_t screen_state_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+
+    extern bool ui_chat_is_active(void);
+    extern bool ui_voice_is_visible(void);
+    extern bool ui_settings_is_visible(void);
+
+    cJSON *root = cJSON_CreateObject();
+    /* Last-requested screen via /navigate.  Defaults to "home" until
+     * the first navigate fires (Tab5 boots into home). */
+    cJSON_AddStringToObject(root, "current",
+        s_nav_target[0] ? s_nav_target : "home");
+    cJSON *overlays = cJSON_CreateObject();
+    cJSON_AddBoolToObject(overlays, "chat",     ui_chat_is_active());
+    cJSON_AddBoolToObject(overlays, "voice",    ui_voice_is_visible());
+    cJSON_AddBoolToObject(overlays, "settings", ui_settings_is_visible());
+    cJSON_AddItemToObject(root, "overlays", overlays);
+
+    char *json = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+    esp_err_t ret = httpd_resp_sendstr(req, json);
+    free(json);
+    return ret;
+}
 
 static esp_err_t voice_state_handler(httpd_req_t *req)
 {
@@ -3343,6 +3384,9 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_chat = {
         .uri = "/chat", .method = HTTP_POST, .handler = chat_handler
     };
+    const httpd_uri_t uri_screen = {
+        .uri = "/screen", .method = HTTP_GET, .handler = screen_state_handler
+    };
     const httpd_uri_t uri_voice_state = {
         .uri = "/voice", .method = HTTP_GET, .handler = voice_state_handler
     };
@@ -3448,6 +3492,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_ota_check);
     httpd_register_uri_handler(server, &uri_ota_apply);
     httpd_register_uri_handler(server, &uri_chat);
+    httpd_register_uri_handler(server, &uri_screen);
     httpd_register_uri_handler(server, &uri_voice_state);
     httpd_register_uri_handler(server, &uri_voice_reconnect);
     httpd_register_uri_handler(server, &uri_video_start);

--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -774,6 +774,10 @@ void cb_record_btn(lv_event_t *e)
         }
         if (!s_rec_timer) s_rec_timer = lv_timer_create(rec_timer_cb, REC_FPS_MS, NULL);
         ESP_LOGI(TAG, "rec: start -> %s", s_rec_path);
+        {
+            extern void tab5_debug_obs_event(const char *kind, const char *detail);
+            tab5_debug_obs_event("camera.record_start", s_rec_path);
+        }
         return;
     }
 
@@ -791,6 +795,14 @@ void cb_record_btn(lv_event_t *e)
     toast_show(msg);
     ESP_LOGI(TAG, "rec: stop %s frames=%u bytes=%u",
              s_rec_path, s_rec_frame_count, s_rec_bytes_total);
+    {
+        extern void tab5_debug_obs_event(const char *kind, const char *detail);
+        char detail[160];
+        snprintf(detail, sizeof(detail), "%s frames=%u bytes=%u",
+                 s_rec_path, (unsigned)s_rec_frame_count,
+                 (unsigned)s_rec_bytes_total);
+        tab5_debug_obs_event("camera.record_stop", detail);
+    }
     /* Send-to-Dragon — fire-and-forget HTTP upload via voice's existing
      * /api/media/upload helper. */
     extern void voice_upload_chat_image(const char *filepath);
@@ -917,6 +929,10 @@ static void capture_btn_cb(lv_event_t *e)
 
     capture_counter++;
     ESP_LOGI(TAG, "Photo saved: %s", path);
+    {
+        extern void tab5_debug_obs_event(const char *kind, const char *detail);
+        tab5_debug_obs_event("camera.capture", path);
+    }
 
     /* Update gallery button text */
     if (lbl_gallery) {

--- a/main/voice.c
+++ b/main/voice.c
@@ -379,6 +379,20 @@ static void voice_set_state(voice_state_t new_state, const char *detail)
          * tab5_lv_async_call(), lock-free and thread-safe. */
         extern void ui_home_refresh_sys_label(void);
         ui_home_refresh_sys_label();
+
+        /* #293: emit a debug obs event on every state transition so the
+         * e2e harness can subscribe to /events instead of polling
+         * /voice every 200ms. */
+        if (old != new_state) {
+            extern void tab5_debug_obs_event(const char *kind, const char *detail);
+            const char *names[] = {
+                "IDLE", "CONNECTING", "READY",
+                "LISTENING", "PROCESSING", "SPEAKING", "RECONNECTING",
+            };
+            const char *name = (new_state >= 0 && new_state < (int)(sizeof(names)/sizeof(names[0])))
+                ? names[new_state] : "UNKNOWN";
+            tab5_debug_obs_event("voice.state", name);
+        }
     }
 
     /* v4·D Gauntlet G1: drain the queued turn on transition to READY.
@@ -1073,6 +1087,14 @@ static void handle_text_message(const char *data, int len)
                  cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,
                  (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
                  (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+        /* #293: emit obs event for e2e harness. */
+        {
+            extern void tab5_debug_obs_event(const char *kind, const char *detail);
+            char latency_str[24];
+            snprintf(latency_str, sizeof(latency_str), "%.0f",
+                     cJSON_IsNumber(ms) ? ms->valuedouble : 0.0);
+            tab5_debug_obs_event("chat.llm_done", latency_str);
+        }
         /* Prefer the full text field in llm_done (TC bypass uses it)
          * falling back to the accumulated streamed tokens. */
         cJSON *full = cJSON_GetObjectItem(root, "text");
@@ -1749,6 +1771,9 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
 
     case WEBSOCKET_EVENT_CONNECTED: {
         ESP_LOGI(TAG, "WS: CONNECTED — sending register frame");
+        /* #293: emit obs event for e2e harness. */
+        extern void tab5_debug_obs_event(const char *kind, const char *detail);
+        tab5_debug_obs_event("ws.connect", "");
         /* US-C02: bump session gen on every successful connect. */
         s_session_gen++;
         s_handshake_fail_cnt = 0;
@@ -1777,6 +1802,10 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
 
     case WEBSOCKET_EVENT_DISCONNECTED:
         ESP_LOGW(TAG, "WS: DISCONNECTED");
+        {
+            extern void tab5_debug_obs_event(const char *kind, const char *detail);
+            tab5_debug_obs_event("ws.disconnect", "");
+        }
         /* Flush playback so we don't keep speaking into a dead pipe. */
         playback_buf_reset();
         tab5_audio_speaker_enable(false);


### PR DESCRIPTION
## Summary
Two gaps that made remote-driven e2e tests brittle:
1. **No `GET /screen`** — could navigate via `POST /navigate` but no way to ask "what screen am I on?"
2. **`/events` mostly empty** — only display/audio/NVS sites called `tab5_debug_obs_event()`. Voice state, navigation, LLM done, WS connect/disconnect, camera/record were all silent.

## Adds
- **`GET /screen`** — returns current screen + overlay visibility (chat/voice/settings)
- **6 new `tab5_debug_obs_event()` call sites:**
  - `screen.navigate` (debug_server navigate handler)
  - `voice.state` (voice_set_state — every transition)
  - `ws.connect` / `ws.disconnect` (voice WS event handler)
  - `chat.llm_done` (voice llm_done JSON handler, with latency_ms detail)
  - `camera.capture` (capture_btn_cb)
  - `camera.record_start` / `camera.record_stop` (cb_record_btn)

## Verified live
- Built clean, flashed Tab5, booted at 36 s.
- `GET /screen` returns `{"current":"home","overlays":{...}}`
- `GET /events?since=0` returns boot events: `voice.state CONNECTING` → `ws.connect` → `voice.state READY`
- After two `POST /navigate` calls, `/events` shows `screen.navigate settings` and `screen.navigate home`

No behavior change. Pure observability for the e2e harness PR landing next.

## Test plan
- [x] Compiles clean
- [x] Flashes successfully
- [x] `/screen` endpoint returns valid JSON
- [x] All new event types fire
- [x] Existing tests unaffected
