### PR TITLE
feat(debug): POST /input/text for harness typing into focused textarea (refs #296)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -1999,6 +1999,154 @@ static esp_err_t chat_handler(httpd_req_t *req)
     return ret;
 }
 
+/* Forward decl — definition is further down the file. */
+static esp_err_t send_json_resp(httpd_req_t *req, cJSON *root);
+
+/* ── POST /input/text — type into the focused LVGL textarea (#296) ────
+ *
+ * Body: {"text": "string", "submit": true|false}
+ * (Also accepts ?text= and ?submit= query params for short payloads.)
+ *
+ * Walks lv_screen_active() + lv_layer_top() looking for textareas; if
+ * one has LV_STATE_FOCUSED that wins, otherwise picks the first
+ * textarea found (deepest-first via recursion).  When `submit` is
+ * true, dispatches LV_EVENT_READY after the write — same path the
+ * keyboard's Done key takes for form submission.
+ *
+ * Returns:
+ *   {"ok": true,  "accepted": N, "submitted": bool, "widget": "0x…"}
+ *   {"ok": false, "error": "no_textarea"}
+ */
+typedef struct {
+    lv_obj_t *focused;
+    lv_obj_t *fallback;
+} find_ta_ctx_t;
+
+static void find_ta_walk(lv_obj_t *node, find_ta_ctx_t *ctx)
+{
+    if (!node) return;
+    /* lv_obj_check_type uses class pointer comparison; the
+     * lv_textarea_class symbol is exported by the LVGL textarea unit. */
+    extern const lv_obj_class_t lv_textarea_class;
+    if (lv_obj_check_type(node, &lv_textarea_class)) {
+        if (!ctx->fallback) ctx->fallback = node;
+        if (lv_obj_has_state(node, LV_STATE_FOCUSED)) ctx->focused = node;
+    }
+    uint32_t n = lv_obj_get_child_count(node);
+    for (uint32_t i = 0; i < n && !ctx->focused; i++) {
+        find_ta_walk(lv_obj_get_child(node, i), ctx);
+    }
+}
+
+typedef struct {
+    char text[1024];
+    bool submit;
+    /* Reply slot — written by the LVGL-thread executor. */
+    bool ok;
+    int  accepted;
+    bool submitted;
+    void *widget;
+    char  err[40];
+    SemaphoreHandle_t done;
+} input_text_args_t;
+
+static void input_text_apply_lvgl(void *arg)
+{
+    input_text_args_t *a = (input_text_args_t *)arg;
+    find_ta_ctx_t ctx = {0};
+    /* Walk active screen + lv_layer_top so overlays count. */
+    find_ta_walk(lv_screen_active(), &ctx);
+    if (!ctx.focused) find_ta_walk(lv_layer_top(), &ctx);
+    lv_obj_t *ta = ctx.focused ? ctx.focused : ctx.fallback;
+    if (!ta) {
+        a->ok = false;
+        snprintf(a->err, sizeof(a->err), "no_textarea");
+    } else {
+        lv_textarea_set_text(ta, a->text);
+        a->ok = true;
+        a->accepted = (int)strlen(a->text);
+        a->widget = ta;
+        if (a->submit) {
+            lv_obj_send_event(ta, LV_EVENT_READY, NULL);
+            a->submitted = true;
+        }
+    }
+    xSemaphoreGive(a->done);
+}
+
+static esp_err_t input_text_handler(httpd_req_t *req)
+{
+    if (!check_auth(req)) return ESP_OK;
+
+    input_text_args_t a = {0};
+    a.done = xSemaphoreCreateBinary();
+    if (!a.done) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_sendstr(req, "{\"error\":\"oom\"}");
+        return ESP_OK;
+    }
+
+    /* Query string first (small payloads). */
+    char query[1280] = {0};
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+        httpd_query_key_value(query, "text", a.text, sizeof(a.text));
+        char sv[8] = {0};
+        if (httpd_query_key_value(query, "submit", sv, sizeof(sv)) == ESP_OK) {
+            a.submit = (sv[0] == '1' || sv[0] == 't');
+        }
+    }
+
+    /* Body fallback (JSON). */
+    if (a.text[0] == '\0') {
+        int total = req->content_len;
+        if (total > 0 && total < 4096) {
+            char *body = heap_caps_malloc(total + 1, MALLOC_CAP_SPIRAM);
+            if (body) {
+                int got = 0;
+                while (got < total) {
+                    int r = httpd_req_recv(req, body + got, total - got);
+                    if (r <= 0) break;
+                    got += r;
+                }
+                body[got] = '\0';
+                cJSON *root = cJSON_Parse(body);
+                heap_caps_free(body);
+                if (root) {
+                    cJSON *t = cJSON_GetObjectItem(root, "text");
+                    cJSON *s = cJSON_GetObjectItem(root, "submit");
+                    if (cJSON_IsString(t) && t->valuestring) {
+                        snprintf(a.text, sizeof(a.text), "%s", t->valuestring);
+                    }
+                    if (cJSON_IsBool(s)) a.submit = cJSON_IsTrue(s);
+                    cJSON_Delete(root);
+                }
+            }
+        }
+    }
+
+    /* Even an empty string is a valid clear-the-field operation, so
+     * we don't reject; just dispatch. */
+    tab5_lv_async_call(input_text_apply_lvgl, &a);
+    /* Wait for the LVGL-thread to fill the reply (cap at 2 s — should
+     * be sub-millisecond in practice). */
+    xSemaphoreTake(a.done, pdMS_TO_TICKS(2000));
+    vSemaphoreDelete(a.done);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", a.ok);
+    if (a.ok) {
+        cJSON_AddNumberToObject(root, "accepted", a.accepted);
+        cJSON_AddBoolToObject(root, "submitted", a.submitted);
+        char wbuf[20];
+        snprintf(wbuf, sizeof(wbuf), "%p", a.widget);
+        cJSON_AddStringToObject(root, "widget", wbuf);
+    } else {
+        cJSON_AddStringToObject(root, "error",
+                                a.err[0] ? a.err : "unknown");
+    }
+    return send_json_resp(req, root);
+}
+
 /* ── Wi-Fi kick endpoint (test harness) ──────────────────────────────── */
 /* POST /wifi/kick?mode=soft|hard|reboot — force the escalation tiers
  * from #146.  Used by the test harness to verify recovery paths without
@@ -2906,6 +3054,14 @@ static esp_err_t events_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
+/* #296 follow-up: a `block_until=<kind>&timeout_ms=N` long-poll
+ * variant of /events was experimentally added and reverted.  ESP-IDF
+ * httpd is single-task — the long-poll vTaskDelay blocked all other
+ * debug-server requests for the wait duration, and a multi-minute
+ * test run accumulated enough heap churn from the per-iteration
+ * cJSON alloc/free to crash the device with a PANIC reset.  Polling
+ * /events at 250-500 ms from the harness side is the safe pattern. */
+
 /* ── GET /heap/history?n=60 ─────────────────────────────────────── */
 static esp_err_t heap_history_handler(httpd_req_t *req)
 {
@@ -3384,6 +3540,9 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_chat = {
         .uri = "/chat", .method = HTTP_POST, .handler = chat_handler
     };
+    const httpd_uri_t uri_input_text = {
+        .uri = "/input/text", .method = HTTP_POST, .handler = input_text_handler
+    };
     const httpd_uri_t uri_screen = {
         .uri = "/screen", .method = HTTP_GET, .handler = screen_state_handler
     };
@@ -3492,6 +3651,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_ota_check);
     httpd_register_uri_handler(server, &uri_ota_apply);
     httpd_register_uri_handler(server, &uri_chat);
+    httpd_register_uri_handler(server, &uri_input_text);
     httpd_register_uri_handler(server, &uri_screen);
     httpd_register_uri_handler(server, &uri_voice_state);
     httpd_register_uri_handler(server, &uri_voice_reconnect);

--- a/tests/e2e/driver.py
+++ b/tests/e2e/driver.py
@@ -222,7 +222,13 @@ class Tab5Driver:
                     detail_match: Callable[[str], bool] | None = None,
                     poll_ms: int = 250) -> Event | None:
         """Block until an event of `kind` appears, or timeout.  Optional
-        `detail_match` filter on the detail string."""
+        `detail_match` filter on the detail string.
+
+        Uses simple polling.  An experimental server-side long-poll
+        was reverted (see debug_server.c #296 follow-up note) — ESP-IDF
+        httpd is single-task and held all other debug requests for
+        the wait duration.
+        """
         deadline = time.time() + timeout_s
         while time.time() < deadline:
             try:
@@ -236,21 +242,33 @@ class Tab5Driver:
             time.sleep(poll_ms / 1000.0)
         return None
 
-    def await_voice_state(self, state: str, timeout_s: float = 30) -> bool:
-        """Wait for voice state == `state`. Checks current state first
-        (in case the transition fired before this call), then polls
-        future events."""
-        try:
-            cur = self.voice_state().get("state_name", "")
-            if cur == state:
+    def input_text(self, text: str, submit: bool = False) -> dict:
+        """Type `text` into the currently-focused LVGL textarea.
+        Optional `submit=True` dispatches LV_EVENT_READY (form submit)."""
+        return self._post("/input/text",
+                          json={"text": text, "submit": submit}).json()
+
+    def await_voice_state(self, state: str, timeout_s: float = 60) -> bool:
+        """Wait for voice state == `state` — re-checks /voice every
+        ~1s in addition to watching voice.state events, so a transition
+        that fired before our cursor still gets picked up."""
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            try:
+                cur = self.voice_state().get("state_name", "")
+                if cur == state:
+                    return True
+            except Exception:
+                pass
+            # Watch the event ring for up to ~1s, then re-check current state
+            evt = self.await_event(
+                "voice.state",
+                timeout_s=min(1.0, max(0.1, deadline - time.time())),
+                detail_match=lambda d: d == state,
+            )
+            if evt is not None:
                 return True
-        except Exception:
-            pass
-        evt = self.await_event(
-            "voice.state", timeout_s=timeout_s,
-            detail_match=lambda d: d == state,
-        )
-        return evt is not None
+        return False
 
     def await_screen(self, screen: str, timeout_s: float = 5) -> bool:
         try:


### PR DESCRIPTION
## Summary
Adds the typing primitive the e2e harness was missing — chat input / notes edit / WiFi password / settings text fields can now be filled remotely instead of simulating on-screen keyboard taps one character at a time.

## What
`POST /input/text` body `{"text":"…","submit":true|false}` (or `?text=&submit=1` query).
- Walks active screen + `lv_layer_top()` for textareas; `LV_STATE_FOCUSED` wins.
- Calls `lv_textarea_set_text()`.
- `submit=true` dispatches `LV_EVENT_READY` (same event the on-screen keyboard's Done key fires).
- Runs on LVGL thread via `tab5_lv_async_call`, waits on binary semaphore for reply.

## Harness
`Tab5Driver.input_text(text, submit=False)` exposes it.
`await_voice_state` updated to also poll `/voice` every ~1s alongside event watching, so transitions that fired before cursor get caught.

## Long-poll experiment reverted
A `?block_until=&timeout_ms=` long-poll for `/events` was prototyped but **caused a PANIC reset** under stress.  ESP-IDF httpd is single-task: the vTaskDelay blocked all other debug requests for the wait duration, and multi-minute test runs accumulated enough heap churn from per-iteration cJSON alloc/free to crash. Reverted; harness uses 250 ms polling. Note left in code for the next person.

## Verified live
- Navigate chat → `/input/text` 'hi from harness' → `ok:true, accepted:15`
- Submit=true → `ok:true, submitted:true`
- Empty text (clear) → `ok:true, accepted:0`
- Reverted /events long-poll: existing simple-poll path still works (event count 7 returned in <50ms).

## Test plan
- [x] Builds clean
- [x] Flashes successfully
- [x] /input/text returns 200 with valid JSON
- [x] LV_EVENT_READY fires on submit=true
- [x] No PANIC after sustained smoke run
- [x] Existing /events polling unaffected