### PR TITLE
docs: cover the new debug endpoints + e2e harness + camera recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,108 @@ curl -s -H "Authorization: Bearer $TOKEN" -X POST http://192.168.1.90:8080/voice
 
 # Self-test (no auth needed)
 curl -s http://192.168.1.90:8080/selftest | python3 -m json.tool
+
+# ── Harness-friendly endpoints (#293/#294/#296/#297, April 2026) ──
+# Current screen + overlay visibility (chat/voice/settings)
+curl -s -H "Authorization: Bearer $TOKEN" http://192.168.1.90:8080/screen | python3 -m json.tool
+# → {"current":"home","overlays":{"chat":false,"voice":false,"settings":false}}
+
+# Type into the focused LVGL textarea — also accepts ?text=&submit=1 query.
+# submit=true dispatches LV_EVENT_READY (same event the Done key fires).
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://192.168.1.90:8080/input/text \
+     -d '{"text":"hello world","submit":true}'
+
+# Long-press at a coordinate (450ms default; 500-5000ms range via duration_ms)
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://192.168.1.90:8080/touch \
+     -d '{"x":360,"y":640,"action":"long_press","duration_ms":1200}'
+
+# Swipe between tile pages (20ms step cadence; 50-3000ms total via duration_ms)
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://192.168.1.90:8080/touch \
+     -d '{"action":"swipe","x1":600,"y1":640,"x2":120,"y2":640,"duration_ms":300}'
+
+# Observability events ring — read everything since uptime_ms=N.
+# Kinds: obs, screen.navigate, voice.state, ws.connect, ws.disconnect,
+#        chat.llm_done, camera.capture, camera.record_start, camera.record_stop,
+#        display.brightness, audio.volume, audio.mic_mute, nvs.
+# Polling-only (long-poll was tried + reverted: PANIC under load on
+# single-threaded httpd — see LEARNINGS).
+curl -s -H "Authorization: Bearer $TOKEN" "http://192.168.1.90:8080/events?since=0" | python3 -m json.tool
 ```
+
+### Observability events
+`tab5_debug_obs_event(kind, detail)` (in `main/debug_obs.{c,h}`) writes to a 32-slot
+ring; `GET /events?since=N` returns everything with `ms >= N`.  Each entry has
+`{"ms": uptime_ms, "kind": "category.subkind", "detail": "..."}`.
+
+| Kind | Where it fires | Detail |
+|------|----------------|--------|
+| `obs` | Boot | `"init"` once |
+| `screen.navigate` | `POST /navigate` handler | target screen name |
+| `voice.state` | `voice_set_state()` on every state transition | `IDLE`/`CONNECTING`/`READY`/`LISTENING`/`PROCESSING`/`SPEAKING`/`RECONNECTING` |
+| `ws.connect` / `ws.disconnect` | WS event handler | empty |
+| `chat.llm_done` | WS llm_done JSON handler | `llm_ms` value as string |
+| `camera.capture` | `capture_btn_cb` after photo saved | absolute SD path |
+| `camera.record_start` / `camera.record_stop` | `cb_record_btn` toggle | path + frame/byte counts on stop |
+| `display.brightness` | `POST /display/brightness` handler | percentage |
+| `audio.volume` / `audio.mic_mute` | `POST /audio` handler | new value |
+| `nvs` | `POST /nvs/erase` | `"erase"` |
+
+The `kind` buffer is 32 chars; `detail` is 48 chars (silently truncated past those).
+Ring is 256 entries, FIFO eviction.
+
+## End-to-End Test Harness
+
+Python-driven scenario runner in [`tests/e2e/`](./tests/e2e/) that drives Tab5
+through long user-story flows via the debug HTTP server above.  See
+[`tests/e2e/README.md`](./tests/e2e/README.md) for the authoring guide.
+
+```bash
+cd ~/projects/TinkerTab
+export TAB5_TOKEN=05eed3b13bf62d92cfd8ac424438b9f2
+
+python3 tests/e2e/runner.py story_smoke    # ~2 min  — nav + voice + camera basics
+python3 tests/e2e/runner.py story_full     # ~2 min  — all 4 voice modes + photo + REC + cloud chat
+python3 tests/e2e/runner.py story_stress   # ~10 min — 6 cycles of mode×screen×chat with heap watchdog
+python3 tests/e2e/runner.py all --reboot   # all 3 with a clean reboot first
+```
+
+Each run produces a per-run directory under `tests/e2e/runs/` (gitignored)
+with:
+- `report.json` — machine-readable pass/fail per step + events captured
+- `report.md`   — human-readable table with inline screenshots
+- `NN_<step>.jpg` — per-step JPEG screenshot
+
+Last validated 2026-04-27: **smoke 14/14, full 24/24, stress 76/77 (single
+LLM-timeout flake — Q6A latency, not a regression)**.
+
+### Driver primitives
+`Tab5Driver` in [`tests/e2e/driver.py`](./tests/e2e/driver.py) wraps the debug
+HTTP API.  Key building blocks:
+- `tab5.tap(x, y)` / `long_press(x, y, ms)` / `swipe(x1, y1, x2, y2)`
+- `tab5.navigate("camera")` (auto-debounced — 600 ms minimum gap)
+- `tab5.screen()` / `tab5.voice_state()` / `tab5.heap()`
+- `tab5.chat(text)` / `tab5.input_text(text, submit=False)`
+- `tab5.mode(0|1|2|3, model="...")`
+- `tab5.camera_frame(save_path)` / `tab5.video_call_start(fps)` / `tab5.call_status()`
+- `tab5.screenshot("/path.jpg")`
+- `tab5.await_event(kind, timeout_s, detail_match=...)` — polls `/events`
+- `tab5.await_voice_state("READY", 60)` — polls `/voice` AND watches events
+- `tab5.await_screen("camera", 5)` / `tab5.await_llm_done(180)`
+
+### Bugs the harness has caught
+Listed in chronological order from real runs:
+1. **Cursor-stealing in events polling** — diagnostic per-step snapshot was
+   advancing `_last_event_ms`, so subsequent `await_event` missed events fired
+   during prior steps.  Fixed via `events(peek=True)`.  See LEARNINGS in
+   TinkerBox repo (#92).
+2. **`obs_event_t.kind` 16-char buffer too small** — `camera.record_start`
+   silently truncated to `camera.record_s`.  Bumped to 32 (#294 / `debug_obs.c`).
+3. **Boot `READY` race** — `await_voice_state` only polled future events;
+   boot's `voice.state READY` fires before harness reset its cursor.  Fixed
+   to also poll `/voice` current state every ~1 s.
+4. **`/events` long-poll attempt → PANIC** — ESP-IDF httpd is single-task,
+   `vTaskDelay` blocked all other requests + accumulated heap fragmentation.
+   Reverted; harness uses 250 ms polling.
 
 ## ESP32-P4 Memory Rules
 - **PSRAM for large buffers (>4KB):** Use `heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)`. Static BSS arrays eat limited internal SRAM (~512KB shared with FreeRTOS).
@@ -271,9 +372,43 @@ Settings dropdown: **Local / Hybrid / Full Cloud / TinkerClaw**
 - **Driver:** Uses `esp_video` + `esp_cam_sensor` stack from M5Stack (NOT raw CSI API)
 - **Resolution:** 1280×720 @ 30fps RGB565
 - **Exposure:** Tuned for indoor lighting (SCCB register writes post-init)
-- **Debug:** `GET /camera` returns live frame as BMP
+- **Debug:** `GET /camera` returns live frame as JPEG
 - **CONFIG_CAMERA_SC202CS=y** must be set in sdkconfig (sensor won't compile without it!)
-- **Software rotation:** NVS `cam_rot` (0/1/2/3 = 0/90/180/270° CW) is applied to each captured frame before display/upload. Settings dropdown writes the key. Added in #261.
+- **Software rotation:** NVS `cam_rot` (0/1/2/3 = 0/90/180/270° CW) is applied to each captured frame before display/upload. Settings dropdown + an in-viewfinder "Rot" button writes the key. Added in #261; live cycle button + PIP rotation in #290.
+
+### Photo capture
+Tap the white circular shutter button (center of the bottom control bar). Saved
+as `/sdcard/IMG_NNNN.jpg` (4-digit counter resumed from existing files on boot).
+Emits `camera.capture` obs event with the saved path. When the camera screen was
+launched from the chat overlay (via "Send photo" button), the capture also
+auto-uploads to Dragon's `/api/media/upload` and announces a `user_image` WS
+event so the chat threads it inline.
+
+### Video recording (#291)
+Tap the red-bordered REC pill button (right of the shutter, before Gallery).
+Records concatenated motion-JPEG to `/sdcard/VID_NNNN.MJP` at 5 fps,
+quality 60, with the same `cam_rot` applied so the recording matches the
+viewfinder.  Tap REC again to stop.
+
+- **File format:** `.MJP` (3-char extension because `CONFIG_FATFS_LFN_NONE=1`
+  forces 8.3 short names — `.mjpeg` would fail). ffmpeg + VLC sniff the magic
+  bytes and play these natively: `ffplay -f mjpeg VID_NNNN.MJP`.
+- **Encoder:** Shared with `voice_video.c` (the call-streaming module) via
+  `voice_video_encode_rgb565()`.  ESP32-P4 has only one HW JPEG engine —
+  attempting to allocate a second crashes with "no memory for jpeg encoder
+  rxlink".  Mutex-guarded inside `voice_video.c`.
+- **Hard cap:** 1500 frames (5 min × 60 s × 5 fps).  Exceeding the cap auto-
+  stops the recording.
+- **DMA buffers:** Allocated lazily on first record start via
+  `jpeg_alloc_encoder_mem()` (DMA-aligned PSRAM); freed when the camera
+  screen is destroyed.  Plain `heap_caps_malloc` doesn't satisfy the JPEG
+  engine's bit-stream alignment requirement.
+- **Auto-upload to Dragon:** On stop, `voice_upload_chat_image(s_rec_path)`
+  POSTs the file to `/api/media/upload`.  The response `media_id` is then
+  announced as a `user_image` WS event so it appears in the chat thread.
+- **Obs events:** `camera.record_start` (path) and `camera.record_stop`
+  (`path frames=N bytes=N`).  The e2e harness (`story_full`) exercises the
+  full start → 6 s record → stop cycle.
 
 ## Two-way Video Calling (April 2026)
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1042,3 +1042,65 @@ Every entry here was learned the hard way. Read this before touching the codebas
 - **Root Cause:** `fflush()` pushes libc's buffer into the kernel; the ESP-IDF FATFS VFS still holds dirty sectors in its own cache until an `f_sync()` lands. The atomic-rename pattern doesn't help if the "new" file is itself half-written.
 - **Fix:** Added `fsync(fileno(f))` between `fflush` and `fclose`. ESP-IDF VFS routes `fsync()` to FATFS's `f_sync()` which pushes dirty sectors to the SD card before we even try the rename.
 - **Prevention:** Atomic-write-via-rename is only atomic if you `fsync` the temp file before renaming. The pattern is: write → fflush → fsync → fclose → rename. Skip any of those steps and the atomicity is theatrical.
+
+---
+
+## Multimodal + Camera
+
+### MJPEG file extension forced to .MJP because LFN is disabled
+- **Date:** 2026-04-27
+- **Symptom:** First end-to-end test of video recording (#291) — REC button tapped, `cb_record_btn` fired, but `fopen("/sdcard/VID_0000.mjpeg", "wb")` returned NULL.  Toast read "Open file failed" and obs ring showed `rec: fopen ... failed`.
+- **Root Cause:** `CONFIG_FATFS_LFN_NONE=1` in sdkconfig.defaults — FATFS only allows 8.3 short filenames.  `.mjpeg` is 5 characters, which doesn't fit the 3-char extension limit.  Other code in the firmware uses 3-char extensions (`.jpg`, `.bmp`, `.wav`, `.txt`) and never tripped this — recording was the first time anything tried `.mjpeg`.
+- **Fix:** Renamed extension to `.MJP` (3 chars).  ffmpeg + VLC sniff the magic bytes and play these natively regardless of extension; `.MJP` is just a cosmetic affordance.  Documented in `ui_camera.c` so the next person doesn't try `.mjpeg` again.
+- **Prevention:**
+  1. **8.3-only is one `grep CONFIG_FATFS_LFN sdkconfig.h` away** — when a new file extension is being introduced, check the LFN config first.
+  2. **Enabling LFN costs RAM** (`LFN_BUF_SIZE` per open file) so the tradeoff is real.  Stay 8.3 unless a feature genuinely requires it.
+
+### ESP32-P4 has only one HW JPEG encoder engine (`jpeg_new_encoder_engine` fails on second alloc)
+- **Date:** 2026-04-27
+- **Symptom:** `ui_camera.c` recording feature initially tried `jpeg_new_encoder_engine()` to get its own encoder.  Always failed with `E (xxx) jpeg.encoder: jpeg_new_encoder_engine(93): no memory for jpeg encoder rxlink` because `voice_video.c` (the call-streaming module) had already allocated the only one at boot.
+- **Root Cause:** The ESP32-P4 SoC has a single hardware JPEG engine (named "rxlink" in IDF).  `jpeg_new_encoder_engine()` claims it; a second call fails.  IDF doesn't expose this as a documented limit but the error message + Espressif HW docs confirm it.
+- **Fix:** Exposed `voice_video_encode_rgb565()` as a public function in `voice_video.{c,h}`.  The recording timer in `ui_camera.c` calls it instead of allocating its own encoder.  The mutex inside `voice_video.c` serialises concurrent uplink-stream + record-to-SD encodes.
+- **Prevention:**
+  1. **For singleton hardware resources, expose a shared accessor + mutex from the module that owns it.**  Don't let multiple modules try to claim the same HW.
+  2. **Check `idf.py -c menuconfig | grep -i jpeg`** at design time — the encoder is a single resource, the decoder ring is also limited.
+
+### Camera recording needs DMA-aligned buffers (`heap_caps_malloc` isn't enough)
+- **Date:** 2026-04-27
+- **Symptom:** First version of the `.MJP` recorder allocated the JPEG output buffer with `heap_caps_malloc(96 KB, MALLOC_CAP_SPIRAM)`.  Encoder returned `ESP_ERR_INVALID_ARG: bit stream is not aligned`.
+- **Root Cause:** The ESP32-P4 JPEG engine reads/writes via DMA and requires its buffers to be aligned to (at minimum) the SoC's cache-line + DMA descriptor size.  Plain PSRAM allocations don't guarantee this alignment.  IDF provides `jpeg_alloc_encoder_mem(size, &cfg, &actual)` which understands the engine's alignment requirements and returns a properly-positioned buffer.
+- **Fix:** Replaced both the JPEG output buffer and the rotation scratch buffer with `jpeg_alloc_encoder_mem()` calls.  The lazy-allocated buffers persist for the lifetime of the camera screen and free in `ui_camera_destroy()`.
+- **Prevention:**
+  1. **For any HW peripheral with DMA, use the IDF-provided allocator helpers** — `jpeg_alloc_encoder_mem`, `dma_alloc_aligned`, etc.  Plain `heap_caps_malloc(MALLOC_CAP_DMA)` only ensures DMA-capable memory; it doesn't guarantee the alignment a specific peripheral requires.
+  2. **Free symmetrically** — the IDF docs aren't always clear which `free` to use.  For `jpeg_alloc_encoder_mem`-returned buffers, plain `free()` is correct (verified via `voice_video.c` precedent).
+
+---
+
+## Debug + Test Harness
+
+### `obs_event_t.kind` 16-char buffer truncated `camera.record_start` to `camera.record_s`
+- **Date:** 2026-04-27
+- **Symptom:** E2E harness's `await_event("camera.record_start", timeout_s=8)` failed every time, even though /events showed an event named `camera.record_s` was firing on REC tap.
+- **Root Cause:** `obs_event_t.kind` was a `char[16]` buffer in `debug_obs.c`.  PR #294 added new event names like `camera.record_start` (19 chars) and `camera.record_stop` (18 chars) — both silently truncated by the `snprintf` write into the fixed buffer.
+- **Fix:** Bumped buffer to `char[32]` in PR #295 (firmware fix included alongside the harness commit).  Existing 16-char names like `voice.state` still fit; new names have 50% headroom.
+- **Prevention:**
+  1. **Whenever you add a new event-name string, check it fits the buffer** — better, use a compile-time `_Static_assert(sizeof("camera.record_start") <= sizeof(((obs_event_t*)0)->kind))` in `debug_obs.c`.  TBD as a follow-up; not blocking.
+  2. **Truncation in observability layers is silent by definition** — the event still gets written, just with the wrong name.  Test harnesses doing exact-string matching will fail without a clear error.
+
+### ESP-IDF httpd is single-task — long-poll handlers freeze the entire debug server
+- **Date:** 2026-04-27
+- **Symptom:** Experimental `?block_until=&timeout_ms=` long-poll variant of `GET /events` worked correctly when the matching event was already in the ring (21 ms first-call latency) but blocked all other requests for the wait duration.  After a multi-minute test run, Tab5 hit a PANIC reset.
+- **Root Cause:** ESP-IDF's `esp_http_server` uses one `httpd_task` to service all connections via `select()`.  When a handler `vTaskDelay`s, every other in-flight or pending request waits.  My implementation also re-allocated the cJSON events array on every 200 ms iteration — across ~minute-long waits, the per-iteration alloc/free churn accumulated heap fragmentation that eventually pushed the device over.
+- **Fix:** Reverted the long-poll feature.  `GET /events?since=N` stays instant-return only.  Note left in `debug_server.c` so the next person who reaches for "but long-poll would be nice" sees the prior art and doesn't try the same approach.  Harness in `tests/e2e/driver.py` uses 250 ms polling instead.
+- **Prevention:**
+  1. **Single-thread http servers cannot host long-poll handlers** — a `vTaskDelay` inside the request handler is equivalent to taking the whole server offline for the wait duration.  If you need push-style notification, either (a) use a different transport (a dedicated WebSocket on a separate task), (b) spawn a per-request background task via `httpd_queue_work`, or (c) just tell the client to poll faster.
+  2. **Per-iteration heap allocation in tight loops on ESP32 is suspicious** — even if balanced (alloc + free), the TLSF heap fragments.  Allocate-once + reuse, or batch the work outside the loop.
+
+### Diagnostic event-snapshots advance the cursor that subsequent waiters need
+- **Date:** 2026-04-27
+- **Symptom:** Harness's `await_event("camera.capture", timeout_s=10)` failed after a `tap(360,1100)` even though `/screenshot` clearly showed "Photo saved!" toast and direct `/events?since=0` confirmed `camera.capture` was in the ring.
+- **Root Cause:** `Tab5Driver.events()` advances `_last_event_ms` to the latest event's timestamp on every call.  The scenario runner's per-step diagnostic block called `events(since_ms=events_before)` to capture what fired during the step — and inadvertently advanced the cursor *past* the events it captured.  The next step's `await_event` started polling from a cursor that was already in the future relative to the events it was looking for.
+- **Fix:** Added `peek=True` parameter to `events()`.  When `peek=True`, the cursor doesn't advance.  The scenario runner's diagnostic snapshot uses `peek=True`; explicit `await_event` still advances the cursor.
+- **Prevention:**
+  1. **Stateful side effects in "read" methods are easy to write and hard to debug.**  Whenever a read advances a cursor, give callers an opt-out for the side effect.
+  2. **Diagnostic plumbing should never compete with primary control plumbing.**  Capturing "what happened" for a report is observation; consuming events for routing is action.  Separate the two.


### PR DESCRIPTION
## Summary
Doc sweep tied to the recent firmware PRs. Audit flagged 4 shipped features with **zero CLAUDE.md mention**: REC button (#291), `GET /screen` (#294), `POST /input/text` (#297), and the entire e2e harness (#295).

## What's documented now
| Section | What changed |
|---------|--------------|
| **Debug Server** | New harness-friendly endpoints with worked curl examples (`/screen`, `/input/text`, long_press, swipe, `/events`). New "Observability events" subsection with full event-kind table (when each fires, detail format, buffer constraints). |
| **End-to-End Test Harness (NEW H2)** | Quickstart for the 3 scenarios, per-run output structure, latest validated counts (smoke 14/14, full 24/24, stress 76/77), driver primitive cheat sheet, list of 4 real bugs the harness has caught. |
| **Camera** | New "Photo capture" + "Video recording (#291)" subsections covering REC button, .MJP format gotcha (LFN disabled), shared HW JPEG encoder, DMA-aligned buffers, auto-upload to Dragon, obs events. |
| **LEARNINGS.md** | 4 new entries on the recent root-cause findings: MJPEG file extension forced to .MJP, single ESP32-P4 JPEG engine, DMA buffer alignment, kind-buffer truncation, ESP-IDF httpd long-poll PANIC, events cursor-stealing. |

## No code change
Pure docs.

## Test plan
- [x] Markdown renders cleanly
- [x] All curl examples copy-paste-runnable
- [x] All linked PRs exist in repo history