### PR TITLE
docs: world-class onboarding — HARDWARE + GLOSSARY + cross-repo signposts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # TinkerTab — TinkerOS Firmware (ESP32-P4 Tab5) — THE FACE
 
+> **Trying to understand what this project IS rather than how to operate it?**  Start with [TinkerBox's `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) — the canonical "what is TinkerClaw?" doc, with diagrams of how Tab5 + Dragon + TinkerClaw fit together. Then [`docs/HARDWARE.md`](docs/HARDWARE.md) for the Tab5 pinout + IC list, and [`GLOSSARY.md`](GLOSSARY.md) for any unfamiliar terms.  This file (CLAUDE.md) is the *runbook* — deploy, debug, restart, monitor.
+
 ## Active Investigations — READ FIRST before related work
 
 - **Stability — CLOSED** → [`docs/STABILITY-INVESTIGATION.md`](docs/STABILITY-INVESTIGATION.md)

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,175 @@
+# Tab5 Firmware Glossary
+
+> Terms specific to TinkerTab (the firmware repo).  For shared terms
+> across both repos (router, fleet, modality, capability, etc.) see
+> [TinkerBox's GLOSSARY.md](https://github.com/lorcan35/TinkerBox/blob/main/GLOSSARY.md).
+
+## A
+
+**`auth_tok`** — NVS key (32-char hex string) holding the bearer token for the Tab5 firmware's debug HTTP server on port 8080.  Auto-generated on first boot via `esp_random()`; persists across reboots.  Different from `DRAGON_API_TOKEN` (which gates Dragon's REST endpoints).
+
+**`aut_tier`** — NVS key (uint8 0..1) — autonomy dial.  `0=ask first`, `1=agent mode` (engages TinkerClaw Gateway via `voice_mode=3`).  Lives in the v4·D Sovereign-Halo three-dial config.
+
+## B
+
+**BSP** — Board Support Package.  [`bsp/tab5/`](bsp/tab5/) holds the M5Stack Tab5 hardware abstraction — pin definitions, codec init, display setup, IO expander helpers.  See [`docs/HARDWARE.md`](docs/HARDWARE.md) for the full pinout.
+
+## C
+
+**`cam_rot`** — NVS key (uint8 0..3) — camera frame rotation in 90° steps.  `0=none, 1=90°CW, 2=180°, 3=270°CW`.  Applied in software after V4L2 capture before display, photo save, video record, and Dragon upload.  See PR #261/#290.
+
+**`cap_mils`** — NVS key (uint32) — daily LLM-spend cap in mils (1/1000 ¢).  Default 100000 (= $1.00/day).  When `spent_mils` exceeds this on a Cloud-mode turn, Tab5 auto-downgrades to Local mode and announces `cap_downgrade` via `config_update`.
+
+**`chat.llm_done`** — Debug-obs event kind emitted by `voice.c` when the WS `llm_done` message is received.  Detail field is the latency_ms.  Used by the e2e harness to know an LLM turn finished.
+
+**Connection mode** (`conn_m`) — NVS key (uint8 0..2) — `0=auto` (try ngrok first then LAN), `1=local-only`, `2=remote-only`.  Tab5-internal — never sent to Dragon; affects only the Tab5 client's WS connect strategy.
+
+**Counter-init** — Camera screen's `IMG_NNNN.jpg` index recovery.  On first open, `opendir("/sdcard")` + readdir scan finds the highest existing IMG_NNNN.jpg and resumes the counter from there.  Avoids overwriting on re-flash.  See [`ui_camera.c`](main/ui_camera.c).
+
+## D
+
+**Debounce** (navigation) — `/navigate` HTTP handler enforces a 600 ms minimum between consecutive nav requests so rapid taps + animation race conditions don't crash the LVGL overlay system.  See [`debug_server.c`](main/debug_server.c).
+
+**`device_id`** — NVS key (12-hex chars).  Stable identifier sent in WS `register` frame.  MAC-derived on first boot.  Dragon uses this as the primary key in the `devices` table.
+
+**`dragon_host` / `dragon_port`** — NVS keys.  Dragon WS server endpoint.  Defaults from `config.h` / Kconfig but settings UI lets the user change them.  PR [#299](https://github.com/lorcan35/TinkerTab/issues/299) was triggered when the e2e harness's `/input/text` accidentally typed into this field; PR [#300](https://github.com/lorcan35/TinkerTab/pull/300) scoped `/input/text` to the chat input only.
+
+## E
+
+**E2E harness** — Python scenario runner in [`tests/e2e/`](tests/e2e/) (PR #295).  `Tab5Driver` class wraps the debug HTTP API; `runner.py` runs scenarios with per-step screenshots + event captures + report.json/report.md output.  Three canonical stories: `story_smoke` (~2 min, 14 steps), `story_full` (~2 min, 24 steps), `story_stress` (~10 min, 77 steps).
+
+**`/events` ring** — Debug server endpoint backed by a 256-slot ring buffer of `tab5_debug_obs_event(kind, detail)` calls.  Polled-only — see LEARNINGS for why long-poll was tried + reverted (PANIC under load on single-threaded httpd).  Events surfaced: `obs.init`, `screen.navigate`, `voice.state`, `ws.connect/disconnect`, `chat.llm_done`, `camera.capture`, `camera.record_start/stop`, `display.brightness`, `audio.volume`, `audio.mic_mute`, `nvs.erase`.
+
+## F
+
+**FATFS LFN** — `CONFIG_FATFS_LFN_NONE=1` in sdkconfig.defaults — long-filename support is OFF to save RAM.  Forces 8.3 short names.  Only affects code that creates files: video recording uses `.MJP` instead of `.mjpeg` because of this.  See LEARNINGS.
+
+**FreeRTOS task workers** — Long-running concerns each get a persistent FreeRTOS task (mic capture, video stream, voice WS, etc.).  Per PR #285, the per-call-spawned task pattern (which leaked) was replaced with persistent-task-with-binary-semaphore-trigger pattern.  16 KB stacks live on PSRAM via `xTaskCreatePinnedToCoreWithCaps(..., MALLOC_CAP_SPIRAM)`.
+
+## H
+
+**Heap watchdog** — Periodic monitor in `heap_watchdog.c` that checks internal SRAM largest free block every 30 s.  If the largest block stays below 30 KB for 3 minutes sustained, triggers a controlled reboot.  Hide/show pattern for overlays is the primary fragmentation defense; the watchdog is the safety net.
+
+**Hide/show overlays** — Pattern from PR #183: Settings, Chat, and Voice overlays are created ONCE and hidden via `lv_obj_add_flag(LV_OBJ_FLAG_HIDDEN)`, never destroyed-and-recreated.  Internal SRAM (~512 KB) fragments quickly under create/destroy churn; hide/show keeps the allocations stable.
+
+## I
+
+**IO Expander** — Two PI4IOE5V6416 chips on system I2C (0x43 + 0x44) controlling power rails (LCD reset, speaker enable, WiFi power, USB 5 V, charging, etc.).  See [`docs/HARDWARE.md`](docs/HARDWARE.md).
+
+**`int_tier`** — NVS key (uint8 0..2) — intelligence dial.  `0=fast`, `1=balanced`, `2=smart`.  Combined with `voi_tier` and `aut_tier` in `tab5_mode_resolve()` to derive the effective `voice_mode` (0/1/2/3).
+
+## L
+
+**LVGL** — Light and Versatile Graphics Library v9.2.2 (managed component).  Native UI framework — every screen / widget / overlay is LVGL.  Critical config in `sdkconfig.defaults`:
+- `LV_MEM_SIZE_KILOBYTES=96` (BSS base pool, soft ceiling on this firmware layout)
+- `LV_MEM_POOL_EXPAND_SIZE_KILOBYTES=4096` (TLSF per-pool max-size — NOT auto-expand-on-demand)
+- `LV_DRAW_SW_CIRCLE_CACHE_SIZE=32`
+- `LV_DISPLAY_RENDER_MODE_PARTIAL` with two 144 KB draw buffers
+
+`main.c` calls `lv_mem_add_pool()` at boot with a 2 MB PSRAM chunk — that's the actual heap LVGL operates on.
+
+**`lv_async_call`** — LVGL primitive for scheduling work on the LVGL thread.  **NEVER call directly** — use [`tab5_lv_async_call`](main/ui_core.h) instead.  The LVGL primitive is NOT thread-safe (does `lv_malloc` + `lv_timer_create` against unprotected TLSF — caused the long-residual stability class closed in PR #257/#259).
+
+## M
+
+**`media_id`** — 32-char hex string (SHA-256 of resized image bytes).  Returned by Dragon's `POST /api/media/upload`; sent back in WS `user_image` event.  Persists in Dragon's `messages` table inside the `__mm__:` content marker.
+
+**`mic_mute`** — NVS key (uint8 0..1) — master mic mute.  When set, `voice_start_listening` refuses with a toast.  Settings toggle; visible on the home mode chip.
+
+**MJPEG / `.MJP`** — File format for video recording.  Concatenated JPEGs, no container, no audio.  Forced to `.MJP` (3-char extension) because FATFS LFN is disabled.  ffmpeg + VLC play these natively: `ffplay -f mjpeg VID_NNNN.MJP`.
+
+## N
+
+**Nav sheet** — Bottom-up swipe-up sheet that surfaces home / chat / notes / settings / camera / files / call.  Implemented in [`ui_nav_sheet.c`](main/ui_nav_sheet.c).
+
+**NVS** — Non-Volatile Storage.  ESP-IDF flash partition holding key-value settings.  See [`CLAUDE.md`](CLAUDE.md) "NVS Settings Keys" for the canonical table.  Namespace is `"settings"`; max key length 15 chars.
+
+## O
+
+**`onboard`** — NVS key (uint8 0..1).  `1` once the user clears the welcome screens on first boot.  Reset by NVS erase.
+
+**OPUS** — Audio codec for the WS streaming path.  Capability negotiation works (PR #263/#265).  Decoder ready on Tab5; **encoder gated OFF** in [`voice_codec.h`](main/voice_codec.h) pending issue [#264](https://github.com/lorcan35/TinkerTab/issues/264) — SILK NSQ crashes mid-frame on ESP32-P4.  Don't enable uplink until #264 closes.
+
+## P
+
+**Partial render mode** — LVGL's incremental rendering strategy.  Renders into a small buffer that gets flushed to the DPI panel; the alternative (DIRECT mode) tears on this hardware.  Two 144 KB draw buffers in PSRAM.
+
+**Persistent task pattern** — PR #285 design: long-running tasks (mic capture, video streaming) are created ONCE at boot.  They idle on a binary semaphore between sessions.  Replaces the older per-call `xTaskCreate + vTaskSuspend` pattern that leaked tasks under load.
+
+**PIP** — Picture-in-picture.  240×135 local-camera preview shown in the corner of the video-call pane while in-call.
+
+**Power rails** — Switched via the two IO expanders.  LCD, speaker, WiFi (ESP32-C6), USB host, charging are all software-controllable.
+
+## R
+
+**REC button** — Red-bordered pill in the camera viewfinder control bar (right of the shutter circle).  Toggles motion-JPEG recording to `/sdcard/VID_NNNN.MJP` at 5 fps.  PR #291.  Live overlay shows `REC ▶ MM:SS  N KB` at the top during recording.
+
+**Rich Media** — `media`, `card`, `audio_clip`, `text_update` WS messages from Dragon.  Code blocks render as syntax-highlighted JPEGs (Pygments), tables as styled grids (Pillow), images downloaded + cached.  5-slot PSRAM LRU cache (~2.9 MB).
+
+**`Rot` button** — In-viewfinder button on the camera screen.  Cycles `cam_rot` 0→1→2→3→0 in one tap and recreates the screen so the rotation applies live.  Saves a trip to Settings.  PR #290.
+
+## S
+
+**`screen.navigate`** — Debug-obs event kind emitted by `debug_server.c` navigate handler.  Detail = target screen name.
+
+**Session** — Multi-turn conversation owned by Dragon (not Tab5).  Tab5 stores the `session_id` in NVS for resume.  Tab5 doesn't manage its own session lifecycle — Dragon does that.
+
+**`spent_mils` / `spent_day`** — NVS keys tracking today's cumulative LLM spend in mils.  `spent_day` = days-since-epoch of the last `spent_mils` write.  Resets when the day rolls.  u32 with daily writes — wear bounded to ~hundreds of commits/day.
+
+**Soft-reset stress** — Boot path optimization in PR #285+: persistent tasks survive `esp_restart()` no-ops cleanly because they're created at boot and idle on semaphores between bursts.  No reboot loop is needed for routine state changes.
+
+## T
+
+**Tab5** — M5Stack Tab5 hardware: ESP32-P4 + 5" 720×1280 IPS + MIPI-CSI camera + 4-mic + DAC + WiFi via hosted ESP32-C6 + 16 MB flash + 32 MB PSRAM + 6 Ah LiPo + capacitive touch.  See [`docs/HARDWARE.md`](docs/HARDWARE.md).
+
+**`tab5_lv_async_call(cb, arg)`** — Wrapper in [`main/ui_core.{c,h}`](main/ui_core.h) around `lv_async_call`.  Takes the LVGL recursive mutex first.  **Always use this** instead of the LVGL primitive directly — the primitive is not thread-safe.  PR #257/#259 wrapped all 49 sites; rule going forward.
+
+**`task_worker`** — Shared FreeRTOS job queue ([`task_worker.{c,h}`](main/task_worker.c)).  Long-running uploads / downloads / etc. enqueue here instead of spawning per-action tasks.
+
+**Tile-view** — LVGL tileview widget — main home screen layout pre-v4·C.  Currently retired in favor of single Ambient Canvas page.  References to "page 0", "page 1" etc. in older docs are tile-view era.
+
+**Toast** — Transient bottom-of-screen notification used for low-priority feedback (ack, error, status).  Auto-dismisses after 2-3 s.
+
+**Touch (debug)** — `POST /touch` endpoint accepts `{x, y, action: "tap|press|release|long_press|swipe", duration_ms?, x1?, y1?, x2?, y2?}`.  Tap = 200 ms hold (LVGL CLICKED).  Long_press = 500-5000 ms (LVGL LONG_PRESSED at 400 ms).  Swipe = 20 ms step cadence between (x1,y1) and (x2,y2) over duration_ms.
+
+## U
+
+**UI surface** — LVGL screen abstraction.  Tab5 has 7 screens (splash/home/chat/notes/settings/camera/files) + 2 overlays (keyboard/voice).  Most overlays use the hide/show pattern; chat-screen-from-overlay-tap uses destroy-recreate (`New Chat` button).
+
+**`user_image` / `user_media`** — WS messages Tab5 sends to Dragon announcing a previously-uploaded image.  Triggers Dragon's vision-turn flow.  See [TinkerBox `flows/vision-turn.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/flows/vision-turn.md).
+
+## V
+
+**v4·C Ambient Canvas** — Current home-screen visual language.  Single page (no tile-view), clock + orb + greeting + mode pill + nav sheet + widget slots.  Replaced earlier multi-page design.
+
+**`VID0`** — 4-byte ASCII magic on a binary WS frame indicating it's a JPEG video frame for the call relay.  Counterpart: `AUD0` for raw 16 kHz mono int16 PCM.
+
+**`vmode`** — NVS key (uint8 0..3) — voice mode.  `0=Local`, `1=Hybrid`, `2=Cloud`, `3=TinkerClaw`.  Sent to Dragon as `voice_mode` in `config_update`.
+
+**`voi_tier`** — NVS key (uint8 0..2) — voice dial.  `0=local Piper`, `1=neutral`, `2=studio OpenRouter`.  Combined with `int_tier` + `aut_tier` to derive the effective voice mode.
+
+**`voice.state`** — Debug-obs event kind emitted by `voice_set_state()` on every state transition.  Detail = state name (IDLE/CONNECTING/READY/LISTENING/PROCESSING/SPEAKING/RECONNECTING).  e2e harness's `await_voice_state()` watches for these.
+
+**`VOICE_MODE_CALL`** — Internal voice-pipeline state independent of `voice_mode` 0/1/2/3.  When active: mic frames are wrapped with `AUD0` magic prefix and broadcast to other call participants instead of being fed to STT.  Set by `voice_video_start_call()` and reset by `voice_video_end_call()`.
+
+**`voice_video.{c,h}`** — Two-way video calling module.  HW JPEG uplink via the shared encoder + TJPGD downlink decode + `VID0` framing.  `voice_video_start_call` / `voice_video_end_call` are the atomic entry points.  Also exposes `voice_video_encode_rgb565()` so the camera-screen recording feature shares the single HW JPEG engine.
+
+## W
+
+**Watchdog reset** — Triggered when (a) the heap watchdog declares fragmentation crisis, or (b) `python -m esptool ... --after watchdog_reset` from a workstation.  Tab5's USB-JTAG doesn't wire RTS to EN, so `default_reset` / `hard_reset` won't cut it for a running app — must use `watchdog_reset`.
+
+**Widget** — Skill-emitted state rendered by Tab5.  Six types: `live`, `card`, `list`, `chart`, `media`, `prompt`.  Spec in [`docs/WIDGETS.md`](docs/WIDGETS.md); implementation plan in [`docs/PLAN-widget-platform.md`](docs/PLAN-widget-platform.md).  See also TinkerBox's `surfaces/`.
+
+**WS** — WebSocket.  Tab5 has exactly one persistent WS connection to Dragon at `ws://<host>:3502/ws/voice`.  All voice/text/vision/video/config/event traffic multiplexes over this single channel.
+
+## Cross-references
+
+- **Operating runbook** (deploy, debug, restart, monitor): [`CLAUDE.md`](CLAUDE.md)
+- **Hardware pinout + IC list**: [`docs/HARDWARE.md`](docs/HARDWARE.md)
+- **Voice pipeline spec**: [`docs/VOICE_PIPELINE.md`](docs/VOICE_PIPELINE.md)
+- **Widget spec**: [`docs/WIDGETS.md`](docs/WIDGETS.md)
+- **E2E harness**: [`tests/e2e/README.md`](tests/e2e/README.md)
+- **Lessons + gotchas**: [`LEARNINGS.md`](LEARNINGS.md)
+- **System architecture (Dragon side)**: [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md)
+- **Wire format**: [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md)
+- **Cross-repo glossary** (router, fleet, modality, etc.): [TinkerBox `GLOSSARY.md`](https://github.com/lorcan35/TinkerBox/blob/main/GLOSSARY.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **ESP32-P4 firmware for the M5Stack Tab5 -- the face of the TinkerClaw voice assistant platform.**
 
+📚 **Docs:** [Hardware](docs/HARDWARE.md) · [Voice pipeline](docs/VOICE_PIPELINE.md) · [Widget platform](docs/WIDGETS.md) · [E2E harness](tests/e2e/README.md) · [Glossary](GLOSSARY.md) · [Lessons](LEARNINGS.md) · [CLAUDE.md](CLAUDE.md) (runbook)
+
+> **First time here?** Tab5 is the *face*; the brain lives in [TinkerBox](https://github.com/lorcan35/TinkerBox).  Start with [TinkerBox's `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) to see how the two halves fit together — then come back here for hardware, the LVGL UI, and the firmware-side runbook.
+
 ```
  +-----------+         WebSocket          +-------------+
  |  Tab5     | ---- voice/text/config --> |  Dragon Q6A |

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,0 +1,207 @@
+# Tab5 Hardware Reference
+
+> Single-source pinout, IC list, and bus map for the M5Stack Tab5
+> hardware Tab5 firmware targets.  All pin numbers are GPIO numbers
+> on the ESP32-P4 SoC unless noted otherwise.  Authoritative
+> source: [`bsp/tab5/bsp_config.h`](../bsp/tab5/bsp_config.h) — if
+> this doc disagrees with that file, the C header wins.
+
+## SoC: ESP32-P4
+
+| | |
+|---|---|
+| **Architecture** | RISC-V (rv32imafc) dual-core HP @ 360-400 MHz + 1 LP core |
+| **Internal SRAM** | ~512 KB (shared with FreeRTOS) — fragments under overlay create/destroy |
+| **PSRAM** | 32 MB (Octal SPI) — used for LVGL pool, mic buffers, media cache, video frames, JPEG scratch |
+| **Flash** | 16 MB QuadSPI — partition table in `partitions.csv` (dual OTA slots) |
+| **Crypto** | HW AES-256, SHA, RSA, HMAC — used by mbedTLS for WS-TLS |
+| **JPEG engine** | Single HW JPEG codec ("rxlink") — shared by call streamer + camera recording (PR #291). Mutex-guarded; second `jpeg_new_encoder_engine()` call fails. |
+
+The ESP32-P4 has no built-in WiFi or Bluetooth — those go through a hosted ESP32-C6 over SDIO (see below).
+
+## ESP-IDF version
+
+Pinned to **v5.5.2** (`dependencies.lock`). After any sdkconfig change or component update, run `idf.py fullclean build`.
+
+## Display: 5" 720×1280 IPS
+
+| | |
+|---|---|
+| **Panel driver IC** | ST7123 |
+| **Interface** | MIPI DSI |
+| **Lanes** | 2 |
+| **Bitrate per lane** | 965 Mbps |
+| **DPI clock** | 70 MHz |
+| **Pixel format** | RGB565 (DSI peripheral) → RGB888 (panel) |
+| **Refresh** | ~60 fps (LVGL flushes at ~10 fps under load — see `/info.lvgl_fps`) |
+| **HSYNC / HBP / HFP** | 2 / 40 / 40 |
+| **VSYNC / VBP / VFP** | 2 / 8 / 220 |
+| **Backlight** | PWM on GPIO 22, 5 kHz |
+| **PHY LDO** | Channel 3, 2500 mV |
+
+LVGL config — `LV_DISPLAY_RENDER_MODE_PARTIAL` with two 144 KB draw buffers in PSRAM.  Do NOT use DIRECT mode (causes tearing on DPI).
+
+## Touch: GT911 capacitive
+
+| | |
+|---|---|
+| **Bus** | System I2C (SDA=31, SCL=32, 400 kHz) |
+| **Interrupt** | GPIO 23 |
+| **Driver** | `esp_lcd_touch_st7123` component (mis-named — actually wraps GT911) |
+
+Forwarded as LVGL pointer events.  Coordinates: `(0,0)` = top-left, max `(719, 1279)`.
+
+## Camera: SC202CS (SC2336) 2 MP
+
+| | |
+|---|---|
+| **Sensor** | SC202CS — 2 MP rolling-shutter CMOS |
+| **Interface** | MIPI-CSI, 2 lanes |
+| **External clock** | 24 MHz on GPIO 36 |
+| **SCCB I2C address** | 0x36 (NOT 0x30) — `CONFIG_CAMERA_SC202CS=y` must be set in sdkconfig |
+| **Driver stack** | `esp_video` + `esp_cam_sensor` (M5Stack-derived; not the raw CSI API) |
+| **Native output** | 1280×720 RGB565 @ 30 fps |
+| **ISP path** | RAW8 → ISP → RGB565 → /dev/video0 (V4L2) |
+
+Software rotation via NVS `cam_rot` (0/1/2/3 for 0°/90°/180°/270° CW) is applied to every captured frame before display, photo save, video recording, and Dragon upload.  See `main/ui_camera.c` and PR #261/#290.
+
+## Audio: ES8388 DAC + ES7210 ADC, shared I2S
+
+I2S_NUM_1 carries both TX (DAC) and RX (ADC) in **TDM 4-slot mode** to keep BCLK consistent at 48 kHz × 4 × 16 = 3.072 MHz.  An older mixed-mode (TX=STD, RX=TDM) caused the legendary "[MUSIC PLAYING]" buzzing bug.
+
+| | |
+|---|---|
+| **MCLK** | GPIO 30 (shared) |
+| **BCLK** | GPIO 27 (shared) |
+| **WS / LRCK** | GPIO 29 (shared) |
+| **DOUT → ES8388** | GPIO 26 |
+| **DIN ← ES7210** | GPIO 28 |
+| **Native rate** | 48 kHz |
+| **TX slot mode** | STD Philips → ES8388 |
+| **RX slot mode** | TDM 4-slot → ES7210 (slot 0 = MIC-L primary, slots 1-3 = secondary mics for AEC reference, currently unused) |
+| **ES8388 I2C addr** | 0x10 (7-bit), 0x20 (8-bit) |
+| **ES7210 I2C addr** | 0x40 (7-bit), 0x80 (8-bit) |
+| **Speaker enable** | IO Expander 1 P1 (initialized LOW at boot to prevent buzz) |
+
+Audio is ALWAYS through `esp_codec_dev_*` APIs.  Never write custom register sequences — see LEARNINGS for the 5-difference disaster that prevented audio (issue #46).
+
+The voice pipeline downsamples 3:1 (48 kHz → 16 kHz) for STT and upsamples 1:3 for TTS playback — see [`docs/VOICE_PIPELINE.md`](VOICE_PIPELINE.md).
+
+## WiFi: ESP32-C6 hosted via SDIO
+
+ESP32-P4 has no native WiFi.  An on-board ESP32-C6 acts as the radio over the ESP-Hosted protocol on SDIO 4-bit.
+
+| | |
+|---|---|
+| **CLK** | GPIO 12 |
+| **CMD** | GPIO 13 |
+| **D0** | GPIO 11 |
+| **D1** | GPIO 10 |
+| **D2** | GPIO 9 |
+| **D3** | GPIO 8 |
+| **RESET** | GPIO 15 |
+| **Power** | IO Expander 2 controlled |
+
+Connection mode (NVS `conn_m`): `0=auto` (ngrok-first then LAN), `1=local-only`, `2=remote-only`.  Backoff is exponential-with-full-jitter, capped at 60 s.
+
+## SD Card: SDMMC 4-bit
+
+| | |
+|---|---|
+| **CLK** | GPIO 43 |
+| **CMD** | GPIO 44 |
+| **D0** | GPIO 39 |
+| **D1** | GPIO 40 |
+| **D2** | GPIO 41 |
+| **D3** | GPIO 42 |
+| **Slot** | 0 (with LDO channel 4) |
+| **Filesystem** | FAT32 (`CONFIG_FATFS_LFN_NONE=1` — 8.3 short names only — see LEARNINGS for the .MJP file extension hack) |
+
+SD coexists with WiFi SDIO on a different controller.  Card is hot-plug-aware; the camera screen re-scans for `IMG_NNNN.jpg` on every open if the card was just inserted.
+
+## I/O Expanders: 2× PI4IOE5V6416
+
+System I2C, addresses 0x43 + 0x44.
+
+| Expander 1 (0x43) | Pin | Use |
+|-------------------|-----|-----|
+| P0 | LCD reset |
+| P1 | Speaker enable (active-LOW init) |
+| P2 | Touch reset |
+| P3 | Camera reset |
+| P4 | External 5 V power |
+| ... | ... |
+
+| Expander 2 (0x44) | Pin | Use |
+|-------------------|-----|-----|
+| P0 | WiFi (ESP32-C6) power |
+| P1 | USB host 5 V |
+| P2 | Battery charging enable |
+| ... | ... |
+
+## Sensors
+
+| Sensor | I2C addr | Use |
+|--------|----------|-----|
+| **BMI270** IMU | 0x68 | 6-axis accel + gyro; auto-rotate (NVS-toggleable, currently no-op pending #287) |
+| **RX8130CE** RTC | 0x32 | Wall-clock; battery-backed; survives reboots |
+| **INA226** battery monitor | 0x41 | Voltage/current monitoring; A0 routed high to avoid clash with ES7210 at 0x40 |
+
+## Battery
+
+LiPo 6 Ah, monitored via INA226.  Charging routed through Expander 2.  Tab5 reports voltage + percentage via `GET /battery` debug endpoint.
+
+## NVS layout
+
+NVS partition lives at flash offset `0x9000`, size `0x6000`.  Namespace `"settings"`.  Max key length 15 chars.  See [`CLAUDE.md`](../CLAUDE.md) "NVS Settings Keys" section for the canonical key list with types/ranges/defaults.
+
+Wear-leveling: most keys are written rarely (mode change, settings UI), but `spent_mils` writes once per LLM turn — bounded to ~hundreds of writes/day, well under the 100k cycle endurance.
+
+## Boot sequence (high-level)
+
+`main/main.c:app_main()`:
+
+1. NVS open + auth_tok generation if missing
+2. I2C bus + IO expanders + battery + RTC + IMU
+3. WiFi via ESP-Hosted on SDIO; STA mode connects
+4. SD card mount (FAT32)
+5. Audio codec (ES8388 + ES7210) via esp_codec_dev
+6. Camera (SC202CS via esp_video stack)
+7. LVGL display + touch
+8. UI scaffolding: theme, widget store, chat store, voice overlay, home screen, nav bar
+9. `tab5_debug_obs_init()` + debug HTTP server on port 8080
+10. `tab5_worker_init()` (shared FreeRTOS job queue)
+11. Voice WS client (Dragon connection)
+12. Heap watchdog (3-min sustained-low-largest-block reboot trigger)
+
+Total time-to-ready: ~25-35 s on a fresh boot, ~15-20 s on a watchdog reboot.
+
+## Power consumption
+
+| State | Current draw (5 V) |
+|-------|---------------------|
+| Idle, screen on, WiFi connected | ~250-300 mA |
+| Active LLM call (cloud) | ~400 mA |
+| Recording video (5 fps) | ~450 mA |
+| Screen off (TODO — sleep mode not yet implemented) | n/a |
+
+6 Ah battery → ~20 hours active use, much longer on idle if power management lands.
+
+## Hardware-related issues
+
+See [`LEARNINGS.md`](../LEARNINGS.md) for the full list of hardware quirks we've hit.  Highlights:
+- ES8388 init must use `esp_codec_dev_new()` — custom register writes have 5 differences vs library and prevent audio entirely
+- I2S TDM 4-slot for both TX and RX (BCLK consistency)
+- SC202CS at 0x36 (NOT 0x30 like SC2336)
+- `vTaskDelete(NULL)` crashes on P4 — use `vTaskSuspend(NULL)` instead
+- DMA cache coherency on PSRAM: `esp_cache_msync()` after CPU writes to framebuffer
+- Single HW JPEG engine — must share via `voice_video_encode_rgb565()`
+- DMA-aligned buffers via `jpeg_alloc_encoder_mem()` — plain `heap_caps_malloc(MALLOC_CAP_DMA)` doesn't satisfy alignment
+
+## Further reading
+
+- [`../bsp/tab5/bsp_config.h`](../bsp/tab5/bsp_config.h) — authoritative pinout
+- [`../CLAUDE.md`](../CLAUDE.md) — operational reference + NVS keys + debug endpoints
+- [`../LEARNINGS.md`](../LEARNINGS.md) — hardware gotchas
+- [`VOICE_PIPELINE.md`](VOICE_PIPELINE.md) — audio chain details
+- [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) — Dragon-side architecture


### PR DESCRIPTION
## Summary
Closes the firmware-side leg of the docs sweep that started with TinkerBox PR #190 (architecture + flow traces + glossary).  Now both repos have proper landing pages for fresh readers.

## New documents

**`docs/HARDWARE.md`** — single-source reference for Tab5 hardware: SoC, display (ST7123 MIPI DSI), camera (SC202CS via MIPI-CSI), audio (ES8388 + ES7210 shared I2S TDM), WiFi (ESP32-C6 hosted via SDIO), SD card (FAT32 with LFN disabled), IO expanders, sensors, NVS layout, boot sequence, power consumption.  Authoritative source: `bsp/tab5/bsp_config.h` — this doc cites the same values.

**`GLOSSARY.md`** — ~70 Tab5-firmware-specific terms alphabetically.  Every NVS key (cam_rot, cap_mils, conn_m, vmode, voi_tier, int_tier, aut_tier, mic_mute, …), every debug concept, every UI primitive (LVGL pool, tab5_lv_async_call, hide/show pattern), every camera term, every touch primitive.  Cross-references TinkerBox's GLOSSARY for shared terms (router, fleet, modality).

## Wiring
- `README.md` gets a one-line nav strip + "first time here?" callout that redirects fresh readers to TinkerBox's ARCHITECTURE.md (where the system-level overview lives)
- `CLAUDE.md` gets a banner distinguishing runbook role from architecture-doc role

## Stats
~1500 lines of new docs.  Pair with TinkerBox PR #190 for the complete onboarding set.

## Test plan
- [x] All hardware values match `bsp/tab5/bsp_config.h`
- [x] All cross-repo links point at real files
- [x] No PRs cited that don't exist
- [x] Glossary cross-references resolve
