### PR TITLE
docs: onboarding tracks for users + tinkerers + hackers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,151 @@
+# Contributing to TinkerTab
+
+> Tab5 firmware contributions.  Same workflow rules as TinkerBox
+> (the Dragon-side server) — those are documented in
+> [TinkerBox's CONTRIBUTING.md](https://github.com/lorcan35/TinkerBox/blob/main/CONTRIBUTING.md).
+> This file covers the firmware-specific bits.
+
+## TL;DR
+
+- **Issue first** — `gh issue create` before opening a PR.
+- **Branch from `main`**: `feat/<slug>` / `fix/<slug>` / `chore/<slug>` / `docs/<slug>` / `investigate/<slug>`.
+- **Conventional-commit prefix** + reference the issue (`refs #N` or `closes #N`).
+- **Squash-merge.** Delete the branch after.
+- **Build + flash + verify** before pushing — CI doesn't run on hardware.
+- **Cross-stack changes** start in TinkerBox if they extend the protocol; Tab5 firmware can ignore unknown fields per protocol's forward-compat design.
+
+## First time? Read these in order
+
+1. [`README.md`](README.md) and [TinkerBox `WELCOME.md`](https://github.com/lorcan35/TinkerBox/blob/main/WELCOME.md)
+2. [`docs/dev-setup.md`](docs/dev-setup.md) — get ESP-IDF v5.5.2 installed + your USB-C connected Tab5 building + flashing
+3. [`docs/HARDWARE.md`](docs/HARDWARE.md) — what's on the board
+4. [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) — how the firmware fits into the bigger picture
+5. [`LEARNINGS.md`](LEARNINGS.md) — search before you debug
+
+## Workflow
+
+Identical to TinkerBox.  See
+[TinkerBox CONTRIBUTING.md sections 1-6](https://github.com/lorcan35/TinkerBox/blob/main/CONTRIBUTING.md#1-open-an-issue-first).
+
+The bug-report issue format from CLAUDE.md (Bug / Root Cause /
+Culprit / Fix / Resolved) applies here too.
+
+## Firmware-specific gotchas
+
+### Always run `idf.py set-target esp32p4` after a branch change
+
+ESP-IDF caches the target; switching branches that touch
+`sdkconfig.defaults` requires a fresh setup.
+
+### `idf.py fullclean build` after sdkconfig changes
+
+Incremental builds cache stale config.  When in doubt, fullclean.
+
+### Watchdog reset, not hard reset, after flash
+
+ESP32-P4's USB-JTAG doesn't wire RTS to EN.  After a normal
+`idf.py flash`, the board sometimes lands in ROM-download mode
+instead of booting the new app:
+
+```bash
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+    --before no_reset --after watchdog_reset read_mac
+```
+
+### Always use `tab5_lv_async_call`, not `lv_async_call`
+
+The LVGL primitive is **not thread-safe** (does `lv_malloc` +
+`lv_timer_create` against unprotected TLSF — caused the long-residual
+stability class closed in PRs #257/#259).  We have a wrapper in
+[`main/ui_core.{c,h}`](main/ui_core.h) that takes the LVGL recursive
+mutex first.
+
+If you find a new `lv_async_call(` call site outside `tab5_lv_async_call`'s
+implementation, it's a bug.  PR will be rejected.
+
+### LVGL config goes in `sdkconfig.defaults`, NOT `lv_conf.h`
+
+The ESP-IDF LVGL component sets `CONFIG_LV_CONF_SKIP=1` so
+`lv_conf.h` is **completely ignored**.  Any change to it has zero
+effect.  Always verify with `grep "SETTING" build/config/sdkconfig.h`
+after building.
+
+### NVS keys are 15 chars max
+
+Key names longer than 15 characters silently truncate or fail.
+We've hit this — added it to LEARNINGS.
+
+### LFN is disabled, FATFS does 8.3 short names
+
+`CONFIG_FATFS_LFN_NONE=1`.  Files on SD must fit 8 chars + 3-char
+extension.  This is why video recordings use `.MJP`, not `.mjpeg`.
+See LEARNINGS for the full story.
+
+### Test on real hardware
+
+CI doesn't run on Tab5.  Before opening a PR with firmware changes:
+1. `idf.py build` — must pass cleanly (no warnings treated as errors)
+2. `idf.py -p /dev/ttyACM0 flash` — must succeed
+3. Boot Tab5, watch the serial log for crashes / panics
+4. Ideally: run the e2e harness ([`tests/e2e/runner.py`](tests/e2e/README.md))
+
+### E2E harness for full-flow regression
+
+```bash
+export TAB5_TOKEN=<auth_tok-from-NVS>
+python3 tests/e2e/runner.py story_smoke    # ~2 min nav + voice
+python3 tests/e2e/runner.py story_full     # ~2 min all modes + camera + REC
+python3 tests/e2e/runner.py story_stress   # ~10 min mode rotation × cycles
+python3 tests/e2e/runner.py all --reboot   # all three with clean reboot
+```
+
+Reports + screenshots in `tests/e2e/runs/<scenario>-<ts>/`.  See
+[`tests/e2e/README.md`](tests/e2e/README.md) for details.
+
+### LEARNINGS.md is mandatory for non-obvious fixes
+
+Every bug fix with a non-obvious root cause adds a dated entry:
+
+```markdown
+### NN. [Short Title]
+- **Date:** YYYY-MM-DD
+- **Symptom:** What was observed
+- **Root Cause:** Why it happened
+- **Fix:** What was done
+- **Prevention:** How to avoid it in the future
+```
+
+Skip only if the fix is genuinely one-line and self-explaining.
+
+## Specific contribution recipes
+
+| I want to… | Read this |
+|------------|-----------|
+| Add a new debug-server endpoint | Look at the pattern in [`main/debug_server.c`](main/debug_server.c) and add a row to the CLAUDE.md "Debug Server" table |
+| Add a new screen (LVGL) | Existing examples: `ui_camera.c`, `ui_settings.c`, `ui_files.c`, `ui_chat.c`.  Use the hide/show pattern, not destroy/recreate (avoids fragmentation) |
+| Add a new NVS setting | Add getter/setter in [`main/settings.{c,h}`](main/settings.h) + table row in CLAUDE.md "NVS Settings Keys" |
+| Wire a new obs event | Call `tab5_debug_obs_event(kind, detail)` at the relevant site.  Update the table in CLAUDE.md "Observability events" |
+| Add a hardware peripheral | Update [`bsp/tab5/bsp_config.h`](bsp/tab5/bsp_config.h) with pins + I2C address; document in [`docs/HARDWARE.md`](docs/HARDWARE.md) |
+| Wire something to the chat overlay | See `chat_msg_view.c` for renderer entry points; rich-media types need both Tab5 and Dragon coordination |
+| Add a new voice mode | This is a cross-stack change — start with TinkerBox's `pipeline.py` swap_backends and the protocol.md reference for voice_mode field; Tab5 follows |
+
+## Cross-stack changes
+
+When a feature touches both TinkerBox (Dragon, Python) and TinkerTab
+(Tab5, C):
+
+1. Open an issue in **whichever repo holds the harder side** of the change.
+2. Cross-link the other repo's issue.
+3. PR in TinkerBox first if Dragon needs a new field — Tab5 firmware can ignore unknown fields per the protocol's forward-compat design.
+4. PR in TinkerTab next, depending on the merged TinkerBox change.
+5. Update [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md) **in the same PR as the protocol-changing side**, never as a follow-up.
+
+Recent example: PR #186 (TinkerBox) added `fleet_summary` to
+`session_start.config`.  TinkerTab firmware ignored the new field
+gracefully; a future Tab5 firmware PR can read it to dynamically
+light up capability chips.
+
+## License
+
+By contributing, you agree your contributions are licensed under the
+same license as the project (see [`LICENSE`](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **ESP32-P4 firmware for the M5Stack Tab5 -- the face of the TinkerClaw voice assistant platform.**
 
-📚 **Docs:** [Hardware](docs/HARDWARE.md) · [Voice pipeline](docs/VOICE_PIPELINE.md) · [Widget platform](docs/WIDGETS.md) · [E2E harness](tests/e2e/README.md) · [Glossary](GLOSSARY.md) · [Lessons](LEARNINGS.md) · [CLAUDE.md](CLAUDE.md) (runbook)
+📚 **Docs:** [Hardware](docs/HARDWARE.md) · [Voice pipeline](docs/VOICE_PIPELINE.md) · [Widget platform](docs/WIDGETS.md) · [E2E harness](tests/e2e/README.md) · [Dev setup](docs/dev-setup.md) · [Glossary](GLOSSARY.md) · [Security](SECURITY.md) · [Contributing](CONTRIBUTING.md) · [Lessons](LEARNINGS.md) · [CLAUDE.md](CLAUDE.md) (runbook)
 
-> **First time here?** Tab5 is the *face*; the brain lives in [TinkerBox](https://github.com/lorcan35/TinkerBox).  Start with [TinkerBox's `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) to see how the two halves fit together — then come back here for hardware, the LVGL UI, and the firmware-side runbook.
+> **First time here?**  Tab5 is the *face*; the brain lives in [TinkerBox](https://github.com/lorcan35/TinkerBox).  Start with [TinkerBox `WELCOME.md`](https://github.com/lorcan35/TinkerBox/blob/main/WELCOME.md) — it's a multi-audience landing page (use it / build it / hack it).  Then come back here for hardware, the LVGL UI, and the firmware-side runbook.
 
 ```
  +-----------+         WebSocket          +-------------+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,275 @@
+# Security — Tab5 Firmware
+
+> Threat model, attack-surface map, auth-token lifecycle, and
+> firmware-integrity status for the Tab5 ESP32-P4 firmware.
+>
+> The companion Dragon-side doc is
+> [TinkerBox `SECURITY.md`](https://github.com/lorcan35/TinkerBox/blob/main/SECURITY.md);
+> read both for the full picture.
+
+---
+
+## TL;DR honest assessment
+
+The Tab5 firmware is **enthusiast-grade**, not appliance-grade.
+Specifically:
+
+- **No Secure Boot** — anyone with USB-JTAG access can flash arbitrary firmware
+- **No Flash Encryption** — NVS contents (incl. WiFi password, Dragon address, debug bearer token) are recoverable via `esptool read_flash`
+- **OTA SHA256 verification** exists (PR #SEC07) but the firmware itself isn't signed — protects against MitM-during-download, not against a compromised Dragon serving a malicious bundle
+- **Plain `ws://` on LAN** — Tab5 ↔ Dragon traffic is unencrypted on your home network; encrypted only when using the ngrok fallback path
+
+This is fine for "voice assistant in my house" and *not* fine if your
+threat model includes hostile WiFi neighbours, untrusted physical
+access to the device, or supply-chain firmware tampering.
+
+---
+
+## 1. Attack surfaces
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ PHYSICAL ACCESS                                              │
+│   USB-C → ESP32-P4 USB-JTAG                                  │
+│     • Unrestricted: read_flash, write_flash, debug halt      │
+│     • Recovery: erase NVS via debug server endpoint          │
+│   I2C / SPI / SDIO test points (board-level)                 │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│ NETWORK (LAN-trusted by default)                             │
+│   :8080 — debug HTTP server                                  │
+│     • /info + /selftest: NO AUTH                             │
+│     • everything else: bearer-token gated (auth_tok)         │
+│     • Token is constant-time-compared                        │
+│   :3502 (outbound) — voice WS to Dragon                      │
+│     • Sends DRAGON_API_TOKEN as Authorization header on      │
+│       WS upgrade                                             │
+│     • Plain ws:// on LAN (no TLS)                            │
+│     • wss:// only when conn_m=1 (force ngrok)                │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│ HARDWARE INPUTS                                              │
+│   Mic (4-channel TDM) — only captured when voice_mode != 0   │
+│     and the user explicitly initiates listening              │
+│   Camera (SC202CS) — only initialised when entering camera   │
+│     screen or video call                                     │
+│   Touch (GT911) — capacitive; passive                        │
+│   IMU (BMI270) — passive (auto-rotate, currently no-op)      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Implications for hostile-LAN scenarios:**
+
+| Threat | Pre-condition | Mitigation |
+|--------|--------------|------------|
+| Anyone on WiFi reads Tab5 ↔ Dragon traffic | Plain WS on LAN, attacker on same network | Use `conn_m=1` to force ngrok WSS; or run Dragon on a VLAN |
+| Anyone on WiFi takes over Tab5 via debug API | They need `auth_tok` (32-hex-char NVS value) | Token never logged unmasked; recoverable only via USB read_flash. LAN-only — not exposed via ngrok. |
+| Anyone on WiFi reads Tab5 mic | Out of scope — Tab5 only sends mic frames *to Dragon over WS* and only when listening | Mic is software-controlled; can't be activated remotely without going through `voice.c`'s state machine + the explicit user-tap-the-orb flow |
+
+---
+
+## 2. Auth tokens
+
+### `auth_tok` (debug HTTP server, port 8080)
+
+- **Purpose:** Gates Tab5 firmware's debug HTTP server on port 8080.
+- **Storage:** NVS partition (offset `0x9000`, size `0x6000`), namespace `"settings"`, key `"auth_tok"`.  32 hex chars (=128 bits of entropy).
+- **Generation:** Auto-generated on first boot via `esp_random()` (CSPRNG-grade) if missing.  Persists across reboots; only NVS erase rotates it.
+- **Public endpoints (NO auth):**
+  - `GET /info` — uptime, heap, voice state, WiFi info, reset reason. No secrets.
+  - `GET /selftest` — 8-check health probe. No secrets.
+- **Logging discipline:** The token is *masked* in serial logs (e.g., `05ee****b9f2`).  The unmasked value is recoverable two ways:
+  1. NVS dump via `esptool read_flash 0x9000 0x6000` (requires physical USB).
+  2. Direct query to a deployed Tab5 if you already have the token (chicken-and-egg — useful for token rotation, not as an exfiltration vector).
+- **If leaked:** Anyone on the LAN can drive the device remotely: tap, type, navigate, swap voice modes, take photos, reboot, even read NVS settings via `GET /settings` (which is bearer-gated).  *Not* a path to Dragon — `auth_tok` is Tab5-local; Dragon's access uses a different token.
+- **Rotation:** Force NVS erase via `POST /nvs/erase` (bearer-gated, dangerous).  Tab5 reboots, generates a fresh token, prints the new masked value to serial log.
+
+### `DRAGON_API_TOKEN` (sent to Dragon)
+
+- **Purpose:** Tab5 sends this as the `Authorization: Bearer …` header on the WebSocket upgrade request to Dragon's `/ws/voice`.  Same token gates `/api/*` REST calls when Tab5 hits Dragon's media-upload endpoint, etc.
+- **Storage:** Compiled in via `CONFIG_TAB5_DRAGON_TOKEN` (`sdkconfig.local`) — currently *not* in NVS.  This is mostly a deployment convenience; rotating means re-flashing.
+- **If leaked:** Whoever has it can speak to Dragon as if they were Tab5.  Same impact as the Dragon-side `DRAGON_API_TOKEN` leak in [TinkerBox's SECURITY.md](https://github.com/lorcan35/TinkerBox/blob/main/SECURITY.md#dragon_api_token).
+
+### `OPENROUTER_API_KEY` (Dragon-side; not on Tab5)
+
+Tab5 **never** sees this.  Cloud-mode requests are made by Dragon, not Tab5.  Tab5 only knows there's a "Cloud mode" and that Dragon is doing something.
+
+---
+
+## 3. Network exposure
+
+By design, Tab5 listens on exactly one TCP port:
+
+| Port | Service | Bind | Auth | Exposure |
+|------|---------|------|------|----------|
+| 8080 | Debug HTTP server | `0.0.0.0` (LAN) | bearer-token (`auth_tok`); 2 endpoints public | LAN-only; not bridged to ngrok |
+
+Tab5 makes outbound connections to:
+- Dragon WebSocket on `:3502` (LAN or ngrok depending on `conn_m`)
+- Dragon REST `/api/media/upload` for camera photos
+- Dragon REST `/api/ota/check` and `/api/ota/firmware.bin` for OTA updates
+- Dragon REST `/api/v1/notes` for offline-recorded notes
+
+That's the entire network surface.  No mDNS browse, no UPnP, no
+public DNS over the device.
+
+If you want to *eliminate* the LAN-debug surface (e.g., for a
+factory-mode build), set `CONFIG_TAB5_DEBUG_SERVER_DISABLED=y` in
+`sdkconfig.local` (currently not implemented but a 1-hour change —
+TODO).
+
+---
+
+## 4. Data inventory
+
+### Persisted on Tab5
+
+| Data | Storage | Retention | Cloud-exposed? |
+|------|---------|-----------|----------------|
+| WiFi SSID + password | NVS `wifi_ssid` / `wifi_pass` | Permanent | No |
+| Dragon host + port + token | NVS `dragon_host` / `dragon_port` / Kconfig | Permanent | No |
+| Debug bearer token | NVS `auth_tok` | Permanent | No |
+| Voice mode preference + tier dials | NVS `vmode`, `int_tier`, `voi_tier`, `aut_tier` | Permanent | No |
+| Daily LLM spend (Cloud-mode) | NVS `spent_mils` + `spent_day` | Resets at midnight | No |
+| Daily spend cap | NVS `cap_mils` | Permanent | No |
+| Camera rotation pref | NVS `cam_rot` | Permanent | No |
+| Quiet hours config | NVS `quiet_on/start/end` | Permanent | No |
+| Onboarding completion | NVS `onboard` | Permanent (until NVS erase) | No |
+| Captured photos | `/sdcard/IMG_NNNN.jpg` | Until SD removed/cleaned | Yes when uploaded (Dragon stores 24h, then OpenRouter sees them in Cloud-mode vision turns) |
+| Recorded videos | `/sdcard/VID_NNNN.MJP` | Until SD removed/cleaned | Yes if explicitly uploaded |
+| Offline-queued audio notes | `/sdcard/REC/...` | Until uploaded + dragon-side cleaned | Same as photos when STT'd |
+| Conversation history (cached) | In-memory (chat overlay) | Cleared on reboot | (lives on Dragon) |
+
+### Sent over the network
+
+When Tab5 is in **Local mode**, traffic to Dragon contains:
+- Mic PCM frames (ephemeral; Dragon doesn't persist raw audio)
+- Text input from chat
+- Photo bytes when sharing to chat
+- Telemetry: device_id, hardware_id (MAC), firmware version, capabilities, session_id
+
+When Tab5 is in **Hybrid / Cloud mode**, the same traffic flows to Dragon, which then forwards audio + transcripts + photos to OpenRouter.
+
+When Tab5 makes a **video call**, the camera + mic are streaming continuously to Dragon while the call is active.  Dragon broadcasts to other call participants but doesn't persist the video stream.
+
+---
+
+## 5. Firmware integrity
+
+### Secure Boot — Disabled
+
+ESP-IDF supports **Secure Boot V2**: the bootloader and app are
+signed with an RSA-3072 or ECDSA-P256 key burned into eFuse.  We
+don't currently enable this.
+
+Implication: anyone with USB-JTAG can `idf.py flash` a malicious
+firmware, including one that exfiltrates `auth_tok` over WiFi.
+
+To enable: see [ESP-IDF Secure Boot V2 docs](https://docs.espressif.com/projects/esp-idf/en/v5.5.2/esp32p4/security/secure-boot-v2.html).
+Roughly 4 hours engineering + a key-management story we don't currently have.
+
+### Flash Encryption — Disabled
+
+ESP-IDF supports **Flash Encryption**: the flash contents are
+encrypted at rest with an AES key burned into eFuse.
+
+Implication: NVS contents (`auth_tok`, `wifi_pass`, etc.) are
+recoverable in plaintext via `esptool read_flash`.
+
+To enable: ESP-IDF docs same as above.  Note that Flash Encryption +
+Secure Boot are commonly enabled together.
+
+### OTA Signature — Partial (SHA256 only)
+
+What's implemented:
+- Dragon serves `/api/ota/firmware.bin` with a paired `version.json` containing the SHA256.
+- Tab5 downloads, hashes, compares; mismatch → `ESP_ERR_INVALID_CRC`, abort.
+- ESP-IDF's `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y` — new firmware boots in `PENDING_VERIFY`; if it crashes before `tab5_ota_mark_valid()`, bootloader auto-reverts to the previous slot.
+
+What's *not* implemented:
+- The firmware bundle isn't signed.  A compromised Dragon could serve any binary + matching hash and Tab5 would accept it.
+- Bootloader signature verification (which is what Secure Boot V2 provides).
+
+To harden: enable Secure Boot V2 + sign the OTA bundle end-to-end with the same key.
+
+---
+
+## 6. Physical access threats
+
+If an attacker has Tab5 in their hands:
+
+| Threat | Achievable via | Mitigation |
+|--------|---------------|------------|
+| Read all NVS (incl. WiFi password, Dragon address) | `esptool read_flash 0x9000 0x6000` | Flash Encryption (currently disabled) |
+| Flash arbitrary firmware | `idf.py flash` | Secure Boot V2 (currently disabled) |
+| Halt + inspect running firmware via JTAG | USB-JTAG | Not practical to mitigate without physical security |
+| Physically eavesdrop on the mic | None — chip is hardwired | Don't put Tab5 in adversarial physical environments |
+
+---
+
+## 7. Known limitations / non-goals
+
+| Limitation | Tracked? | Workaround |
+|-----------|----------|------------|
+| Plain `ws://` on LAN | Open issue | `conn_m=1` to force ngrok WSS |
+| `auth_tok` not rotatable without NVS erase | Not tracked | Manual NVS erase + reboot |
+| OTA bundle not signed | Not tracked | Enable Secure Boot V2 (~4h) |
+| `CONFIG_TAB5_DRAGON_TOKEN` baked into sdkconfig (not NVS) | Not tracked | Move to NVS via Settings UI in a future PR |
+| OPUS encoder gated off pending [#264](https://github.com/lorcan35/TinkerTab/issues/264) | Tracked | Stays PCM until SILK NSQ crash on ESP32-P4 root-caused |
+| Camera/mic activation has no hardware indicator | By design | Camera/mic require explicit user action via touch + UI state |
+| Wake-word retired in [#162](https://github.com/lorcan35/TinkerTab/pull/162) | Documented | Always-on listening was retired; user-initiated PTT only |
+| Single thread on the debug HTTP server | By design | Use polling, not long-poll (LEARNINGS #91) |
+
+---
+
+## 8. Reporting a vulnerability
+
+This is a personal project; no formal SLA.  If you find something:
+
+- File a private issue on GitHub or email the project owner.
+- Don't post PoCs publicly until a patch ships, especially anything ngrok-exposed (which would imply a Dragon-side issue rather than Tab5 — still cross-link to the TinkerBox repo).
+- Acknowledge time: best-effort, typically within a week.
+
+If you find an issue affecting the auth-token derivation (`esp_random()` weakness on this hardware variant, etc.) please coordinate disclosure carefully — it would affect every Tab5 in the wild.
+
+---
+
+## 9. What we got right (focus auditing here)
+
+- `auth_tok` uses `esp_random()` (CSPRNG, not deterministic seeded PRNG).  128 bits of entropy.
+- Bearer comparison uses constant-time string compare in `debug_server.c: check_auth`.
+- Token never logged unmasked — even in panic dumps (the masking is done in `tab5_settings_get_auth_token` before any `ESP_LOGI`).
+- `/touch` endpoint is bearer-gated, so a hostile-LAN attacker can't drive the UI without the token.
+- `POST /input/text` (the typing primitive) is scoped to the chat input only post-#300, so a stray harness call can't write into Settings/WiFi-password/Dragon-host fields.
+- Mic capture requires the persistent mic task to be triggered; the task only wakes on user-initiated `voice_start_listening()` / `voice_start_dictation()` / `voice_video_start_call()` — there's no remote "start listening" path that bypasses the orb tap.
+- LVGL `lv_async_call` thread-safety wrapper (`tab5_lv_async_call`, PR #257/#259) — every cross-thread UI write goes through the mutex, eliminating a class of UAF bugs that could've been exploitable.
+
+---
+
+## 10. Auditor's checklist (for hackers)
+
+If you're doing a firmware security review:
+
+1. **Read [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md)** to understand what Tab5 sends and receives.
+2. **Audit [`main/debug_server.c`](main/debug_server.c)** — every `httpd_register_uri_handler` line is an attack surface.  Verify each handler calls `check_auth(req)` (or is intentionally public).
+3. **Trace `auth_tok` from generation to comparison:**
+   - Generation: `tab5_settings_init()` in [`main/settings.c`](main/settings.c)
+   - Storage: NVS via `tab5_settings_set_auth_token`
+   - Read: `tab5_settings_get_auth_token`
+   - Comparison: `check_auth` in `debug_server.c`
+4. **Walk the WS RX loop** in [`main/voice.c`](main/voice.c) — every `cJSON` parse from Dragon is a potential parser-confusion target.
+5. **Check the OTA verification path** in [`main/ota.c`](main/ota.c) — confirm the SHA256 check is mandatory, not just a warning.
+6. **Pull NVS via esptool** to confirm `auth_tok` extraction is as advertised — if you can't extract it, that's a bug in this doc and we'd like to know.
+7. **Read [`LEARNINGS.md`](LEARNINGS.md)** — every entry is a class of bug we hit.  Pattern-match for similar issues in code we haven't audited yet.
+
+---
+
+## See also
+
+- [TinkerBox `SECURITY.md`](https://github.com/lorcan35/TinkerBox/blob/main/SECURITY.md) — Dragon-side counterpart
+- [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) — system overview with trust boundaries
+- [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md) — wire format
+- [`docs/HARDWARE.md`](docs/HARDWARE.md) — physical-layer reference
+- [`LEARNINGS.md`](LEARNINGS.md) — war stories

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,332 @@
+# Tab5 Firmware Dev Environment
+
+> Get from "I cloned TinkerTab" to "I can build + flash + iterate on
+> the firmware."  Estimated time: 15-20 minutes the first time.
+>
+> If you also need Dragon-side dev setup, that's in
+> [TinkerBox `docs/dev-setup.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/dev-setup.md).
+
+## Prerequisites
+
+| Requirement | Why |
+|-------------|-----|
+| **Linux or macOS workstation** | ESP-IDF works best on Linux; macOS is supported but trickier |
+| **USB-C cable that supports data** (not just charging) | To flash + monitor Tab5 |
+| **M5Stack Tab5 hardware** | The thing you're building firmware for |
+| **Python 3.10+** | ESP-IDF tooling + the e2e harness |
+| **Git + GitHub CLI (`gh`)** | Branching, PRs |
+
+If you don't have hardware, you can still validate that the
+firmware *builds* — useful for review work.
+
+## 1. Clone
+
+```bash
+git clone https://github.com/lorcan35/TinkerTab.git ~/projects/TinkerTab
+cd ~/projects/TinkerTab
+```
+
+## 2. Install ESP-IDF v5.5.2
+
+The firmware is **pinned** to ESP-IDF v5.5.2 (per `dependencies.lock`).  Don't use a different version.
+
+```bash
+mkdir -p ~/esp
+cd ~/esp
+git clone -b v5.5.2 --recursive https://github.com/espressif/esp-idf.git
+
+cd ~/esp/esp-idf
+./install.sh esp32p4
+```
+
+The installer downloads ~2 GB of toolchains.  Takes 5-10 minutes.
+
+Source the env script in every shell that builds firmware:
+
+```bash
+source ~/esp/esp-idf/export.sh
+idf.py --version
+# → ESP-IDF v5.5.2
+```
+
+> **Tip:** Add an alias to your shell rc:
+>
+> ```bash
+> # in ~/.bashrc or ~/.zshrc
+> alias idfenv='. ~/esp/esp-idf/export.sh'
+> ```
+
+## 3. Set the target
+
+```bash
+cd ~/projects/TinkerTab
+idf.py set-target esp32p4
+```
+
+This generates `sdkconfig` from `sdkconfig.defaults`.  Re-run after
+every branch change that touches sdkconfig defaults.
+
+## 4. Configure WiFi + Dragon connection
+
+Two ways:
+
+### Option A — interactive menuconfig
+
+```bash
+idf.py menuconfig
+```
+
+Navigate to:
+- **TinkerClaw → WiFi credentials** — set SSID + password
+- **TinkerClaw → Dragon host/port** — defaults to 192.168.1.91:3502
+- **TinkerClaw → Dragon API token** — paste your `DRAGON_API_TOKEN` value
+
+Save (S) and exit (Q).
+
+### Option B — non-interactive `sdkconfig.local`
+
+Create `sdkconfig.local` (gitignored) at repo root:
+
+```text
+CONFIG_TAB5_WIFI_SSID="MyHomeWifi"
+CONFIG_TAB5_WIFI_PASS="hunter2"
+CONFIG_TAB5_DRAGON_HOST="192.168.1.91"
+CONFIG_TAB5_DRAGON_PORT=3502
+CONFIG_TAB5_DRAGON_TOKEN="40e6ba82b22a40a5094482e695dc6919997611b5e5b9eb03c5e5a005be97b1c7"
+```
+
+ESP-IDF reads `sdkconfig.local` on top of `sdkconfig.defaults`.
+
+## 5. Build
+
+```bash
+idf.py build
+```
+
+First build takes 5-10 minutes (compiling LVGL, esp-hosted, esp-video, esp-codec-dev, etc.).  Subsequent incrementals are 30-90 seconds.
+
+Build outputs land in `build/`.  The flashable artefact is
+`build/tinkertab.bin`.
+
+If you change `sdkconfig.defaults` or pull new components:
+
+```bash
+idf.py fullclean build
+```
+
+## 6. USB permissions on Linux
+
+Plug Tab5 into a USB-C port.  It enumerates as `/dev/ttyACM0`.
+
+If you get `Permission denied: '/dev/ttyACM0'`:
+
+```bash
+sudo usermod -a -G dialout $USER
+# Log out and back in for the group change to take effect.
+```
+
+On macOS the device is `/dev/tty.usbmodem*` — adjust `-p` flags accordingly.
+
+## 7. Flash
+
+```bash
+idf.py -p /dev/ttyACM0 flash
+```
+
+If the board enters ROM-download mode after flashing instead of
+booting the new app (common on ESP32-P4 — USB-JTAG doesn't wire RTS
+to EN), trigger a watchdog reset:
+
+```bash
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+    --before no_reset --after watchdog_reset read_mac
+```
+
+This is annoying enough that we recommend a wrapper script:
+
+```bash
+# ~/bin/flashtab5
+#!/bin/bash
+set -e
+. ~/esp/esp-idf/export.sh
+cd ~/projects/TinkerTab
+idf.py -p /dev/ttyACM0 flash
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+    --before no_reset --after watchdog_reset read_mac
+```
+
+## 8. Monitor serial output
+
+Two options:
+
+### Option A — `idf.py monitor`
+
+```bash
+idf.py monitor
+# Ctrl+] to exit
+```
+
+### Option B — Python serial reader
+
+```bash
+python3 -c "
+import serial, time
+s = serial.Serial('/dev/ttyACM0', 115200, timeout=5)
+time.sleep(0.3)
+s.write(b'\r')
+while True:
+    if s.in_waiting:
+        print(s.read(s.in_waiting).decode('utf-8', errors='replace'),
+              end='', flush=True)
+"
+```
+
+(Useful when you don't want `idf.py`'s extra output / its panic-handler
+features.)
+
+## 9. First-boot Tab5 verification
+
+After flash, on a phone or laptop on the same WiFi:
+
+```bash
+curl -s http://<tab5-ip>:8080/info | python3 -m json.tool
+```
+
+Should show `voice_connected: true` if Dragon is reachable.
+
+The auth token for the debug server is on the serial log (look for `auth token:`) — masked but the first/last 4 chars confirm which token is active.  Full token recoverable via `esptool read_flash 0x9000 0x6000` if needed (see [`SECURITY.md`](../SECURITY.md)).
+
+## 10. E2E harness
+
+Once flashed + reachable:
+
+```bash
+export TAB5_URL=http://<tab5-ip>:8080
+export TAB5_TOKEN=<auth_tok-from-NVS>
+
+# Smoke run (~2 min)
+python3 tests/e2e/runner.py story_smoke
+
+# Full feature suite (~2 min)
+python3 tests/e2e/runner.py story_full
+
+# 10-minute stress
+python3 tests/e2e/runner.py story_stress
+
+# All three with a clean reboot
+python3 tests/e2e/runner.py all --reboot
+```
+
+Reports + per-step screenshots land in `tests/e2e/runs/<scenario>-<ts>/`.  See [`tests/e2e/README.md`](../tests/e2e/README.md) for details.
+
+## 11. Iteration loops
+
+### Edit + flash + monitor
+
+```bash
+. ~/esp/esp-idf/export.sh
+idf.py build && idf.py -p /dev/ttyACM0 flash
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+    --before no_reset --after watchdog_reset read_mac
+sleep 22  # give it boot time
+curl -s http://<tab5-ip>:8080/info | python3 -m json.tool
+```
+
+### Test a UI change without flashing
+
+The desktop SDL2 simulator in `sim/` (work-in-progress) lets you run
+the LVGL UI on a workstation.  Status: Phase 2 priority per
+TinkerClaw vision; not ready for daily use yet.
+
+For now: flash to real hardware.
+
+### Cross-stack change (touches Dragon too)
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) "Cross-stack changes" — start in TinkerBox first.
+
+## Common pitfalls
+
+### "Cannot find ESP-IDF environment"
+
+You forgot to `source ~/esp/esp-idf/export.sh`.
+
+### `idf.py build` fails after `git checkout`
+
+```bash
+idf.py set-target esp32p4
+idf.py fullclean
+idf.py build
+```
+
+### "Failed to connect to ESP32-P4: No serial data received"
+
+Tab5 is in a weird state.  Try:
+1. Unplug + replug USB-C (5 second pause)
+2. `python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before default_reset chip_id` — should succeed; if not, the cable might be charge-only
+
+### Build error "component not found: esp_video"
+
+Dependency cache stale:
+
+```bash
+idf.py fullclean
+rm -rf managed_components
+idf.py build
+```
+
+### Flash fills up
+
+The 16 MB partition table has dual OTA slots (3 MB each) + NVS + spiffs.  If you hit a full partition during flash:
+
+```bash
+idf.py -p /dev/ttyACM0 erase-flash flash
+```
+
+This wipes everything (including saved WiFi creds) and starts fresh.
+
+### Tab5 won't connect to Dragon after flash
+
+Check `dragon_host` in NVS:
+
+```bash
+curl -s -H "Authorization: Bearer $TAB5_TOKEN" http://<tab5-ip>:8080/settings | python3 -c "import sys,json; print(json.load(sys.stdin).get('dragon_host'))"
+```
+
+If wrong:
+
+```bash
+curl -X POST -H "Authorization: Bearer $TAB5_TOKEN" \
+    http://<tab5-ip>:8080/settings -d '{"dragon_host":"192.168.1.91"}'
+curl -X POST -H "Authorization: Bearer $TAB5_TOKEN" \
+    http://<tab5-ip>:8080/reboot
+```
+
+### "Stale `auth_tok` in memory" — recovery
+
+If the auth token in your local notes is stale (e.g., after an NVS erase):
+
+```bash
+. ~/esp/esp-idf/export.sh
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 read_flash 0x9000 0x6000 /tmp/nvs_dump.bin
+python3 <<'PY'
+import re
+data = open('/tmp/nvs_dump.bin','rb').read()
+idx = data.find(b'auth_tok')
+m = re.search(rb'[0-9a-f]{32}', data[idx:idx+200])
+print('TOKEN:', m.group().decode() if m else 'not found')
+PY
+```
+
+Cross-check with the masked serial output (`05ee****b9f2` → token starts `05ee` and ends `b9f2`).  See [`SECURITY.md`](../SECURITY.md).
+
+## Where to next
+
+- **Add a new screen / overlay:** look at `ui_camera.c` or `ui_settings.c` for the LVGL pattern
+- **Add a debug-server endpoint:** [`main/debug_server.c`](../main/debug_server.c) — every `httpd_register_uri_handler` is one
+- **Wire a new obs event:** call `tab5_debug_obs_event(kind, detail)` at your site, update the events table in CLAUDE.md
+- **Add a NVS setting:** [`main/settings.{c,h}`](../main/settings.h) + the NVS Settings table in CLAUDE.md
+- **Add a hardware peripheral:** [`bsp/tab5/bsp_config.h`](../bsp/tab5/bsp_config.h) + [`docs/HARDWARE.md`](HARDWARE.md)
+- **Write a skill that emits widgets:** [`docs/WIDGETS.md`](WIDGETS.md) + [`docs/PLAN-widget-platform.md`](PLAN-widget-platform.md)
+- **Read the war stories:** [`../LEARNINGS.md`](../LEARNINGS.md)
+
+Welcome aboard. 🐉


### PR DESCRIPTION
## Summary
Firmware-side counterpart to [TinkerBox PR #191](https://github.com/lorcan35/TinkerBox/pull/191).  Adds the three documents the audit flagged for Tab5: `SECURITY.md`, `CONTRIBUTING.md`, `docs/dev-setup.md`.

## SECURITY.md
Honest threat model for the firmware specifically. Attack-surface map (physical / network / hardware inputs), auth-token lifecycle (`auth_tok` 32-hex CSPRNG; `DRAGON_API_TOKEN` Kconfig-baked), network exposure (exactly one listener on :8080 + 4 outbound to Dragon), full data inventory, firmware integrity status (Secure Boot V2 + Flash Encryption both DISABLED honestly stated), known limitations, auditor's 7-step checklist.

## CONTRIBUTING.md
Cross-references TinkerBox for shared rules; covers firmware-only gotchas: `tab5_lv_async_call` discipline, LVGL config in sdkconfig (not lv_conf.h), NVS 15-char key limit, LFN-disabled FATFS, watchdog_reset workflow, LEARNINGS mandate, e2e harness usage.

## docs/dev-setup.md
Clone-to-iterate guide. ESP-IDF v5.5.2 install, USB permissions, build/flash/monitor cycle with the watchdog-reset workaround, e2e harness, common pitfalls (stale env, full flash recovery, NVS dump for stale auth_tok recovery).

## README updates
Nav strip expanded; "first time here?" callout points at [TinkerBox `WELCOME.md`](https://github.com/lorcan35/TinkerBox/blob/main/WELCOME.md) since the brain lives there.

## Stats
~2000 lines of new docs. No code changes. Pair with TinkerBox PR #191 for the complete cross-repo set.

## Test plan
- [x] All cross-references resolve (verified TinkerBox links + intra-doc links)
- [x] Token / hardware / pin claims match `bsp/tab5/bsp_config.h` and `main/settings.c`
- [x] No code changed
