### PR TITLE
feat(widget): chat card optional action button (closes #70 phase 2, refs #67)

### DIFF
--- a/main/chat_msg_store.h
+++ b/main/chat_msg_store.h
@@ -21,6 +21,13 @@
 #define CHAT_TEXT_LEN         512
 #define CHAT_MEDIA_URL_LEN    256
 #define CHAT_SUBTITLE_LEN     128
+/* Widget-platform phase 2 (#70): card action slot.  Per docs/WIDGETS.md
+ * §6 the protocol limits action.label to ≤8 visible chars; we allow a
+ * bit more bytes to cover UTF-8 + a NUL.  card_id matches WIDGET_ID_LEN
+ * (32) in widget.h. */
+#define CHAT_CARD_ID_LEN      32
+#define CHAT_ACTION_LABEL_LEN 16
+#define CHAT_ACTION_EVENT_LEN 32
 
 typedef enum {
     MSG_TEXT = 0,        /* Plain text (user or AI) */
@@ -58,6 +65,15 @@ typedef struct {
     uint16_t   receipt_ctok;
     char       receipt_model_short[16];  /* "haiku-3.5", "sonnet-3.5", etc */
     bool       receipt_retried;          /* v4·D Gauntlet G2: context-trim or 429 retry */
+    /* Widget-platform phase 2 (#70): MSG_CARD optional tappable action.
+     * card_id[0]=='\0' means no card_id known; action_label[0]=='\0'
+     * means no action button rendered.  When both label and event are
+     * non-empty the renderer draws an amber pill at the bottom-right of
+     * the breakout that fires voice_send_widget_action(card_id, event)
+     * on tap. */
+    char       card_id[CHAT_CARD_ID_LEN];
+    char       action_label[CHAT_ACTION_LABEL_LEN];
+    char       action_event[CHAT_ACTION_EVENT_LEN];
 } chat_msg_t;
 
 /* ── API ─────────────────────────────────────────────────────── */

--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -16,6 +16,7 @@
 #include "chat_msg_view.h"
 #include "chat_msg_store.h"
 #include "ui_chat.h"                  /* U5: ui_chat_play_audio_clip */
+#include "voice.h"                    /* Phase 2 (#70): voice_send_widget_action */
 #include "ui_core.h"                  /* tab5_lv_async_call (#258) */
 #include "ui_theme.h"
 #include "config.h"
@@ -69,6 +70,11 @@ typedef struct {
     lv_image_dsc_t brk_dsc; /* decoded pixel buffer owned by media_cache */
     char      brk_url[256]; /* the URL currently bound to brk_image */
     bool      brk_fetch_inflight;
+    /* Phase 2 (#70): MSG_CARD optional tappable action button.  Lazy-
+     * created on first card-with-action; subsequent renders re-use
+     * the same widgets via show/hide. */
+    lv_obj_t *brk_action_btn;
+    lv_obj_t *brk_action_lbl;
     int       data_idx;     /* store logical index bound to this slot, -1 = empty */
 } msg_slot_t;
 
@@ -215,6 +221,7 @@ static void slot_reset(msg_slot_t *slot)
 
 /* U5 (#206): forward decl — defined below with the AUDIO_CLIP wiring. */
 static void brk_body_clicked_cb(lv_event_t *e);
+static void brk_action_clicked_cb(lv_event_t *e);  /* Phase 2 (#70) */
 
 static void slot_ensure_breakout(msg_slot_t *slot, lv_obj_t *parent, uint32_t accent)
 {
@@ -307,6 +314,12 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
          * AUDIO_CLIP branch below re-adds the flag. */
         if (slot->brk_body)
             lv_obj_clear_flag(slot->brk_body, LV_OBJ_FLAG_CLICKABLE);
+        /* Phase 2 (#70): hide any prior action button on rebind.  The
+         * MSG_CARD branch re-shows it when the new message carries
+         * action_label + action_event + card_id; for MSG_IMAGE /
+         * MSG_AUDIO_CLIP / no-action cards it stays hidden. */
+        if (slot->brk_action_btn)
+            lv_obj_add_flag(slot->brk_action_btn, LV_OBJ_FLAG_HIDDEN);
 
         char kicker[64];
         switch (msg->type) {
@@ -389,6 +402,41 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
             lv_label_set_text(slot->brk_body, body);
             lv_obj_set_pos(slot->brk_body, SIDE_PAD, 40);
             lv_obj_set_size(slot->breakout, 720, BREAK_H);
+
+            /* Phase 2 (#70): optional tappable action button.  Lazy-
+             * create on first card-with-action; show/hide on subsequent
+             * renders.  Position bottom-right of breakout (-16, -16)
+             * with a 120×40 footprint so a 5-line body still has room
+             * above it.  Amber pill matches the v5 accent colour the
+             * card kicker uses for read-order continuity. */
+            bool has_action = (msg->action_label[0] && msg->action_event[0]
+                               && msg->card_id[0]);
+            if (has_action) {
+                if (!slot->brk_action_btn) {
+                    slot->brk_action_btn = lv_button_create(slot->breakout);
+                    lv_obj_set_size(slot->brk_action_btn, 140, 44);
+                    lv_obj_set_style_bg_color(slot->brk_action_btn,
+                        lv_color_hex(TH_AMBER), 0);
+                    lv_obj_set_style_bg_opa(slot->brk_action_btn, LV_OPA_COVER, 0);
+                    lv_obj_set_style_radius(slot->brk_action_btn, 22, 0);
+                    lv_obj_set_style_border_width(slot->brk_action_btn, 0, 0);
+                    lv_obj_set_style_shadow_width(slot->brk_action_btn, 0, 0);
+                    lv_obj_set_style_pad_all(slot->brk_action_btn, 0, 0);
+                    lv_obj_add_event_cb(slot->brk_action_btn,
+                        brk_action_clicked_cb, LV_EVENT_CLICKED, slot);
+                    slot->brk_action_lbl = lv_label_create(slot->brk_action_btn);
+                    lv_obj_set_style_text_font(slot->brk_action_lbl, FONT_BODY, 0);
+                    lv_obj_set_style_text_color(slot->brk_action_lbl,
+                        lv_color_hex(0x000000), 0);
+                    lv_obj_center(slot->brk_action_lbl);
+                }
+                lv_label_set_text(slot->brk_action_lbl, msg->action_label);
+                lv_obj_align(slot->brk_action_btn, LV_ALIGN_BOTTOM_RIGHT,
+                             -SIDE_PAD, -16);
+                lv_obj_clear_flag(slot->brk_action_btn, LV_OBJ_FLAG_HIDDEN);
+            } else if (slot->brk_action_btn) {
+                lv_obj_add_flag(slot->brk_action_btn, LV_OBJ_FLAG_HIDDEN);
+            }
         } else { /* MSG_AUDIO_CLIP */
             lv_obj_set_style_text_font(slot->brk_body, FONT_BODY, 0);
             lv_obj_set_style_text_color(slot->brk_body, lv_color_hex(TH_AMBER), 0);
@@ -854,4 +902,19 @@ static void brk_body_clicked_cb(lv_event_t *e)
     if (!msg || msg->type != MSG_AUDIO_CLIP) return;
     if (!msg->media_url[0]) return;
     ui_chat_play_audio_clip(msg->media_url);
+}
+
+/* Phase 2 (#70): widget_card action button click → fire widget_action
+ * back to Dragon.  Slot rebind is safe because we re-read the bound
+ * card from the store every time; if the slot's been recycled to a
+ * different message between render and tap, msg->card_id will be empty
+ * and we no-op. */
+static void brk_action_clicked_cb(lv_event_t *e)
+{
+    msg_slot_t *slot = (msg_slot_t *)lv_event_get_user_data(e);
+    if (!slot || slot->data_idx < 0) return;
+    const chat_msg_t *msg = chat_store_get(slot->data_idx);
+    if (!msg || msg->type != MSG_CARD) return;
+    if (!msg->card_id[0] || !msg->action_event[0]) return;
+    voice_send_widget_action(msg->card_id, msg->action_event, NULL);
 }

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -81,7 +81,13 @@ static voice_state_t         s_last_state = VOICE_STATE_IDLE;
 /* Async push payloads. */
 typedef struct { char *role; char *text; } push_msg_t;
 typedef struct { char url[256]; char alt[128]; int w, h; } push_media_t;
-typedef struct { char title[128]; char subtitle[256]; char img[256]; char desc[256]; } push_card_t;
+typedef struct {
+    char title[128]; char subtitle[256]; char img[256]; char desc[256];
+    /* Phase 2 (#70) */
+    char card_id[CHAT_CARD_ID_LEN];
+    char action_label[CHAT_ACTION_LABEL_LEN];
+    char action_event[CHAT_ACTION_EVENT_LEN];
+} push_card_t;
 typedef struct { char url[256]; float dur; char label[128]; } push_audio_t;
 typedef struct { char *text; } push_update_t;
 
@@ -856,6 +862,11 @@ static void async_push_card_cb(void *arg)
     safe_copy(msg.text, sizeof(msg.text), c->title);
     safe_copy(msg.subtitle, sizeof(msg.subtitle), c->subtitle);
     if (c->img[0]) safe_copy(msg.media_url, sizeof(msg.media_url), c->img);
+    /* Phase 2 (#70): plumb action fields through to the renderer.
+     * action_label[0]=='\0' is the no-action sentinel. */
+    safe_copy(msg.card_id,      sizeof(msg.card_id),      c->card_id);
+    safe_copy(msg.action_label, sizeof(msg.action_label), c->action_label);
+    safe_copy(msg.action_event, sizeof(msg.action_event), c->action_event);
     chat_store_add(&msg);
     suggestions_sync_visibility();
     if (s_view) {
@@ -868,12 +879,35 @@ static void async_push_card_cb(void *arg)
 void ui_chat_push_card(const char *title, const char *subtitle,
                        const char *image_url, const char *description)
 {
+    /* Phase 2 (#70): legacy entry point — no action.  Delegate to the
+     * full path with NULL action so there's a single async cb to
+     * maintain. */
+    ui_chat_push_card_action(title, subtitle, image_url, description,
+                             NULL, NULL, NULL);
+}
+
+void ui_chat_push_card_action(const char *title, const char *subtitle,
+                              const char *image_url, const char *description,
+                              const char *card_id,
+                              const char *action_label,
+                              const char *action_event)
+{
     push_card_t *c = calloc(1, sizeof(*c));
     if (!c) return;
     safe_copy(c->title,    sizeof(c->title),    title);
     safe_copy(c->subtitle, sizeof(c->subtitle), subtitle);
     safe_copy(c->img,      sizeof(c->img),      image_url);
     safe_copy(c->desc,     sizeof(c->desc),     description);
+    /* Phase 2 (#70): only stamp action fields when ALL three are
+     * present.  Skill emitting card_id without action would still
+     * round-trip cleanly (id is informational), but rendering an
+     * action button without an event to fire makes no sense. */
+    if (card_id && card_id[0] && action_label && action_label[0]
+        && action_event && action_event[0]) {
+        safe_copy(c->card_id,      sizeof(c->card_id),      card_id);
+        safe_copy(c->action_label, sizeof(c->action_label), action_label);
+        safe_copy(c->action_event, sizeof(c->action_event), action_event);
+    }
     tab5_lv_async_call(async_push_card_cb, c);
 }
 

--- a/main/ui_chat.h
+++ b/main/ui_chat.h
@@ -24,6 +24,23 @@ void ui_chat_push_media(const char *url, const char *media_type,
                         int width, int height, const char *alt);
 void ui_chat_push_card(const char *title, const char *subtitle,
                        const char *image_url, const char *description);
+
+/**
+ * Widget-platform phase 2 (#70): push a chat card carrying an optional
+ * tappable action button.  When `action_label` and `action_event` are
+ * both non-NULL/non-empty AND `card_id` is non-empty, the chat renderer
+ * draws an amber pill at the bottom-right of the card breakout; tap
+ * fires voice_send_widget_action(card_id, action_event, NULL).
+ *
+ * Pass NULL for any of card_id / action_label / action_event to render
+ * a plain card (no button).  card_id alone with no action is fine —
+ * future user-side dismiss could use it.
+ */
+void ui_chat_push_card_action(const char *title, const char *subtitle,
+                              const char *image_url, const char *description,
+                              const char *card_id,
+                              const char *action_label,
+                              const char *action_event);
 void ui_chat_push_audio_clip(const char *url, float duration_s, const char *label);
 
 /**

--- a/main/voice.c
+++ b/main/voice.c
@@ -1397,15 +1397,31 @@ static void handle_text_message(const char *data, int len)
          * is a different shape than the legacy "card" message used by
          * rich-media turns — title + body + tone + optional image_url.
          * Route it to the same chat bubble renderer so skills can push
-         * context cards into the conversation. */
+         * context cards into the conversation.
+         *
+         * Phase 2 (#70): also read card_id + action.{label,event} so the
+         * chat renderer can draw a tappable button that round-trips a
+         * widget_action back to the skill. */
         const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
         const char *body = cJSON_GetStringValue(cJSON_GetObjectItem(root, "body"));
         const char *img = cJSON_GetStringValue(cJSON_GetObjectItem(root, "image_url"));
+        const char *card_id = cJSON_GetStringValue(cJSON_GetObjectItem(root, "card_id"));
+        const char *action_label = NULL;
+        const char *action_event = NULL;
+        cJSON *action = cJSON_GetObjectItem(root, "action");
+        if (cJSON_IsObject(action)) {
+            action_label = cJSON_GetStringValue(cJSON_GetObjectItem(action, "label"));
+            action_event = cJSON_GetStringValue(cJSON_GetObjectItem(action, "event"));
+        }
         if (title) {
-            ESP_LOGI(TAG, "widget_card: %s", title);
-            /* chat_push_card takes (title, subtitle, image_url, description).
-             * Map body → description for read-order; subtitle stays NULL. */
-            ui_chat_push_card(title, NULL, img, body);
+            ESP_LOGI(TAG, "widget_card: %s%s", title,
+                     (action_label && action_label[0]) ? " [+action]" : "");
+            /* chat_push_card_action takes (title, subtitle, image_url,
+             * description, card_id, action_label, action_event).
+             * Map body → description for read-order; subtitle stays NULL.
+             * Action fields gated behind all-three-present in the helper. */
+            ui_chat_push_card_action(title, NULL, img, body,
+                                     card_id, action_label, action_event);
         }
     } else if (strcmp(type_str, "audio_clip") == 0) {
         const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));


### PR DESCRIPTION
## Summary
Phase 2 of the widget platform per [docs/PLAN-widget-platform.md](docs/PLAN-widget-platform.md) — extends \`widget_card\` with an optional tappable action button. Tap round-trips a \`widget_action\` back to the emitting skill so cards like "Workshop draft ready / [Open]" or "Reminder fires in 5 min / [Snooze]" become real interactive surfaces.

## Wire path
```
Skill → Tab5Surface.card(action=("Open","my_event"))
     → WS widget_card { card_id, title, body, action:{label,event} }
     → voice.c handler reads card_id + action.{label,event}
     → ui_chat_push_card_action(...) stamps chat_msg_t
     → chat_msg_view MSG_CARD branch lazy-creates an amber pill at
       bottom-right of the breakout when all three fields present
     → tap fires voice_send_widget_action(card_id, event, NULL)
     → Dragon's surface_mgr routes to the skill's registered handler
```

## Slot lifecycle
- Action button hidden on every slot rebind (defensive)
- Re-shown only inside MSG_CARD when card has `card_id + action_label + action_event` all set
- Tap reads `slot->data_idx → store`, so a slot recycled mid-tap no-ops cleanly (msg type or card_id mismatch)

## Backwards compat
- `ui_chat_push_card(...)` keeps the old 4-arg signature; delegates to `ui_chat_push_card_action` with NULL action params
- Plain widget_cards (no action field) render exactly as before

## Live verification on Tab5 + Dragon
- Build clean
- Flash + boot OK
- POST /debug/widget_card with action_label="Open" action_event="audit_open" → amber "Open" pill renders at bottom-right of card
- Tap → Dragon journal:
  ```
  widget_action: session=0db142d45e0d card=audit_card_0db142 event=audit_open
  audit widget_card action: session=0db142d45e0d card=audit_card_0db142 event=audit_open
  ```
- Smoke regression: 14/14 PASS

## Pairs with
- TinkerBox PR adding `action_label`/`action_event` params to `/debug/widget_card` for harness-driven testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)