### PR TITLE
chore(ci): bump ESP-IDF 5.4.3→5.5.2 + scope clang-format to changed lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,15 @@ jobs:
       # Rolling our own was fragile — install.sh's pwd-based IDF_PATH
       # detection kept picking up /home/runner/work/_temp instead of the
       # downloaded tree, regardless of how we exported IDF_PATH.
-      - name: Build with ESP-IDF v5.4.3
+      # CLAUDE.md pins ESP-IDF 5.5.2 — matches dependencies.lock + the
+      # local build target.  v5.4.3 had a -Werror=format= mismatch in
+      # esp_log_color.h between %u and uint32_t (long unsigned int on
+      # ARM64) that broke every CI build.  Bumping to 5.5.2 aligns CI
+      # with what we actually flash to the device.
+      - name: Build with ESP-IDF v5.5.2
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: v5.4.3
+          esp_idf_version: v5.5.2
           target: esp32p4
           path: .
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # git-clang-format needs the full history + the merge base
+          fetch-depth: 0
 
       - name: Install clang-format
         run: |
@@ -30,14 +33,32 @@ jobs:
           EOF
           fi
 
-      - name: Check formatting
+      # Scope the gate to lines actually changed in this PR.  The whole-
+      # tree dry-run failed on every PR because main/ has accumulated
+      # pre-existing format rot from before clang-format adoption.
+      # git-clang-format exits 0 if no changes are needed for the
+      # changed lines, prints a unified diff otherwise.
+      - name: Check formatting (changed lines only)
         run: |
-          unformatted=$(clang-format-18 --dry-run --Werror main/*.c main/*.h 2>&1 || true)
-          if [ -n "$unformatted" ]; then
-            echo "The following files need formatting:"
-            echo "$unformatted"
-            echo ""
-            echo "Format them with: clang-format-18 -i main/*.c main/*.h"
-            exit 1
+          # Resolve the merge base with origin/main.
+          git fetch origin main:refs/remotes/origin/main
+          BASE=$(git merge-base origin/main HEAD)
+          echo "Comparing against merge-base $BASE"
+
+          # git-clang-format is shipped alongside clang-format-18.
+          which git-clang-format || ls /usr/share/clang/
+
+          # Restrict to main/*.{c,h} since that's the firmware tree.
+          DIFF=$(git-clang-format --binary clang-format-18 \
+                                  --diff "$BASE" -- 'main/*.c' 'main/*.h' 2>&1)
+          if [ -z "$DIFF" ] || [ "$DIFF" = "no modified files to format" ] \
+             || [ "$DIFF" = "clang-format did not modify any files" ]; then
+            echo "✓ Format check passed — no violations on changed lines."
+            exit 0
           fi
-          echo "All files are correctly formatted."
+          echo "✗ Format violations on lines changed in this PR:"
+          echo "$DIFF"
+          echo ""
+          echo "Reproduce locally:"
+          echo "  git-clang-format --binary clang-format-18 origin/main"
+          exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,12 +14,19 @@ jobs:
           # git-clang-format needs the full history + the merge base
           fetch-depth: 0
 
-      - name: Install clang-format
+      - name: Install clang-format + git-clang-format
         run: |
           wget -q https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 18
           which clang-format-18
+          # The LLVM apt package doesn't bundle git-clang-format on the
+          # runner image; pull the script straight from the matching
+          # release tag and drop it on PATH.
+          sudo curl -sSL -o /usr/local/bin/git-clang-format \
+            https://raw.githubusercontent.com/llvm/llvm-project/release/18.x/clang/tools/clang-format/git-clang-format
+          sudo chmod +x /usr/local/bin/git-clang-format
+          git-clang-format --help | head -3
 
       - name: Create .clang-format
         run: |


### PR DESCRIPTION
## Why
Both Build and Format Check have been failing on every PR (including merges to main) for unrelated infra reasons:

### Build failure
Pinned to ESP-IDF v5.4.3, which has a \`-Werror=format=\` mismatch in \`/opt/esp/idf/components/log/include/esp_log_color.h\` between \`%u\` and \`uint32_t\` (long unsigned int on ARM64). \`CLAUDE.md\` and \`dependencies.lock\` pin **v5.5.2** — what we actually flash. Bumping CI aligns the gate with reality.

### Format Check failure
Ran \`clang-format-18 --dry-run --Werror main/*.{c,h}\` on the entire firmware tree. \`main/\` has accumulated pre-existing format rot (~50 files with violations). Result: every PR fails this gate, including ones that didn't touch C files.

## What
1. **build.yml**: \`v5.4.3\` → \`v5.5.2\`
2. **clang-format.yml**: scope to lines actually changed in the PR via \`git-clang-format --diff\` against the \`origin/main\` merge base. Pre-existing rot stays untouched (a separate cleanup PR would fix it), but new violations on changed lines are caught.

Mirrors the curated-clean-list pattern (TinkerBox #199 mypy strict).

## Test plan
- [x] Workflow YAML syntax (verified by github actions parser on push)
- [ ] Self-test: this PR's CI must go green (v5.5.2 build succeeds + format check passes since no main/ files changed)
- [ ] After merge: in-flight TT PRs (#306, #307, #308) should re-run CI and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)