### PR TITLE
feat(anim): voice orb size transitions via spring engine (refs #42)

### DIFF
--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -14,20 +14,23 @@
  */
 
 #include "ui_voice.h"
-#include "ui_core.h"       /* tab5_lv_async_call (#258) */
-#include "md_strip.h"      /* #116: inline markdown cleanup */
-#include "ui_notes.h"
-#include "mode_manager.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
-#include "settings.h"
-#include "task_worker.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include "md_strip.h" /* #116: inline markdown cleanup */
+#include "mode_manager.h"
+#include "settings.h"
+#include "spring_anim.h" /* Phase 3 of #42 — spring-driven orb size */
+#include "task_worker.h"
+#include "ui_core.h" /* tab5_lv_async_call (#258) */
+#include "ui_notes.h"
 
 static const char *TAG = "ui_voice";
 
@@ -1311,17 +1314,78 @@ static void set_orb_color(uint32_t ring_hex, uint32_t glow_hex, lv_opa_t ring_op
     }
 }
 
-static void set_orb_size(int32_t sz)
-{
-    lv_obj_set_size(s_orb_ring, sz, sz);
-    lv_obj_center(s_orb_ring);
+/* Phase 3 of #42: spring-driven orb size transitions.
+ *
+ * Pre-fix the orb's diameter snapped instantly between LISTEN/PROCESS/
+ * SPEAK sizes (300 / 240 / 340 px) on every state change.  Visible
+ * artefact: rapid PROCESSING → SPEAKING transitions (LLM cold-start
+ * then immediate token emit) made the orb visibly jump 100 px in one
+ * frame.
+ *
+ * Post-fix: set_orb_size retargets a SPRING_SMOOTH-driven anim that
+ * carries velocity across mid-flight retargets — feels physical
+ * instead of teleporty.  SMOOTH (zeta = 1.0, critically damped) is
+ * the right preset for this slot: no overshoot (orb shouldn't
+ * jiggle), ~600 ms convergence on a 100 px swing.
+ *
+ * State invariants:
+ *   s_orb_size_current is the live displayed size (= s_orb_spring.pos)
+ *   s_orb_anim_t is non-NULL exactly while the spring is animating
+ *   First-ever set_orb_size call snaps without animating (no velocity
+ *   to carry, and instant "at-rest" first paint matches the existing
+ *   visual contract on screen-create) */
+static spring_anim_t s_orb_spring;
+static lv_timer_t *s_orb_anim_t = NULL;
+static float s_orb_size_current = 0.0f;
 
-    for (int i = ORB_GLOW_LAYERS - 1; i >= 0; i--) {
-        float frac = (float)(ORB_GLOW_LAYERS - i) / (float)ORB_GLOW_LAYERS;
-        int32_t layer_sz = (int32_t)(sz * (0.4f + 0.6f * frac));
-        lv_obj_set_size(s_orb_glow[i], layer_sz, layer_sz);
-        lv_obj_center(s_orb_glow[i]);
-    }
+static void apply_orb_size_now(int32_t sz) {
+   if (!s_orb_ring) return;
+   lv_obj_set_size(s_orb_ring, sz, sz);
+   lv_obj_center(s_orb_ring);
+
+   for (int i = ORB_GLOW_LAYERS - 1; i >= 0; i--) {
+      float frac = (float)(ORB_GLOW_LAYERS - i) / (float)ORB_GLOW_LAYERS;
+      int32_t layer_sz = (int32_t)(sz * (0.4f + 0.6f * frac));
+      lv_obj_set_size(s_orb_glow[i], layer_sz, layer_sz);
+      lv_obj_center(s_orb_glow[i]);
+   }
+}
+
+static void orb_size_anim_cb(lv_timer_t *t) {
+   if (!s_orb_ring) {
+      s_orb_anim_t = NULL;
+      lv_timer_delete(t);
+      return;
+   }
+   float sz = spring_anim_update(&s_orb_spring, 1.0f / 60.0f);
+   s_orb_size_current = sz;
+   apply_orb_size_now((int32_t)(sz + 0.5f));
+   if (spring_anim_done(&s_orb_spring)) {
+      s_orb_anim_t = NULL;
+      lv_timer_delete(t);
+   }
+}
+
+static void set_orb_size(int32_t sz) {
+   if (s_orb_size_current <= 0.0f) {
+      /* First call: snap without animating.  No velocity to carry,
+       * and the first paint should be at-rest at the requested size
+       * (matches the existing visual contract on overlay create). */
+      spring_anim_init(&s_orb_spring, SPRING_SMOOTH);
+      s_orb_size_current = (float)sz;
+      apply_orb_size_now(sz);
+      return;
+   }
+   if ((int32_t)(s_orb_size_current + 0.5f) == sz && spring_anim_done(&s_orb_spring)) {
+      /* Already at target with no in-flight motion → no-op. */
+      return;
+   }
+   /* Retarget mid-flight if still animating; carries the spring's
+    * current velocity so back-to-back state changes feel physical. */
+   spring_anim_retarget(&s_orb_spring, s_orb_size_current, (float)sz, s_orb_spring.velocity);
+   if (!s_orb_anim_t) {
+      s_orb_anim_t = lv_timer_create(orb_size_anim_cb, 16, NULL);
+   }
 }
 
 static void update_mic_button_state(voice_state_t state)
@@ -1573,11 +1637,22 @@ static void start_wave_anim(void)
 
 static void stop_all_anims(void)
 {
-    /* Stop orb animations */
-    lv_anim_delete(s_orb_ring, orb_ring_opa_cb);
-    for (int i = 0; i < ORB_GLOW_LAYERS; i++) {
-        lv_anim_delete(s_orb_glow[i], orb_breathe_cb);
-    }
+   /* Phase 3 of #42: also tear down the spring-driven orb size anim
+    * so its 60 fps timer doesn't fire on a freed s_orb_ring after
+    * overlay hide / screen change.  Resets s_orb_size_current so
+    * the next overlay show snaps to the correct first-frame size
+    * via the "first call" branch in set_orb_size. */
+   if (s_orb_anim_t) {
+      lv_timer_delete(s_orb_anim_t);
+      s_orb_anim_t = NULL;
+   }
+   s_orb_size_current = 0.0f;
+
+   /* Stop orb animations */
+   lv_anim_delete(s_orb_ring, orb_ring_opa_cb);
+   for (int i = 0; i < ORB_GLOW_LAYERS; i++) {
+      lv_anim_delete(s_orb_glow[i], orb_breathe_cb);
+   }
 
     /* Stop wave bar animations */
     for (int i = 0; i < WAVE_BARS; i++) {


### PR DESCRIPTION
## Summary
Phase 3 of #42 — second user-visible wiring of the spring engine shipped in #310. The voice orb's diameter previously snapped instantly between LISTEN (300 px), PROCESSING (240 px), and SPEAK (340 px) sizes on every state change. Visible artefact: rapid PROCESSING → SPEAKING transitions (LLM cold-start then immediate token emit) made the orb visibly jump 100 px in one frame.

## What
\`set_orb_size(target)\` now retargets a SPRING_SMOOTH-driven animation that carries velocity across mid-flight retargets. SMOOTH (zeta = 1.0, critically damped) is the right preset:
- **No overshoot** — the orb shouldn't jiggle
- **~600 ms convergence on a 100 px swing** — calm, not laggy
- **Mid-flight retarget carries velocity** — e.g. PROCESSING → SPEAKING within 100 ms shows the orb pivoting mid-shrink instead of teleporting

## State invariants
- \`s_orb_size_current\` = live displayed size (= \`s_orb_spring.pos\`)
- \`s_orb_anim_t\` = non-NULL exactly while the spring is animating
- First-ever \`set_orb_size\` snaps without animating (matches the existing visual contract on overlay create — first paint is at-rest, no zero-to-300 sweep)

## Lifecycle
\`stop_all_anims()\` tears down the spring's per-frame timer and resets \`s_orb_size_current\` to 0 so the next overlay show snaps cleanly. Called from \`ui_voice_hide()\` and screen-change paths that already torn down the existing breathing/pulse \`lv_anim_t\`s.

## Verified live on Tab5
- [x] Build clean
- [x] Format check clean (changed-lines gate)
- [x] Flash + boot OK; voice WS reconnects fine
- [x] Orb appears at correct size on LISTEN entry
- [x] No crashes / regressions

(Visual capture of the 600 ms transition itself is hard via 80 ms HTTP screenshots; settled positions are correct on every capture and the spring engine's correctness was verified by #310's boot smoke.)

## Out of scope
Orb breathing / RMS-driven inner-glow animations remain on the existing \`lv_anim_t\` infinite-repeat path. Those are fine as-is — smooth sinusoidal modulation, not abrupt transitions where the spring would help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)