### PR TITLE
fix(ui): kill hardcoded demo data in Focus + tighten now-card tap

### DIFF
--- a/main/ui_focus.c
+++ b/main/ui_focus.c
@@ -36,6 +36,12 @@ static lv_obj_t *s_overlay   = NULL;
 static lv_obj_t *s_back_btn  = NULL;
 static lv_obj_t *s_narrative = NULL;     /* U8 (#206): refreshed on each show */
 static lv_obj_t *s_tasks     = NULL;
+/* Phase-follow-up to U8: the EARLIER TODAY header + feed are now
+ * rebuilt on each show from tool_log instead of hardcoded demo
+ * strings.  Hide the entire section when tool_log has nothing past
+ * the newest event. */
+static lv_obj_t *s_history_header = NULL;
+static lv_obj_t *s_history_feed = NULL;
 static bool      s_visible   = false;
 
 static void render_live_focus(void);
@@ -196,7 +202,10 @@ void ui_focus_show(void)
     lv_obj_clear_flag(sec1, LV_OBJ_FLAG_SCROLLABLE);
 
     lv_obj_t *h = lv_label_create(sec1);
-    lv_label_set_text(h, "HEARTBEAT  •  2 MIN LIVE");
+    /* Pre-fix said "HEARTBEAT  •  2 MIN LIVE" hardcoded — looked like
+     * filler.  Keep just "HEARTBEAT" since the narrative line already
+     * conveys whether anything is live. */
+    lv_label_set_text(h, "HEARTBEAT");
     lv_obj_set_style_text_font(h, FONT_CAPTION, 0);
     lv_obj_set_style_text_color(h, lv_color_hex(TH_AMBER), 0);
     lv_obj_set_style_text_letter_space(h, 3, 0);
@@ -219,23 +228,29 @@ void ui_focus_show(void)
     lv_obj_set_style_pad_row(s_tasks, 2, 0);
     lv_obj_clear_flag(s_tasks, LV_OBJ_FLAG_SCROLLABLE);
 
-    /* Section 2 — EARLIER TODAY */
-    lv_obj_t *sec2h = lv_label_create(s_overlay);
-    lv_label_set_text(sec2h, "EARLIER TODAY");
-    lv_obj_set_style_text_font(sec2h, FONT_CAPTION, 0);
-    lv_obj_set_style_text_color(sec2h, lv_color_hex(TH_TEXT_SECONDARY), 0);
-    lv_obj_set_style_text_letter_space(sec2h, 4, 0);
-    lv_obj_set_pos(sec2h, SIDE_PAD, 680);
+    /* Section 2 — EARLIER TODAY (live tool_log entries past the
+     * newest, mirroring the agents overlay's history list).  Pre-fix
+     * this section had two hardcoded demo strings ("AirPods vs Sony
+     * XM5" / "TinkerClaw roadmap -- Phase 2 outline") that always
+     * appeared regardless of what the user actually did.  Looked like
+     * filler.  Now the rows come from the same tool_log ring the
+     * Agents overlay uses; if there's no history we hide the section
+     * entirely instead of fabricating activity. */
+    s_history_header = lv_label_create(s_overlay);
+    lv_label_set_text(s_history_header, "EARLIER TODAY");
+    lv_obj_set_style_text_font(s_history_header, FONT_CAPTION, 0);
+    lv_obj_set_style_text_color(s_history_header, lv_color_hex(TH_TEXT_SECONDARY), 0);
+    lv_obj_set_style_text_letter_space(s_history_header, 4, 0);
+    lv_obj_set_pos(s_history_header, SIDE_PAD, 680);
+    lv_obj_add_flag(s_history_header, LV_OBJ_FLAG_HIDDEN); /* show iff history exists */
 
-    lv_obj_t *feed = lv_obj_create(s_overlay);
-    lv_obj_remove_style_all(feed);
-    lv_obj_set_size(feed, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
-    lv_obj_set_pos(feed, SIDE_PAD, 720);
-    lv_obj_set_flex_flow(feed, LV_FLEX_FLOW_COLUMN);
-    lv_obj_clear_flag(feed, LV_OBJ_FLAG_SCROLLABLE);
-
-    build_feed_row(feed, "11:42", "NOTE",  TH_AMBER,  "TinkerClaw roadmap -- Phase 2 outline");
-    build_feed_row(feed, "10:15", "CHAT",  0x9EB8FF,  "AirPods vs Sony XM5 -- Sonnet");
+    s_history_feed = lv_obj_create(s_overlay);
+    lv_obj_remove_style_all(s_history_feed);
+    lv_obj_set_size(s_history_feed, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
+    lv_obj_set_pos(s_history_feed, SIDE_PAD, 720);
+    lv_obj_set_flex_flow(s_history_feed, LV_FLEX_FLOW_COLUMN);
+    lv_obj_clear_flag(s_history_feed, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_history_feed, LV_OBJ_FLAG_HIDDEN); /* render_live_focus reveals iff have_history */
 
     /* Ask prompt at bottom */
     lv_obj_t *ask_cursor = lv_obj_create(s_overlay);
@@ -310,6 +325,35 @@ static void render_live_focus(void)
         build_task_row(s_tasks,
                        e.detail[0] ? e.detail : e.name,
                        meta, color);
+    }
+
+    /* EARLIER TODAY: tool_log entries past the first n_show, shown as
+     * a compact "time / kind / detail" feed.  When tool_log has at
+     * most n_show entries (i.e. nothing older to show), hide the
+     * entire section instead of fabricating demo rows. */
+    bool have_history = (total > n_show);
+    if (s_history_header) {
+       if (have_history)
+          lv_obj_remove_flag(s_history_header, LV_OBJ_FLAG_HIDDEN);
+       else
+          lv_obj_add_flag(s_history_header, LV_OBJ_FLAG_HIDDEN);
+    }
+    if (s_history_feed) {
+       lv_obj_clean(s_history_feed);
+       if (have_history) {
+          lv_obj_remove_flag(s_history_feed, LV_OBJ_FLAG_HIDDEN);
+          for (int i = n_show; i < total && i < n_show + 4; i++) {
+             tool_log_event_t e;
+             if (!tool_log_get(i, &e)) continue;
+             struct tm tm_l;
+             localtime_r(&e.started_at, &tm_l);
+             char tbuf[8];
+             snprintf(tbuf, sizeof(tbuf), "%02d:%02d", tm_l.tm_hour, tm_l.tm_min);
+             build_feed_row(s_history_feed, tbuf, "TOOL", TH_AMBER, e.detail[0] ? e.detail : e.name);
+          }
+       } else {
+          lv_obj_add_flag(s_history_feed, LV_OBJ_FLAG_HIDDEN);
+       }
     }
 }
 

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1580,6 +1580,20 @@ static void now_card_click_cb(lv_event_t *e)
         return;
     }
     if (any_overlay_visible()) return;
+
+    /* When there's no agent activity to show, the navigation to the
+     * Agents overlay just lands the user on the empty-state which
+     * reads as "dummy page" — they expect substantive content from
+     * tapping the now-card.  Surface a hint via toast instead so the
+     * tap isn't silent and the surface stays honest about what's
+     * available.  Once any tool fires the count flips and the tap
+     * navigates as before. */
+    extern int tool_log_count(void);
+    if (tool_log_count() == 0) {
+       ESP_LOGI(TAG, "now-card tapped — no agent activity yet, showing toast");
+       show_toast_internal("Nothing running yet. Try voice.");
+       return;
+    }
     ESP_LOGI(TAG, "now-card tapped -> Agents");
     ui_agents_show();
 }


### PR DESCRIPTION
## User reports
Both surfaced together in live voice-mode testing:
1. **\"swipe up shows filler data\"** — Focus overlay had hardcoded \"AirPods vs Sony XM5\" / \"TinkerClaw roadmap\" demo rows + static \"HEARTBEAT • 2 MIN LIVE\" caption
2. **\"now widget at the bottom takes me to a dummy page\"** — now-card tap always navigated to Agents even when tool_log was empty, landing on the empty state

## Fixes

### ui_focus.c
- Dropped the 2 hardcoded \`build_feed_row\` calls
- Section header + feed (\`s_history_header\`, \`s_history_feed\`) now hide-by-default and \`render_live_focus\` populates them from tool_log entries past the first n_show
- When tool_log has nothing older to show, the entire EARLIER TODAY section hides
- \"HEARTBEAT • 2 MIN LIVE\" → \"HEARTBEAT\" (no honest source for the \"2 MIN LIVE\" duration; narrative line conveys live state)

### ui_home.c now_card_click_cb
- Gate Agents nav on \`tool_log_count() > 0\`
- When empty, surface toast \"Nothing running yet. Try voice.\" instead of navigating
- Plain-ASCII string — em-dash rendered as tofu box on FONT_SECONDARY (Montserrat subset on Tab5 doesn't ship that glyph)

## Live verification

**Before / After Focus overlay:**

| Before | After |
|---|---|
| \"HEARTBEAT • 2 MIN LIVE\" + 2 hardcoded NOTE/CHAT demo rows | \"HEARTBEAT\" only; clean empty state when no tool history |

**Before / After now-card tap (with empty tool_log):**

| Before | After |
|---|---|
| Navigates to Agents overlay → empty \"No tool activity yet\" page | Stays on home + toast \"Nothing running yet. Try voice.\" |

Both verified via screenshots on Tab5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)