### PR TITLE
docs: parking plans for Grove sensor support + M5Stack LLM Module integration

### DIFF
--- a/docs/PLAN-grove.md
+++ b/docs/PLAN-grove.md
@@ -1,0 +1,229 @@
+# Plan — Grove sensor support on Tab5
+
+**Status:** parked, not started.
+**Owner:** unassigned.
+**Tracking issue:** TBD (filed alongside this doc).
+**Last updated:** 2026-04-28.
+
+---
+
+## What this enables
+
+Plug a 4-pin Grove sensor (BME280, SHT3x, MPU6050, soil-moisture, light, anything I2C) into Tab5's **Port A** connector and surface its readings to Dragon, where they become available as conversational context for the LLM ("how warm is it in here?", "remind me to drink water if humidity drops below 30%"). Foundation for any future hardware-extension story — temperature dashboards, environmental triggers for skills, custom bench sensors.
+
+This is **additive infrastructure**, not a feature. Done well it's invisible: a new sensor is one new file and one driver registry entry.
+
+## Why this isn't trivial
+
+Tab5 ships the connector physically but our firmware doesn't initialize the bus, doesn't know the EXT5V pin, doesn't have a sensor-emit WS protocol. Three layers — pinout discovery, driver wrapper, protocol — all of which need to land before the first sensor reading reaches Dragon.
+
+---
+
+## Hardware reality
+
+### Port A (HY2.0-4P, Grove-compatible)
+
+| Pin | Wire | Tab5 connection | Notes |
+|---|---|---|---|
+| 1 | yellow | **GPIO 53** (SCL) | Community-confirmed via Arduino's `M5.getPin(port_a_scl)`. **Not in our `bsp_config.h` yet.** |
+| 2 | white | **GPIO 54** (SDA) | Same — community-confirmed, not in our pin map. |
+| 3 | red | **5 V (gated)** | The 5 V rail is gated by `EXT5V_EN` on one of the IO expanders (0x43 or 0x44). Without flipping that pin, Port A is dark. |
+| 4 | black | GND | — |
+
+### EXT5V_EN — the unknown pin
+
+Both `bsp/tab5/io_expander.{c,h}` and `bsp/tab5/bsp_config.h` document the IO expanders' P-pins **partially**:
+
+- **0x43:** P0 = LCD reset, P1 = speaker amp, P2 = touch reset, P3 = camera reset, P4 = ??? (likely EXT5V), P5-P15 = ???
+- **0x44:** P0 = WiFi C6 power, P1 = USB 5V, P2 = battery charging, P3-P15 = ???
+
+The EXT5V pin is **mentioned in M5's docs as existing** but the exact P-number isn't recorded in our firmware. **First task:** read both expanders' GPIO direction registers + states, log them, then probe Port A for any device while toggling each unknown pin. Whichever pin makes a sensor appear at I2C addr 0x77 is EXT5V.
+
+### Voltage levels
+
+- VCC on the connector: **5 V** (when EXT5V_EN is high).
+- Logic on SCL/SDA: **3.3 V** (Tab5 GPIOs are 3.3 V LVCMOS; pulled up to 3.3 V).
+
+Most Grove I2C breakouts ship with an onboard 3.3 V LDO and tolerate either 3.3 V or 5 V VCC. **Verify per sensor.** If a board only runs at 3.3 V, you'll need a separate 3.3 V supply (USB-C dev board) or to mod the breakout.
+
+### Existing I2C0 bus is full-but-not-claimed
+
+Our system bus (`SDA=31, SCL=32`) has 8 devices on it but **plenty of free 7-bit addresses** (0x08-0x77 range, minus the 8 in use). Port A is a **second physical bus on different GPIOs** — we'll initialize it as I2C Port 1, separate from I2C Port 0.
+
+> Why not just put new sensors on the system bus? Two reasons: (a) the IC list there is closely tied to internal hardware (camera, codec, IMU, RTC, expanders) and we shouldn't risk a cable-induced glitch knocking out the audio codec. (b) Port A is where M5 ships sensors; respecting that contract means a Grove cable Just Works.
+
+---
+
+## Code architecture — where this slots in
+
+### Service-registry pattern
+
+We have a 4-step lifecycle (see `main/service_registry.{c,h}` and `main/service_audio.c` as the cleanest example):
+
+```c
+esp_err_t  XXX_service_init(void);   // probe + alloc, no side effects
+esp_err_t  XXX_service_start(void);  // begin sampling
+esp_err_t  XXX_service_stop(void);   // pause cleanly
+// + register in service_registry.c
+```
+
+Boot sequence in `main.c`:
+1. `tab5_services_register_all()` — populate registry metadata (line 278).
+2. `tab5_services_init_all()` — STORAGE → DISPLAY → AUDIO → NETWORK → DRAGON in order (line 317).
+3. `tab5_services_start(...)` — start each in dependency order (lines 368-384).
+
+A new sensor is a new service. Three file edits per sensor.
+
+### WS protocol extension
+
+Today the Tab5 → Dragon WS messages are `register`, `start/stop` (audio), `text`, `cancel`, `ping`, `config_update`, `user_image`, `widget_action`. None of these carry sensor telemetry.
+
+**New message type to define and ship:**
+
+```json
+{
+  "type": "sensor_data",
+  "kind": "bme280",
+  "ts": 1714329600000,
+  "values": {
+    "temp_c": 23.4,
+    "humidity_pct": 45.2,
+    "pressure_hpa": 1013.7
+  }
+}
+```
+
+Cadence: 1 Hz default, configurable per sensor via the `register` capability advertisement.
+
+**Capability advertisement** at register time extends the existing `capabilities` object:
+
+```json
+{
+  "type": "register",
+  "device_id": "...",
+  "capabilities": {
+    "audio_codec": ["pcm","opus"],
+    "sensors": [
+      {"kind":"bme280","fields":["temp_c","humidity_pct","pressure_hpa"]}
+    ]
+  }
+}
+```
+
+Dragon-side: a small handler in `dragon_voice/server.py` that logs to the session events table or surfaces in the dashboard. Future LLM context-builder can pull recent sensor readings as input ("user is in a 23°C room, 45% humidity") so skills can react.
+
+---
+
+## Phased plan — six small PRs
+
+### Phase 1 — Port A I2C bring-up (no sensor yet)
+
+**Files:** `bsp/tab5/i2c_port_a.{c,h}` (new), `bsp/tab5/bsp_config.h` (define GPIO 53/54 as `TAB5_PORT_A_SCL/SDA`), `main/service_port_a.{c,h}` (new), `main/service_registry.c` (add enum), `main/CMakeLists.txt`.
+
+**Acceptance:**
+- Boot logs "Port A bus ready (SDA=54, SCL=53, 100 kHz)" — chosen 100 kHz for cable robustness.
+- A `tab5_get_i2c_port_a_bus()` accessor returns a valid `i2c_master_bus_handle_t`.
+- `i2c_master_probe(port_a_bus, 0x77, 100)` returns `ESP_ERR_NOT_FOUND` (nothing plugged in yet).
+
+**Risk:** Low. Pure infrastructure, no sensor dependency.
+
+### Phase 2 — EXT5V pin discovery
+
+**Files:** debug helper + `bsp/tab5/io_expander.{c,h}` patch.
+
+**Acceptance:**
+- Identify which IO-expander P-pin enables Port A's 5 V rail.
+- Document in `bsp_config.h` as `TAB5_IOEXP_EXT5V_PIN`.
+- Add `tab5_io_expander_set_ext5v(bool)` API; default-on at boot.
+- After flip: `i2c_master_probe(port_a_bus, 0x77, 100)` finds a BME280 (when one is plugged in).
+
+**Risk:** Medium. Probing the wrong expander pin could disable WiFi or speakers temporarily. Test in a controlled environment.
+
+### Phase 3 — BME280 worked example
+
+**Files:** `main/service_bme280.{c,h}` (new), `main/CMakeLists.txt`, `idf_component.yml` (add `espressif/bme280`).
+
+**Acceptance:**
+- BME280 plugged into Port A is detected at boot.
+- Service samples temp/humidity/pressure at 1 Hz.
+- Readings logged to serial: `bme280: 23.4°C  45.2% RH  1013.7 hPa`.
+
+**Risk:** Low. Driver is upstream-supported and small.
+
+### Phase 4 — `sensor_data` WS protocol
+
+**Files:** `main/voice.c` (new emit function), `dragon_voice/server.py` + `dragon_voice/db.py` (handler + storage), `docs/protocol.md` (TinkerBox).
+
+**Acceptance:**
+- Tab5 emits `sensor_data` frames at 1 Hz when sensor is present.
+- Dragon logs them to `events` table with `event_type = "sensor_data"`.
+- Dashboard "Events" tab can filter to sensor-data frames and show a chart.
+
+**Risk:** Low-medium. Two-repo change; careful with test coverage on both sides.
+
+### Phase 5 — Capability advertisement
+
+**Files:** `main/voice.c` (extend `register` frame), `dragon_voice/server.py` (parse).
+
+**Acceptance:**
+- Tab5's register frame includes `capabilities.sensors` array.
+- Dragon stores per-device sensor list in the `devices` table.
+- LLM context-builder can query "what sensors does this device have?".
+
+**Risk:** Low.
+
+### Phase 6 — LLM context injection
+
+**Files:** `dragon_voice/conversation.py` (extend system prompt with sensor context).
+
+**Acceptance:**
+- Most-recent sensor reading appears in the LLM's system prompt when the user asks about environmental state.
+- LLM responses naturally reference the data ("It's 23°C in your room").
+
+**Risk:** Low (just prompt engineering + a DB query).
+
+---
+
+## Multi-sensor support
+
+Phase 1-6 ship a single sensor. For multiple sensors, two paths:
+
+**Option A — Same Port A bus, different addresses.** BME280 at 0x77, MPU6050 at 0x68 (collision with on-board IMU — don't use), SHT3x at 0x44 (collision with IO expander 2 — don't use). Address conflicts are real on Tab5; check carefully.
+
+**Option B — I2C multiplexer (PCA9548A) on Port A.** 1× 8-channel mux; each channel becomes a virtual sub-bus. Standard ESP-IDF pattern. Adds ~$2-5 hardware, ~50 LOC mux driver, near-zero protocol impact.
+
+**Recommended:** Option B once we have ≥3 sensors; Option A for the first 2.
+
+---
+
+## Honest unknowns
+
+1. **EXT5V_EN pin number** — Phase 2's whole job. Could be P4 on 0x43, could be elsewhere. No way to know without bench probe.
+2. **Whether Port A's GPIO 53/54 work without level-shifting** — most M5 hosts run Port A at 3.3 V logic with a 5 V rail. Should be fine. Verify with scope before plugging fragile sensors.
+3. **Multiplexer bus contention if both audio + sensor poll at high rate** — we share the system bus with the codec (different bus, but mux bring-up could expose latencies). Bench under load.
+
+## Out of scope
+
+- Grove devices using **UART/analog/digital** variants of the connector. Tab5's Port A is I2C-only.
+- 1-Wire / SPI sensors. Different connector, different bus.
+- Hot-swap detection. We assume sensors are present at boot; replug requires reboot.
+- Alerting / threshold rules on Tab5. The LLM can do that via prompt; no firmware-side rule engine.
+
+---
+
+## References
+
+- M5 Tab5 product page: https://docs.m5stack.com/en/core/Tab5
+- Arduino Forum — I2C on Tab5 (GPIO 53/54): https://forum.arduino.cc/t/i2c-on-the-m5stack-tab5/1403830
+- Espressif BME280 driver: https://components.espressif.com/components/espressif/bme280
+- Seeed Wiki — Grove System: https://wiki.seeedstudio.com/Grove_System/
+- HY2.0-4P SMD spec: https://docs.m5stack.com/en/accessory/converter/hy2.0_4p_smd
+
+## Code anchors
+
+- I2C bus init pattern: `bsp/tab5/audio.c:60-140` (system bus + ES8388 codec dev)
+- Service-registry pattern: `main/service_registry.{c,h}` + `main/service_audio.c:16-50`
+- IO expander API: `main/io_expander.h` + `bsp/tab5/io_expander.c`
+- Boot sequence: `main/main.c:278, 317, 368-384`
+- WS register frame emit: `main/voice.c` (search for `"type":"register"` or `voice_send_register`)
+- Pinout reference: `bsp/tab5/bsp_config.h` (the canonical pin map; missing GPIO 53/54 today)

--- a/docs/PLAN-m5-llm-module.md
+++ b/docs/PLAN-m5-llm-module.md
@@ -1,0 +1,264 @@
+# Plan — M5Stack LLM Module integration on Tab5
+
+**Status:** parked, not started.
+**Owner:** unassigned.
+**Tracking issue:** TBD (filed alongside this doc).
+**Last updated:** 2026-04-28.
+**Related:** TinkerTab #67 (widget platform), TinkerBox `docs/ARCHITECTURE.md` (router design).
+
+---
+
+## What this enables
+
+Plug an **M5Stack Module LLM Kit (K144, $79.90)** into Tab5 and have a Local-mode voice path that runs **entirely on-device** — no Dragon, no cloud, no network. Speaker → ASR (Whisper-tiny on the module) → LLM (Qwen2.5-0.5B / Llama-3.2-1B on the module) → TTS (MeloTTS on the module) → speaker. End-to-end ~3-8 seconds for a short reply, smaller models than Dragon's ministral-3B but **5-10× faster**.
+
+Strategic value: a **truly offline** TinkerClaw. Today our "Local" mode still needs a Dragon box on the LAN. With the LLM Module, Tab5 + the module is the entire system. Suitcase TinkerClaw, off-grid TinkerClaw, demo-without-network TinkerClaw.
+
+## SKU clarification — K144 vs K143
+
+| Product | SKU | Form factor | Use here |
+|---|---|---|---|
+| **Module LLM Kit** | **K144** ($79.90) | Stackable M5-Bus + USB-C carrier | **THIS** — sidecar that plugs into Tab5 |
+| LLM630 Compute Kit | K143 (price TBD) | Standalone Linux box w/ GbE, MIPI DSI | Not this — standalone replacement for Dragon |
+
+The user previously mentioned "Module 631" — that's a conflation. The two real products are K144 (sidecar, supersedes the EOL'd M140 module) and K143 (standalone). For our integration: **K144**.
+
+## Hardware specs
+
+| | |
+|---|---|
+| **SoC** | Axera AX630C (dual ARM Cortex-A53 @ 1.2 GHz + 3.2 TOPS NPU @ INT8 / 12.8 TOPS @ INT4) |
+| **Memory** | 4 GB LPDDR4 (split 1 GB system / 3 GB NPU-reserved) |
+| **Storage** | 32 GB eMMC 5.1 |
+| **Power** | ~1.5 W average; ~500-800 mA peak under inference load |
+| **OS** | Debian-flavour Linux + M5's **StackFlow** inference framework |
+| **Models shipped** | Qwen2.5-0.5B/1.5B, Llama-3.2-1B, InternVL2.5-1B (vision), DeepSeek-R1-distill-Qwen-1.5B + Whisper-tiny/base + MeloTTS + YOLO11 |
+| **Throughput** | ~12.88 tok/s for Qwen3-0.6B INT8 (M5's published benchmark) |
+| **Context** | ~2.5 K tokens (`max_token_len=2559, kv_cache=1024, prefill_token_num=128`) |
+| **Cost** | $79.90 (Kit including the carrier) |
+
+### Wire interface — UART @ 115200 8N1
+
+The module is a Linux box that speaks **JSON-over-UART** to the host. Each interaction is a JSON object:
+
+```json
+{
+  "request_id": "1",
+  "work_id": "llm.1234",
+  "action": "inference",
+  "object": "llm.utf-8.stream",
+  "data": "what is the capital of France?"
+}
+```
+
+**Functional units** (separate Linux services on the module):
+`kws`, `vad`, `asr`, `whisper`, `llm`, `vlm`, `tts`, `melotts`, `camera`, `yolo`.
+
+**Lifecycle per unit:** `sys.reset` → `setup(unit, model, params)` returns a `work_id` → `inference(work_id, payload)` (streaming) → `exit`.
+
+**Authoritative source for the JSON schema:** the M5Module-LLM Arduino library at https://github.com/m5stack/M5Module-LLM (v1.7.0 / 2025-09-05, MIT). M5's docs don't publish the full grammar in one place — the C++ source is the de-facto spec.
+
+### Physical connection on Tab5
+
+K144 ships with a **carrier board** (Module13.2 LLM Mate) exposing USB-C + RJ45 + a 4-pin TX/RX/GND/5V header. On Tab5 we'd connect via **Port C** (4-pin UART side connector).
+
+| Tab5 Port C pin | K144 |
+|---|---|
+| GND | GND |
+| 5V (gated by EXT5V_EN) | 5V in |
+| TX (Tab5) | RX (module) |
+| RX (Tab5) | TX (module) |
+
+We don't currently initialize Port C in firmware. **First firmware step:** stand up a UART driver on Port C, do a loopback test, then a "send `sys.reset`, expect ACK" test before plugging the actual module.
+
+---
+
+## Three integration strategies
+
+The decision between these is a **product call**, not an engineering call. Each has different scope, latency, and complexity.
+
+### Option A — Sidecar over UART, transparent (lowest scope)
+
+The module is a "fallback LLM" that voice.c can route to **only when Dragon is unreachable**. Dragon stays the orchestrator. No new voice mode.
+
+**Shape:**
+- New `voice_m5_llm.{c,h}` — pure UART transport + StackFlow JSON marshalling. ~200 LOC.
+- Probe the module on boot; if alive, register as fallback.
+- voice.c's WS-disconnect handler tries the module before showing "Dragon unreachable".
+- Module returns LLM responses; voice.c surfaces them as if from Dragon.
+
+**Pros:**
+- Zero refactor to voice.c — module is a hidden failover.
+- Easy to ship; fast to validate.
+- Doesn't change product surface (no new mode toggle).
+
+**Cons:**
+- Module sits idle 99% of the time (when Dragon is up).
+- Can't use the module's superior latency (3-8 s) when Dragon is reachable.
+- ASR + TTS still go to Dragon; we only fall back the LLM step.
+
+**Effort:** ~3 days.
+
+### Option B — New `voice_mode = LOCAL_ONBOARD` (the obvious shape)
+
+Adds a fourth tier alongside Local / Hybrid / Cloud / TinkerClaw. Selected explicitly by the user via the mode sheet.
+
+**Shape:**
+- New `voice_local_llm.{c,h}` implementing the full Local-onboard pipeline (ASR + LLM + TTS all on the module).
+- Refactor voice.c to abstract the LLM backend behind a `llm_backend_t` interface — today voice.c is hardcoded to a single Dragon WS connection.
+- New mode-sheet entry "Onboard" with copy explaining the tradeoff (smaller models, faster, fully offline).
+- Capability detection at boot — if module isn't plugged in, the mode is grayed out in the sheet.
+
+**Pros:**
+- Cleanest separation; user-controlled which backend runs.
+- Can reuse the module's KWS/VAD/ASR/TTS units, removing CPU pressure from ESP32-P4.
+- Future-proof: adding more backends (Qualcomm AI Hub, Hailo, etc.) becomes a one-line addition.
+
+**Cons:**
+- voice.c refactor is the riskiest part — that file is ~3000 LOC of WebSocket + audio pipeline; introducing a backend abstraction touches every state transition.
+- New mode-sheet UX work.
+- Quality cliff: Qwen2.5-0.5B vs ministral-3B (Local mode today) — instruction-following will be noticeably worse. UX should communicate this honestly.
+
+**Effort:** ~5 days.
+
+### Option C — Replace Dragon entirely (most ambitious)
+
+Module does ASR (Whisper) + LLM + TTS (MeloTTS) all locally. Dragon becomes optional. Conversation state lives on Tab5 (NVS / SD card).
+
+**Shape:**
+- All of Option B, plus:
+- Re-implement Dragon's `pipeline.py` (multi-turn context, tool-calling, memory) in C on Tab5.
+- Conversation history persisted to SD.
+- Skill platform translates from Dragon-side Python skills to module-StackFlow units (or skills disable in Onboard mode).
+
+**Pros:**
+- Suitcase TinkerClaw — works anywhere with no infrastructure.
+- Cool factor: a complete voice assistant on a $200 device.
+
+**Cons:**
+- Multi-week effort.
+- Loses the entire skill ecosystem (Dragon-only Python tools).
+- Conversation memory + RAG can't replicate Dragon's MemoryService / DocumentService without a vector store on Tab5 — possible but heavy.
+
+**Effort:** Multi-week (3+).
+
+### Recommendation
+
+**Ship A first** as a probe — it validates the wire protocol, the carrier-board behavior, the StackFlow schema, the latency math, all without product-surface risk. ~3 days. If the bench results look good (token throughput as advertised, JSON parsing stable, no thermal issues), **escalate to B**. **Skip C** unless we explicitly want offline-only TinkerClaw as a product story.
+
+---
+
+## Phased plan
+
+Same structure as PLAN-grove.md but with bigger phases.
+
+### Phase 0 — Buy K144 + bench standalone (1 day)
+
+**No firmware work.**
+- Order from M5 store ($79.90 + shipping).
+- Wire K144 to a dev board (XIAO ESP32-S3 or similar) with the official Arduino library.
+- Run the `TextAssistant.ino` example.
+- Measure: TTFT, tok/s for `qwen2.5-0.5b`, JSON shapes for setup/inference/exit, error responses.
+- Document any deviations from the published spec in this file.
+
+### Phase 1 — Port C UART bring-up (1 day)
+
+**Files:** `bsp/tab5/uart_port_c.{c,h}` (new), `bsp/tab5/bsp_config.h` (TX/RX pins TBD per Phase 0 bench), `main/service_uart_port_c.{c,h}`.
+
+**Acceptance:**
+- Boot logs "Port C UART ready (TX=N, RX=M, 115200 8N1)".
+- `tab5_port_c_send(buf, len)` and `tab5_port_c_recv(buf, len, timeout)` APIs work.
+- A loopback test (TX shorted to RX) round-trips.
+
+### Phase 2 — StackFlow JSON marshalling (1 day)
+
+**Files:** `main/m5_stackflow.{c,h}` (new) — request builder + response parser. Reuses cJSON which we already include.
+
+**Acceptance:**
+- `m5_stackflow_send_request(...)` builds a JSON object and sends over Port C.
+- `m5_stackflow_parse_response(...)` validates `request_id` matching and unmarshals payloads.
+- Test against bench-captured frames from Phase 0 — at least one round-trip per unit (`sys`, `llm`, `whisper`, `melotts`).
+
+### Phase 3 — `voice_m5_llm.c` sidecar service (1 day)
+
+**Files:** `main/voice_m5_llm.{c,h}` (new), `main/service_registry.c` (add).
+
+**Acceptance:**
+- On boot, attempt `sys.reset` to the module; success means module is alive.
+- Service exposes a synchronous `voice_m5_llm_infer(prompt, output, output_cap, timeout_s)` API.
+- Bench: `voice_m5_llm_infer("Hello, how are you?", buf, 256, 30)` returns a sensible response in ≤8 s.
+
+### Phase 4 — Failover wiring (Option A) (half day)
+
+**Files:** `main/voice.c` (WS-disconnect handler).
+
+**Acceptance:**
+- When Dragon WS is unreachable for 30 s and voice_mode is Local, voice.c routes the next text turn through `voice_m5_llm_infer`.
+- A toast informs the user "Using onboard LLM (Dragon unreachable)".
+- Reconnect to Dragon switches back automatically.
+
+### Phase 5 (optional, decided later) — voice_mode = LOCAL_ONBOARD (Option B) (~5 days)
+
+**Files:** voice.c refactor + new mode-sheet entry + capability gating.
+
+**Out of scope of this initial plan.** File a follow-up issue when we get there.
+
+---
+
+## Latency comparison (estimated)
+
+| Backend | TTFT | tok/s | 100-token reply |
+|---|---|---|---|
+| Cloud (OpenRouter Haiku-3.5) | 1-2 s | 30+ | **3-6 s** |
+| **M5 Module LLM (Qwen2.5-0.5B)** | <1 s* | ~12.88 | **3-8 s** |
+| Dragon Q6A ministral-3B (Local) | ~30 s | ~1.5 | ~65 s |
+
+\* M5 hasn't published TTFT figures — inferred from `prefill_token_num=128` + AX630C clock. **Phase 0 bench will replace these estimates with measurements.**
+
+**Quality cliff:** M5 ships 0.5B-1.5B models. Dragon's ministral is 3B. Cloud is 8B-70B. Expect noticeably worse instruction-following from M5 vs current Local mode, but **5-10× faster** end-to-end.
+
+---
+
+## Honest unknowns
+
+1. **TTFT on AX630C** — no published figure. Phase 0 will measure it directly.
+2. **Module's wire-protocol completeness** — the M5Module-LLM Arduino library is the de facto spec but might not cover every edge case (timeouts, error responses, partial-token streaming). Phase 0 documents gaps.
+3. **Whether VLM (`internvl2.5-1B`) and LLM can co-reside in 3 GB NPU budget** — undocumented. If we want vision-on-device, this is the blocking question.
+4. **Whether M5 still ships a working AX630C model toolchain** as of 2026 — needed for custom models. If Axera deprecated it, we're stuck with the pre-converted models in their package repo.
+5. **Power draw under sustained load + thermal throttling** — 500-800 mA peak per spec. Tab5's 30 Wh battery → ~30-36 hr if module is plugged in continuously. Episodic use is fine. Continuous voice for hours is not.
+6. **Whether Port C exposes UART pins without rework** — research says yes (4-pin connector on the side), but our firmware never tested it.
+
+## Out of scope of this plan
+
+- Vision (`vlm` / `yolo` units on the module). Future work.
+- Multi-module setups (two K144s for redundancy). Why would we?
+- Custom model conversion. We use M5's pre-quantized models from their package repo.
+- Cloud fallback for the module (e.g. when its eMMC fills up). It's local-only by design.
+- Dragon-side awareness of the module. This is a Tab5-firmware-only feature.
+
+---
+
+## References (verified live 2026-04-28)
+
+- M5 Module LLM Kit K144 — store: https://shop.m5stack.com/products/m5stack-llm-large-language-model-module-kit-ax630c
+- M5Module-LLM Arduino library (de-facto protocol spec): https://github.com/m5stack/M5Module-LLM
+- M5 Docs Module LLM main page: https://docs.m5stack.com/en/module/Module-LLM
+- StackFlow software / package list: https://docs.m5stack.com/en/stackflow/module_llm/software
+- AX630C Qwen3-0.6B benchmark, 12.88 tok/s: https://docs.m5stack.com/en/guide/ai_accelerator/llm-8850/m5_llm_8850_qwen3_0.6b
+- Hackster.io launch coverage: https://www.hackster.io/news/m5stack-adds-large-language-model-support-to-its-offerings-with-the-3-2-tops-llm-module-f0a4e061f0de
+- M5 Tab5 product page (Port C reference): https://docs.m5stack.com/en/core/Tab5
+- TextAssistant.ino canonical Arduino example: https://github.com/m5stack/M5Module-LLM/blob/main/examples/TextAssistant/TextAssistant.ino
+
+## Code anchors
+
+- voice.c WS connect path: `main/voice.c` (search `voice_ws_start_client`)
+- Mode-sheet UI: `main/ui_mode_sheet.c`
+- Capability negotiation pattern (audio codec): `main/voice_codec.h:1-41` + `main/voice.c` config_update handler
+- Service-registry pattern: `main/service_registry.{c,h}` + `main/service_audio.c:16-50`
+- Boot sequence: `main/main.c:278, 317, 368-384`
+- IO expander API (for EXT5V_EN gate on Port C 5V rail — same gate as Port A): `main/io_expander.h`
+- TinkerBox router (where a future Onboard backend would slot in if we ever extend the router to the firmware side): `dragon_voice/llm/router.py`
+
+## Companion plan
+
+This document is the LLM-Module half of an external-hardware push. The companion is **`docs/PLAN-grove.md`** which covers Port A I2C sensor support. The two plans share infrastructure work (EXT5V_EN pin discovery on the IO expander) — whichever ships first should land that part for both.


### PR DESCRIPTION
## Summary
Two new external-hardware projects scoped + parked as canonical references. **Documentation only** — no firmware code changes. Lands the deep-research artifacts so the prerequisites + integration shapes don't evaporate before the work starts.

## Companion tracking issues
Will be filed alongside this PR (one per project), each pointing at its plan doc:
1. \"feat: Grove sensor support — Port A I2C bring-up + worked BME280\"
2. \"feat: M5Stack LLM Module integration via UART/StackFlow\"

## Plan docs landed

### \`docs/PLAN-grove.md\` (~250 lines)
- Tab5 Port A pinout (HY2.0-4P, GPIO 53/54, 5V via EXT5V_EN)
- EXT5V_EN pin discovery as Phase 2 (unknown which IO-expander P-pin gates the rail)
- Service-registry pattern for new sensor drivers
- \`sensor_data\` WS protocol design + capability advertisement extension
- 6-phase plan: Port A I2C → EXT5V → BME280 → WS protocol → capability advert → LLM context injection
- Multi-sensor strategy (PCA9548A I2C mux past 2 sensors)

### \`docs/PLAN-m5-llm-module.md\` (~280 lines)
- SKU disambiguation (**K144 sidecar**, not 631 / not LLM630 standalone)
- AX630C specs (3.2 TOPS NPU, 4 GB LPDDR4, 32 GB eMMC, ~\$80)
- StackFlow JSON wire protocol (115200 8N1 over Port C UART)
- **Three integration strategies** with effort + tradeoff:
  - **A**: failover sidecar (~3 days, no voice.c refactor)
  - **B**: new \`voice_mode = LOCAL_ONBOARD\` (~5 days, refactor needed)
  - **C**: replace Dragon entirely (multi-week, big product call)
- 5-phase Option-A plan; Option B/C deferred to follow-up issues
- Honest unknowns documented: TTFT on AX630C, wire-protocol completeness, VLM+LLM co-residency, model-toolchain availability

## Why now, why docs not code
Both projects need real hardware orders ($80 K144 module, plus assorted Grove cables/sensors) before the first PR can land.  Parking the research as docs means anyone (us, future-us, contributors) starts from a complete spec rather than re-doing the SKU hunt and the Axera spec deep-dive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)