### PR TITLE
docs: lock 'modular addon' as non-negotiable in Grove + M5 LLM plans

### DIFF
--- a/docs/PLAN-grove.md
+++ b/docs/PLAN-grove.md
@@ -19,6 +19,23 @@ Tab5 ships the connector physically but our firmware doesn't initialize the bus,
 
 ---
 
+## Non-negotiable: modular addon
+
+**Tab5 must never depend on a Grove sensor being plugged in.** Same architectural rule as the M5 LLM Module plan — sensors are additive features that light up when present and silent when absent.
+
+Translated into rules:
+
+1. **Boot path is sensor-agnostic.** No "waiting for sensor" probes that block boot. The Port A bus comes up; if no device responds at any expected address, the sensor service stays in `IDLE` state.
+2. **No Tab5-side feature regresses without a sensor.** All existing functionality works identically. The LLM context-builder gates on "sensor data available" before injecting — no sensor → no injection, normal prompt.
+3. **Capability detection is the gate.** On boot, the sensor service probes its expected address (≤200 ms). Found → start sampling task + advertise via WS register frame. Not found → silent.
+4. **WS protocol is additive.** `sensor_data` frames only emit when a sensor is present. Dragon must tolerate any subset of capabilities (zero, one, many). No "sensor required" code path on either side.
+5. **Hot-unplug is graceful.** If a sensor stops responding mid-session, the sample task logs a warning, drops the capability advertisement, and the Tab5 keeps running. No reboot, no toast spam.
+6. **No firmware build-time coupling.** Each sensor driver lives behind a runtime probe; no `#ifdef TAB5_HAS_BME280` branches.
+
+This makes the work **strictly additive** — every sensor PR can land without touching production paths used today.
+
+---
+
 ## Hardware reality
 
 ### Port A (HY2.0-4P, Grove-compatible)

--- a/docs/PLAN-m5-llm-module.md
+++ b/docs/PLAN-m5-llm-module.md
@@ -73,6 +73,25 @@ We don't currently initialize Port C in firmware. **First firmware step:** stand
 
 ---
 
+## Non-negotiable: modular addon
+
+**Tab5 must never depend on the LLM Module being present.** This is the architectural constraint that shapes every design choice below.
+
+Translated into rules:
+
+1. **Boot path is module-agnostic.** Tab5 boots identically whether the module is plugged in, unplugged mid-flight, or never present. No "waiting for module" loops. No error dialogs. No log spam past a single "module not detected" debug line.
+2. **No Tab5-side feature regresses if the module is absent.** Local mode still works via Dragon. Cloud still works. Voice overlay still functions. The user must not lose anything by not having the module.
+3. **Capability detection is the gate.** On boot, probe with a short `sys.ping` (≤500 ms timeout). Present → light up addon paths. Absent → silent, no UI artifacts.
+4. **UI surfaces gate on detection.** Mode-sheet entry "Onboard" (if/when shipped) appears **grayed out with a subtitle "module not detected"** when absent — never just missing. Predictable UX.
+5. **Hot-unplug is graceful.** If the module disappears mid-session, in-flight inference fails-soft (toast + reconnect to Dragon path); no Tab5 crash, no LVGL screen-load fault.
+6. **No firmware build-time coupling.** The module-driver code lives behind a runtime check, not `#ifdef TAB5_HAS_M5_LLM`. Same firmware binary works with or without the module.
+
+This **rules out Option C** (replace Dragon entirely) and **constrains Option B** (capability-gated, never default).
+
+**Option A is already shape-correct** — failover sidecar that's silent when Dragon is up, so Tab5 with no module behaves identically to Tab5 with module + Dragon-up.
+
+---
+
 ## Three integration strategies
 
 The decision between these is a **product call**, not an engineering call. Each has different scope, latency, and complexity.


### PR DESCRIPTION
## Why
Per user direction: both Grove sensor support and the M5Stack LLM Module integration must be **additive** — Tab5 must never depend on either being present.

## What changed
Adds a \`## Non-negotiable: modular addon\` section to both \`docs/PLAN-grove.md\` and \`docs/PLAN-m5-llm-module.md\` with six explicit rules:

1. Boot path is module/sensor-agnostic
2. No Tab5-side feature regresses without it
3. Capability detection gates everything
4. UI surfaces gray-out when absent (never missing)
5. Hot-unplug is graceful (no crash)
6. No firmware build-time coupling (#ifdef-free; runtime probe)

## Architectural impact
- **Rules out Option C** (replace Dragon entirely) for the LLM Module
- **Constrains Option B** (capability-gated, never default)
- **Option A is already shape-correct** — failover sidecar that's silent when Dragon is up

## Code-side checklist (deferred to actual implementation PRs)
- Probe timeouts ≤500 ms (LLM Module) / ≤200 ms (sensors)
- Same firmware binary boots with-or-without addons
- WS register frame's \`capabilities\` array is variable-length, never required
- Mode sheet shows grayed-out \"Onboard\" when module absent (never missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)