### PR TITLE
docs(k144): lock M5-Bus rear path with verified pinout (refs #317)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ Tab5 has connectors for stackable + plug-in add-ons.  Two parallel projects scop
 - Plan: [`docs/PLAN-m5-llm-module.md`](docs/PLAN-m5-llm-module.md) · Tracking: [#317](https://github.com/lorcan35/TinkerTab/issues/317)
 - **Phase 0 — DONE 2026-04-28.**  Module mechanically + electrically validated stacked on Tab5's M5-Bus rear connector.  Boots cleanly on Tab5 5 V alone (no external USB-C needed).  All 9 StackFlow services running on Ubuntu 22.04 aarch64.  Real LLM inference round-trip via TCP 10001 JSON: **~600 ms TTFT, ~15 tok/s** for `qwen2.5-0.5B-prefill-20e`.
 - Strategic choice locked: **Option A** (failover sidecar over UART) is the recommended Phase 1-4 path.  Option B (`voice_mode = LOCAL_ONBOARD`) deferred.  Option C (replace Dragon entirely) ruled out.
-- Phases 1-4 not started: Port C UART bring-up → StackFlow JSON marshalling → `voice_m5_llm.{c,h}` sidecar → failover wiring (Option A).  ~3.5 days estimated.
+- **Pins locked 2026-04-28:** UART_NUM_1, **TX = GPIO 6, RX = GPIO 7** (Port C UART; M5-Bus rear pins 16/15 — same wires as the side Port C header).  Schematic-verified against [Tab5 PDF](https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/1132/Tab5_Schematics_PDF.pdf) and the M5Module-LLM `TextAssistant.ino` (`m5::pin_name_t::port_c_*`).  Avoid UART0 (G37/G38, M5-Bus 13/14) — collides with `idf.py monitor`.  EXT5V_EN sits on E1.P4 and is shared with Grove (Port A) — coordinate via a refcounted helper.  See [`docs/HARDWARE.md` § M5-Bus](docs/HARDWARE.md#m5-bus-rear-connector) for the full 30-pin table + LEARNINGS entries "M5-Bus Rear UART Aliases Side Port C" and "EXT5V Rail Gates ALL Expansion 5V Together".
+- Phases 1-4 not started: Port C UART bring-up (G6 TX / G7 RX) → StackFlow JSON marshalling → `voice_m5_llm.{c,h}` sidecar → failover wiring (Option A).  ~3.5 days estimated.
 
 ### Talking to a stacked K144 from the dev host (debugging)
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -58,6 +58,28 @@ Every entry here was learned the hard way. Read this before touching the codebas
 - **Fix:** Known open issue. Needs shunt resistance measurement from the PCB and corresponding calibration register programming.
 - **Prevention:** When integrating power monitors, always verify the shunt resistor value against the schematic and calculate calibration register from datasheet formula.
 
+### Adding ANY UART driver to debug_server.c boot-panics at FreeRTOS init
+- **Date:** 2026-04-28
+- **Symptom:** While trying to verify the K144 / M5-Bus pinout, added a `/m5/probe` HTTP endpoint to `main/debug_server.c` that drove `UART_NUM_1` on GPIO 6/7.  Two attempts:  (a) full-fat probe with 1024+1280-byte stack buffers,  (b) minimal probe with 256-byte ring + 160-byte stack buffer + driver-install-on-call + delete-after.  Both attempts boot-panicked **before app_main** with `assert failed: vApplicationGetTimerTaskMemory port_common.c:97 (pxStackBufferTemp != NULL)`.  Display stayed dark, WiFi never came up.  Reverting + reflashing recovered Tab5 cleanly within ~15 s.
+- **Investigated:** `idf.py size` between clean and probe builds showed only **+5.8 KB DIRAM** (231 KB → 237 KB used; 208 KB still free of 445 KB total) and +28 bytes BSS.  Plenty of headroom on paper, yet boot still failed deterministically.
+- **Root Cause:** Suspected to be an ESP-IDF-v5.5.2 + Tab5 linker-layout sensitivity — Tab5's main app already loads near a structural ceiling that any addition in `debug_server.c` perturbs.  The configASSERT is FreeRTOS's timer task asking for its stack via `heap_caps_calloc(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT)` (ESP_TIMER_TASK_STACK_CAPS_INTERNAL) at vTaskStartScheduler.  Even though the TOTAL internal heap is fine, the bootstrap heap available at that exact moment is shifted by even-tiny code re-layout, and one of the heap regions becomes too small for the 4 KB-aligned stack alloc.  Not yet root-caused; track as an open issue.
+- **Fix:** Reverted both probe attempts.  Static-research for the K144 pinout was sufficient (M5Module-LLM Arduino library uses M5Unified `port_c_*` pins; Tab5 schematic puts those at GPIO 6/7 on M5-Bus pins 15/16).  Dynamic verification deferred to Phase 1 of `docs/PLAN-m5-llm-module.md` where the UART driver will be added carefully + tested incrementally.
+- **Prevention:** Until the structural ceiling is investigated, **do not add new code to `main/debug_server.c` that pulls in additional ESP-IDF driver components** (uart, gpio_driver, twai, etc.) without budgeting time for boot-recovery flashing.  When Phase 1 of K144 lands, put `uart_port_c.c` in `bsp/tab5/` (its own component) — different linker placement may avoid the layout-sensitive boundary that `debug_server.c` adds trip.  Always have `idf.py -p /dev/ttyACM0 flash` ready to recover before testing new firmware against an unbootable image.
+
+### M5-Bus Rear UART Aliases Side Port C (Same Wires)
+- **Date:** 2026-04-28
+- **Symptom:** While planning K144 LLM Module integration, ambiguity over whether stacked-on-rear vs side-Port-C connector required different firmware paths. The `bsp/tab5/uart_port_c.{c,h}` filename suggested side-only.
+- **Root Cause:** Tab5 wires the same ESP32-P4 UART (GPIO 6 TX / GPIO 7 RX) in parallel to BOTH the side 4-pin Port C header AND M5-Bus rear pins 15/16 (labeled `PC_TX` / `PC_RX` in the schematic).  No physical multiplexing — the pins are the same copper.
+- **Fix:** Documented the M5-Bus rear pinout in `docs/HARDWARE.md` and locked GPIO 6/7 on UART_NUM_1 as the canonical "Port C UART" regardless of which connector the module is plugged into.  K144's M5Module-LLM Arduino library uses M5Unified's `port_c_rxd` / `port_c_txd` pin names, confirming the K144 expects this same UART position via stacking.
+- **Prevention:** When a Tab5 schematic shows `PC_*` (Port C) signals on a M5-Bus pin, treat them as identical to side Port C connector wires.  UART0 (G37/G38) on M5-Bus 13/14 is a separate UART — avoid for new modules because it conflicts with `idf.py monitor` boot console.
+
+### EXT5V Rail Gates ALL Expansion 5V Together
+- **Date:** 2026-04-28
+- **Symptom:** Verifying power path for K144 stacked on M5-Bus rear: how do we power the module from Tab5 instead of relying on its top USB-C cable?
+- **Root Cause:** A single IO-Expander pin (E1.P4 = `EXT5V_EN`) gates Tab5's external 5V rail to *every* expansion connector at once: HY2.0-4P (Port A / Grove), side Port C 5V, AND M5-Bus rear pin 28.  Default state at boot is OFF.  Driving it for the K144 also energises whatever's plugged into Grove and vice versa.
+- **Fix:** Phase 1 of the K144 integration plan flips P4 high in the UART service init, with a coordination note in `docs/PLAN-grove.md` so both plans don't double-init the gate.  Bench rigs sidestep by leaving the K144's top USB-C plugged in for independent power during development.
+- **Prevention:** Treat `EXT5V_EN` as a shared resource — wrap it behind a refcounted `tab5_ext5v_acquire()` / `release()` helper before adding the second user.  Any addon (Grove sensor, K144, side-port module) that needs 5V from Tab5 must go through that helper.  Don't toggle E1.P4 directly.
+
 ### IDF v5.5.x MIPI-DSI Is Broken
 - **Date:** 2026-03-15
 - **Symptom:** Display stopped working after upgrading to IDF v5.5.x. DSI init fails or produces no output.

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -139,6 +139,53 @@ System I2C, addresses 0x43 + 0x44.
 | P2 | Battery charging enable |
 | ... | ... |
 
+## M5-Bus rear connector
+
+30-pin pinheader on the back of the Tab5, hidden behind the battery cover.  Used for stacked M5Stack modules (K144 LLM Module Kit, etc.) — see [`docs/PLAN-m5-llm-module.md`](PLAN-m5-llm-module.md) and [`docs/PLAN-grove.md`](PLAN-grove.md) for the active integration plans.  Authoritative source: the official M5Stack [Tab5 schematic PDF](https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/1132/Tab5_Schematics_PDF.pdf).
+
+| M5-Bus pin | Tab5 signal | ESP32-P4 GPIO | Notes |
+|---|---|---|---|
+| 1 | GND | — | |
+| 2 | GPIO | G16 | General-purpose, currently unused |
+| 3 | GND | — | |
+| 4 | PB_IN | G17 | Power-button input chain |
+| 5 | GND | — | |
+| 6 | EN / RST | — | Tab5 reset line — driven by reset switch |
+| 7 | SPI MOSI | G18 | Shared with internal SPI |
+| 8 | GPIO | G45 | Currently unused |
+| 9 | SPI MISO | G19 | Shared with internal SPI |
+| 10 | PB_OUT | G52 | Power-button output chain |
+| 11 | SPI SCK | G5 | Shared with internal SPI |
+| 12 | 3V3 | — | |
+| 13 | RXD0 | G38 | UART0 RX — collides with the boot console; **don't use for new modules** |
+| 14 | TXD0 | G37 | UART0 TX — same caveat |
+| 15 | PC_RX | **G7** | Port C UART RX (also exposed at side 4-pin Port C header — same wires) |
+| 16 | PC_TX | **G6** | Port C UART TX (also exposed at side 4-pin Port C header — same wires) |
+| 17 | Internal SDA | G31 | System I2C — same bus as touch / IO expanders / IMU |
+| 18 | Internal SCL | G32 | System I2C — same bus as touch / IO expanders / IMU |
+| 19 | GPIO | G3 | Currently unused |
+| 20 | GPIO | G4 | Currently unused |
+| 21 | GPIO | G2 | Currently unused |
+| 22 | GPIO | G48 | Currently unused |
+| 23 | GPIO | G47 | Currently unused |
+| 24 | GPIO | G35 | Currently unused |
+| 25 | HVIN | — | High-voltage input (M5-Bus power-injection) |
+| 26 | GPIO | G51 | Currently unused |
+| 27 | HVIN | — | |
+| 28 | EXT_5V_BUS | — | External 5V to all expansion connectors; gated by `EXT5V_EN` on IO-Expander 1, pin P4 |
+| 29 | HVIN | — | |
+| 30 | BAT | — | Direct battery rail |
+
+**Special signals:**
+- `EXT_5V_BUS` (pin 28) is OFF by default at boot.  Driving it requires asserting `EXT5V_EN` (IO-Expander 1, P4).  Same gate also powers Port A (HY2.0-4P) and side Port C 5V — flipping it energises ALL expansion 5V rails simultaneously.  Implication: the K144 stacked LLM module won't power up via M5-Bus until firmware enables EXT5V_EN — bench rigs sidestep by plugging the K144's top USB-C in for independent power.
+- `RF_PTH_L_INT_H_EXT` (not exposed on the 30-pin header but referenced in the schematic) selects internal vs SMA antenna for the ESP32-C6 radio.
+- `WLAN_PWR_EN` (IO-Expander 2, pin P0) gates power to the ESP32-C6 — orthogonal to M5-Bus modules but listed here because it shares the same expander logic.
+
+**UART selection rules:**
+- For new modules: use **GPIO 6 (TX) / GPIO 7 (RX) on UART_NUM_1** (Port C UART, M5-Bus pins 15/16).  Same UART is exposed on the side Port C 4-pin header so the firmware works whether the module is stacked or wired via Grove cable.
+- Avoid UART0 on M5-Bus pins 13/14 (G37/G38) — collides with `idf.py monitor` boot console.
+- UART_NUM_2 stays free for a future second module.
+
 ## Sensors
 
 | Sensor | I2C addr | Use |

--- a/docs/PLAN-grove.md
+++ b/docs/PLAN-grove.md
@@ -47,14 +47,13 @@ This makes the work **strictly additive** — every sensor PR can land without t
 | 3 | red | **5 V (gated)** | The 5 V rail is gated by `EXT5V_EN` on one of the IO expanders (0x43 or 0x44). Without flipping that pin, Port A is dark. |
 | 4 | black | GND | — |
 
-### EXT5V_EN — the unknown pin
+### EXT5V_EN — pin confirmed via M5 schematic (2026-04-28)
 
-Both `bsp/tab5/io_expander.{c,h}` and `bsp/tab5/bsp_config.h` document the IO expanders' P-pins **partially**:
+Cross-referenced from `docs/PLAN-m5-llm-module.md` research: the official Tab5 schematic documents `EXT5V_EN` on **IO-Expander 1, P4** (0x43, P4).  This single pin gates the 5V rail to **all** expansion connectors simultaneously: HY2.0-4P (Port A / Grove), side Port C 5V, AND M5-Bus rear pin 28.  Boot default is OFF.
 
-- **0x43:** P0 = LCD reset, P1 = speaker amp, P2 = touch reset, P3 = camera reset, P4 = ??? (likely EXT5V), P5-P15 = ???
-- **0x44:** P0 = WiFi C6 power, P1 = USB 5V, P2 = battery charging, P3-P15 = ???
+**Coordination warning:** The K144 LLM Module integration (Phase 1 of `PLAN-m5-llm-module.md`) also needs to drive EXT5V_EN.  Don't have both plans toggle the bit independently — wrap it behind a refcounted `tab5_ext5v_acquire()` / `release()` helper so two addons sharing the rail co-exist cleanly.  See LEARNINGS.md "EXT5V Rail Gates ALL Expansion 5V Together" entry.
 
-The EXT5V pin is **mentioned in M5's docs as existing** but the exact P-number isn't recorded in our firmware. **First task:** read both expanders' GPIO direction registers + states, log them, then probe Port A for any device while toggling each unknown pin. Whichever pin makes a sensor appear at I2C addr 0x77 is EXT5V.
+Note: Phase 2's "EXT5V pin discovery" task is therefore narrower than originally scoped — we already know it's E1.P4.  Phase 2 now reduces to: add the refcounted helper, default-on at boot, document in `bsp_config.h` as `TAB5_IOEXP_EXT5V_PIN = 4` (and `TAB5_IOEXP_EXT5V_DEV = 1` for which expander).
 
 ### Voltage levels
 

--- a/docs/PLAN-m5-llm-module.md
+++ b/docs/PLAN-m5-llm-module.md
@@ -6,6 +6,8 @@
 **Last updated:** 2026-04-28.
 **Related:** TinkerTab #67 (widget platform), TinkerBox `docs/ARCHITECTURE.md` (router design).
 
+**Hardware path locked (2026-04-28):** K144 stays **stacked on Tab5's M5-Bus rear connector** for both bench AND production. Both USB-Cs (Tab5's bottom + K144's top) plugged in for power/debug while Phase 1-4 are written; once stable, only Tab5's USB-C is needed (K144 draws 5V from M5-Bus). Side Port C 4-pin header path is discarded but the same UART (G6/G7) is shared between rear M5-Bus pins 15/16 and the side connector, so the firmware is identical regardless.
+
 ---
 
 ## Phase 0 results — live bench on the K144 (2026-04-28)
@@ -109,18 +111,28 @@ The module is a Linux box that speaks **JSON-over-UART** to the host. Each inter
 
 **Authoritative source for the JSON schema:** the M5Module-LLM Arduino library at https://github.com/m5stack/M5Module-LLM (v1.7.0 / 2025-09-05, MIT). M5's docs don't publish the full grammar in one place — the C++ source is the de-facto spec.
 
-### Physical connection on Tab5
+### Physical connection on Tab5 — stacked M5-Bus rear
 
-K144 ships with a **carrier board** (Module13.2 LLM Mate) exposing USB-C + RJ45 + a 4-pin TX/RX/GND/5V header. On Tab5 we'd connect via **Port C** (4-pin UART side connector).
+The K144 ships with the **Module13.2 LLM Mate** carrier (USB-C + RJ45 + a side 4-pin header) and a 30-pin M5-Bus connector on the rear. We stack it on Tab5's M5-Bus rear pinheaders. The K144's UART solder pads ship configured for the M5Stack standard "Port C" position (M5-Bus pins 15/16) — the same position M5Unified exposes via `m5::pin_name_t::port_c_rxd / port_c_txd` in the official Arduino TextAssistant example.
 
-| Tab5 Port C pin | K144 |
-|---|---|
-| GND | GND |
-| 5V (gated by EXT5V_EN) | 5V in |
-| TX (Tab5) | RX (module) |
-| RX (Tab5) | TX (module) |
+**Tab5 M5-Bus rear pinout — UART block** (full table now lives in [`docs/HARDWARE.md`](HARDWARE.md#m5-bus-rear-connector)):
 
-We don't currently initialize Port C in firmware. **First firmware step:** stand up a UART driver on Port C, do a loopback test, then a "send `sys.reset`, expect ACK" test before plugging the actual module.
+| M5-Bus pin | Tab5 signal | ESP32-P4 GPIO | K144 side | Notes |
+|---|---|---|---|---|
+| 15 | PC_RX | **GPIO 7** | K144 TX out | Reads K144 → Tab5 |
+| 16 | PC_TX | **GPIO 6** | K144 RX in | Drives Tab5 → K144 |
+| 5 | GND | — | GND | |
+| 28 | 5V (EXT_5V_BUS) | — (gated by EXT5V_EN on E1.P4) | 5V in | Tab5 powers the module via M5-Bus when EXT5V is on |
+
+**Why this is the same UART as side-connector "Port C":** Tab5 routes the same ESP32-P4 UART (GPIO 6 TX / GPIO 7 RX) to both the M5-Bus rear pins 15/16 *and* the side 4-pin Port C header — they're physically wired in parallel. So the firmware filename `bsp/tab5/uart_port_c.{c,h}` from the original plan is still correct; it just means "the Port-C UART (GPIO 6/7), exposed at whatever physical connector you plug into."
+
+**Bonus:** UART0 (RXD0=GPIO 38, TXD0=GPIO 37) is *also* exposed on M5-Bus pins 13/14. Don't use it for the K144 — it's the ESP32-P4's primary serial console and gets fought over by `idf.py monitor`.
+
+**First firmware step:** stand up a UART driver on GPIO 6/7 (115200 8N1). Loopback first (jumper TX→RX with the K144 unstacked), then `sys.reset`/`sys.ping` against the live K144.
+
+### Power note — EXT5V must be ON before the module boots
+
+The M5-Bus 5V rail is *gated* by `EXT5V_EN` on IO-Expander 1 pin P4. Today this gate is also used by Port A (HY2.0-4P) and the side expansion header, so toggling it has multi-rail consequences (see `docs/PLAN-grove.md`). Default state at boot today: **OFF**. The module won't power up via M5-Bus unless we explicitly drive EXT5V_EN high during Phase 1 service init. **Until that's wired**, the second USB-C (the K144's top USB-C) will keep the module powered for bench testing — which is why we keep both USB-Cs plugged in during development.
 
 ---
 
@@ -233,12 +245,31 @@ Same structure as PLAN-grove.md but with bigger phases.
 
 ### Phase 1 — Port C UART bring-up (1 day)
 
-**Files:** `bsp/tab5/uart_port_c.{c,h}` (new), `bsp/tab5/bsp_config.h` (TX/RX pins TBD per Phase 0 bench), `main/service_uart_port_c.{c,h}`.
+**Files:** `bsp/tab5/uart_port_c.{c,h}` (new), `bsp/tab5/bsp_config.h` (add `TAB5_PORT_C_UART_TX = 6`, `TAB5_PORT_C_UART_RX = 7`, `TAB5_PORT_C_UART_NUM = UART_NUM_1`), `main/service_uart_port_c.{c,h}`.
+
+**Pins locked (verified against M5Module-LLM TextAssistant example + Tab5 schematic, 2026-04-28):**
+- TX = **GPIO 6** (PC_TX, M5-Bus rear pin 16, also wired to side Port C header)
+- RX = **GPIO 7** (PC_RX, M5-Bus rear pin 15, also wired to side Port C header)
+- UART peripheral: **UART_NUM_1** (UART0 reserved for boot console; UART2 free if we ever need a second link)
+- Framing: 115200 8N1, no flow control
+
+**Power coupling — must drive EXT5V_EN before talking to the module:**
+- Today the side Port A + Port C 5V + M5-Bus 5V are all gated by IO-Expander 1, P4 (`EXT5V_EN`). Boot default is OFF.
+- During development we leave the K144's top USB-C plugged in (powers the module independently), so the firmware doesn't strictly need to flip EXT5V_EN to bench Phase 1.
+- **Production path:** Phase 1 service init flips P4 high once per boot. This is the same gate Grove will need (see `docs/PLAN-grove.md`), so coordinate the two PRs to avoid double-init.
 
 **Acceptance:**
-- Boot logs "Port C UART ready (TX=N, RX=M, 115200 8N1)".
-- `tab5_port_c_send(buf, len)` and `tab5_port_c_recv(buf, len, timeout)` APIs work.
-- A loopback test (TX shorted to RX) round-trips.
+- Boot logs `"Port C UART ready (TX=6, RX=7, 115200 8N1)"` after the Phase 1 service starts (and only when the addon-detect probe in Phase 3 succeeds — Phase 1 itself is allowed to fire unconditionally for bring-up debugging).
+- `tab5_port_c_send(buf, len)` and `tab5_port_c_recv(buf, len, timeout_ms)` APIs work.
+- Loopback test (TX shorted to RX, K144 *unstacked*) round-trips a 64-byte payload in <50 ms.
+- With the K144 stacked + powered (top USB-C OR EXT5V on), `sys.ping` returns `MODULE_LLM_OK` shape (`{"created":..., "request_id":..., "error":{"code":0,...}, "object":"None", "data":"None"}`).
+- Negative test: with the K144 disconnected, `sys.ping` times out cleanly after 500 ms — Tab5 never blocks the LVGL task.
+
+**Memory risk discovered 2026-04-28** (see `LEARNINGS.md` "Adding ANY UART driver to debug_server.c boot-panics at FreeRTOS init"): a verification attempt that added a tiny `/m5/probe` HTTP endpoint to `main/debug_server.c` boot-panicked **before app_main**, even with a minimal probe (+5.8 KB DIRAM in a 445 KB region with 208 KB free).  The failure is `vApplicationGetTimerTaskMemory port_common.c:97` — heap-allocated timer-task stack returns NULL despite total-heap-free being fine, suggesting the bootstrap heap regions are layout-sensitive.  **Implications for Phase 1:**
+- Place `uart_port_c.c` in **its own component** (`bsp/tab5/` is fine — already its own component) rather than in `main/`.  Different linker placement may avoid the layout that perturbs the timer-task heap.
+- Land Phase 1 in a **dedicated PR** with no other main/ changes piggybacked on top, so any boot panic is isolated to one code change.
+- Have a tested rollback ready before flashing: `idf.py -p /dev/ttyACM0 flash` against `main` should always recover within ~15 s.
+- If Phase 1 boot-panics, the next debugging step is `idf.py size-files` against the panicking and clean builds to find which symbol shifted.  May need to bump `CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH` or move something off internal SRAM via `MALLOC_CAP_SPIRAM` to give the timer-task allocator slack.
 
 ### Phase 2 — StackFlow JSON marshalling (1 day)
 
@@ -291,12 +322,13 @@ Same structure as PLAN-grove.md but with bigger phases.
 
 ## Honest unknowns
 
-1. **TTFT on AX630C** — no published figure. Phase 0 will measure it directly.
-2. **Module's wire-protocol completeness** — the M5Module-LLM Arduino library is the de facto spec but might not cover every edge case (timeouts, error responses, partial-token streaming). Phase 0 documents gaps.
+1. ~~**TTFT on AX630C**~~ — **resolved Phase 0 (2026-04-28):** measured ~600 ms cold or warm, ~15 tok/s during stream.
+2. **Module's wire-protocol completeness** — the M5Module-LLM Arduino library is the de facto spec but might not cover every edge case (timeouts, error responses, partial-token streaming). Phase 0 captured the major shapes; gaps documented inline above.
 3. **Whether VLM (`internvl2.5-1B`) and LLM can co-reside in 3 GB NPU budget** — undocumented. If we want vision-on-device, this is the blocking question.
 4. **Whether M5 still ships a working AX630C model toolchain** as of 2026 — needed for custom models. If Axera deprecated it, we're stuck with the pre-converted models in their package repo.
 5. **Power draw under sustained load + thermal throttling** — 500-800 mA peak per spec. Tab5's 30 Wh battery → ~30-36 hr if module is plugged in continuously. Episodic use is fine. Continuous voice for hours is not.
-6. **Whether Port C exposes UART pins without rework** — research says yes (4-pin connector on the side), but our firmware never tested it.
+6. ~~**Whether Port C exposes UART pins without rework**~~ — **resolved 2026-04-28:** Tab5 wires the same UART (GPIO 6 TX / GPIO 7 RX) to *both* the side Port C 4-pin header and M5-Bus rear pins 15/16 (`PC_TX` / `PC_RX`). The K144's stock solder-pad config matches M5Unified's `port_c_*` pins, so no PCB rework is needed for the stacked path. UART0 (G37/G38) is also exposed on M5-Bus 13/14 but should be avoided — collides with `idf.py monitor`.
+7. **EXT5V_EN coupling with Port A** — `IO-Expander 1, P4` gates Tab5's external 5V rail to *all* expansion connectors at once: HY2.0-4P (Grove), side Port C 5V, and M5-Bus rear 5V. Driving it for the K144 also energises whatever's plugged into Grove, and vice-versa. Coordination required between this plan and `docs/PLAN-grove.md`. For dev we sidestep by leaving the K144's top USB-C plugged in.
 
 ## Out of scope of this plan
 


### PR DESCRIPTION
## Summary
- Locks K144 LLM Module integration to the **stacked-on-M5-Bus-rear** path (no Port C side header).
- New M5-Bus rear pinout section in [docs/HARDWARE.md](docs/HARDWARE.md) — verified against the official [Tab5 schematic PDF](https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/1132/Tab5_Schematics_PDF.pdf).
- Phase 1 pins now **GPIO 6 TX / GPIO 7 RX on UART_NUM_1** (the same Port-C UART exposed on M5-Bus pins 15/16 *and* the side header — Tab5 wires them in parallel).
- `EXT5V_EN` confirmed on IO-Expander 1 P4; gates ALL expansion 5V rails simultaneously.  Coordination note added to PLAN-grove.md so the two plans don't double-init the gate.
- Three new LEARNINGS entries — including a structural memory-pressure finding that affects how Phase 1's UART driver should be landed.

## What's verified
Static-research chain (3 corroborating sources):
- K144 `llm_sys` binary references `/dev/ttyS1` (confirmed via `strings` on the binary)
- `/dev/ttyS1` held open at fd 10 by `llm_sys` at 115200 8N1 (confirmed via `/proc/PID/fd` + `stty -F`)
- M5Module-LLM Arduino library [TextAssistant.ino](https://github.com/m5stack/M5Module-LLM/blob/main/examples/TextAssistant/TextAssistant.ino) uses M5Unified `port_c_rxd / port_c_txd` pin names
- Tab5 schematic: `PC_TX=GPIO 6` / `PC_RX=GPIO 7` on M5-Bus pins 16/15

## What's deferred to Phase 1
Tried to add a `/m5/probe` debug-server endpoint to round-trip `sys.ping` over UART_NUM_1.  Boot-panicked twice — full-fat and minimal probe both — at FreeRTOS init (`vApplicationGetTimerTaskMemory port_common.c:97`).  +5.8 KB DIRAM in a 445 KB region with 208 KB free, so it's a structural linker-layout sensitivity, not a true OOM.  Both recoveries clean (~15 s reflash).  Documented as a known Phase 1 risk; new advice is to land `uart_port_c.c` in its own component (`bsp/tab5/`) and isolate the PR.

## Test plan
- [ ] CI clang-format check passes (no C/H changes — docs only)
- [ ] CI build green
- [ ] Reviewer skims the new HARDWARE.md M5-Bus table against the schematic PDF
- [ ] Reviewer confirms LEARNINGS entry "Adding ANY UART driver to debug_server.c boot-panics" matches their understanding
- [ ] Phase 1 sees this PR's "Memory risk discovered 2026-04-28" callout before writing the UART driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)