### PR TITLE
refactor(debug_server): extract K144 endpoint family (Wave 23b, refs #332)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
         SRCS "main.c"
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
-             "debug_server.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
+             "debug_server.c" "debug_server_m5.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"
              "ui_core.c" ${UI_SRCS}

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -56,8 +56,9 @@
 #include "ui_settings.h"
 #include "ui_wifi.h"
 #include "voice.h"
-#include "voice_m5_llm.h"  /* TT #327 Wave 5: K144 baud accessor for /m5 */
-#include "voice_onboard.h" /* TT #327 Wave 4b: chain_active + failover_state */
+/* Wave 23b (#332): K144 endpoint family + auth shim moved to siblings. */
+#include "debug_server_internal.h"
+#include "debug_server_m5.h"
 #include "widget.h"        /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -158,6 +159,12 @@ static bool check_auth(httpd_req_t *req)
     }
     return true;
 }
+
+/* Wave 23b (#332): public wrapper for the per-family extracted modules
+ * (debug_server_m5.c, …) — see debug_server_internal.h.  The historic
+ * 65 in-tree call sites still use the static `check_auth` to keep the
+ * extraction diff minimal; new family files go through this wrapper. */
+bool tab5_debug_check_auth(httpd_req_t *req) { return check_auth(req); }
 
 /* ======================================================================== */
 /*  Touch injection state — read by the LVGL indev read callback             */
@@ -2437,238 +2444,7 @@ static esp_err_t voice_state_handler(httpd_req_t *req)
     return ret;
 }
 
-/* ── M5 / K144 status endpoint (TT #327 Wave 5) ─────────────────────────
- * GET /m5 — diagnostic snapshot of K144 LLM Module state.  Closes audit
- * #18 (no remote diagnostic for "chain didn't start" / "is K144 warm").
- */
-/* Wave 14 — cached hwinfo + version snapshot.  GET /m5 may be polled
- * by the dashboard / harness every few seconds; refreshing sys.hwinfo
- * on every call would saturate the UART (~150 ms per round-trip ×
- * concurrent polls = head-of-line blocking on llm.infer calls).  Cache
- * for 30 s; clients that want fresh data poll less often or use
- * POST /m5/refresh to force an update.
- *
- * Also avoids the worst-case path where K144 is hung mid-NPU-load and
- * sys.hwinfo silently stalls — every /m5 GET would otherwise block
- * 1.5 s on the timeout.  The cache bounds this to once per 30 s. */
-static voice_m5_hwinfo_t s_m5_hwinfo_cache = {0};
-static char s_m5_version_cache[16] = {0};
-static int64_t s_m5_hwinfo_refreshed_us = 0; /* time of last SUCCESS */
-static int64_t s_m5_hwinfo_attempted_us = 0; /* time of last ATTEMPT (success OR skip) */
-#define M5_HWINFO_CACHE_TTL_US (30LL * 1000LL * 1000LL)
-#define M5_HWINFO_RETRY_GATE_US (5LL * 1000LL * 1000LL) /* 5 s — bounds rate when K144 not READY */
-
-static void m5_refresh_hwinfo_if_stale(bool force) {
-   int64_t now = esp_timer_get_time();
-   /* Cache hit fast-path — last successful fetch within TTL window. */
-   if (!force && s_m5_hwinfo_refreshed_us != 0 && (now - s_m5_hwinfo_refreshed_us) < M5_HWINFO_CACHE_TTL_US) {
-      return;
-   }
-   /* Even if cache is stale, throttle attempts (avoids hammering the
-    * UART when /m5 is polled rapidly during a recovery cycle).  5 s
-    * is short enough that a UNAVAILABLE→READY transition picks up new
-    * data within ~10 s; long enough that 50 polls/sec from a script
-    * don't queue 50 sys.hwinfo round-trips. */
-   if (!force && s_m5_hwinfo_attempted_us != 0 && (now - s_m5_hwinfo_attempted_us) < M5_HWINFO_RETRY_GATE_US) {
-      return;
-   }
-   s_m5_hwinfo_attempted_us = now;
-
-   /* Skip the actual sys.hwinfo if K144 isn't READY — it would just
-    * time out and waste 1.5 s.  Cached values stay; client sees old
-    * data with `cache_age_ms` shown so they can decide what to trust. */
-   int fs = voice_onboard_failover_state();
-   if (fs != 2 /* M5_FAIL_READY */) {
-      return;
-   }
-
-   voice_m5_hwinfo_t fresh = {0};
-   esp_err_t he = voice_m5_llm_sys_hwinfo(&fresh);
-   if (he == ESP_OK && fresh.valid) {
-      s_m5_hwinfo_cache = fresh;
-      s_m5_hwinfo_refreshed_us = now;
-   }
-   /* Version is fixed per K144 firmware install — read once and cache.
-    * Cache survives sys.reset (daemon restart, version unchanged) but
-    * does NOT survive a Tab5 reboot. */
-   if (s_m5_version_cache[0] == '\0') {
-      (void)voice_m5_llm_sys_version(s_m5_version_cache, sizeof(s_m5_version_cache));
-   }
-}
-
-static esp_err_t m5_status_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-
-   /* Wave 14 — refresh hwinfo cache (no-op if warm + fresh enough). */
-   m5_refresh_hwinfo_if_stale(false);
-
-   cJSON *root = cJSON_CreateObject();
-   cJSON_AddBoolToObject(root, "chain_active", voice_onboard_chain_active());
-   /* Wave 7: chain_uptime_ms — 0 if not active.  Lets a remote operator
-    * spot a stuck chain without a serial cable. */
-   cJSON_AddNumberToObject(root, "chain_uptime_ms", (double)voice_onboard_chain_uptime_ms());
-   int fs = voice_onboard_failover_state();
-   cJSON_AddNumberToObject(root, "failover_state", fs);
-   const char *fs_names[] = {"unknown", "probing", "ready", "unavailable"};
-   cJSON_AddStringToObject(root, "failover_state_name", (fs >= 0 && fs <= 3) ? fs_names[fs] : "?");
-   cJSON_AddNumberToObject(root, "uart_baud", (double)voice_m5_llm_get_baud());
-
-   /* Wave 14 — hardware status.  `valid` is true only when the cache
-    * holds a successfully-parsed sys.hwinfo response; `cache_age_ms`
-    * tells the client how stale the snapshot is.  `temp_celsius`
-    * comes from the milli-degree field divided by 1000 (preserving
-    * one decimal — JSON consumer can format). */
-   cJSON *hw = cJSON_CreateObject();
-   bool hw_valid = (s_m5_hwinfo_cache.valid != 0);
-   cJSON_AddBoolToObject(hw, "valid", hw_valid);
-   if (hw_valid) {
-      double temp_c = (double)s_m5_hwinfo_cache.temperature_milli_c / 1000.0;
-      cJSON_AddNumberToObject(hw, "temp_celsius", temp_c);
-      cJSON_AddNumberToObject(hw, "temp_milli_c", (double)s_m5_hwinfo_cache.temperature_milli_c);
-      cJSON_AddNumberToObject(hw, "cpu_loadavg", (double)s_m5_hwinfo_cache.cpu_loadavg);
-      cJSON_AddNumberToObject(hw, "mem", (double)s_m5_hwinfo_cache.mem);
-   }
-   if (s_m5_hwinfo_refreshed_us != 0) {
-      int64_t age_ms = (esp_timer_get_time() - s_m5_hwinfo_refreshed_us) / 1000;
-      cJSON_AddNumberToObject(hw, "cache_age_ms", (double)age_ms);
-   }
-   cJSON_AddItemToObject(root, "hwinfo", hw);
-
-   /* Wave 14 — daemon version (read once on first hwinfo refresh,
-    * empty until then).  Surfaces "is K144 firmware up-to-date" + lets
-    * remote diagnostics correlate behavior with daemon version. */
-   cJSON_AddStringToObject(root, "version", s_m5_version_cache);
-
-   char *json = cJSON_PrintUnformatted(root);
-   cJSON_Delete(root);
-   httpd_resp_set_type(req, "application/json");
-   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-   esp_err_t ret = httpd_resp_sendstr(req, json);
-   free(json);
-   return ret;
-}
-
-/* TT #328 Wave 14 — POST /m5/refresh.  Forces a sys.hwinfo refresh
- * regardless of the 30 s cache TTL.  Useful when a remote operator or
- * the e2e harness wants a guaranteed-fresh reading.  Returns the same
- * shape as GET /m5 with the cache freshly populated. */
-static esp_err_t m5_refresh_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   m5_refresh_hwinfo_if_stale(true);
-   return m5_status_handler(req);
-}
-
-/* TT #328 Wave 15 — GET /m5/models.  Surfaces the K144 model registry
- * (sys.lsmode response) so the dashboard + e2e harness can see what's
- * installed.  Cached for 5 min — sys.lsmode is ~50 ms warm but the
- * registry doesn't change between K144 reboots, so re-fetching often
- * is wasteful.  ?force=1 bypasses the cache for a fresh fetch.
- *
- * Cache lives in PSRAM (heap_caps_calloc, lazy on first request) —
- * NOT BSS-static.  An earlier draft used a BSS-static
- * voice_m5_modelist_t (~1.8 KB) and tripped the same boot-loop
- * `vApplicationGetTimerTaskMemory` assert as Wave 11 / Wave 13's
- * first attempt.  See LEARNINGS "BSS-static caches >3 KB push Tab5
- * over a boot SRAM threshold" — same lesson, different size band:
- * we hit the threshold around ~1.8 KB on top of Wave 14's BSS
- * additions.  Lazy PSRAM is the universal fix. */
-static voice_m5_modelist_t *s_m5_modelist_cache = NULL;
-static int64_t s_m5_modelist_refreshed_us = 0;
-#define M5_MODELLIST_CACHE_TTL_US (5LL * 60LL * 1000LL * 1000LL) /* 5 min */
-
-static void m5_refresh_modelist_if_stale(bool force) {
-   int64_t now = esp_timer_get_time();
-   if (!force && s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid &&
-       (now - s_m5_modelist_refreshed_us) < M5_MODELLIST_CACHE_TTL_US) {
-      return;
-   }
-   if (voice_onboard_failover_state() != 2 /* M5_FAIL_READY */) {
-      return; /* Don't waste 3 s on UART timeout when K144 is offline */
-   }
-   if (s_m5_modelist_cache == NULL) {
-      s_m5_modelist_cache = heap_caps_calloc(1, sizeof(*s_m5_modelist_cache), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-      if (s_m5_modelist_cache == NULL) {
-         ESP_LOGE(TAG, "modelist PSRAM alloc failed");
-         return;
-      }
-   }
-   voice_m5_modelist_t fresh = {0};
-   if (voice_m5_llm_sys_lsmode(&fresh) == ESP_OK && fresh.valid) {
-      memcpy(s_m5_modelist_cache, &fresh, sizeof(fresh));
-      s_m5_modelist_refreshed_us = now;
-   }
-}
-
-static esp_err_t m5_models_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   bool force = false;
-   {
-      char qbuf[64];
-      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
-         char val[8];
-         if (httpd_query_key_value(qbuf, "force", val, sizeof(val)) == ESP_OK && (val[0] == '1' || val[0] == 't')) {
-            force = true;
-         }
-      }
-   }
-   m5_refresh_modelist_if_stale(force);
-
-   cJSON *root = cJSON_CreateObject();
-   bool valid = (s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid);
-   cJSON_AddBoolToObject(root, "valid", valid);
-   cJSON_AddNumberToObject(root, "count", valid ? (double)s_m5_modelist_cache->n : 0.0);
-   cJSON *arr = cJSON_AddArrayToObject(root, "models");
-   if (valid) {
-      for (int i = 0; i < s_m5_modelist_cache->n; i++) {
-         cJSON *m = cJSON_CreateObject();
-         cJSON_AddStringToObject(m, "mode", s_m5_modelist_cache->models[i].mode);
-         cJSON_AddStringToObject(m, "primary_cap", s_m5_modelist_cache->models[i].primary_cap);
-         cJSON_AddStringToObject(m, "language", s_m5_modelist_cache->models[i].language);
-         cJSON_AddItemToArray(arr, m);
-      }
-   }
-   if (s_m5_modelist_refreshed_us != 0) {
-      int64_t age_s = (esp_timer_get_time() - s_m5_modelist_refreshed_us) / 1000000;
-      cJSON_AddNumberToObject(root, "cache_age_s", (double)age_s);
-   }
-   char *json = cJSON_PrintUnformatted(root);
-   cJSON_Delete(root);
-   httpd_resp_set_type(req, "application/json");
-   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-   esp_err_t ret = httpd_resp_sendstr(req, json);
-   free(json);
-   return ret;
-}
-
-/* TT #328 Wave 13 — POST /m5/reset.  Triggers
- * voice_onboard_reset_failover(), which sends sys.reset to the K144
- * StackFlow daemon, waits for it to come back, and re-runs the warmup
- * probe.  The actual reset happens asynchronously on tab5_worker; the
- * caller can poll GET /m5 to observe state cycle PROBING → READY (or
- * UNAVAILABLE on continued failure).
- *
- * Useful for both the e2e harness (verifies recovery round-trip
- * without UI tap geometry) and dashboard / remote-operator debugging
- * (a Tab5 stuck in UNAVAILABLE can be unstuck without a reboot or a
- * physical tap on the Settings health chip). */
-static esp_err_t m5_reset_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   esp_err_t qe = voice_onboard_reset_failover();
-   cJSON *root = cJSON_CreateObject();
-   cJSON_AddStringToObject(root, "status", qe == ESP_OK ? "queued" : "rejected");
-   cJSON_AddStringToObject(root, "detail",
-                           qe == ESP_OK ? "K144 reset job enqueued — poll GET /m5"
-                                        : "Probe already in flight — try again "
-                                          "after current cycle finishes");
-   cJSON_AddNumberToObject(root, "failover_state", voice_onboard_failover_state());
-   char *json = cJSON_PrintUnformatted(root);
-   cJSON_Delete(root);
-   httpd_resp_set_type(req, "application/json");
-   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-   esp_err_t ret = httpd_resp_sendstr(req, json);
-   free(json);
-   return ret;
-}
+/* ── K144 endpoint family extracted to debug_server_m5.c (Wave 23b, #332) ─ */
 
 /* ── Voice reconnect endpoint ─────────────────────────────────────────── */
 
@@ -4315,14 +4091,9 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_voice_reconnect = {
         .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
     };
-    /* TT #327 Wave 5: K144 / chain diagnostic snapshot. */
-    const httpd_uri_t uri_m5_status = {.uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
-    /* TT #328 Wave 13: K144 software reset (sys.reset + re-warmup). */
-    const httpd_uri_t uri_m5_reset = {.uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
-    /* TT #328 Wave 14: K144 hwinfo cache refresh (forces sys.hwinfo + sys.version). */
-    const httpd_uri_t uri_m5_refresh = {.uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
-    /* TT #328 Wave 15: K144 model registry (sys.lsmode). */
-    const httpd_uri_t uri_m5_models = {.uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
+    /* Wave 23b (#332): K144 endpoint family — the 4 URIs (/m5, /m5/reset,
+     * /m5/refresh, /m5/models) are registered via debug_server_m5_register()
+     * below so the handlers + their cache layers live in their own .c file. */
     /* #266: live video streaming control.  #268 adds /video/show + hide. */
     const httpd_uri_t uri_video_start = {
         .uri = "/video/start", .method = HTTP_POST, .handler = video_start_handler
@@ -4447,10 +4218,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_screen);
     httpd_register_uri_handler(server, &uri_voice_state);
     httpd_register_uri_handler(server, &uri_voice_reconnect);
-    httpd_register_uri_handler(server, &uri_m5_status);
-    httpd_register_uri_handler(server, &uri_m5_reset);
-    httpd_register_uri_handler(server, &uri_m5_refresh);
-    httpd_register_uri_handler(server, &uri_m5_models);
+    /* Wave 23b (#332): K144 endpoint family registered en-bloc. */
+    debug_server_m5_register(server);
     httpd_register_uri_handler(server, &uri_video_start);
     httpd_register_uri_handler(server, &uri_video_stop);
     httpd_register_uri_handler(server, &uri_video_state);

--- a/main/debug_server_internal.h
+++ b/main/debug_server_internal.h
@@ -1,0 +1,28 @@
+/*
+ * debug_server_internal.h — shared interface for debug_server.c and its
+ * per-family extracted modules (debug_server_m5.c, …).
+ *
+ * Wave 23b (#332): the historical 4,520-LOC debug_server.c is being
+ * split family-by-family per the cross-stack architecture audit
+ * (2026-05-01).  Each family file owns its handlers + URI registrations
+ * + family-local helpers; this header exposes the cross-cutting
+ * primitives every family needs (auth gate, common types).
+ *
+ * Not exposed publicly — `debug_server.h` remains the only public-facing
+ * header.  This file is for in-tree compilation units that participate in
+ * the debug server's URI map.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "esp_http_server.h"
+
+/* Bearer-token auth gate.  Every family handler that requires auth
+ * (i.e. everything except /info and /selftest) calls this as the
+ * first line and returns ESP_OK on `false`.  See debug_server.c for
+ * the implementation — this is a thin wrapper around the existing
+ * `check_auth` static so the historic call sites stay untouched.
+ */
+bool tab5_debug_check_auth(httpd_req_t *req);

--- a/main/debug_server_m5.c
+++ b/main/debug_server_m5.c
@@ -1,0 +1,278 @@
+/*
+ * debug_server_m5.c — K144 (M5Stack LLM Module) HTTP endpoint family.
+ *
+ * Wave 23b (#332): extracted verbatim from debug_server.c as the
+ * proof-of-pattern for the per-family split called for in the
+ * cross-stack architecture audit (2026-05-01).  The handlers + helpers
+ * + statics moved over with zero behavior change; the only difference
+ * is the `check_auth(req)` calls now go through the shared wrapper
+ * `tab5_debug_check_auth(req)` declared in debug_server_internal.h.
+ *
+ * The two-tier caching strategy (hwinfo: 30 s success TTL + 5 s attempt
+ * rate-limit; modelist: 5 min PSRAM-lazy) was added in TT #328 Wave 14
+ * and Wave 15 respectively — see CLAUDE.md "K144 hwinfo cache freshness
+ * lie" + the LEARNINGS entry on PSRAM-lazy patterns.  The historical
+ * comments are preserved verbatim.
+ */
+
+#include "debug_server_m5.h"
+
+#include "cJSON.h"
+#include "debug_server_internal.h" /* tab5_debug_check_auth */
+#include "esp_heap_caps.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "voice_m5_llm.h"  /* TT #327 Wave 5: K144 baud accessor for /m5 */
+#include "voice_onboard.h" /* TT #327 Wave 4b: chain_active + failover_state */
+
+static const char *TAG = "debug_m5";
+
+/* ── Cached hwinfo + version snapshot ────────────────────────────────
+ *
+ * Wave 14 — cached hwinfo + version snapshot.  GET /m5 may be polled
+ * by the dashboard / harness every few seconds; refreshing sys.hwinfo
+ * on every call would saturate the UART (~150 ms per round-trip ×
+ * concurrent polls = head-of-line blocking on llm.infer calls).  Cache
+ * for 30 s; clients that want fresh data poll less often or use
+ * POST /m5/refresh to force an update.
+ *
+ * Also avoids the worst-case path where K144 is hung mid-NPU-load and
+ * sys.hwinfo silently stalls — every /m5 GET would otherwise block
+ * 1.5 s on the timeout.  The cache bounds this to once per 30 s. */
+static voice_m5_hwinfo_t s_m5_hwinfo_cache = {0};
+static char s_m5_version_cache[16] = {0};
+static int64_t s_m5_hwinfo_refreshed_us = 0; /* time of last SUCCESS */
+static int64_t s_m5_hwinfo_attempted_us = 0; /* time of last ATTEMPT (success OR skip) */
+#define M5_HWINFO_CACHE_TTL_US (30LL * 1000LL * 1000LL)
+#define M5_HWINFO_RETRY_GATE_US (5LL * 1000LL * 1000LL) /* 5 s — bounds rate when K144 not READY */
+
+static void m5_refresh_hwinfo_if_stale(bool force) {
+   int64_t now = esp_timer_get_time();
+   /* Cache hit fast-path — last successful fetch within TTL window. */
+   if (!force && s_m5_hwinfo_refreshed_us != 0 && (now - s_m5_hwinfo_refreshed_us) < M5_HWINFO_CACHE_TTL_US) {
+      return;
+   }
+   /* Even if cache is stale, throttle attempts (avoids hammering the
+    * UART when /m5 is polled rapidly during a recovery cycle).  5 s
+    * is short enough that a UNAVAILABLE→READY transition picks up new
+    * data within ~10 s; long enough that 50 polls/sec from a script
+    * don't queue 50 sys.hwinfo round-trips. */
+   if (!force && s_m5_hwinfo_attempted_us != 0 && (now - s_m5_hwinfo_attempted_us) < M5_HWINFO_RETRY_GATE_US) {
+      return;
+   }
+   s_m5_hwinfo_attempted_us = now;
+
+   /* Skip the actual sys.hwinfo if K144 isn't READY — it would just
+    * time out and waste 1.5 s.  Cached values stay; client sees old
+    * data with `cache_age_ms` shown so they can decide what to trust. */
+   int fs = voice_onboard_failover_state();
+   if (fs != 2 /* M5_FAIL_READY */) {
+      return;
+   }
+
+   voice_m5_hwinfo_t fresh = {0};
+   esp_err_t he = voice_m5_llm_sys_hwinfo(&fresh);
+   if (he == ESP_OK && fresh.valid) {
+      s_m5_hwinfo_cache = fresh;
+      s_m5_hwinfo_refreshed_us = now;
+   }
+   /* Version is fixed per K144 firmware install — read once and cache.
+    * Cache survives sys.reset (daemon restart, version unchanged) but
+    * does NOT survive a Tab5 reboot. */
+   if (s_m5_version_cache[0] == '\0') {
+      (void)voice_m5_llm_sys_version(s_m5_version_cache, sizeof(s_m5_version_cache));
+   }
+}
+
+static esp_err_t m5_status_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   /* Wave 14 — refresh hwinfo cache (no-op if warm + fresh enough). */
+   m5_refresh_hwinfo_if_stale(false);
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "chain_active", voice_onboard_chain_active());
+   /* Wave 7: chain_uptime_ms — 0 if not active.  Lets a remote operator
+    * spot a stuck chain without a serial cable. */
+   cJSON_AddNumberToObject(root, "chain_uptime_ms", (double)voice_onboard_chain_uptime_ms());
+   int fs = voice_onboard_failover_state();
+   cJSON_AddNumberToObject(root, "failover_state", fs);
+   const char *fs_names[] = {"unknown", "probing", "ready", "unavailable"};
+   cJSON_AddStringToObject(root, "failover_state_name", (fs >= 0 && fs <= 3) ? fs_names[fs] : "?");
+   cJSON_AddNumberToObject(root, "uart_baud", (double)voice_m5_llm_get_baud());
+
+   /* Wave 14 — hardware status.  `valid` is true only when the cache
+    * holds a successfully-parsed sys.hwinfo response; `cache_age_ms`
+    * tells the client how stale the snapshot is.  `temp_celsius`
+    * comes from the milli-degree field divided by 1000 (preserving
+    * one decimal — JSON consumer can format). */
+   cJSON *hw = cJSON_CreateObject();
+   bool hw_valid = (s_m5_hwinfo_cache.valid != 0);
+   cJSON_AddBoolToObject(hw, "valid", hw_valid);
+   if (hw_valid) {
+      double temp_c = (double)s_m5_hwinfo_cache.temperature_milli_c / 1000.0;
+      cJSON_AddNumberToObject(hw, "temp_celsius", temp_c);
+      cJSON_AddNumberToObject(hw, "temp_milli_c", (double)s_m5_hwinfo_cache.temperature_milli_c);
+      cJSON_AddNumberToObject(hw, "cpu_loadavg", (double)s_m5_hwinfo_cache.cpu_loadavg);
+      cJSON_AddNumberToObject(hw, "mem", (double)s_m5_hwinfo_cache.mem);
+   }
+   if (s_m5_hwinfo_refreshed_us != 0) {
+      int64_t age_ms = (esp_timer_get_time() - s_m5_hwinfo_refreshed_us) / 1000;
+      cJSON_AddNumberToObject(hw, "cache_age_ms", (double)age_ms);
+   }
+   cJSON_AddItemToObject(root, "hwinfo", hw);
+
+   /* Wave 14 — daemon version (read once on first hwinfo refresh,
+    * empty until then).  Surfaces "is K144 firmware up-to-date" + lets
+    * remote diagnostics correlate behavior with daemon version. */
+   cJSON_AddStringToObject(root, "version", s_m5_version_cache);
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* TT #328 Wave 14 — POST /m5/refresh.  Forces a sys.hwinfo refresh
+ * regardless of the 30 s cache TTL.  Useful when a remote operator or
+ * the e2e harness wants a guaranteed-fresh reading.  Returns the same
+ * shape as GET /m5 with the cache freshly populated. */
+static esp_err_t m5_refresh_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   m5_refresh_hwinfo_if_stale(true);
+   return m5_status_handler(req);
+}
+
+/* TT #328 Wave 15 — GET /m5/models.  Surfaces the K144 model registry
+ * (sys.lsmode response) so the dashboard + e2e harness can see what's
+ * installed.  Cached for 5 min — sys.lsmode is ~50 ms warm but the
+ * registry doesn't change between K144 reboots, so re-fetching often
+ * is wasteful.  ?force=1 bypasses the cache for a fresh fetch.
+ *
+ * Cache lives in PSRAM (heap_caps_calloc, lazy on first request) —
+ * NOT BSS-static.  An earlier draft used a BSS-static
+ * voice_m5_modelist_t (~1.8 KB) and tripped the same boot-loop
+ * `vApplicationGetTimerTaskMemory` assert as Wave 11 / Wave 13's
+ * first attempt.  See LEARNINGS "BSS-static caches >3 KB push Tab5
+ * over a boot SRAM threshold" — same lesson, different size band:
+ * we hit the threshold around ~1.8 KB on top of Wave 14's BSS
+ * additions.  Lazy PSRAM is the universal fix. */
+static voice_m5_modelist_t *s_m5_modelist_cache = NULL;
+static int64_t s_m5_modelist_refreshed_us = 0;
+#define M5_MODELLIST_CACHE_TTL_US (5LL * 60LL * 1000LL * 1000LL) /* 5 min */
+
+static void m5_refresh_modelist_if_stale(bool force) {
+   int64_t now = esp_timer_get_time();
+   if (!force && s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid &&
+       (now - s_m5_modelist_refreshed_us) < M5_MODELLIST_CACHE_TTL_US) {
+      return;
+   }
+   if (voice_onboard_failover_state() != 2 /* M5_FAIL_READY */) {
+      return; /* Don't waste 3 s on UART timeout when K144 is offline */
+   }
+   if (s_m5_modelist_cache == NULL) {
+      s_m5_modelist_cache = heap_caps_calloc(1, sizeof(*s_m5_modelist_cache), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (s_m5_modelist_cache == NULL) {
+         ESP_LOGE(TAG, "modelist PSRAM alloc failed");
+         return;
+      }
+   }
+   voice_m5_modelist_t fresh = {0};
+   if (voice_m5_llm_sys_lsmode(&fresh) == ESP_OK && fresh.valid) {
+      memcpy(s_m5_modelist_cache, &fresh, sizeof(fresh));
+      s_m5_modelist_refreshed_us = now;
+   }
+}
+
+static esp_err_t m5_models_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   bool force = false;
+   {
+      char qbuf[64];
+      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+         char val[8];
+         if (httpd_query_key_value(qbuf, "force", val, sizeof(val)) == ESP_OK && (val[0] == '1' || val[0] == 't')) {
+            force = true;
+         }
+      }
+   }
+   m5_refresh_modelist_if_stale(force);
+
+   cJSON *root = cJSON_CreateObject();
+   bool valid = (s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid);
+   cJSON_AddBoolToObject(root, "valid", valid);
+   cJSON_AddNumberToObject(root, "count", valid ? (double)s_m5_modelist_cache->n : 0.0);
+   cJSON *arr = cJSON_AddArrayToObject(root, "models");
+   if (valid) {
+      for (int i = 0; i < s_m5_modelist_cache->n; i++) {
+         cJSON *m = cJSON_CreateObject();
+         cJSON_AddStringToObject(m, "mode", s_m5_modelist_cache->models[i].mode);
+         cJSON_AddStringToObject(m, "primary_cap", s_m5_modelist_cache->models[i].primary_cap);
+         cJSON_AddStringToObject(m, "language", s_m5_modelist_cache->models[i].language);
+         cJSON_AddItemToArray(arr, m);
+      }
+   }
+   if (s_m5_modelist_refreshed_us != 0) {
+      int64_t age_s = (esp_timer_get_time() - s_m5_modelist_refreshed_us) / 1000000;
+      cJSON_AddNumberToObject(root, "cache_age_s", (double)age_s);
+   }
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* TT #328 Wave 13 — POST /m5/reset.  Triggers
+ * voice_onboard_reset_failover(), which sends sys.reset to the K144
+ * StackFlow daemon, waits for it to come back, and re-runs the warmup
+ * probe.  The actual reset happens asynchronously on tab5_worker; the
+ * caller can poll GET /m5 to observe state cycle PROBING → READY (or
+ * UNAVAILABLE on continued failure).
+ *
+ * Useful for both the e2e harness (verifies recovery round-trip
+ * without UI tap geometry) and dashboard / remote-operator debugging
+ * (a Tab5 stuck in UNAVAILABLE can be unstuck without a reboot or a
+ * physical tap on the Settings health chip). */
+static esp_err_t m5_reset_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   esp_err_t qe = voice_onboard_reset_failover();
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "status", qe == ESP_OK ? "queued" : "rejected");
+   cJSON_AddStringToObject(root, "detail",
+                           qe == ESP_OK ? "K144 reset job enqueued — poll GET /m5"
+                                        : "Probe already in flight — try again "
+                                          "after current cycle finishes");
+   cJSON_AddNumberToObject(root, "failover_state", voice_onboard_failover_state());
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* ── Public registration entry point ─────────────────────────────────
+ * Called once from tab5_debug_server_start() during boot.  All four
+ * URI structs are local to this function (matching the inline pattern
+ * the rest of debug_server.c still uses for the other families). */
+void debug_server_m5_register(httpd_handle_t server) {
+   const httpd_uri_t uri_m5_status = {.uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
+   const httpd_uri_t uri_m5_reset = {.uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
+   const httpd_uri_t uri_m5_refresh = {.uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
+   const httpd_uri_t uri_m5_models = {.uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
+
+   httpd_register_uri_handler(server, &uri_m5_status);
+   httpd_register_uri_handler(server, &uri_m5_reset);
+   httpd_register_uri_handler(server, &uri_m5_refresh);
+   httpd_register_uri_handler(server, &uri_m5_models);
+
+   ESP_LOGI(TAG, "K144 endpoint family registered (4 URIs)");
+}

--- a/main/debug_server_m5.h
+++ b/main/debug_server_m5.h
@@ -1,0 +1,23 @@
+/*
+ * debug_server_m5.h — K144 (M5Stack LLM Module) endpoint family.
+ *
+ * Wave 23b (#332): extracted from debug_server.c as the proof-of-pattern
+ * for the per-family split called for in the cross-stack architecture
+ * audit (2026-05-01).
+ *
+ * Endpoints owned by this module:
+ *   GET  /m5          — diagnostic snapshot (chain + failover + cached hwinfo)
+ *   POST /m5/refresh  — force sys.hwinfo refresh outside the 30 s TTL
+ *   GET  /m5/models   — surface sys.lsmode model registry (5 min cache)
+ *   POST /m5/reset    — trigger voice_onboard_reset_failover()
+ *
+ * Plus two private cache layers (hwinfo + modelist) — see the .c file.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the K144 endpoint family on `server`.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_m5_register(httpd_handle_t server);


### PR DESCRIPTION
## Summary

Wave 23b from the cross-stack architecture audit ([#332](https://github.com/lorcan35/TinkerTab/issues/332)). Establishes the per-family split pattern for the 4,520-LOC `debug_server.c` by extracting the **K144 endpoint family** (4 endpoints: `/m5`, `/m5/refresh`, `/m5/models`, `/m5/reset`) into its own file.

This is the proof-of-pattern PR. The other 6 endpoint families (camera, video/call, voice/chat/mode, settings/nvs, OTA, codec) follow the same shape as separate PRs.

## Diff at a glance

```
 main/CMakeLists.txt          |   2 +-
 main/debug_server.c          | 263 ++++-----------------------------
 main/debug_server_internal.h |  28 ++++ (new)
 main/debug_server_m5.h       |  23 +++ (new)
 main/debug_server_m5.c       | 283 +++++++++++++++++++++++++++++++++ (new)
```

`debug_server.c`: 4,520 → 4,293 LOC (−227). Drops the K144 block + the 4 inline URI definitions + 4 register calls + 2 stale includes (`voice_m5_llm.h`, `voice_onboard.h`).

## What changed (mechanically)

- **Three new files** — one shared internal header, one per-family header, one per-family `.c`
- **Handlers + cache helpers + statics moved verbatim** — no internal restructuring (CLAUDE.md "extract before decompose")
- **`tab5_debug_check_auth()` wrapper** added to debug_server.c so the 65 historic `check_auth(req)` call sites stay untouched; only the moved file uses the new wrapper
- **`tab5_debug_server_start()`** loses 4 inline URI definitions + 4 register calls, gains one `debug_server_m5_register(server)` call

## Test plan

- [x] `idf.py build` — only the 3 new files compiled, `debug_server.c` relinked, no warnings
- [x] Flashed to Tab5 (192.168.1.90), boot reached uptime ~17s
- [x] `GET /m5` → 200, JSON shape identical to pre-extract: `{chain_active, chain_uptime_ms, failover_state, failover_state_name, uart_baud, hwinfo:{valid,...}, version}`
- [x] `POST /m5/refresh` → 200, returns m5_status_handler shape (refresh delegates)
- [x] `GET /m5/models` → 200, `{valid, count, models[], cache_age_s}` shape
- [x] `POST /m5/reset` → 200, `{status, detail, failover_state}` shape
- [x] `python3 tests/e2e/runner.py story_smoke` → **14/14 PASS in 168s** (covers Local-mode chat, camera, settings — exercises `check_auth` + every other endpoint family unchanged)

## Why pattern + 1 family in this PR (not all 7)

CLAUDE.md "small is kind" — one mechanical extract is reviewable in minutes; seven at once is hours. Each subsequent family extract is a self-contained ~150-300 LOC PR following the exact same shape established here. Issue [#332](https://github.com/lorcan35/TinkerTab/issues/332) stays open until all 7 families have moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)