### PR TITLE
refactor(debug_server): extract OTA endpoint family (Wave 23b · stacked on #336)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -33,7 +33,8 @@ else()
         SRCS "main.c"
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
-             "debug_server.c" "debug_server_m5.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
+             "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
+             "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"
              "ui_core.c" ${UI_SRCS}

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -56,9 +56,10 @@
 #include "ui_settings.h"
 #include "ui_wifi.h"
 #include "voice.h"
-/* Wave 23b (#332): K144 endpoint family + auth shim moved to siblings. */
+/* Wave 23b (#332): per-family endpoint extracts + auth shim. */
 #include "debug_server_internal.h"
 #include "debug_server_m5.h"
+#include "debug_server_ota.h"
 #include "widget.h"        /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -1077,95 +1078,7 @@ static esp_err_t sdcard_handler(httpd_req_t *req)
     return ret;
 }
 
-/* ── OTA debug endpoints ──────────────────────────────────────────────── */
-
-static esp_err_t ota_check_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    tab5_ota_info_t info;
-    esp_err_t err = tab5_ota_check(&info);
-
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "current", TAB5_FIRMWARE_VER);
-    cJSON_AddStringToObject(root, "partition", tab5_ota_current_partition());
-    if (err == ESP_OK) {
-        cJSON_AddBoolToObject(root, "update_available", info.available);
-        if (info.available) {
-            cJSON_AddStringToObject(root, "new_version", info.version);
-            cJSON_AddStringToObject(root, "url", info.url);
-        }
-    } else {
-        cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
-    }
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, json);
-    free(json);
-    return ret;
-}
-
-typedef struct {
-    char *url;
-    char sha256[65];
-} ota_apply_args_t;
-
-static void ota_apply_task(void *arg)
-{
-    ota_apply_args_t *args = (ota_apply_args_t *)arg;
-    ESP_LOGI("ota", "Scheduling OTA for next boot: %s (sha256=%s)", args->url,
-             args->sha256[0] ? args->sha256 : "none");
-    /* Wave 10 #77 extended-use fix: schedule instead of apply in-process.
-     * tab5_ota_schedule stores url+sha to NVS, reboots, and the fresh
-     * boot applies with a pristine DMA heap (see main.c near WiFi init).
-     * Prevents the "esp_dma_capable_malloc: Not enough heap memory"
-     * failure mode that hits after 30+ min of normal use. */
-    esp_err_t err = tab5_ota_schedule(args->url, args->sha256[0] ? args->sha256 : NULL);
-    /* If we get here, schedule failed (success reboots) */
-    ESP_LOGE("ota", "OTA schedule failed: %s", esp_err_to_name(err));
-    free(args->url);
-    free(args);
-    vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
-}
-
-static esp_err_t ota_apply_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* Check for update first */
-    tab5_ota_info_t info;
-    esp_err_t err = tab5_ota_check(&info);
-    if (err != ESP_OK || !info.available) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_sendstr(req, "{\"error\":\"no update available\"}");
-        return ESP_OK;
-    }
-
-    /* Spawn OTA task with SHA256 from version.json (SEC07) */
-    ota_apply_args_t *args = malloc(sizeof(ota_apply_args_t));
-    if (args) {
-        args->url = strdup(info.url);
-        strncpy(args->sha256, info.sha256, sizeof(args->sha256) - 1);
-        args->sha256[sizeof(args->sha256) - 1] = '\0';
-        if (args->url) {
-            xTaskCreate(ota_apply_task, "ota_apply", 8192, args, 5, NULL);
-        } else {
-            free(args);
-        }
-    }
-
-    httpd_resp_set_type(req, "application/json");
-    char resp[512];
-    snprintf(resp, sizeof(resp),
-             "{\"status\":\"updating\",\"version\":\"%s\",\"url\":\"%s\",\"sha256_verify\":%s}",
-             info.version, info.url, info.sha256[0] ? "true" : "false");
-    httpd_resp_sendstr(req, resp);
-    return ESP_OK;
-}
+/* ── OTA endpoint family extracted to debug_server_ota.c (Wave 23b, #332) ─ */
 
 /* ── ADB-style debug APIs ─────────────────────────────────────────────── */
 
@@ -4070,12 +3983,8 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_camera = {
         .uri = "/camera", .method = HTTP_GET, .handler = camera_handler
     };
-    const httpd_uri_t uri_ota_check = {
-        .uri = "/ota/check", .method = HTTP_GET, .handler = ota_check_handler
-    };
-    const httpd_uri_t uri_ota_apply = {
-        .uri = "/ota/apply", .method = HTTP_POST, .handler = ota_apply_handler
-    };
+    /* Wave 23b (#332): OTA endpoint family — registered en-bloc via
+     * debug_server_ota_register() below. */
     const httpd_uri_t uri_chat = {
         .uri = "/chat", .method = HTTP_POST, .handler = chat_handler
     };
@@ -4211,8 +4120,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_navigate);
     httpd_register_uri_handler(server, &uri_widget);
     httpd_register_uri_handler(server, &uri_camera);
-    httpd_register_uri_handler(server, &uri_ota_check);
-    httpd_register_uri_handler(server, &uri_ota_apply);
+    /* Wave 23b (#332): OTA endpoint family registered en-bloc. */
+    debug_server_ota_register(server);
     httpd_register_uri_handler(server, &uri_chat);
     httpd_register_uri_handler(server, &uri_input_text);
     httpd_register_uri_handler(server, &uri_screen);

--- a/main/debug_server_m5.c
+++ b/main/debug_server_m5.c
@@ -18,14 +18,13 @@
 #include "debug_server_m5.h"
 
 #include "cJSON.h"
+#include "debug_server_internal.h" /* tab5_debug_check_auth */
 #include "esp_heap_caps.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-
-#include "debug_server_internal.h" /* tab5_debug_check_auth */
-#include "voice_m5_llm.h"          /* TT #327 Wave 5: K144 baud accessor for /m5 */
-#include "voice_onboard.h"         /* TT #327 Wave 4b: chain_active + failover_state */
+#include "voice_m5_llm.h"  /* TT #327 Wave 5: K144 baud accessor for /m5 */
+#include "voice_onboard.h" /* TT #327 Wave 4b: chain_active + failover_state */
 
 static const char *TAG = "debug_m5";
 
@@ -265,14 +264,10 @@ static esp_err_t m5_reset_handler(httpd_req_t *req) {
  * URI structs are local to this function (matching the inline pattern
  * the rest of debug_server.c still uses for the other families). */
 void debug_server_m5_register(httpd_handle_t server) {
-   const httpd_uri_t uri_m5_status = {
-       .uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
-   const httpd_uri_t uri_m5_reset = {
-       .uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
-   const httpd_uri_t uri_m5_refresh = {
-       .uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
-   const httpd_uri_t uri_m5_models = {
-       .uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
+   const httpd_uri_t uri_m5_status = {.uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
+   const httpd_uri_t uri_m5_reset = {.uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
+   const httpd_uri_t uri_m5_refresh = {.uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
+   const httpd_uri_t uri_m5_models = {.uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
 
    httpd_register_uri_handler(server, &uri_m5_status);
    httpd_register_uri_handler(server, &uri_m5_reset);

--- a/main/debug_server_m5.c
+++ b/main/debug_server_m5.c
@@ -18,13 +18,14 @@
 #include "debug_server_m5.h"
 
 #include "cJSON.h"
-#include "debug_server_internal.h" /* tab5_debug_check_auth */
 #include "esp_heap_caps.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_timer.h"
-#include "voice_m5_llm.h"  /* TT #327 Wave 5: K144 baud accessor for /m5 */
-#include "voice_onboard.h" /* TT #327 Wave 4b: chain_active + failover_state */
+
+#include "debug_server_internal.h" /* tab5_debug_check_auth */
+#include "voice_m5_llm.h"          /* TT #327 Wave 5: K144 baud accessor for /m5 */
+#include "voice_onboard.h"         /* TT #327 Wave 4b: chain_active + failover_state */
 
 static const char *TAG = "debug_m5";
 
@@ -264,10 +265,14 @@ static esp_err_t m5_reset_handler(httpd_req_t *req) {
  * URI structs are local to this function (matching the inline pattern
  * the rest of debug_server.c still uses for the other families). */
 void debug_server_m5_register(httpd_handle_t server) {
-   const httpd_uri_t uri_m5_status = {.uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
-   const httpd_uri_t uri_m5_reset = {.uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
-   const httpd_uri_t uri_m5_refresh = {.uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
-   const httpd_uri_t uri_m5_models = {.uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
+   const httpd_uri_t uri_m5_status = {
+       .uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
+   const httpd_uri_t uri_m5_reset = {
+       .uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
+   const httpd_uri_t uri_m5_refresh = {
+       .uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
+   const httpd_uri_t uri_m5_models = {
+       .uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
 
    httpd_register_uri_handler(server, &uri_m5_status);
    httpd_register_uri_handler(server, &uri_m5_reset);

--- a/main/debug_server_ota.c
+++ b/main/debug_server_ota.c
@@ -1,0 +1,119 @@
+/*
+ * debug_server_ota.c — OTA firmware update HTTP endpoint family.
+ *
+ * Wave 23b follow-up (#332): mechanical extract of the 2 OTA endpoints
+ * from debug_server.c.  Handlers + the local ota_apply_args_t /
+ * ota_apply_task helpers moved verbatim; the only call-site change is
+ * `check_auth(req)` → `tab5_debug_check_auth(req)` so the moved file
+ * goes through the shared internal-header wrapper.
+ *
+ * The Wave 10 #77 "schedule, don't apply in-process" pattern is
+ * preserved — see ota_apply_task() comment for why a fresh boot is
+ * required for the DMA heap.  Behavior is identical pre/post extract.
+ */
+
+#include "debug_server_ota.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "config.h"                /* TAB5_FIRMWARE_VER */
+#include "debug_server_internal.h" /* tab5_debug_check_auth */
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "ota.h" /* tab5_ota_check / _schedule / _info_t */
+
+static esp_err_t ota_check_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   tab5_ota_info_t info;
+   esp_err_t err = tab5_ota_check(&info);
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "current", TAB5_FIRMWARE_VER);
+   cJSON_AddStringToObject(root, "partition", tab5_ota_current_partition());
+   if (err == ESP_OK) {
+      cJSON_AddBoolToObject(root, "update_available", info.available);
+      if (info.available) {
+         cJSON_AddStringToObject(root, "new_version", info.version);
+         cJSON_AddStringToObject(root, "url", info.url);
+      }
+   } else {
+      cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+   }
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+typedef struct {
+   char *url;
+   char sha256[65];
+} ota_apply_args_t;
+
+static void ota_apply_task(void *arg) {
+   ota_apply_args_t *args = (ota_apply_args_t *)arg;
+   ESP_LOGI("ota", "Scheduling OTA for next boot: %s (sha256=%s)", args->url, args->sha256[0] ? args->sha256 : "none");
+   /* Wave 10 #77 extended-use fix: schedule instead of apply in-process.
+    * tab5_ota_schedule stores url+sha to NVS, reboots, and the fresh
+    * boot applies with a pristine DMA heap (see main.c near WiFi init).
+    * Prevents the "esp_dma_capable_malloc: Not enough heap memory"
+    * failure mode that hits after 30+ min of normal use. */
+   esp_err_t err = tab5_ota_schedule(args->url, args->sha256[0] ? args->sha256 : NULL);
+   /* If we get here, schedule failed (success reboots) */
+   ESP_LOGE("ota", "OTA schedule failed: %s", esp_err_to_name(err));
+   free(args->url);
+   free(args);
+   vTaskSuspend(NULL) /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
+}
+
+static esp_err_t ota_apply_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   /* Check for update first */
+   tab5_ota_info_t info;
+   esp_err_t err = tab5_ota_check(&info);
+   if (err != ESP_OK || !info.available) {
+      httpd_resp_set_type(req, "application/json");
+      httpd_resp_sendstr(req, "{\"error\":\"no update available\"}");
+      return ESP_OK;
+   }
+
+   /* Spawn OTA task with SHA256 from version.json (SEC07) */
+   ota_apply_args_t *args = malloc(sizeof(ota_apply_args_t));
+   if (args) {
+      args->url = strdup(info.url);
+      strncpy(args->sha256, info.sha256, sizeof(args->sha256) - 1);
+      args->sha256[sizeof(args->sha256) - 1] = '\0';
+      if (args->url) {
+         xTaskCreate(ota_apply_task, "ota_apply", 8192, args, 5, NULL);
+      } else {
+         free(args);
+      }
+   }
+
+   httpd_resp_set_type(req, "application/json");
+   char resp[512];
+   snprintf(resp, sizeof(resp), "{\"status\":\"updating\",\"version\":\"%s\",\"url\":\"%s\",\"sha256_verify\":%s}",
+            info.version, info.url, info.sha256[0] ? "true" : "false");
+   httpd_resp_sendstr(req, resp);
+   return ESP_OK;
+}
+
+void debug_server_ota_register(httpd_handle_t server) {
+   const httpd_uri_t uri_ota_check = {.uri = "/ota/check", .method = HTTP_GET, .handler = ota_check_handler};
+   const httpd_uri_t uri_ota_apply = {.uri = "/ota/apply", .method = HTTP_POST, .handler = ota_apply_handler};
+
+   httpd_register_uri_handler(server, &uri_ota_check);
+   httpd_register_uri_handler(server, &uri_ota_apply);
+   ESP_LOGI("debug_ota", "OTA endpoint family registered (2 URIs)");
+}

--- a/main/debug_server_ota.h
+++ b/main/debug_server_ota.h
@@ -1,0 +1,18 @@
+/*
+ * debug_server_ota.h — OTA firmware update endpoint family.
+ *
+ * Wave 23b follow-up (#332): second per-family extract from
+ * debug_server.c, after K144 (#336).  Same shape as debug_server_m5.h.
+ *
+ * Endpoints:
+ *   GET  /ota/check  — query Dragon for available firmware update
+ *   POST /ota/apply  — schedule the update (reboots into fresh DMA heap)
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the OTA endpoint family on `server`.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_ota_register(httpd_handle_t server);


### PR DESCRIPTION
## Summary

Second per-family extract from `debug_server.c`, **stacked on top of [#336](https://github.com/lorcan35/TinkerTab/pull/336)** (the K144 family). Same mechanical move pattern.

Endpoints owned by this PR:
- `GET /ota/check` — query Dragon for available firmware update
- `POST /ota/apply` — schedule the update (reboots into fresh DMA heap)

## Diff

```
 main/CMakeLists.txt      |   3 +-
 main/debug_server.c      |  99 +----------------- (the OTA block + URI defs + register calls)
 main/debug_server_ota.h  |  19 ++++ (new)
 main/debug_server_ota.c  | 130 +++++++++++++++++++++++ (new)
```

`debug_server.c`: 4,293 → 4,202 LOC. Cumulative on this branch (K144 + OTA): 4,520 → 4,202 = **−318 LOC** from `origin/main` baseline.

## Test plan

- [x] `idf.py build` clean — only `debug_server_ota.c` compiled, `debug_server.c` relinked
- [x] Flashed to Tab5 (192.168.1.90), boot uptime 18s
- [x] `GET /ota/check` → 200, JSON shape identical pre/post extract: `{current:"0.8.0", partition:"ota_0", error:"ESP_ERR_NOT_SUPPORTED"}` (NOT_SUPPORTED is normal — Dragon doesn't have OTA configured for this dev unit; the route resolves and handler returns the right shape)
- [x] `GET /m5` (from #336) still works → confirms the stacked extracts coexist
- [x] `python3 tests/e2e/runner.py story_smoke` → **14/14 PASS in 99s**

## Stacking

Base branch: `refactor/debug-server-split` (PR #336). Once #336 merges, this PR's base auto-rebases to `main` and shows only the OTA delta.

## Remaining families

- camera + screenshot (2 endpoints, ~180 LOC)
- video + call (~10 endpoints, ~250 LOC)
- voice + chat + mode (~6 endpoints)
- settings + nvs (~3 endpoints)
- codec (~1 endpoint)

Each follows the exact same shape as #336 + this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)