### PR TITLE
refactor(debug_server): extract voice endpoint family (Wave 23b · stacked on #338)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
         SRCS "main.c"
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
-             "debug_server.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
+             "debug_server.c" "debug_server_m5.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"
              "ui_core.c" ${UI_SRCS}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,6 +34,7 @@ else()
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
+             "debug_server_codec.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
-             "debug_server_codec.c"
+             "debug_server_codec.c" "debug_server_voice.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -33,7 +33,8 @@ else()
         SRCS "main.c"
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
-             "debug_server.c" "debug_server_m5.c" "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
+             "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
+             "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"
              "ui_core.c" ${UI_SRCS}

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -56,8 +56,9 @@
 #include "ui_settings.h"
 #include "ui_wifi.h"
 #include "voice.h"
-#include "voice_m5_llm.h"  /* TT #327 Wave 5: K144 baud accessor for /m5 */
-#include "voice_onboard.h" /* TT #327 Wave 4b: chain_active + failover_state */
+/* Wave 23b (#332): K144 endpoint family + auth shim moved to siblings. */
+#include "debug_server_internal.h"
+#include "debug_server_m5.h"
 #include "widget.h"        /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -157,6 +158,15 @@ static bool check_auth(httpd_req_t *req)
         return false;
     }
     return true;
+}
+
+/* Wave 23b (#332): public wrapper for the per-family extracted modules
+ * (debug_server_m5.c, …) — see debug_server_internal.h.  The historic
+ * 65 in-tree call sites still use the static `check_auth` to keep the
+ * extraction diff minimal; new family files go through this wrapper. */
+bool tab5_debug_check_auth(httpd_req_t *req)
+{
+    return check_auth(req);
 }
 
 /* ======================================================================== */
@@ -2437,238 +2447,8 @@ static esp_err_t voice_state_handler(httpd_req_t *req)
     return ret;
 }
 
-/* ── M5 / K144 status endpoint (TT #327 Wave 5) ─────────────────────────
- * GET /m5 — diagnostic snapshot of K144 LLM Module state.  Closes audit
- * #18 (no remote diagnostic for "chain didn't start" / "is K144 warm").
- */
-/* Wave 14 — cached hwinfo + version snapshot.  GET /m5 may be polled
- * by the dashboard / harness every few seconds; refreshing sys.hwinfo
- * on every call would saturate the UART (~150 ms per round-trip ×
- * concurrent polls = head-of-line blocking on llm.infer calls).  Cache
- * for 30 s; clients that want fresh data poll less often or use
- * POST /m5/refresh to force an update.
- *
- * Also avoids the worst-case path where K144 is hung mid-NPU-load and
- * sys.hwinfo silently stalls — every /m5 GET would otherwise block
- * 1.5 s on the timeout.  The cache bounds this to once per 30 s. */
-static voice_m5_hwinfo_t s_m5_hwinfo_cache = {0};
-static char s_m5_version_cache[16] = {0};
-static int64_t s_m5_hwinfo_refreshed_us = 0; /* time of last SUCCESS */
-static int64_t s_m5_hwinfo_attempted_us = 0; /* time of last ATTEMPT (success OR skip) */
-#define M5_HWINFO_CACHE_TTL_US (30LL * 1000LL * 1000LL)
-#define M5_HWINFO_RETRY_GATE_US (5LL * 1000LL * 1000LL) /* 5 s — bounds rate when K144 not READY */
+/* ── K144 endpoint family extracted to debug_server_m5.c (Wave 23b, #332) ─ */
 
-static void m5_refresh_hwinfo_if_stale(bool force) {
-   int64_t now = esp_timer_get_time();
-   /* Cache hit fast-path — last successful fetch within TTL window. */
-   if (!force && s_m5_hwinfo_refreshed_us != 0 && (now - s_m5_hwinfo_refreshed_us) < M5_HWINFO_CACHE_TTL_US) {
-      return;
-   }
-   /* Even if cache is stale, throttle attempts (avoids hammering the
-    * UART when /m5 is polled rapidly during a recovery cycle).  5 s
-    * is short enough that a UNAVAILABLE→READY transition picks up new
-    * data within ~10 s; long enough that 50 polls/sec from a script
-    * don't queue 50 sys.hwinfo round-trips. */
-   if (!force && s_m5_hwinfo_attempted_us != 0 && (now - s_m5_hwinfo_attempted_us) < M5_HWINFO_RETRY_GATE_US) {
-      return;
-   }
-   s_m5_hwinfo_attempted_us = now;
-
-   /* Skip the actual sys.hwinfo if K144 isn't READY — it would just
-    * time out and waste 1.5 s.  Cached values stay; client sees old
-    * data with `cache_age_ms` shown so they can decide what to trust. */
-   int fs = voice_onboard_failover_state();
-   if (fs != 2 /* M5_FAIL_READY */) {
-      return;
-   }
-
-   voice_m5_hwinfo_t fresh = {0};
-   esp_err_t he = voice_m5_llm_sys_hwinfo(&fresh);
-   if (he == ESP_OK && fresh.valid) {
-      s_m5_hwinfo_cache = fresh;
-      s_m5_hwinfo_refreshed_us = now;
-   }
-   /* Version is fixed per K144 firmware install — read once and cache.
-    * Cache survives sys.reset (daemon restart, version unchanged) but
-    * does NOT survive a Tab5 reboot. */
-   if (s_m5_version_cache[0] == '\0') {
-      (void)voice_m5_llm_sys_version(s_m5_version_cache, sizeof(s_m5_version_cache));
-   }
-}
-
-static esp_err_t m5_status_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-
-   /* Wave 14 — refresh hwinfo cache (no-op if warm + fresh enough). */
-   m5_refresh_hwinfo_if_stale(false);
-
-   cJSON *root = cJSON_CreateObject();
-   cJSON_AddBoolToObject(root, "chain_active", voice_onboard_chain_active());
-   /* Wave 7: chain_uptime_ms — 0 if not active.  Lets a remote operator
-    * spot a stuck chain without a serial cable. */
-   cJSON_AddNumberToObject(root, "chain_uptime_ms", (double)voice_onboard_chain_uptime_ms());
-   int fs = voice_onboard_failover_state();
-   cJSON_AddNumberToObject(root, "failover_state", fs);
-   const char *fs_names[] = {"unknown", "probing", "ready", "unavailable"};
-   cJSON_AddStringToObject(root, "failover_state_name", (fs >= 0 && fs <= 3) ? fs_names[fs] : "?");
-   cJSON_AddNumberToObject(root, "uart_baud", (double)voice_m5_llm_get_baud());
-
-   /* Wave 14 — hardware status.  `valid` is true only when the cache
-    * holds a successfully-parsed sys.hwinfo response; `cache_age_ms`
-    * tells the client how stale the snapshot is.  `temp_celsius`
-    * comes from the milli-degree field divided by 1000 (preserving
-    * one decimal — JSON consumer can format). */
-   cJSON *hw = cJSON_CreateObject();
-   bool hw_valid = (s_m5_hwinfo_cache.valid != 0);
-   cJSON_AddBoolToObject(hw, "valid", hw_valid);
-   if (hw_valid) {
-      double temp_c = (double)s_m5_hwinfo_cache.temperature_milli_c / 1000.0;
-      cJSON_AddNumberToObject(hw, "temp_celsius", temp_c);
-      cJSON_AddNumberToObject(hw, "temp_milli_c", (double)s_m5_hwinfo_cache.temperature_milli_c);
-      cJSON_AddNumberToObject(hw, "cpu_loadavg", (double)s_m5_hwinfo_cache.cpu_loadavg);
-      cJSON_AddNumberToObject(hw, "mem", (double)s_m5_hwinfo_cache.mem);
-   }
-   if (s_m5_hwinfo_refreshed_us != 0) {
-      int64_t age_ms = (esp_timer_get_time() - s_m5_hwinfo_refreshed_us) / 1000;
-      cJSON_AddNumberToObject(hw, "cache_age_ms", (double)age_ms);
-   }
-   cJSON_AddItemToObject(root, "hwinfo", hw);
-
-   /* Wave 14 — daemon version (read once on first hwinfo refresh,
-    * empty until then).  Surfaces "is K144 firmware up-to-date" + lets
-    * remote diagnostics correlate behavior with daemon version. */
-   cJSON_AddStringToObject(root, "version", s_m5_version_cache);
-
-   char *json = cJSON_PrintUnformatted(root);
-   cJSON_Delete(root);
-   httpd_resp_set_type(req, "application/json");
-   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-   esp_err_t ret = httpd_resp_sendstr(req, json);
-   free(json);
-   return ret;
-}
-
-/* TT #328 Wave 14 — POST /m5/refresh.  Forces a sys.hwinfo refresh
- * regardless of the 30 s cache TTL.  Useful when a remote operator or
- * the e2e harness wants a guaranteed-fresh reading.  Returns the same
- * shape as GET /m5 with the cache freshly populated. */
-static esp_err_t m5_refresh_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   m5_refresh_hwinfo_if_stale(true);
-   return m5_status_handler(req);
-}
-
-/* TT #328 Wave 15 — GET /m5/models.  Surfaces the K144 model registry
- * (sys.lsmode response) so the dashboard + e2e harness can see what's
- * installed.  Cached for 5 min — sys.lsmode is ~50 ms warm but the
- * registry doesn't change between K144 reboots, so re-fetching often
- * is wasteful.  ?force=1 bypasses the cache for a fresh fetch.
- *
- * Cache lives in PSRAM (heap_caps_calloc, lazy on first request) —
- * NOT BSS-static.  An earlier draft used a BSS-static
- * voice_m5_modelist_t (~1.8 KB) and tripped the same boot-loop
- * `vApplicationGetTimerTaskMemory` assert as Wave 11 / Wave 13's
- * first attempt.  See LEARNINGS "BSS-static caches >3 KB push Tab5
- * over a boot SRAM threshold" — same lesson, different size band:
- * we hit the threshold around ~1.8 KB on top of Wave 14's BSS
- * additions.  Lazy PSRAM is the universal fix. */
-static voice_m5_modelist_t *s_m5_modelist_cache = NULL;
-static int64_t s_m5_modelist_refreshed_us = 0;
-#define M5_MODELLIST_CACHE_TTL_US (5LL * 60LL * 1000LL * 1000LL) /* 5 min */
-
-static void m5_refresh_modelist_if_stale(bool force) {
-   int64_t now = esp_timer_get_time();
-   if (!force && s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid &&
-       (now - s_m5_modelist_refreshed_us) < M5_MODELLIST_CACHE_TTL_US) {
-      return;
-   }
-   if (voice_onboard_failover_state() != 2 /* M5_FAIL_READY */) {
-      return; /* Don't waste 3 s on UART timeout when K144 is offline */
-   }
-   if (s_m5_modelist_cache == NULL) {
-      s_m5_modelist_cache = heap_caps_calloc(1, sizeof(*s_m5_modelist_cache), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-      if (s_m5_modelist_cache == NULL) {
-         ESP_LOGE(TAG, "modelist PSRAM alloc failed");
-         return;
-      }
-   }
-   voice_m5_modelist_t fresh = {0};
-   if (voice_m5_llm_sys_lsmode(&fresh) == ESP_OK && fresh.valid) {
-      memcpy(s_m5_modelist_cache, &fresh, sizeof(fresh));
-      s_m5_modelist_refreshed_us = now;
-   }
-}
-
-static esp_err_t m5_models_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   bool force = false;
-   {
-      char qbuf[64];
-      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
-         char val[8];
-         if (httpd_query_key_value(qbuf, "force", val, sizeof(val)) == ESP_OK && (val[0] == '1' || val[0] == 't')) {
-            force = true;
-         }
-      }
-   }
-   m5_refresh_modelist_if_stale(force);
-
-   cJSON *root = cJSON_CreateObject();
-   bool valid = (s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid);
-   cJSON_AddBoolToObject(root, "valid", valid);
-   cJSON_AddNumberToObject(root, "count", valid ? (double)s_m5_modelist_cache->n : 0.0);
-   cJSON *arr = cJSON_AddArrayToObject(root, "models");
-   if (valid) {
-      for (int i = 0; i < s_m5_modelist_cache->n; i++) {
-         cJSON *m = cJSON_CreateObject();
-         cJSON_AddStringToObject(m, "mode", s_m5_modelist_cache->models[i].mode);
-         cJSON_AddStringToObject(m, "primary_cap", s_m5_modelist_cache->models[i].primary_cap);
-         cJSON_AddStringToObject(m, "language", s_m5_modelist_cache->models[i].language);
-         cJSON_AddItemToArray(arr, m);
-      }
-   }
-   if (s_m5_modelist_refreshed_us != 0) {
-      int64_t age_s = (esp_timer_get_time() - s_m5_modelist_refreshed_us) / 1000000;
-      cJSON_AddNumberToObject(root, "cache_age_s", (double)age_s);
-   }
-   char *json = cJSON_PrintUnformatted(root);
-   cJSON_Delete(root);
-   httpd_resp_set_type(req, "application/json");
-   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-   esp_err_t ret = httpd_resp_sendstr(req, json);
-   free(json);
-   return ret;
-}
-
-/* TT #328 Wave 13 — POST /m5/reset.  Triggers
- * voice_onboard_reset_failover(), which sends sys.reset to the K144
- * StackFlow daemon, waits for it to come back, and re-runs the warmup
- * probe.  The actual reset happens asynchronously on tab5_worker; the
- * caller can poll GET /m5 to observe state cycle PROBING → READY (or
- * UNAVAILABLE on continued failure).
- *
- * Useful for both the e2e harness (verifies recovery round-trip
- * without UI tap geometry) and dashboard / remote-operator debugging
- * (a Tab5 stuck in UNAVAILABLE can be unstuck without a reboot or a
- * physical tap on the Settings health chip). */
-static esp_err_t m5_reset_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   esp_err_t qe = voice_onboard_reset_failover();
-   cJSON *root = cJSON_CreateObject();
-   cJSON_AddStringToObject(root, "status", qe == ESP_OK ? "queued" : "rejected");
-   cJSON_AddStringToObject(root, "detail",
-                           qe == ESP_OK ? "K144 reset job enqueued — poll GET /m5"
-                                        : "Probe already in flight — try again "
-                                          "after current cycle finishes");
-   cJSON_AddNumberToObject(root, "failover_state", voice_onboard_failover_state());
-   char *json = cJSON_PrintUnformatted(root);
-   cJSON_Delete(root);
-   httpd_resp_set_type(req, "application/json");
-   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-   esp_err_t ret = httpd_resp_sendstr(req, json);
-   free(json);
-   return ret;
-}
 
 /* ── Voice reconnect endpoint ─────────────────────────────────────────── */
 
@@ -4315,14 +4095,9 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_voice_reconnect = {
         .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
     };
-    /* TT #327 Wave 5: K144 / chain diagnostic snapshot. */
-    const httpd_uri_t uri_m5_status = {.uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
-    /* TT #328 Wave 13: K144 software reset (sys.reset + re-warmup). */
-    const httpd_uri_t uri_m5_reset = {.uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
-    /* TT #328 Wave 14: K144 hwinfo cache refresh (forces sys.hwinfo + sys.version). */
-    const httpd_uri_t uri_m5_refresh = {.uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
-    /* TT #328 Wave 15: K144 model registry (sys.lsmode). */
-    const httpd_uri_t uri_m5_models = {.uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
+    /* Wave 23b (#332): K144 endpoint family — the 4 URIs (/m5, /m5/reset,
+     * /m5/refresh, /m5/models) are registered via debug_server_m5_register()
+     * below so the handlers + their cache layers live in their own .c file. */
     /* #266: live video streaming control.  #268 adds /video/show + hide. */
     const httpd_uri_t uri_video_start = {
         .uri = "/video/start", .method = HTTP_POST, .handler = video_start_handler
@@ -4447,10 +4222,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_screen);
     httpd_register_uri_handler(server, &uri_voice_state);
     httpd_register_uri_handler(server, &uri_voice_reconnect);
-    httpd_register_uri_handler(server, &uri_m5_status);
-    httpd_register_uri_handler(server, &uri_m5_reset);
-    httpd_register_uri_handler(server, &uri_m5_refresh);
-    httpd_register_uri_handler(server, &uri_m5_models);
+    /* Wave 23b (#332): K144 endpoint family registered en-bloc. */
+    debug_server_m5_register(server);
     httpd_register_uri_handler(server, &uri_video_start);
     httpd_register_uri_handler(server, &uri_video_stop);
     httpd_register_uri_handler(server, &uri_video_state);

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -58,6 +58,7 @@
 #include "voice.h"
 /* Wave 23b (#332): per-family endpoint extracts + auth shim. */
 #include "debug_server_internal.h"
+#include "debug_server_codec.h"
 #include "debug_server_m5.h"
 #include "debug_server_ota.h"
 #include "widget.h"        /* Audit C4 (#202): widget_store_evictions_total */
@@ -2816,6 +2817,14 @@ static esp_err_t send_json_resp(httpd_req_t *req, cJSON *root)
     return r;
 }
 
+/* Wave 23b (#332): public wrapper for the per-family extracts —
+ * see debug_server_internal.h.  The 57 in-file callers still use
+ * the static; new family files go through this. */
+esp_err_t tab5_debug_send_json_resp(httpd_req_t *req, struct cJSON *root)
+{
+    return send_json_resp(req, (cJSON *)root);
+}
+
 /* ── GET /tasks — FreeRTOS task snapshot ────────────────────────── */
 /* Full per-task dump requires configUSE_TRACE_FACILITY + the
  * run-time-stats infra to be enabled in sdkconfig.  Most ESP-IDF
@@ -3535,195 +3544,8 @@ static esp_err_t debug_inject_audio_handler_impl(httpd_req_t *req) {
 
 esp_err_t debug_inject_audio_handler(httpd_req_t *req) { return debug_inject_audio_handler_impl(req); }
 
-/* TT #264 — synthetic OPUS encoder smoke test.  Drives
- * voice_codec_encode_uplink directly with N frames of synthetic
- * 16 kHz mono PCM (sine wave at 440 Hz, low amplitude).  Bypasses
- * the WS/mic pipeline so we can isolate "is the SILK NSQ encoder
- * working?" without coordinating Dragon's codec choice or a live mic.
- *
- * Runs the encode loop in a one-shot worker task with a 48 KB stack
- * (the issue reported 16 KB on voice_mic still triggers the SILK NSQ
- * panic — this is investigation step "expand stack until it works").
- *
- * Query params: ?frames=N (1-1000), ?heap=psram|internal|dma,
- * ?align=16|32|64, ?stack=N (KB, default 48).
- *
- * Returns counters: frames_attempted, frames_ok, frames_failed,
- * total_bytes_out.  If Tab5 panics mid-test the response never
- * lands; check uptime + reset_reason via /info to confirm. */
-#include "freertos/semphr.h"
-#include "voice_codec.h"
+/* ── Codec endpoint family extracted to debug_server_codec.c (Wave 23b, #332) ─ */
 
-typedef struct {
-   const int16_t *pcm;
-   size_t n_samples;
-   int frames;
-   int frames_ok;
-   int frames_failed;
-   uint32_t total_bytes_out;
-   int64_t dt_us;
-   SemaphoreHandle_t done;
-} opus_test_ctx_t;
-
-static void opus_test_task(void *arg) {
-   opus_test_ctx_t *ctx = (opus_test_ctx_t *)arg;
-   uint8_t out[1024];
-   int64_t t0 = esp_timer_get_time();
-   for (int i = 0; i < ctx->frames; i++) {
-      size_t out_len = 0;
-      esp_err_t e = voice_codec_encode_uplink(ctx->pcm, ctx->n_samples, out, sizeof(out), &out_len);
-      if (e == ESP_OK && out_len > 0) {
-         ctx->frames_ok++;
-         ctx->total_bytes_out += out_len;
-      } else {
-         ctx->frames_failed++;
-      }
-   }
-   ctx->dt_us = esp_timer_get_time() - t0;
-   xSemaphoreGive(ctx->done);
-   vTaskDelete(NULL);
-}
-static esp_err_t debug_opus_test_handler(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-
-   /* Frame count: 50 frames = 1 second at 20 ms / frame.  Caller can
-    * override via ?frames=N (capped at 1000 to avoid DoS-ing a busy
-    * mic loop). */
-   int frames = 50;
-   {
-      char qbuf[64];
-      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
-         char val[16];
-         if (httpd_query_key_value(qbuf, "frames", val, sizeof(val)) == ESP_OK) {
-            int n = atoi(val);
-            if (n > 0 && n <= 1000) frames = n;
-         }
-      }
-   }
-
-   /* Allocate a 320-sample (20 ms @ 16 kHz) PCM frame.  The buffer
-    * heap_caps + alignment are part of what we're testing — issue
-    * #264 suspects the SILK encoder requires DMA-capable internal
-    * SRAM and/or 32/64-byte alignment.  Caller can override:
-    *   ?heap=psram  (default: same as the real mic buffer)
-    *   ?heap=internal  (try MALLOC_CAP_INTERNAL — investigation step 2)
-    *   ?align=N  (use heap_caps_aligned_alloc — step 1)
-    */
-   const size_t n_samples = 320;
-   int16_t *pcm = NULL;
-   uint32_t caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
-   int align = 0;
-   {
-      char qbuf[64];
-      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
-         char val[16];
-         if (httpd_query_key_value(qbuf, "heap", val, sizeof(val)) == ESP_OK) {
-            if (strcmp(val, "internal") == 0) {
-               caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
-            } else if (strcmp(val, "dma") == 0) {
-               caps = MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
-            }
-         }
-         if (httpd_query_key_value(qbuf, "align", val, sizeof(val)) == ESP_OK) {
-            int a = atoi(val);
-            if (a == 16 || a == 32 || a == 64) align = a;
-         }
-      }
-   }
-   if (align > 0) {
-      pcm = heap_caps_aligned_alloc((size_t)align, n_samples * sizeof(int16_t), caps);
-   } else {
-      pcm = heap_caps_malloc(n_samples * sizeof(int16_t), caps);
-   }
-   if (pcm == NULL) {
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "PSRAM alloc failed");
-      return send_json_resp(req, r);
-   }
-   /* Sine wave: 16 kHz sample rate, 440 Hz target.  Amplitude
-    * 0.1 × INT16_MAX = ~3276 (low to keep VBR honest). */
-   for (size_t i = 0; i < n_samples; i++) {
-      double t = (double)i / 16000.0;
-      double s = sin(2.0 * 3.14159265 * 440.0 * t);
-      pcm[i] = (int16_t)(s * 3276.0);
-   }
-
-   /* Force OPUS uplink — encoder spins up here on first call (will
-    * fall back to PCM silently if init fails). */
-   voice_codec_set_uplink(VOICE_CODEC_OPUS);
-   bool encoder_active = (voice_codec_get_uplink() == VOICE_CODEC_OPUS);
-
-   /* Pick the encode-task stack size from query (default 48 KB).
-    * Issue #264 reported voice_mic's 16 KB stack triggers SILK NSQ
-    * stack-protection-fault panic; this lets us bisect the minimum
-    * size that survives.  Cap at 96 KB to keep the alloc bounded. */
-   int stack_kb = 48;
-   {
-      char qbuf[64];
-      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
-         char val[16];
-         if (httpd_query_key_value(qbuf, "stack", val, sizeof(val)) == ESP_OK) {
-            int s = atoi(val);
-            if (s >= 8 && s <= 96) stack_kb = s;
-         }
-      }
-   }
-
-   /* Run the encode loop in a dedicated task with the requested
-    * stack — httpd's task stack is too small (4-8 KB depending on
-    * config) for SILK NSQ working storage.  Wait synchronously via
-    * semaphore. */
-   opus_test_ctx_t ctx = {
-       .pcm = pcm,
-       .n_samples = n_samples,
-       .frames = frames,
-       .done = xSemaphoreCreateBinary(),
-   };
-   if (ctx.done == NULL) {
-      heap_caps_free(pcm);
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "semaphore alloc failed");
-      return send_json_resp(req, r);
-   }
-   BaseType_t tc = xTaskCreate(opus_test_task, "opus_test", (uint32_t)stack_kb * 1024, &ctx, 5, NULL);
-   if (tc != pdPASS) {
-      vSemaphoreDelete(ctx.done);
-      heap_caps_free(pcm);
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "xTaskCreate failed");
-      cJSON_AddNumberToObject(r, "stack_kb", stack_kb);
-      return send_json_resp(req, r);
-   }
-   /* Wait up to 10 s for the task to finish.  At ~1 ms per frame
-    * even 1000 frames is well under this budget; if the task panics
-    * or hangs we'll fail-soft after 10 s with no payload to return. */
-   xSemaphoreTake(ctx.done, pdMS_TO_TICKS(10000));
-   vSemaphoreDelete(ctx.done);
-   int frames_ok = ctx.frames_ok;
-   int frames_failed = ctx.frames_failed;
-   uint32_t total_bytes_out = ctx.total_bytes_out;
-   int64_t dt_us = ctx.dt_us;
-   heap_caps_free(pcm);
-
-   cJSON *r = cJSON_CreateObject();
-   cJSON_AddBoolToObject(r, "encoder_active", encoder_active);
-   cJSON_AddStringToObject(r, "buf_heap", (caps & MALLOC_CAP_INTERNAL) ? "internal" : "psram");
-   cJSON_AddNumberToObject(r, "buf_align", align);
-   cJSON_AddNumberToObject(r, "task_stack_kb", stack_kb);
-   cJSON_AddNumberToObject(r, "frames_attempted", frames);
-   cJSON_AddNumberToObject(r, "frames_ok", frames_ok);
-   cJSON_AddNumberToObject(r, "frames_failed", frames_failed);
-   cJSON_AddNumberToObject(r, "total_bytes_out", (double)total_bytes_out);
-   cJSON_AddNumberToObject(r, "elapsed_ms", (double)(dt_us / 1000));
-   if (frames > 0) {
-      cJSON_AddNumberToObject(r, "avg_bytes_per_frame", (double)total_bytes_out / (double)frames);
-      cJSON_AddNumberToObject(r, "us_per_frame", (double)dt_us / (double)frames);
-   }
-   /* Restore PCM uplink so subsequent real WS traffic isn't
-    * unexpectedly OPUS-encoded. */
-   voice_codec_set_uplink(VOICE_CODEC_PCM);
-   return send_json_resp(req, r);
-}
 
 /* TT #328 Wave 12 — synthesize Wave 3 error.* events + their banner/
  * toast UX without needing real fault conditions.  POST body or query
@@ -4095,9 +3917,8 @@ esp_err_t tab5_debug_server_init(void)
     extern esp_err_t debug_inject_audio_handler(httpd_req_t * req);
     const httpd_uri_t uri_inject_audio = {
         .uri = "/debug/inject_audio", .method = HTTP_POST, .handler = debug_inject_audio_handler};
-    /* TT #264 — synthetic OPUS encoder smoke test. */
-    const httpd_uri_t uri_opus_test = {
-        .uri = "/codec/opus_test", .method = HTTP_POST, .handler = debug_opus_test_handler};
+    /* Wave 23b (#332): codec endpoint family — registered en-bloc via
+     * debug_server_codec_register() below. */
 
     /* TT #328 Wave 2 — synthetic WS-frame injector for error-surfacing
      * user-story tests (config_update.error, dictation_postprocessing_*,
@@ -4175,7 +3996,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_nvs_erase);
     httpd_register_uri_handler(server, &uri_inject_error);
     httpd_register_uri_handler(server, &uri_inject_audio);
-    httpd_register_uri_handler(server, &uri_opus_test);
+    /* Wave 23b (#332): codec endpoint family registered en-bloc. */
+    debug_server_codec_register(server);
     httpd_register_uri_handler(server, &uri_inject_ws);
 
     /* Log the URL */

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -56,9 +56,10 @@
 #include "ui_settings.h"
 #include "ui_wifi.h"
 #include "voice.h"
-/* Wave 23b (#332): K144 endpoint family + auth shim moved to siblings. */
+/* Wave 23b (#332): per-family endpoint extracts + auth shim. */
 #include "debug_server_internal.h"
 #include "debug_server_m5.h"
+#include "debug_server_ota.h"
 #include "widget.h"        /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -1080,95 +1081,7 @@ static esp_err_t sdcard_handler(httpd_req_t *req)
     return ret;
 }
 
-/* ── OTA debug endpoints ──────────────────────────────────────────────── */
-
-static esp_err_t ota_check_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    tab5_ota_info_t info;
-    esp_err_t err = tab5_ota_check(&info);
-
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "current", TAB5_FIRMWARE_VER);
-    cJSON_AddStringToObject(root, "partition", tab5_ota_current_partition());
-    if (err == ESP_OK) {
-        cJSON_AddBoolToObject(root, "update_available", info.available);
-        if (info.available) {
-            cJSON_AddStringToObject(root, "new_version", info.version);
-            cJSON_AddStringToObject(root, "url", info.url);
-        }
-    } else {
-        cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
-    }
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, json);
-    free(json);
-    return ret;
-}
-
-typedef struct {
-    char *url;
-    char sha256[65];
-} ota_apply_args_t;
-
-static void ota_apply_task(void *arg)
-{
-    ota_apply_args_t *args = (ota_apply_args_t *)arg;
-    ESP_LOGI("ota", "Scheduling OTA for next boot: %s (sha256=%s)", args->url,
-             args->sha256[0] ? args->sha256 : "none");
-    /* Wave 10 #77 extended-use fix: schedule instead of apply in-process.
-     * tab5_ota_schedule stores url+sha to NVS, reboots, and the fresh
-     * boot applies with a pristine DMA heap (see main.c near WiFi init).
-     * Prevents the "esp_dma_capable_malloc: Not enough heap memory"
-     * failure mode that hits after 30+ min of normal use. */
-    esp_err_t err = tab5_ota_schedule(args->url, args->sha256[0] ? args->sha256 : NULL);
-    /* If we get here, schedule failed (success reboots) */
-    ESP_LOGE("ota", "OTA schedule failed: %s", esp_err_to_name(err));
-    free(args->url);
-    free(args);
-    vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
-}
-
-static esp_err_t ota_apply_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* Check for update first */
-    tab5_ota_info_t info;
-    esp_err_t err = tab5_ota_check(&info);
-    if (err != ESP_OK || !info.available) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_sendstr(req, "{\"error\":\"no update available\"}");
-        return ESP_OK;
-    }
-
-    /* Spawn OTA task with SHA256 from version.json (SEC07) */
-    ota_apply_args_t *args = malloc(sizeof(ota_apply_args_t));
-    if (args) {
-        args->url = strdup(info.url);
-        strncpy(args->sha256, info.sha256, sizeof(args->sha256) - 1);
-        args->sha256[sizeof(args->sha256) - 1] = '\0';
-        if (args->url) {
-            xTaskCreate(ota_apply_task, "ota_apply", 8192, args, 5, NULL);
-        } else {
-            free(args);
-        }
-    }
-
-    httpd_resp_set_type(req, "application/json");
-    char resp[512];
-    snprintf(resp, sizeof(resp),
-             "{\"status\":\"updating\",\"version\":\"%s\",\"url\":\"%s\",\"sha256_verify\":%s}",
-             info.version, info.url, info.sha256[0] ? "true" : "false");
-    httpd_resp_sendstr(req, resp);
-    return ESP_OK;
-}
+/* ── OTA endpoint family extracted to debug_server_ota.c (Wave 23b, #332) ─ */
 
 /* ── ADB-style debug APIs ─────────────────────────────────────────────── */
 
@@ -4074,12 +3987,8 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_camera = {
         .uri = "/camera", .method = HTTP_GET, .handler = camera_handler
     };
-    const httpd_uri_t uri_ota_check = {
-        .uri = "/ota/check", .method = HTTP_GET, .handler = ota_check_handler
-    };
-    const httpd_uri_t uri_ota_apply = {
-        .uri = "/ota/apply", .method = HTTP_POST, .handler = ota_apply_handler
-    };
+    /* Wave 23b (#332): OTA endpoint family — registered en-bloc via
+     * debug_server_ota_register() below. */
     const httpd_uri_t uri_chat = {
         .uri = "/chat", .method = HTTP_POST, .handler = chat_handler
     };
@@ -4215,8 +4124,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_navigate);
     httpd_register_uri_handler(server, &uri_widget);
     httpd_register_uri_handler(server, &uri_camera);
-    httpd_register_uri_handler(server, &uri_ota_check);
-    httpd_register_uri_handler(server, &uri_ota_apply);
+    /* Wave 23b (#332): OTA endpoint family registered en-bloc. */
+    debug_server_ota_register(server);
     httpd_register_uri_handler(server, &uri_chat);
     httpd_register_uri_handler(server, &uri_input_text);
     httpd_register_uri_handler(server, &uri_screen);

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -61,6 +61,7 @@
 #include "debug_server_codec.h"
 #include "debug_server_m5.h"
 #include "debug_server_ota.h"
+#include "debug_server_voice.h"
 #include "widget.h"        /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -2322,69 +2323,8 @@ static esp_err_t screen_state_handler(httpd_req_t *req)
     return ret;
 }
 
-static esp_err_t voice_state_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
+/* ── Voice endpoint family extracted to debug_server_voice.c (Wave 23b, #332) ─ */
 
-    /* GET /voice — full voice pipeline state */
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "connected", voice_is_connected());
-    cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
-
-    const char *state_names[] = {"IDLE", "CONNECTING", "READY", "LISTENING", "PROCESSING", "SPEAKING", "RECONNECTING", "DICTATING"};
-    int st = (int)voice_get_state();
-    /* State enum has 8 values (0..7); the old bound stopped at 6 which
-     * reported DICTATING as "UNKNOWN" — fix alongside the /dictation
-     * endpoint so test harness sees the right label. */
-    cJSON_AddStringToObject(root, "state_name", (st >= 0 && st <= 7) ? state_names[st] : "UNKNOWN");
-
-    /* Wave 14 W14-M01: the debug httpd task races with voice.c's
-     * WS RX task.  Use the copy-under-mutex variants to avoid
-     * observing a mid-strcat string. */
-    char llm_buf[512];
-    if (voice_get_llm_text_copy(llm_buf, sizeof(llm_buf)) && llm_buf[0]) {
-        cJSON_AddStringToObject(root, "last_llm_text", llm_buf);
-    }
-
-    char stt_buf[512];
-    if (voice_get_stt_text_copy(stt_buf, sizeof(stt_buf)) && stt_buf[0]) {
-        cJSON_AddStringToObject(root, "last_stt_text", stt_buf);
-    }
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, json);
-    free(json);
-    return ret;
-}
-
-/* ── K144 endpoint family extracted to debug_server_m5.c (Wave 23b, #332) ─ */
-
-
-/* ── Voice reconnect endpoint ─────────────────────────────────────────── */
-
-static esp_err_t voice_reconnect_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* POST /voice/reconnect — force voice WS reconnect */
-    ESP_LOGI(TAG, "Debug: forcing voice reconnect");
-    voice_disconnect();
-    vTaskDelay(pdMS_TO_TICKS(500));
-    /* Reconnect using current NVS settings + voice port (3502, not dragon_port which is 3501 for CDP) */
-    char host[64] = {0};
-    tab5_settings_get_dragon_host(host, sizeof(host));
-    voice_connect(host, TAB5_VOICE_PORT);
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    httpd_resp_sendstr(req, "{\"status\":\"reconnecting\"}");
-    return ESP_OK;
-}
 
 /* ── #266: live video streaming control (POST /video/start, /video/stop,
  *           GET /video).  #268 adds /video/show + /video/hide for the
@@ -2900,31 +2840,6 @@ static esp_err_t voice_text_handler(httpd_req_t *req)
     return chat_handler(req);
 }
 
-/* ── POST /voice/cancel ─────────────────────────────────────────── */
-static esp_err_t voice_cancel_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-    esp_err_t r = voice_cancel();
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
-    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
-    return send_json_resp(req, root);
-}
-
-/* ── POST /voice/clear — clear Dragon conversation history ────── */
-static esp_err_t voice_clear_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-    esp_err_t r = voice_clear_history();
-    /* Also wipe Tab5 side so UI matches. */
-    extern void chat_store_clear(void);
-    chat_store_clear();
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
-    cJSON_AddBoolToObject(root, "store_cleared", true);
-    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
-    return send_json_resp(req, root);
-}
 
 /* ── GET /wifi/status ──────────────────────────────────────────── */
 static esp_err_t wifi_status_handler(httpd_req_t *req)
@@ -3820,12 +3735,9 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_screen = {
         .uri = "/screen", .method = HTTP_GET, .handler = screen_state_handler
     };
-    const httpd_uri_t uri_voice_state = {
-        .uri = "/voice", .method = HTTP_GET, .handler = voice_state_handler
-    };
-    const httpd_uri_t uri_voice_reconnect = {
-        .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
-    };
+    /* Wave 23b (#332): voice endpoint family (/voice, /voice/reconnect,
+     * /voice/cancel, /voice/clear) registered en-bloc via
+     * debug_server_voice_register() below. */
     /* Wave 23b (#332): K144 endpoint family — the 4 URIs (/m5, /m5/reset,
      * /m5/refresh, /m5/models) are registered via debug_server_m5_register()
      * below so the handlers + their cache layers live in their own .c file. */
@@ -3887,8 +3799,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_tasks          = { .uri = "/tasks",          .method = HTTP_GET,  .handler = tasks_handler };
     const httpd_uri_t uri_logs_tail      = { .uri = "/logs/tail",      .method = HTTP_GET,  .handler = logs_tail_handler };
     const httpd_uri_t uri_voice_text     = { .uri = "/voice/text",     .method = HTTP_POST, .handler = voice_text_handler };
-    const httpd_uri_t uri_voice_cancel   = { .uri = "/voice/cancel",   .method = HTTP_POST, .handler = voice_cancel_handler };
-    const httpd_uri_t uri_voice_clear    = { .uri = "/voice/clear",    .method = HTTP_POST, .handler = voice_clear_handler };
+    /* Wave 23b (#332): /voice/cancel + /voice/clear moved to debug_server_voice.c. */
     const httpd_uri_t uri_wifi_status    = { .uri = "/wifi/status",    .method = HTTP_GET,  .handler = wifi_status_handler };
     const httpd_uri_t uri_battery        = { .uri = "/battery",        .method = HTTP_GET,  .handler = battery_handler };
     const httpd_uri_t uri_disp_bright    = { .uri = "/display/brightness", .method = HTTP_POST, .handler = display_brightness_handler };
@@ -3950,8 +3861,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_chat);
     httpd_register_uri_handler(server, &uri_input_text);
     httpd_register_uri_handler(server, &uri_screen);
-    httpd_register_uri_handler(server, &uri_voice_state);
-    httpd_register_uri_handler(server, &uri_voice_reconnect);
+    /* Wave 23b (#332): voice endpoint family registered en-bloc. */
+    debug_server_voice_register(server);
     /* Wave 23b (#332): K144 endpoint family registered en-bloc. */
     debug_server_m5_register(server);
     httpd_register_uri_handler(server, &uri_video_start);
@@ -3975,8 +3886,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_tasks);
     httpd_register_uri_handler(server, &uri_logs_tail);
     httpd_register_uri_handler(server, &uri_voice_text);
-    httpd_register_uri_handler(server, &uri_voice_cancel);
-    httpd_register_uri_handler(server, &uri_voice_clear);
+    /* Wave 23b (#332): /voice/cancel + /voice/clear registered via
+     * debug_server_voice_register() above. */
     httpd_register_uri_handler(server, &uri_wifi_status);
     httpd_register_uri_handler(server, &uri_battery);
     httpd_register_uri_handler(server, &uri_disp_bright);

--- a/main/debug_server_codec.c
+++ b/main/debug_server_codec.c
@@ -1,0 +1,230 @@
+/*
+ * debug_server_codec.c — codec stack debug HTTP endpoint family.
+ *
+ * Wave 23b follow-up (#332): third per-family extract from
+ * debug_server.c (after K144 #336 and OTA #337).  The opus_test
+ * endpoint was added in TT #264 (Wave 19) to bisect the SILK NSQ
+ * stack-overflow crash; bisect found 24 KB as the watermark, leading
+ * to the MIC_TASK_STACK_SIZE bump in voice.c.  The endpoint stays as
+ * a permanent diagnostic for codec health checks + stack-budget
+ * validation.
+ *
+ * Mechanical move from debug_server.c — handlers + the worker task +
+ * the opus_test_ctx_t typedef all moved verbatim.  Only call-site
+ * changes: `check_auth(req)` → `tab5_debug_check_auth(req)` and
+ * `send_json_resp(req, r)` → `tab5_debug_send_json_resp(req, r)`,
+ * both via the shared internal-header wrappers.
+ */
+
+#include "debug_server_codec.h"
+
+#include <math.h>   /* TT #264 sin() for OPUS encoder synthetic test */
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "esp_heap_caps.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+#include "debug_server_internal.h" /* tab5_debug_check_auth + send_json_resp */
+#include "voice_codec.h"           /* voice_codec_encode_uplink + set_uplink */
+
+/* TT #264 — synthetic OPUS encoder smoke test.  Drives
+ * voice_codec_encode_uplink directly with N frames of synthetic
+ * 16 kHz mono PCM (sine wave at 440 Hz, low amplitude).  Bypasses
+ * the WS/mic pipeline so we can isolate "is the SILK NSQ encoder
+ * working?" without coordinating Dragon's codec choice or a live mic.
+ *
+ * Runs the encode loop in a one-shot worker task with a 48 KB stack
+ * (the issue reported 16 KB on voice_mic still triggers the SILK NSQ
+ * panic — this is investigation step "expand stack until it works").
+ *
+ * Query params: ?frames=N (1-1000), ?heap=psram|internal|dma,
+ * ?align=16|32|64, ?stack=N (KB, default 48).
+ *
+ * Returns counters: frames_attempted, frames_ok, frames_failed,
+ * total_bytes_out.  If Tab5 panics mid-test the response never
+ * lands; check uptime + reset_reason via /info to confirm. */
+typedef struct {
+   const int16_t *pcm;
+   size_t n_samples;
+   int frames;
+   int frames_ok;
+   int frames_failed;
+   uint32_t total_bytes_out;
+   int64_t dt_us;
+   SemaphoreHandle_t done;
+} opus_test_ctx_t;
+
+static void opus_test_task(void *arg) {
+   opus_test_ctx_t *ctx = (opus_test_ctx_t *)arg;
+   uint8_t out[1024];
+   int64_t t0 = esp_timer_get_time();
+   for (int i = 0; i < ctx->frames; i++) {
+      size_t out_len = 0;
+      esp_err_t e = voice_codec_encode_uplink(ctx->pcm, ctx->n_samples, out, sizeof(out), &out_len);
+      if (e == ESP_OK && out_len > 0) {
+         ctx->frames_ok++;
+         ctx->total_bytes_out += out_len;
+      } else {
+         ctx->frames_failed++;
+      }
+   }
+   ctx->dt_us = esp_timer_get_time() - t0;
+   xSemaphoreGive(ctx->done);
+   vTaskDelete(NULL);
+}
+
+static esp_err_t debug_opus_test_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   /* Frame count: 50 frames = 1 second at 20 ms / frame.  Caller can
+    * override via ?frames=N (capped at 1000 to avoid DoS-ing a busy
+    * mic loop). */
+   int frames = 50;
+   {
+      char qbuf[64];
+      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+         char val[16];
+         if (httpd_query_key_value(qbuf, "frames", val, sizeof(val)) == ESP_OK) {
+            int n = atoi(val);
+            if (n > 0 && n <= 1000) frames = n;
+         }
+      }
+   }
+
+   /* Allocate a 320-sample (20 ms @ 16 kHz) PCM frame.  The buffer
+    * heap_caps + alignment are part of what we're testing — issue
+    * #264 suspects the SILK encoder requires DMA-capable internal
+    * SRAM and/or 32/64-byte alignment.  Caller can override:
+    *   ?heap=psram  (default: same as the real mic buffer)
+    *   ?heap=internal  (try MALLOC_CAP_INTERNAL — investigation step 2)
+    *   ?align=N  (use heap_caps_aligned_alloc — step 1)
+    */
+   const size_t n_samples = 320;
+   int16_t *pcm = NULL;
+   uint32_t caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
+   int align = 0;
+   {
+      char qbuf[64];
+      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+         char val[16];
+         if (httpd_query_key_value(qbuf, "heap", val, sizeof(val)) == ESP_OK) {
+            if (strcmp(val, "internal") == 0) {
+               caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+            } else if (strcmp(val, "dma") == 0) {
+               caps = MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+            }
+         }
+         if (httpd_query_key_value(qbuf, "align", val, sizeof(val)) == ESP_OK) {
+            int a = atoi(val);
+            if (a == 16 || a == 32 || a == 64) align = a;
+         }
+      }
+   }
+   if (align > 0) {
+      pcm = heap_caps_aligned_alloc((size_t)align, n_samples * sizeof(int16_t), caps);
+   } else {
+      pcm = heap_caps_malloc(n_samples * sizeof(int16_t), caps);
+   }
+   if (pcm == NULL) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "PSRAM alloc failed");
+      return tab5_debug_send_json_resp(req, r);
+   }
+   /* Sine wave: 16 kHz sample rate, 440 Hz target.  Amplitude
+    * 0.1 × INT16_MAX = ~3276 (low to keep VBR honest). */
+   for (size_t i = 0; i < n_samples; i++) {
+      double t = (double)i / 16000.0;
+      double s = sin(2.0 * 3.14159265 * 440.0 * t);
+      pcm[i] = (int16_t)(s * 3276.0);
+   }
+
+   /* Force OPUS uplink — encoder spins up here on first call (will
+    * fall back to PCM silently if init fails). */
+   voice_codec_set_uplink(VOICE_CODEC_OPUS);
+   bool encoder_active = (voice_codec_get_uplink() == VOICE_CODEC_OPUS);
+
+   /* Pick the encode-task stack size from query (default 48 KB).
+    * Issue #264 reported voice_mic's 16 KB stack triggers SILK NSQ
+    * stack-protection-fault panic; this lets us bisect the minimum
+    * size that survives.  Cap at 96 KB to keep the alloc bounded. */
+   int stack_kb = 48;
+   {
+      char qbuf[64];
+      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+         char val[16];
+         if (httpd_query_key_value(qbuf, "stack", val, sizeof(val)) == ESP_OK) {
+            int s = atoi(val);
+            if (s >= 8 && s <= 96) stack_kb = s;
+         }
+      }
+   }
+
+   /* Run the encode loop in a dedicated task with the requested
+    * stack — httpd's task stack is too small (4-8 KB depending on
+    * config) for SILK NSQ working storage.  Wait synchronously via
+    * semaphore. */
+   opus_test_ctx_t ctx = {
+       .pcm = pcm,
+       .n_samples = n_samples,
+       .frames = frames,
+       .done = xSemaphoreCreateBinary(),
+   };
+   if (ctx.done == NULL) {
+      heap_caps_free(pcm);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "semaphore alloc failed");
+      return tab5_debug_send_json_resp(req, r);
+   }
+   BaseType_t tc = xTaskCreate(opus_test_task, "opus_test", (uint32_t)stack_kb * 1024, &ctx, 5, NULL);
+   if (tc != pdPASS) {
+      vSemaphoreDelete(ctx.done);
+      heap_caps_free(pcm);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "xTaskCreate failed");
+      cJSON_AddNumberToObject(r, "stack_kb", stack_kb);
+      return tab5_debug_send_json_resp(req, r);
+   }
+   /* Wait up to 10 s for the task to finish.  At ~1 ms per frame
+    * even 1000 frames is well under this budget; if the task panics
+    * or hangs we'll fail-soft after 10 s with no payload to return. */
+   xSemaphoreTake(ctx.done, pdMS_TO_TICKS(10000));
+   vSemaphoreDelete(ctx.done);
+   int frames_ok = ctx.frames_ok;
+   int frames_failed = ctx.frames_failed;
+   uint32_t total_bytes_out = ctx.total_bytes_out;
+   int64_t dt_us = ctx.dt_us;
+   heap_caps_free(pcm);
+
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddBoolToObject(r, "encoder_active", encoder_active);
+   cJSON_AddStringToObject(r, "buf_heap", (caps & MALLOC_CAP_INTERNAL) ? "internal" : "psram");
+   cJSON_AddNumberToObject(r, "buf_align", align);
+   cJSON_AddNumberToObject(r, "task_stack_kb", stack_kb);
+   cJSON_AddNumberToObject(r, "frames_attempted", frames);
+   cJSON_AddNumberToObject(r, "frames_ok", frames_ok);
+   cJSON_AddNumberToObject(r, "frames_failed", frames_failed);
+   cJSON_AddNumberToObject(r, "total_bytes_out", (double)total_bytes_out);
+   cJSON_AddNumberToObject(r, "elapsed_ms", (double)(dt_us / 1000));
+   if (frames > 0) {
+      cJSON_AddNumberToObject(r, "avg_bytes_per_frame", (double)total_bytes_out / (double)frames);
+      cJSON_AddNumberToObject(r, "us_per_frame", (double)dt_us / (double)frames);
+   }
+   /* Restore PCM uplink so subsequent real WS traffic isn't
+    * unexpectedly OPUS-encoded. */
+   voice_codec_set_uplink(VOICE_CODEC_PCM);
+   return tab5_debug_send_json_resp(req, r);
+}
+
+void debug_server_codec_register(httpd_handle_t server) {
+   const httpd_uri_t uri_opus_test = {
+       .uri = "/codec/opus_test", .method = HTTP_POST, .handler = debug_opus_test_handler};
+   httpd_register_uri_handler(server, &uri_opus_test);
+   ESP_LOGI("debug_codec", "Codec endpoint family registered (1 URI)");
+}

--- a/main/debug_server_codec.h
+++ b/main/debug_server_codec.h
@@ -1,0 +1,23 @@
+/*
+ * debug_server_codec.h — codec stack debug endpoint family.
+ *
+ * Wave 23b follow-up (#332): third per-family extract from
+ * debug_server.c, after K144 (#336) and OTA (#337).
+ *
+ * Endpoints:
+ *   POST /codec/opus_test  — synthetic OPUS encoder smoke test
+ *
+ * The opus_test endpoint was added in TT #264 (Wave 19) to bisect the
+ * SILK NSQ stack-overflow crash; the bisect found 24 KB as the
+ * watermark, which led to the MIC_TASK_STACK_SIZE bump in voice.c.
+ * The endpoint stays as a permanent diagnostic — useful for any
+ * future codec-stack health check or stack-budget validation.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the codec endpoint family on `server`.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_codec_register(httpd_handle_t server);

--- a/main/debug_server_internal.h
+++ b/main/debug_server_internal.h
@@ -26,3 +26,14 @@
  * `check_auth` static so the historic call sites stay untouched.
  */
 bool tab5_debug_check_auth(httpd_req_t *req);
+
+/* Forward decl for cJSON — keep this header self-sufficient without
+ * pulling cJSON.h into every consumer just for the prototype. */
+struct cJSON;
+
+/* Build-and-send-JSON helper.  Takes ownership of `root` (calls
+ * cJSON_Delete after PrintUnformatted) and emits with
+ * Content-Type: application/json + the standard CORS headers.
+ * Used by ~57 handlers in debug_server.c and growing — each
+ * per-family extract gains access without re-implementing. */
+esp_err_t tab5_debug_send_json_resp(httpd_req_t *req, struct cJSON *root);

--- a/main/debug_server_internal.h
+++ b/main/debug_server_internal.h
@@ -1,0 +1,28 @@
+/*
+ * debug_server_internal.h — shared interface for debug_server.c and its
+ * per-family extracted modules (debug_server_m5.c, …).
+ *
+ * Wave 23b (#332): the historical 4,520-LOC debug_server.c is being
+ * split family-by-family per the cross-stack architecture audit
+ * (2026-05-01).  Each family file owns its handlers + URI registrations
+ * + family-local helpers; this header exposes the cross-cutting
+ * primitives every family needs (auth gate, common types).
+ *
+ * Not exposed publicly — `debug_server.h` remains the only public-facing
+ * header.  This file is for in-tree compilation units that participate in
+ * the debug server's URI map.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "esp_http_server.h"
+
+/* Bearer-token auth gate.  Every family handler that requires auth
+ * (i.e. everything except /info and /selftest) calls this as the
+ * first line and returns ESP_OK on `false`.  See debug_server.c for
+ * the implementation — this is a thin wrapper around the existing
+ * `check_auth` static so the historic call sites stay untouched.
+ */
+bool tab5_debug_check_auth(httpd_req_t *req);

--- a/main/debug_server_m5.c
+++ b/main/debug_server_m5.c
@@ -1,0 +1,283 @@
+/*
+ * debug_server_m5.c — K144 (M5Stack LLM Module) HTTP endpoint family.
+ *
+ * Wave 23b (#332): extracted verbatim from debug_server.c as the
+ * proof-of-pattern for the per-family split called for in the
+ * cross-stack architecture audit (2026-05-01).  The handlers + helpers
+ * + statics moved over with zero behavior change; the only difference
+ * is the `check_auth(req)` calls now go through the shared wrapper
+ * `tab5_debug_check_auth(req)` declared in debug_server_internal.h.
+ *
+ * The two-tier caching strategy (hwinfo: 30 s success TTL + 5 s attempt
+ * rate-limit; modelist: 5 min PSRAM-lazy) was added in TT #328 Wave 14
+ * and Wave 15 respectively — see CLAUDE.md "K144 hwinfo cache freshness
+ * lie" + the LEARNINGS entry on PSRAM-lazy patterns.  The historical
+ * comments are preserved verbatim.
+ */
+
+#include "debug_server_m5.h"
+
+#include "cJSON.h"
+#include "esp_heap_caps.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+
+#include "debug_server_internal.h" /* tab5_debug_check_auth */
+#include "voice_m5_llm.h"          /* TT #327 Wave 5: K144 baud accessor for /m5 */
+#include "voice_onboard.h"         /* TT #327 Wave 4b: chain_active + failover_state */
+
+static const char *TAG = "debug_m5";
+
+/* ── Cached hwinfo + version snapshot ────────────────────────────────
+ *
+ * Wave 14 — cached hwinfo + version snapshot.  GET /m5 may be polled
+ * by the dashboard / harness every few seconds; refreshing sys.hwinfo
+ * on every call would saturate the UART (~150 ms per round-trip ×
+ * concurrent polls = head-of-line blocking on llm.infer calls).  Cache
+ * for 30 s; clients that want fresh data poll less often or use
+ * POST /m5/refresh to force an update.
+ *
+ * Also avoids the worst-case path where K144 is hung mid-NPU-load and
+ * sys.hwinfo silently stalls — every /m5 GET would otherwise block
+ * 1.5 s on the timeout.  The cache bounds this to once per 30 s. */
+static voice_m5_hwinfo_t s_m5_hwinfo_cache = {0};
+static char s_m5_version_cache[16] = {0};
+static int64_t s_m5_hwinfo_refreshed_us = 0; /* time of last SUCCESS */
+static int64_t s_m5_hwinfo_attempted_us = 0; /* time of last ATTEMPT (success OR skip) */
+#define M5_HWINFO_CACHE_TTL_US (30LL * 1000LL * 1000LL)
+#define M5_HWINFO_RETRY_GATE_US (5LL * 1000LL * 1000LL) /* 5 s — bounds rate when K144 not READY */
+
+static void m5_refresh_hwinfo_if_stale(bool force) {
+   int64_t now = esp_timer_get_time();
+   /* Cache hit fast-path — last successful fetch within TTL window. */
+   if (!force && s_m5_hwinfo_refreshed_us != 0 && (now - s_m5_hwinfo_refreshed_us) < M5_HWINFO_CACHE_TTL_US) {
+      return;
+   }
+   /* Even if cache is stale, throttle attempts (avoids hammering the
+    * UART when /m5 is polled rapidly during a recovery cycle).  5 s
+    * is short enough that a UNAVAILABLE→READY transition picks up new
+    * data within ~10 s; long enough that 50 polls/sec from a script
+    * don't queue 50 sys.hwinfo round-trips. */
+   if (!force && s_m5_hwinfo_attempted_us != 0 && (now - s_m5_hwinfo_attempted_us) < M5_HWINFO_RETRY_GATE_US) {
+      return;
+   }
+   s_m5_hwinfo_attempted_us = now;
+
+   /* Skip the actual sys.hwinfo if K144 isn't READY — it would just
+    * time out and waste 1.5 s.  Cached values stay; client sees old
+    * data with `cache_age_ms` shown so they can decide what to trust. */
+   int fs = voice_onboard_failover_state();
+   if (fs != 2 /* M5_FAIL_READY */) {
+      return;
+   }
+
+   voice_m5_hwinfo_t fresh = {0};
+   esp_err_t he = voice_m5_llm_sys_hwinfo(&fresh);
+   if (he == ESP_OK && fresh.valid) {
+      s_m5_hwinfo_cache = fresh;
+      s_m5_hwinfo_refreshed_us = now;
+   }
+   /* Version is fixed per K144 firmware install — read once and cache.
+    * Cache survives sys.reset (daemon restart, version unchanged) but
+    * does NOT survive a Tab5 reboot. */
+   if (s_m5_version_cache[0] == '\0') {
+      (void)voice_m5_llm_sys_version(s_m5_version_cache, sizeof(s_m5_version_cache));
+   }
+}
+
+static esp_err_t m5_status_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   /* Wave 14 — refresh hwinfo cache (no-op if warm + fresh enough). */
+   m5_refresh_hwinfo_if_stale(false);
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "chain_active", voice_onboard_chain_active());
+   /* Wave 7: chain_uptime_ms — 0 if not active.  Lets a remote operator
+    * spot a stuck chain without a serial cable. */
+   cJSON_AddNumberToObject(root, "chain_uptime_ms", (double)voice_onboard_chain_uptime_ms());
+   int fs = voice_onboard_failover_state();
+   cJSON_AddNumberToObject(root, "failover_state", fs);
+   const char *fs_names[] = {"unknown", "probing", "ready", "unavailable"};
+   cJSON_AddStringToObject(root, "failover_state_name", (fs >= 0 && fs <= 3) ? fs_names[fs] : "?");
+   cJSON_AddNumberToObject(root, "uart_baud", (double)voice_m5_llm_get_baud());
+
+   /* Wave 14 — hardware status.  `valid` is true only when the cache
+    * holds a successfully-parsed sys.hwinfo response; `cache_age_ms`
+    * tells the client how stale the snapshot is.  `temp_celsius`
+    * comes from the milli-degree field divided by 1000 (preserving
+    * one decimal — JSON consumer can format). */
+   cJSON *hw = cJSON_CreateObject();
+   bool hw_valid = (s_m5_hwinfo_cache.valid != 0);
+   cJSON_AddBoolToObject(hw, "valid", hw_valid);
+   if (hw_valid) {
+      double temp_c = (double)s_m5_hwinfo_cache.temperature_milli_c / 1000.0;
+      cJSON_AddNumberToObject(hw, "temp_celsius", temp_c);
+      cJSON_AddNumberToObject(hw, "temp_milli_c", (double)s_m5_hwinfo_cache.temperature_milli_c);
+      cJSON_AddNumberToObject(hw, "cpu_loadavg", (double)s_m5_hwinfo_cache.cpu_loadavg);
+      cJSON_AddNumberToObject(hw, "mem", (double)s_m5_hwinfo_cache.mem);
+   }
+   if (s_m5_hwinfo_refreshed_us != 0) {
+      int64_t age_ms = (esp_timer_get_time() - s_m5_hwinfo_refreshed_us) / 1000;
+      cJSON_AddNumberToObject(hw, "cache_age_ms", (double)age_ms);
+   }
+   cJSON_AddItemToObject(root, "hwinfo", hw);
+
+   /* Wave 14 — daemon version (read once on first hwinfo refresh,
+    * empty until then).  Surfaces "is K144 firmware up-to-date" + lets
+    * remote diagnostics correlate behavior with daemon version. */
+   cJSON_AddStringToObject(root, "version", s_m5_version_cache);
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* TT #328 Wave 14 — POST /m5/refresh.  Forces a sys.hwinfo refresh
+ * regardless of the 30 s cache TTL.  Useful when a remote operator or
+ * the e2e harness wants a guaranteed-fresh reading.  Returns the same
+ * shape as GET /m5 with the cache freshly populated. */
+static esp_err_t m5_refresh_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   m5_refresh_hwinfo_if_stale(true);
+   return m5_status_handler(req);
+}
+
+/* TT #328 Wave 15 — GET /m5/models.  Surfaces the K144 model registry
+ * (sys.lsmode response) so the dashboard + e2e harness can see what's
+ * installed.  Cached for 5 min — sys.lsmode is ~50 ms warm but the
+ * registry doesn't change between K144 reboots, so re-fetching often
+ * is wasteful.  ?force=1 bypasses the cache for a fresh fetch.
+ *
+ * Cache lives in PSRAM (heap_caps_calloc, lazy on first request) —
+ * NOT BSS-static.  An earlier draft used a BSS-static
+ * voice_m5_modelist_t (~1.8 KB) and tripped the same boot-loop
+ * `vApplicationGetTimerTaskMemory` assert as Wave 11 / Wave 13's
+ * first attempt.  See LEARNINGS "BSS-static caches >3 KB push Tab5
+ * over a boot SRAM threshold" — same lesson, different size band:
+ * we hit the threshold around ~1.8 KB on top of Wave 14's BSS
+ * additions.  Lazy PSRAM is the universal fix. */
+static voice_m5_modelist_t *s_m5_modelist_cache = NULL;
+static int64_t s_m5_modelist_refreshed_us = 0;
+#define M5_MODELLIST_CACHE_TTL_US (5LL * 60LL * 1000LL * 1000LL) /* 5 min */
+
+static void m5_refresh_modelist_if_stale(bool force) {
+   int64_t now = esp_timer_get_time();
+   if (!force && s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid &&
+       (now - s_m5_modelist_refreshed_us) < M5_MODELLIST_CACHE_TTL_US) {
+      return;
+   }
+   if (voice_onboard_failover_state() != 2 /* M5_FAIL_READY */) {
+      return; /* Don't waste 3 s on UART timeout when K144 is offline */
+   }
+   if (s_m5_modelist_cache == NULL) {
+      s_m5_modelist_cache = heap_caps_calloc(1, sizeof(*s_m5_modelist_cache), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (s_m5_modelist_cache == NULL) {
+         ESP_LOGE(TAG, "modelist PSRAM alloc failed");
+         return;
+      }
+   }
+   voice_m5_modelist_t fresh = {0};
+   if (voice_m5_llm_sys_lsmode(&fresh) == ESP_OK && fresh.valid) {
+      memcpy(s_m5_modelist_cache, &fresh, sizeof(fresh));
+      s_m5_modelist_refreshed_us = now;
+   }
+}
+
+static esp_err_t m5_models_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   bool force = false;
+   {
+      char qbuf[64];
+      if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+         char val[8];
+         if (httpd_query_key_value(qbuf, "force", val, sizeof(val)) == ESP_OK && (val[0] == '1' || val[0] == 't')) {
+            force = true;
+         }
+      }
+   }
+   m5_refresh_modelist_if_stale(force);
+
+   cJSON *root = cJSON_CreateObject();
+   bool valid = (s_m5_modelist_cache != NULL && s_m5_modelist_cache->valid);
+   cJSON_AddBoolToObject(root, "valid", valid);
+   cJSON_AddNumberToObject(root, "count", valid ? (double)s_m5_modelist_cache->n : 0.0);
+   cJSON *arr = cJSON_AddArrayToObject(root, "models");
+   if (valid) {
+      for (int i = 0; i < s_m5_modelist_cache->n; i++) {
+         cJSON *m = cJSON_CreateObject();
+         cJSON_AddStringToObject(m, "mode", s_m5_modelist_cache->models[i].mode);
+         cJSON_AddStringToObject(m, "primary_cap", s_m5_modelist_cache->models[i].primary_cap);
+         cJSON_AddStringToObject(m, "language", s_m5_modelist_cache->models[i].language);
+         cJSON_AddItemToArray(arr, m);
+      }
+   }
+   if (s_m5_modelist_refreshed_us != 0) {
+      int64_t age_s = (esp_timer_get_time() - s_m5_modelist_refreshed_us) / 1000000;
+      cJSON_AddNumberToObject(root, "cache_age_s", (double)age_s);
+   }
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* TT #328 Wave 13 — POST /m5/reset.  Triggers
+ * voice_onboard_reset_failover(), which sends sys.reset to the K144
+ * StackFlow daemon, waits for it to come back, and re-runs the warmup
+ * probe.  The actual reset happens asynchronously on tab5_worker; the
+ * caller can poll GET /m5 to observe state cycle PROBING → READY (or
+ * UNAVAILABLE on continued failure).
+ *
+ * Useful for both the e2e harness (verifies recovery round-trip
+ * without UI tap geometry) and dashboard / remote-operator debugging
+ * (a Tab5 stuck in UNAVAILABLE can be unstuck without a reboot or a
+ * physical tap on the Settings health chip). */
+static esp_err_t m5_reset_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   esp_err_t qe = voice_onboard_reset_failover();
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "status", qe == ESP_OK ? "queued" : "rejected");
+   cJSON_AddStringToObject(root, "detail",
+                           qe == ESP_OK ? "K144 reset job enqueued — poll GET /m5"
+                                        : "Probe already in flight — try again "
+                                          "after current cycle finishes");
+   cJSON_AddNumberToObject(root, "failover_state", voice_onboard_failover_state());
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* ── Public registration entry point ─────────────────────────────────
+ * Called once from tab5_debug_server_start() during boot.  All four
+ * URI structs are local to this function (matching the inline pattern
+ * the rest of debug_server.c still uses for the other families). */
+void debug_server_m5_register(httpd_handle_t server) {
+   const httpd_uri_t uri_m5_status = {
+       .uri = "/m5", .method = HTTP_GET, .handler = m5_status_handler};
+   const httpd_uri_t uri_m5_reset = {
+       .uri = "/m5/reset", .method = HTTP_POST, .handler = m5_reset_handler};
+   const httpd_uri_t uri_m5_refresh = {
+       .uri = "/m5/refresh", .method = HTTP_POST, .handler = m5_refresh_handler};
+   const httpd_uri_t uri_m5_models = {
+       .uri = "/m5/models", .method = HTTP_GET, .handler = m5_models_handler};
+
+   httpd_register_uri_handler(server, &uri_m5_status);
+   httpd_register_uri_handler(server, &uri_m5_reset);
+   httpd_register_uri_handler(server, &uri_m5_refresh);
+   httpd_register_uri_handler(server, &uri_m5_models);
+
+   ESP_LOGI(TAG, "K144 endpoint family registered (4 URIs)");
+}

--- a/main/debug_server_m5.h
+++ b/main/debug_server_m5.h
@@ -1,0 +1,23 @@
+/*
+ * debug_server_m5.h — K144 (M5Stack LLM Module) endpoint family.
+ *
+ * Wave 23b (#332): extracted from debug_server.c as the proof-of-pattern
+ * for the per-family split called for in the cross-stack architecture
+ * audit (2026-05-01).
+ *
+ * Endpoints owned by this module:
+ *   GET  /m5          — diagnostic snapshot (chain + failover + cached hwinfo)
+ *   POST /m5/refresh  — force sys.hwinfo refresh outside the 30 s TTL
+ *   GET  /m5/models   — surface sys.lsmode model registry (5 min cache)
+ *   POST /m5/reset    — trigger voice_onboard_reset_failover()
+ *
+ * Plus two private cache layers (hwinfo + modelist) — see the .c file.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the K144 endpoint family on `server`.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_m5_register(httpd_handle_t server);

--- a/main/debug_server_ota.c
+++ b/main/debug_server_ota.c
@@ -1,0 +1,130 @@
+/*
+ * debug_server_ota.c — OTA firmware update HTTP endpoint family.
+ *
+ * Wave 23b follow-up (#332): mechanical extract of the 2 OTA endpoints
+ * from debug_server.c.  Handlers + the local ota_apply_args_t /
+ * ota_apply_task helpers moved verbatim; the only call-site change is
+ * `check_auth(req)` → `tab5_debug_check_auth(req)` so the moved file
+ * goes through the shared internal-header wrapper.
+ *
+ * The Wave 10 #77 "schedule, don't apply in-process" pattern is
+ * preserved — see ota_apply_task() comment for why a fresh boot is
+ * required for the DMA heap.  Behavior is identical pre/post extract.
+ */
+
+#include "debug_server_ota.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "config.h"                 /* TAB5_FIRMWARE_VER */
+#include "debug_server_internal.h"  /* tab5_debug_check_auth */
+#include "ota.h"                    /* tab5_ota_check / _schedule / _info_t */
+
+static esp_err_t ota_check_handler(httpd_req_t *req)
+{
+    if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+    tab5_ota_info_t info;
+    esp_err_t err = tab5_ota_check(&info);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "current", TAB5_FIRMWARE_VER);
+    cJSON_AddStringToObject(root, "partition", tab5_ota_current_partition());
+    if (err == ESP_OK) {
+        cJSON_AddBoolToObject(root, "update_available", info.available);
+        if (info.available) {
+            cJSON_AddStringToObject(root, "new_version", info.version);
+            cJSON_AddStringToObject(root, "url", info.url);
+        }
+    } else {
+        cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+    }
+
+    char *json = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+    esp_err_t ret = httpd_resp_sendstr(req, json);
+    free(json);
+    return ret;
+}
+
+typedef struct {
+    char *url;
+    char sha256[65];
+} ota_apply_args_t;
+
+static void ota_apply_task(void *arg)
+{
+    ota_apply_args_t *args = (ota_apply_args_t *)arg;
+    ESP_LOGI("ota", "Scheduling OTA for next boot: %s (sha256=%s)", args->url,
+             args->sha256[0] ? args->sha256 : "none");
+    /* Wave 10 #77 extended-use fix: schedule instead of apply in-process.
+     * tab5_ota_schedule stores url+sha to NVS, reboots, and the fresh
+     * boot applies with a pristine DMA heap (see main.c near WiFi init).
+     * Prevents the "esp_dma_capable_malloc: Not enough heap memory"
+     * failure mode that hits after 30+ min of normal use. */
+    esp_err_t err = tab5_ota_schedule(args->url, args->sha256[0] ? args->sha256 : NULL);
+    /* If we get here, schedule failed (success reboots) */
+    ESP_LOGE("ota", "OTA schedule failed: %s", esp_err_to_name(err));
+    free(args->url);
+    free(args);
+    vTaskSuspend(NULL)  /* wave 13 C4: P4 TLSP crash on delete — suspend instead */;
+}
+
+static esp_err_t ota_apply_handler(httpd_req_t *req)
+{
+    if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+    /* Check for update first */
+    tab5_ota_info_t info;
+    esp_err_t err = tab5_ota_check(&info);
+    if (err != ESP_OK || !info.available) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_sendstr(req, "{\"error\":\"no update available\"}");
+        return ESP_OK;
+    }
+
+    /* Spawn OTA task with SHA256 from version.json (SEC07) */
+    ota_apply_args_t *args = malloc(sizeof(ota_apply_args_t));
+    if (args) {
+        args->url = strdup(info.url);
+        strncpy(args->sha256, info.sha256, sizeof(args->sha256) - 1);
+        args->sha256[sizeof(args->sha256) - 1] = '\0';
+        if (args->url) {
+            xTaskCreate(ota_apply_task, "ota_apply", 8192, args, 5, NULL);
+        } else {
+            free(args);
+        }
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    char resp[512];
+    snprintf(resp, sizeof(resp),
+             "{\"status\":\"updating\",\"version\":\"%s\",\"url\":\"%s\",\"sha256_verify\":%s}",
+             info.version, info.url, info.sha256[0] ? "true" : "false");
+    httpd_resp_sendstr(req, resp);
+    return ESP_OK;
+}
+
+void debug_server_ota_register(httpd_handle_t server)
+{
+    const httpd_uri_t uri_ota_check = {
+        .uri = "/ota/check", .method = HTTP_GET, .handler = ota_check_handler
+    };
+    const httpd_uri_t uri_ota_apply = {
+        .uri = "/ota/apply", .method = HTTP_POST, .handler = ota_apply_handler
+    };
+
+    httpd_register_uri_handler(server, &uri_ota_check);
+    httpd_register_uri_handler(server, &uri_ota_apply);
+    ESP_LOGI("debug_ota", "OTA endpoint family registered (2 URIs)");
+}

--- a/main/debug_server_ota.h
+++ b/main/debug_server_ota.h
@@ -1,0 +1,18 @@
+/*
+ * debug_server_ota.h — OTA firmware update endpoint family.
+ *
+ * Wave 23b follow-up (#332): second per-family extract from
+ * debug_server.c, after K144 (#336).  Same shape as debug_server_m5.h.
+ *
+ * Endpoints:
+ *   GET  /ota/check  — query Dragon for available firmware update
+ *   POST /ota/apply  — schedule the update (reboots into fresh DMA heap)
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the OTA endpoint family on `server`.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_ota_register(httpd_handle_t server);

--- a/main/debug_server_voice.c
+++ b/main/debug_server_voice.c
@@ -1,0 +1,132 @@
+/*
+ * debug_server_voice.c — voice-pipeline debug HTTP endpoint family.
+ *
+ * Wave 23b follow-up (#332): fourth per-family extract.  Four
+ * handlers moved verbatim from debug_server.c with `check_auth(req)`
+ * → `tab5_debug_check_auth(req)` and `send_json_resp(req, root)` →
+ * `tab5_debug_send_json_resp(req, root)`.  Identical behavior.
+ */
+
+#include "debug_server_voice.h"
+
+#include <stddef.h>
+
+#include "cJSON.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "config.h"                /* TAB5_VOICE_PORT */
+#include "debug_server_internal.h" /* tab5_debug_check_auth / send_json_resp */
+#include "settings.h"              /* tab5_settings_get_dragon_host */
+#include "voice.h"                 /* voice_* state + lifecycle */
+
+/* chat_store_clear() is declared as extern at its single original
+ * call site to avoid pulling all of chat_msg_store.h into this file
+ * (matches the pattern from the pre-extract code). */
+extern void chat_store_clear(void);
+
+static const char *TAG = "debug_voice";
+
+/* ── GET /voice — voice pipeline state snapshot ──────────────────── */
+static esp_err_t voice_state_handler(httpd_req_t *req)
+{
+    if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "connected", voice_is_connected());
+    cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
+
+    const char *state_names[] = {
+        "IDLE", "CONNECTING", "READY", "LISTENING",
+        "PROCESSING", "SPEAKING", "RECONNECTING", "DICTATING"
+    };
+    int st = (int)voice_get_state();
+    /* State enum has 8 values (0..7); the old bound stopped at 6 which
+     * reported DICTATING as "UNKNOWN" — fix alongside the /dictation
+     * endpoint so test harness sees the right label. */
+    cJSON_AddStringToObject(root, "state_name",
+                             (st >= 0 && st <= 7) ? state_names[st] : "UNKNOWN");
+
+    /* Wave 14 W14-M01: the debug httpd task races with voice.c's
+     * WS RX task.  Use the copy-under-mutex variants to avoid
+     * observing a mid-strcat string. */
+    char llm_buf[512];
+    if (voice_get_llm_text_copy(llm_buf, sizeof(llm_buf)) && llm_buf[0]) {
+        cJSON_AddStringToObject(root, "last_llm_text", llm_buf);
+    }
+
+    char stt_buf[512];
+    if (voice_get_stt_text_copy(stt_buf, sizeof(stt_buf)) && stt_buf[0]) {
+        cJSON_AddStringToObject(root, "last_stt_text", stt_buf);
+    }
+
+    return tab5_debug_send_json_resp(req, root);
+}
+
+/* ── POST /voice/reconnect — force voice WS reconnect ──────────── */
+static esp_err_t voice_reconnect_handler(httpd_req_t *req)
+{
+    if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+    ESP_LOGI(TAG, "Debug: forcing voice reconnect");
+    voice_disconnect();
+    vTaskDelay(pdMS_TO_TICKS(500));
+    /* Reconnect using current NVS settings + voice port (3502, not
+     * dragon_port which is 3501 for CDP). */
+    char host[64] = {0};
+    tab5_settings_get_dragon_host(host, sizeof(host));
+    voice_connect(host, TAB5_VOICE_PORT);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "status", "reconnecting");
+    return tab5_debug_send_json_resp(req, root);
+}
+
+/* ── POST /voice/cancel — cancel in-flight voice turn ──────────── */
+static esp_err_t voice_cancel_handler(httpd_req_t *req)
+{
+    if (!tab5_debug_check_auth(req)) return ESP_OK;
+    esp_err_t r = voice_cancel();
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+    return tab5_debug_send_json_resp(req, root);
+}
+
+/* ── POST /voice/clear — clear Dragon + Tab5 conversation history ── */
+static esp_err_t voice_clear_handler(httpd_req_t *req)
+{
+    if (!tab5_debug_check_auth(req)) return ESP_OK;
+    esp_err_t r = voice_clear_history();
+    /* Also wipe Tab5 side so UI matches. */
+    chat_store_clear();
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+    cJSON_AddBoolToObject(root, "store_cleared", true);
+    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+    return tab5_debug_send_json_resp(req, root);
+}
+
+void debug_server_voice_register(httpd_handle_t server)
+{
+    const httpd_uri_t uri_voice_state = {
+        .uri = "/voice", .method = HTTP_GET, .handler = voice_state_handler
+    };
+    const httpd_uri_t uri_voice_reconnect = {
+        .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
+    };
+    const httpd_uri_t uri_voice_cancel = {
+        .uri = "/voice/cancel", .method = HTTP_POST, .handler = voice_cancel_handler
+    };
+    const httpd_uri_t uri_voice_clear = {
+        .uri = "/voice/clear", .method = HTTP_POST, .handler = voice_clear_handler
+    };
+
+    httpd_register_uri_handler(server, &uri_voice_state);
+    httpd_register_uri_handler(server, &uri_voice_reconnect);
+    httpd_register_uri_handler(server, &uri_voice_cancel);
+    httpd_register_uri_handler(server, &uri_voice_clear);
+    ESP_LOGI(TAG, "Voice endpoint family registered (4 URIs)");
+}

--- a/main/debug_server_voice.h
+++ b/main/debug_server_voice.h
@@ -1,0 +1,25 @@
+/*
+ * debug_server_voice.h — voice-pipeline debug endpoint family.
+ *
+ * Wave 23b follow-up (#332): fourth per-family extract from
+ * debug_server.c (after K144 #336, OTA #337, codec #338).
+ *
+ * Endpoints owned by this module:
+ *   GET  /voice            — voice pipeline state snapshot
+ *   POST /voice/reconnect  — force voice WS reconnect
+ *   POST /voice/cancel     — cancel in-flight voice turn
+ *   POST /voice/clear      — clear Dragon + Tab5 conversation history
+ *
+ * Out of scope (separate future PRs): /voice/text (which delegates to
+ * /chat), the /chat family, /mode, /input/text, /dictation — those
+ * depend on chat_handler + chat_msg_store + heavier coupling and ship
+ * as their own families.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the voice endpoint family on `server`.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_voice_register(httpd_handle_t server);


### PR DESCRIPTION
## Summary

Fourth per-family extract from `debug_server.c`, **stacked on top of [#338](https://github.com/lorcan35/TinkerTab/pull/338)** which is stacked on #337 → #336.

## Endpoints

- `GET /voice` — voice pipeline state snapshot
- `POST /voice/reconnect` — force voice WS reconnect
- `POST /voice/cancel` — cancel in-flight voice turn
- `POST /voice/clear` — clear Dragon + Tab5 conversation history

## Diff

```
 main/CMakeLists.txt          |   2 +-
 main/debug_server.c          | 100 +----- (4 handlers, 2 non-contiguous regions, URI defs + register calls)
 main/debug_server_voice.h    |  29 +++ (new)
 main/debug_server_voice.c    | 137 +++++ (new)
```

`debug_server.c`: 4,023 → 3,938 LOC. **Cumulative on this branch** (K144 + OTA + codec + voice): 4,520 → 3,938 = **−582 LOC, 13% shrinkage** from origin/main baseline.

## Test plan

- [x] `idf.py build` — clean (after one fix: `/chat/*` literal in the header doc-comment caught by GCC's `-Werror=comment` for `*/` ambiguity)
- [x] Flashed to Tab5 (192.168.1.90), boot uptime 29s
- [x] `GET /voice` → `{connected: true, state: 2, state_name: "READY"}` (matches pre-extract shape)
- [x] `POST /voice/cancel` → `{ok: true}`
- [x] `python3 tests/e2e/runner.py story_smoke` → **14/14 PASS in 92s** (step 4 "Voice ready" exercises `GET /voice` via the new module)

## Stacking

Base: `refactor/debug-server-codec` (PR #338).

## Remaining families (separate PRs)

- /voice/text + /chat + /chat/messages + /chat/llm_done + /chat/partial + /chat/audio_clip + /input/text (~6 handlers, ~500 LOC, depends on chat_msg_store)
- /mode + /dictation (~2 handlers)
- camera + screenshot (needs JPEG encoder helper movement)
- video + call (~10 endpoints)
- settings + nvs (~3 handlers, big body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)