### PR TITLE
fix(debug_server): resolve leftover merge conflict markers from #342 (URGENT — main build broken)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,8 +34,7 @@ else()
              "sdcard.c" "wifi.c"
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
-<<<<<<< HEAD
-             "debug_server_codec.c"
+             "debug_server_codec.c" "debug_server_voice.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -59,9 +59,9 @@
 /* Wave 23b (#332): per-family endpoint extracts + auth shim. */
 #include "debug_server_codec.h"
 #include "debug_server_internal.h"
-#include "debug_server_codec.h"
 #include "debug_server_m5.h"
 #include "debug_server_ota.h"
+#include "debug_server_voice.h"
 #include "widget.h" /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -2322,67 +2322,6 @@ static esp_err_t screen_state_handler(httpd_req_t *req)
 
 /* ── Voice endpoint family extracted to debug_server_voice.c (Wave 23b, #332) ─ */
 
-<<<<<<< HEAD
-    /* GET /voice — full voice pipeline state */
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "connected", voice_is_connected());
-    cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
-
-    const char *state_names[] = {"IDLE", "CONNECTING", "READY", "LISTENING", "PROCESSING", "SPEAKING", "RECONNECTING", "DICTATING"};
-    int st = (int)voice_get_state();
-    /* State enum has 8 values (0..7); the old bound stopped at 6 which
-     * reported DICTATING as "UNKNOWN" — fix alongside the /dictation
-     * endpoint so test harness sees the right label. */
-    cJSON_AddStringToObject(root, "state_name", (st >= 0 && st <= 7) ? state_names[st] : "UNKNOWN");
-
-    /* Wave 14 W14-M01: the debug httpd task races with voice.c's
-     * WS RX task.  Use the copy-under-mutex variants to avoid
-     * observing a mid-strcat string. */
-    char llm_buf[512];
-    if (voice_get_llm_text_copy(llm_buf, sizeof(llm_buf)) && llm_buf[0]) {
-        cJSON_AddStringToObject(root, "last_llm_text", llm_buf);
-    }
-
-    char stt_buf[512];
-    if (voice_get_stt_text_copy(stt_buf, sizeof(stt_buf)) && stt_buf[0]) {
-        cJSON_AddStringToObject(root, "last_stt_text", stt_buf);
-    }
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, json);
-    free(json);
-    return ret;
-}
-
-/* ── K144 endpoint family extracted to debug_server_m5.c (Wave 23b, #332) ─ */
-
-/* ── Voice reconnect endpoint ─────────────────────────────────────────── */
-
-static esp_err_t voice_reconnect_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* POST /voice/reconnect — force voice WS reconnect */
-    ESP_LOGI(TAG, "Debug: forcing voice reconnect");
-    voice_disconnect();
-    vTaskDelay(pdMS_TO_TICKS(500));
-    /* Reconnect using current NVS settings + voice port (3502, not dragon_port which is 3501 for CDP) */
-    char host[64] = {0};
-    tab5_settings_get_dragon_host(host, sizeof(host));
-    voice_connect(host, TAB5_VOICE_PORT);
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    httpd_resp_sendstr(req, "{\"status\":\"reconnecting\"}");
-    return ESP_OK;
-}
-=======
->>>>>>> 1254d41 (refactor(debug_server): extract voice endpoint family (refs #332))
 
 /* ── #266: live video streaming control (POST /video/start, /video/stop,
  *           GET /video).  #268 adds /video/show + /video/hide for the


### PR DESCRIPTION
## URGENT — main build is broken

PR #342 (voice family extract) merged with **unresolved `<<<<<<< HEAD` conflict markers** in `main/debug_server.c` and `main/CMakeLists.txt`. The build fails on main with `CMake Error ... Cannot find source file: /main/<<<<<<<`.

My in-session rebase + force-push between the stacked PRs left the resolution incomplete on the final branch. CI's format check correctly flagged it; the build check was non-blocking on that PR so it merged anyway.

## Fix

- Remove duplicated `voice_state_handler` + `voice_reconnect_handler` stubs (lines 2325-2384) from `debug_server.c` — they live in `debug_server_voice.c` already
- Remove duplicate `#include "debug_server_codec.h"` and add missing `#include "debug_server_voice.h"`
- Add missing `"debug_server_voice.c"` entry to `CMakeLists.txt`
- Strip orphaned `<<<<<<< HEAD` marker from `CMakeLists.txt`

## Verified live

```
build:  clean (was broken — CMake "Cannot find source file" error)
flash:  OK to /dev/ttyACM0, boot uptime ~30s
GET /voice  → {connected:true, state:2, state_name:"READY"}  (via voice family)
GET /m5     → {failover_state_name:"ready"}                  (via m5 family)
```

## Lesson

Force-pushing rebased branches in a stacked-PR chain mid-session, before each preceding PR has merged, is a recipe for unresolved conflict markers slipping through. Better future flow: merge each PR in the stack BEFORE rebasing the next branch on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)