### PR TITLE
chore(format): clang-format the two debug_server family files that slipped through

### DIFF
--- a/main/debug_server_mode.c
+++ b/main/debug_server_mode.c
@@ -14,87 +14,79 @@
 #include <string.h>
 
 #include "cJSON.h"
+#include "debug_server_internal.h" /* tab5_debug_check_auth + send_json_resp */
 #include "esp_http_server.h"
 #include "esp_log.h"
-
-#include "debug_server_internal.h" /* tab5_debug_check_auth + send_json_resp */
-#include "settings.h"              /* tab5_settings_set_voice_mode etc. */
-#include "ui_core.h"               /* tab5_lv_async_call (#258) */
-#include "voice.h"                 /* voice_is_connected, voice_send_config_update */
+#include "settings.h" /* tab5_settings_set_voice_mode etc. */
+#include "ui_core.h"  /* tab5_lv_async_call (#258) */
+#include "voice.h"    /* voice_is_connected, voice_send_config_update */
 
 /* Async wrapper for tab5_lv_async_call — refreshes home mode badge on LVGL thread. */
-static void async_refresh_mode_badge(void *arg)
-{
-    (void)arg;
-    extern void ui_home_refresh_mode_badge(void);
-    ui_home_refresh_mode_badge();
+static void async_refresh_mode_badge(void *arg) {
+   (void)arg;
+   extern void ui_home_refresh_mode_badge(void);
+   ui_home_refresh_mode_badge();
 }
 
 /* POST /mode?m=0|1|2|3|4&model=... — switch voice mode.
  * mode 3=TinkerClaw; mode 4=VMODE_LOCAL_ONBOARD (K144, Tab5-side only). */
-static esp_err_t mode_set_handler(httpd_req_t *req)
-{
-    if (!tab5_debug_check_auth(req)) return ESP_OK;
+static esp_err_t mode_set_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
 
-    /* Parse query string */
-    char query[128] = {0};
-    if (httpd_req_get_url_query_str(req, query, sizeof(query)) != ESP_OK) {
-        cJSON *err = cJSON_CreateObject();
-        cJSON_AddStringToObject(err, "error",
-                                "use ?m=0|1|2|3|4&model=... (3=TinkerClaw, 4=K144 onboard)");
-        return tab5_debug_send_json_resp(req, err);
-    }
+   /* Parse query string */
+   char query[128] = {0};
+   if (httpd_req_get_url_query_str(req, query, sizeof(query)) != ESP_OK) {
+      cJSON *err = cJSON_CreateObject();
+      cJSON_AddStringToObject(err, "error", "use ?m=0|1|2|3|4&model=... (3=TinkerClaw, 4=K144 onboard)");
+      return tab5_debug_send_json_resp(req, err);
+   }
 
-    char val[8] = {0};
-    char model[64] = {0};
-    httpd_query_key_value(query, "m", val, sizeof(val));
-    httpd_query_key_value(query, "model", model, sizeof(model));
+   char val[8] = {0};
+   char model[64] = {0};
+   httpd_query_key_value(query, "m", val, sizeof(val));
+   httpd_query_key_value(query, "model", model, sizeof(model));
 
-    int mode = atoi(val);
-    /* TT #317 Phase 5: vmode=4 added for VMODE_LOCAL_ONBOARD (K144). */
-    if (mode < 0 || mode > 4) mode = 0;
+   int mode = atoi(val);
+   /* TT #317 Phase 5: vmode=4 added for VMODE_LOCAL_ONBOARD (K144). */
+   if (mode < 0 || mode > 4) mode = 0;
 
-    /* Save to NVS */
-    tab5_settings_set_voice_mode((uint8_t)mode);
-    if (model[0]) {
-        tab5_settings_set_llm_model(model);
-    }
+   /* Save to NVS */
+   tab5_settings_set_voice_mode((uint8_t)mode);
+   if (model[0]) {
+      tab5_settings_set_llm_model(model);
+   }
 
-    ESP_LOGI("debug_mode", "Mode switch: voice_mode=%d, llm_model=%s",
-             mode, model[0] ? model : "(unchanged)");
+   ESP_LOGI("debug_mode", "Mode switch: voice_mode=%d, llm_model=%s", mode, model[0] ? model : "(unchanged)");
 
-    /* Send config_update to Dragon via voice WS — except for vmode=4
-     * (VMODE_LOCAL_ONBOARD) which is a Tab5-side-only tier.  Dragon
-     * doesn't understand it and would ACK with an error that reverts our
-     * NVS write back to 0.  When user picks ONBOARD, tell Dragon we're
-     * still in "local" (mode=0) so its STT/TTS stay on local backends;
-     * Tab5 then bypasses Dragon for the LLM turn via voice_send_text. */
-    if (voice_is_connected()) {
-        int dragon_mode = (mode == 4) ? 0 : mode;
-        voice_send_config_update(dragon_mode, model[0] ? model : NULL);
-    }
+   /* Send config_update to Dragon via voice WS — except for vmode=4
+    * (VMODE_LOCAL_ONBOARD) which is a Tab5-side-only tier.  Dragon
+    * doesn't understand it and would ACK with an error that reverts our
+    * NVS write back to 0.  When user picks ONBOARD, tell Dragon we're
+    * still in "local" (mode=0) so its STT/TTS stay on local backends;
+    * Tab5 then bypasses Dragon for the LLM turn via voice_send_text. */
+   if (voice_is_connected()) {
+      int dragon_mode = (mode == 4) ? 0 : mode;
+      voice_send_config_update(dragon_mode, model[0] ? model : NULL);
+   }
 
-    /* Refresh home screen mode badge (runs on LVGL thread) */
-    tab5_lv_async_call(async_refresh_mode_badge, NULL);
+   /* Refresh home screen mode badge (runs on LVGL thread) */
+   tab5_lv_async_call(async_refresh_mode_badge, NULL);
 
-    /* Return current state */
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddNumberToObject(root, "voice_mode", mode);
-    const char *mode_names[] = {"local", "hybrid", "cloud", "tinkerclaw", "local_onboard"};
-    cJSON_AddStringToObject(root, "mode_name", mode <= 4 ? mode_names[mode] : "unknown");
-    char cur_model[64];
-    tab5_settings_get_llm_model(cur_model, sizeof(cur_model));
-    cJSON_AddStringToObject(root, "llm_model", cur_model);
-    cJSON_AddBoolToObject(root, "voice_connected", voice_is_connected());
-    cJSON_AddStringToObject(root, "status", "applied");
-    return tab5_debug_send_json_resp(req, root);
+   /* Return current state */
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddNumberToObject(root, "voice_mode", mode);
+   const char *mode_names[] = {"local", "hybrid", "cloud", "tinkerclaw", "local_onboard"};
+   cJSON_AddStringToObject(root, "mode_name", mode <= 4 ? mode_names[mode] : "unknown");
+   char cur_model[64];
+   tab5_settings_get_llm_model(cur_model, sizeof(cur_model));
+   cJSON_AddStringToObject(root, "llm_model", cur_model);
+   cJSON_AddBoolToObject(root, "voice_connected", voice_is_connected());
+   cJSON_AddStringToObject(root, "status", "applied");
+   return tab5_debug_send_json_resp(req, root);
 }
 
-void debug_server_mode_register(httpd_handle_t server)
-{
-    const httpd_uri_t uri_mode_set = {
-        .uri = "/mode", .method = HTTP_POST, .handler = mode_set_handler
-    };
-    httpd_register_uri_handler(server, &uri_mode_set);
-    ESP_LOGI("debug_mode", "Mode endpoint family registered (1 URI)");
+void debug_server_mode_register(httpd_handle_t server) {
+   const httpd_uri_t uri_mode_set = {.uri = "/mode", .method = HTTP_POST, .handler = mode_set_handler};
+   httpd_register_uri_handler(server, &uri_mode_set);
+   ESP_LOGI("debug_mode", "Mode endpoint family registered (1 URI)");
 }

--- a/main/debug_server_voice.c
+++ b/main/debug_server_voice.c
@@ -12,15 +12,14 @@
 #include <stddef.h>
 
 #include "cJSON.h"
+#include "config.h"                /* TAB5_VOICE_PORT */
+#include "debug_server_internal.h" /* tab5_debug_check_auth / send_json_resp */
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-
-#include "config.h"                /* TAB5_VOICE_PORT */
-#include "debug_server_internal.h" /* tab5_debug_check_auth / send_json_resp */
-#include "settings.h"              /* tab5_settings_get_dragon_host */
-#include "voice.h"                 /* voice_* state + lifecycle */
+#include "settings.h" /* tab5_settings_get_dragon_host */
+#include "voice.h"    /* voice_* state + lifecycle */
 
 /* chat_store_clear() is declared as extern at its single original
  * call site to avoid pulling all of chat_msg_store.h into this file
@@ -30,103 +29,88 @@ extern void chat_store_clear(void);
 static const char *TAG = "debug_voice";
 
 /* ── GET /voice — voice pipeline state snapshot ──────────────────── */
-static esp_err_t voice_state_handler(httpd_req_t *req)
-{
-    if (!tab5_debug_check_auth(req)) return ESP_OK;
+static esp_err_t voice_state_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
 
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "connected", voice_is_connected());
-    cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "connected", voice_is_connected());
+   cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
 
-    const char *state_names[] = {
-        "IDLE", "CONNECTING", "READY", "LISTENING",
-        "PROCESSING", "SPEAKING", "RECONNECTING", "DICTATING"
-    };
-    int st = (int)voice_get_state();
-    /* State enum has 8 values (0..7); the old bound stopped at 6 which
-     * reported DICTATING as "UNKNOWN" — fix alongside the /dictation
-     * endpoint so test harness sees the right label. */
-    cJSON_AddStringToObject(root, "state_name",
-                             (st >= 0 && st <= 7) ? state_names[st] : "UNKNOWN");
+   const char *state_names[] = {"IDLE",       "CONNECTING", "READY",        "LISTENING",
+                                "PROCESSING", "SPEAKING",   "RECONNECTING", "DICTATING"};
+   int st = (int)voice_get_state();
+   /* State enum has 8 values (0..7); the old bound stopped at 6 which
+    * reported DICTATING as "UNKNOWN" — fix alongside the /dictation
+    * endpoint so test harness sees the right label. */
+   cJSON_AddStringToObject(root, "state_name", (st >= 0 && st <= 7) ? state_names[st] : "UNKNOWN");
 
-    /* Wave 14 W14-M01: the debug httpd task races with voice.c's
-     * WS RX task.  Use the copy-under-mutex variants to avoid
-     * observing a mid-strcat string. */
-    char llm_buf[512];
-    if (voice_get_llm_text_copy(llm_buf, sizeof(llm_buf)) && llm_buf[0]) {
-        cJSON_AddStringToObject(root, "last_llm_text", llm_buf);
-    }
+   /* Wave 14 W14-M01: the debug httpd task races with voice.c's
+    * WS RX task.  Use the copy-under-mutex variants to avoid
+    * observing a mid-strcat string. */
+   char llm_buf[512];
+   if (voice_get_llm_text_copy(llm_buf, sizeof(llm_buf)) && llm_buf[0]) {
+      cJSON_AddStringToObject(root, "last_llm_text", llm_buf);
+   }
 
-    char stt_buf[512];
-    if (voice_get_stt_text_copy(stt_buf, sizeof(stt_buf)) && stt_buf[0]) {
-        cJSON_AddStringToObject(root, "last_stt_text", stt_buf);
-    }
+   char stt_buf[512];
+   if (voice_get_stt_text_copy(stt_buf, sizeof(stt_buf)) && stt_buf[0]) {
+      cJSON_AddStringToObject(root, "last_stt_text", stt_buf);
+   }
 
-    return tab5_debug_send_json_resp(req, root);
+   return tab5_debug_send_json_resp(req, root);
 }
 
 /* ── POST /voice/reconnect — force voice WS reconnect ──────────── */
-static esp_err_t voice_reconnect_handler(httpd_req_t *req)
-{
-    if (!tab5_debug_check_auth(req)) return ESP_OK;
+static esp_err_t voice_reconnect_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
 
-    ESP_LOGI(TAG, "Debug: forcing voice reconnect");
-    voice_disconnect();
-    vTaskDelay(pdMS_TO_TICKS(500));
-    /* Reconnect using current NVS settings + voice port (3502, not
-     * dragon_port which is 3501 for CDP). */
-    char host[64] = {0};
-    tab5_settings_get_dragon_host(host, sizeof(host));
-    voice_connect(host, TAB5_VOICE_PORT);
+   ESP_LOGI(TAG, "Debug: forcing voice reconnect");
+   voice_disconnect();
+   vTaskDelay(pdMS_TO_TICKS(500));
+   /* Reconnect using current NVS settings + voice port (3502, not
+    * dragon_port which is 3501 for CDP). */
+   char host[64] = {0};
+   tab5_settings_get_dragon_host(host, sizeof(host));
+   voice_connect(host, TAB5_VOICE_PORT);
 
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "status", "reconnecting");
-    return tab5_debug_send_json_resp(req, root);
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "status", "reconnecting");
+   return tab5_debug_send_json_resp(req, root);
 }
 
 /* ── POST /voice/cancel — cancel in-flight voice turn ──────────── */
-static esp_err_t voice_cancel_handler(httpd_req_t *req)
-{
-    if (!tab5_debug_check_auth(req)) return ESP_OK;
-    esp_err_t r = voice_cancel();
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
-    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
-    return tab5_debug_send_json_resp(req, root);
+static esp_err_t voice_cancel_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   esp_err_t r = voice_cancel();
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+   if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+   return tab5_debug_send_json_resp(req, root);
 }
 
 /* ── POST /voice/clear — clear Dragon + Tab5 conversation history ── */
-static esp_err_t voice_clear_handler(httpd_req_t *req)
-{
-    if (!tab5_debug_check_auth(req)) return ESP_OK;
-    esp_err_t r = voice_clear_history();
-    /* Also wipe Tab5 side so UI matches. */
-    chat_store_clear();
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
-    cJSON_AddBoolToObject(root, "store_cleared", true);
-    if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
-    return tab5_debug_send_json_resp(req, root);
+static esp_err_t voice_clear_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   esp_err_t r = voice_clear_history();
+   /* Also wipe Tab5 side so UI matches. */
+   chat_store_clear();
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+   cJSON_AddBoolToObject(root, "store_cleared", true);
+   if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+   return tab5_debug_send_json_resp(req, root);
 }
 
-void debug_server_voice_register(httpd_handle_t server)
-{
-    const httpd_uri_t uri_voice_state = {
-        .uri = "/voice", .method = HTTP_GET, .handler = voice_state_handler
-    };
-    const httpd_uri_t uri_voice_reconnect = {
-        .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler
-    };
-    const httpd_uri_t uri_voice_cancel = {
-        .uri = "/voice/cancel", .method = HTTP_POST, .handler = voice_cancel_handler
-    };
-    const httpd_uri_t uri_voice_clear = {
-        .uri = "/voice/clear", .method = HTTP_POST, .handler = voice_clear_handler
-    };
+void debug_server_voice_register(httpd_handle_t server) {
+   const httpd_uri_t uri_voice_state = {.uri = "/voice", .method = HTTP_GET, .handler = voice_state_handler};
+   const httpd_uri_t uri_voice_reconnect = {
+       .uri = "/voice/reconnect", .method = HTTP_POST, .handler = voice_reconnect_handler};
+   const httpd_uri_t uri_voice_cancel = {.uri = "/voice/cancel", .method = HTTP_POST, .handler = voice_cancel_handler};
+   const httpd_uri_t uri_voice_clear = {.uri = "/voice/clear", .method = HTTP_POST, .handler = voice_clear_handler};
 
-    httpd_register_uri_handler(server, &uri_voice_state);
-    httpd_register_uri_handler(server, &uri_voice_reconnect);
-    httpd_register_uri_handler(server, &uri_voice_cancel);
-    httpd_register_uri_handler(server, &uri_voice_clear);
-    ESP_LOGI(TAG, "Voice endpoint family registered (4 URIs)");
+   httpd_register_uri_handler(server, &uri_voice_state);
+   httpd_register_uri_handler(server, &uri_voice_reconnect);
+   httpd_register_uri_handler(server, &uri_voice_cancel);
+   httpd_register_uri_handler(server, &uri_voice_clear);
+   ESP_LOGI(TAG, "Voice endpoint family registered (4 URIs)");
 }


### PR DESCRIPTION
## What

Clang-format `main/debug_server_voice.c` (added in #342) and `main/debug_server_mode.c` (added in #344) to match the project's `.clang-format` (Google base, `IndentWidth: 3`, `ColumnLimit: 120`).

Both files were extracted verbatim from `debug_server.c`, which inherited 4-space-indent / Allman-brace style from before the project's clang-format adoption.  The CI format check has been intentionally non-blocking since #309/#318 (because `main/` has accumulated pre-existing format rot we don't want to gate on), but it still generates "format-FAILURE" annotations on every PR that touches these new files — drowning real reviewer signal.

This is the format-debt cleanup pass for the 23b debug_server family extracts.  After this lands, every existing per-family file (`m5`, `ota`, `codec`, `voice`, `mode`, `internal`) will be format-clean against `origin/main`.

## Why now

10 PRs merged on `main` in the last week as part of the Wave 23b per-family extract program — every one of them had its own format-FAILURE annotation.  Closing the rot in a single small chore PR means:

1. The next family extract (settings, expected ~500 LOC) will pass the format gate without effort.
2. Future reviewers don't have to mentally subtract format diffs from real changes when touching these files.

## Verification

Local CI gate replication:

```bash
$ git-clang-format --binary clang-format-18 --diff origin/main \
    -- main/debug_server_voice.c main/debug_server_mode.c
clang-format did not modify any files
```

Build:

```
[12/15] Linking CXX executable tinkertab.elf
[13/15] Generating binary image from built executable
tinkertab.bin binary size 0x27db60 bytes. Smallest app partition is 0x300000 bytes. 0x824a0 bytes (17%) free.
```

## Diff shape

134 insertions / 158 deletions — pure mechanical:
- 4-space → 3-space indent
- Allman braces → K&R same-line braces
- Sort `#include` alphabetically and merge the `<system> + <project>` groups

No behavioural changes; identical bytes go through `mode_set_handler`, `voice_state_handler`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)