### PR TITLE
refactor(debug_server): extract /settings + /nvs/erase family (Wave 23b · 7th family)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
+             "debug_server_settings.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -62,6 +62,7 @@
 #include "debug_server_m5.h"
 #include "debug_server_mode.h"
 #include "debug_server_ota.h"
+#include "debug_server_settings.h"
 #include "debug_server_voice.h"
 #include "widget.h" /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
@@ -169,6 +170,21 @@ static bool check_auth(httpd_req_t *req)
  * 65 in-tree call sites still use the static `check_auth` to keep the
  * extraction diff minimal; new family files go through this wrapper. */
 bool tab5_debug_check_auth(httpd_req_t *req) { return check_auth(req); }
+
+/* Settings family extract (Wave 23b): the /nvs/erase factory-reset
+ * guard compares ?confirm=<token> against the first 8 chars of the
+ * file-static `s_auth_token`.  Expose just the comparison so the
+ * settings family doesn't need access to the secret itself.
+ *
+ * Use memcmp on a fixed prefix length so we don't trip
+ * -Werror=stringop-truncation (which fires on strncpy when the copy
+ * length matches the destination buffer size) and so we don't depend
+ * on the caller having null-terminated their query parameter beyond
+ * the first 8 chars. */
+bool tab5_debug_check_factory_reset_confirm(const char *confirm) {
+   if (!confirm || strlen(confirm) < 8) return false;
+   return memcmp(confirm, s_auth_token, 8) == 0;
+}
 
 /* ======================================================================== */
 /*  Touch injection state — read by the LVGL indev read callback             */
@@ -1085,392 +1101,8 @@ static esp_err_t sdcard_handler(httpd_req_t *req)
 
 /* ── ADB-style debug APIs ─────────────────────────────────────────────── */
 
-/* GET /settings — dump all NVS settings as JSON */
-static esp_err_t settings_get_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* #148: full NVS key coverage — was exposing only 10 of ~25 keys.
-     * wifi_pass + auth_tok are intentionally omitted (secrets).  Runtime
-     * state (voice_connected, voice_state) stays for backward compat. */
-    cJSON *root = cJSON_CreateObject();
-    char buf[96];
-
-    /* Network */
-    tab5_settings_get_wifi_ssid(buf, sizeof(buf));
-    cJSON_AddStringToObject(root, "wifi_ssid", buf);
-    tab5_settings_get_dragon_host(buf, sizeof(buf));
-    cJSON_AddStringToObject(root, "dragon_host", buf);
-    cJSON_AddNumberToObject(root, "dragon_port", tab5_settings_get_dragon_port());
-    cJSON_AddNumberToObject(root, "conn_mode", tab5_settings_get_connection_mode());
-    /* TT #328 Wave 8 — surface dragon_api_token presence (NOT the
-     * value, since /settings is bearer-auth on the Tab5 debug server
-     * itself but the token is sensitive Dragon-side credential).  The
-     * caller can verify the token is set without exposing it.  POST
-     * setters accept a "dragon_api_token" key to write. */
-    {
-       /* 96-byte buffer accommodates 64-char tokens + null + headroom
-        * for future-format tokens (UUIDs, JWT prefixes).  The 64-char
-        * cap on the writer is the meaningful limit, not the reader. */
-       char tok[96] = {0};
-       tab5_settings_get_dragon_api_token(tok, sizeof(tok));
-       cJSON_AddBoolToObject(root, "dragon_api_token_set", tok[0] != '\0');
-       cJSON_AddNumberToObject(root, "dragon_api_token_len", (double)strlen(tok));
-    }
-    /* TT #328 Wave 11 — starred-skills list.  Tool names are public
-     * via /api/v1/tools so exposing the list is fine + lets the
-     * harness verify the toggle round-trip via /settings GET. */
-    {
-       char stars[256] = {0};
-       tab5_settings_get_starred_skills(stars, sizeof(stars));
-       cJSON_AddStringToObject(root, "starred_skills", stars);
-    }
-
-    /* Hardware */
-    cJSON_AddNumberToObject(root, "brightness", tab5_settings_get_brightness());
-    cJSON_AddNumberToObject(root, "volume",     tab5_settings_get_volume());
-    cJSON_AddNumberToObject(root, "mic_mute",   tab5_settings_get_mic_mute());
-
-    /* Identity */
-    if (tab5_settings_get_device_id(buf, sizeof(buf)) == ESP_OK) {
-        cJSON_AddStringToObject(root, "device_id", buf);
-    }
-    if (tab5_settings_get_hardware_id(buf, sizeof(buf)) == ESP_OK) {
-        cJSON_AddStringToObject(root, "hardware_id", buf);
-    }
-    if (tab5_settings_get_session_id(buf, sizeof(buf)) == ESP_OK) {
-        cJSON_AddStringToObject(root, "session_id", buf);
-    }
-
-    /* Voice / AI */
-    cJSON_AddNumberToObject(root, "voice_mode", tab5_settings_get_voice_mode());
-    char model[64];
-    tab5_settings_get_llm_model(model, sizeof(model));
-    cJSON_AddStringToObject(root, "llm_model", model);
-    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
-    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
-    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
-    cJSON_AddBoolToObject(root, "onboarded", tab5_settings_is_onboarded());
-
-    /* Quiet hours */
-    cJSON_AddNumberToObject(root, "quiet_on",    tab5_settings_get_quiet_on());
-    cJSON_AddNumberToObject(root, "quiet_start", tab5_settings_get_quiet_start());
-    cJSON_AddNumberToObject(root, "quiet_end",   tab5_settings_get_quiet_end());
-
-    /* Audit U2 (#206): auto-rotate persisted preference. */
-    cJSON_AddNumberToObject(root, "auto_rot",    tab5_settings_get_auto_rotate());
-    /* #260: camera rotation persisted preference. */
-    cJSON_AddNumberToObject(root, "cam_rot",     tab5_settings_get_cam_rotation());
-
-    /* Budget */
-    cJSON_AddNumberToObject(root, "spent_mils", (double)tab5_budget_get_today_mils());
-    cJSON_AddNumberToObject(root, "cap_mils",   (double)tab5_budget_get_cap_mils());
-
-    /* Runtime state (handy for "dump everything once" callers) */
-    cJSON_AddBoolToObject(root,   "voice_connected", voice_is_connected());
-    cJSON_AddNumberToObject(root, "voice_state",     voice_get_state());
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, json);
-    free(json);
-    return ret;
-}
-
-
-/* POST /settings — update NVS keys via JSON body.
- * Accepts any combination of: wifi_ssid, wifi_pass, dragon_host, dragon_port,
- * conn_mode, brightness, volume, mic_mute, quiet_on, quiet_start, quiet_end,
- * voice_mode, llm_model, session_id, int_tier, voi_tier, aut_tier, cap_mils,
- * reset_spent (bool).
- *
- * Returns: {"updated":[...], "skipped":[...], "resolved_voice_mode":N?, ...}
- * Note: does NOT reconnect voice WS automatically — call /voice/reconnect after.
- */
-static esp_err_t settings_set_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* #148: body cap bumped 512 → 2048 to fit a full key dump.
-     * Heap-allocated via PSRAM so the httpd task stack doesn't balloon. */
-    const size_t MAX_BODY = 2048;
-    int total = req->content_len;
-    if (total <= 0 || total > (int)MAX_BODY) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "{\"error\":\"body 1..2048 bytes required\"}");
-        return ESP_OK;
-    }
-
-    char *body = heap_caps_malloc(total + 1, MALLOC_CAP_SPIRAM);
-    if (!body) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "{\"error\":\"oom\"}");
-        return ESP_OK;
-    }
-    int received = 0;
-    while (received < total) {
-        int r = httpd_req_recv(req, body + received, total - received);
-        if (r <= 0) {
-            heap_caps_free(body);
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "{\"error\":\"recv failed\"}");
-            return ESP_OK;
-        }
-        received += r;
-    }
-    body[received] = '\0';
-
-    cJSON *req_json = cJSON_Parse(body);
-    heap_caps_free(body);
-    if (!req_json) {
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "{\"error\":\"invalid JSON\"}");
-        return ESP_OK;
-    }
-
-    cJSON *resp = cJSON_CreateObject();
-    cJSON *updated = cJSON_CreateArray();
-
-    /* ── Network ────────────────────────────────────────────────── */
-    cJSON *ssid = cJSON_GetObjectItem(req_json, "wifi_ssid");
-    if (cJSON_IsString(ssid) && ssid->valuestring && strlen(ssid->valuestring) > 0) {
-        if (tab5_settings_set_wifi_ssid(ssid->valuestring) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("wifi_ssid"));
-        }
-    }
-    cJSON *pass = cJSON_GetObjectItem(req_json, "wifi_pass");
-    if (cJSON_IsString(pass) && pass->valuestring) {
-        if (tab5_settings_set_wifi_pass(pass->valuestring) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("wifi_pass"));
-        }
-    }
-    cJSON *host = cJSON_GetObjectItem(req_json, "dragon_host");
-    if (cJSON_IsString(host) && host->valuestring && strlen(host->valuestring) > 0) {
-        if (tab5_settings_set_dragon_host(host->valuestring) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("dragon_host"));
-        }
-    }
-
-    cJSON *port = cJSON_GetObjectItem(req_json, "dragon_port");
-    if (cJSON_IsNumber(port)) {
-        int p = (int)port->valuedouble;
-        if (p > 0 && p < 65536) {
-            if (tab5_settings_set_dragon_port((uint16_t)p) == ESP_OK) {
-                cJSON_AddItemToArray(updated, cJSON_CreateString("dragon_port"));
-            }
-        }
-    }
-
-    /* TT #328 Wave 8 — Dragon REST API bearer token.  Empty string is
-     * valid (clears the token).  Length cap 64 is conservative for
-     * common secret formats (UUIDs, base64, hex). */
-    cJSON *tok = cJSON_GetObjectItem(req_json, "dragon_api_token");
-    if (cJSON_IsString(tok)) {
-       if (strlen(tok->valuestring) <= 64 && tab5_settings_set_dragon_api_token(tok->valuestring) == ESP_OK) {
-          cJSON_AddItemToArray(updated, cJSON_CreateString("dragon_api_token"));
-       }
-    }
-
-    /* TT #328 Wave 11 — starred-skills list (comma-separated tool
-     * names).  Lets the test harness seed/clear the list; users
-     * normally toggle individual entries via tap on a skill card.
-     * Empty string clears.  Cap 240 chars (the NVS string write
-     * path is fine up to ~4 KB but 240 keeps the JSON tidy). */
-    cJSON *stars_in = cJSON_GetObjectItem(req_json, "starred_skills");
-    if (cJSON_IsString(stars_in)) {
-       if (strlen(stars_in->valuestring) <= 240 && tab5_settings_set_starred_skills(stars_in->valuestring) == ESP_OK) {
-          cJSON_AddItemToArray(updated, cJSON_CreateString("starred_skills"));
-       }
-    }
-
-    /* ── Hardware ───────────────────────────────────────────────── */
-    cJSON *br = cJSON_GetObjectItem(req_json, "brightness");
-    if (cJSON_IsNumber(br)) {
-        int v = (int)br->valuedouble;
-        if (v >= 0 && v <= 100 &&
-            tab5_settings_set_brightness((uint8_t)v) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("brightness"));
-        }
-    }
-    cJSON *vol = cJSON_GetObjectItem(req_json, "volume");
-    if (cJSON_IsNumber(vol)) {
-        int v = (int)vol->valuedouble;
-        if (v >= 0 && v <= 100 &&
-            tab5_settings_set_volume((uint8_t)v) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("volume"));
-        }
-    }
-    cJSON *mic = cJSON_GetObjectItem(req_json, "mic_mute");
-    if (cJSON_IsNumber(mic) || cJSON_IsBool(mic)) {
-        int v = cJSON_IsBool(mic) ? cJSON_IsTrue(mic) : (int)mic->valuedouble;
-        if (tab5_settings_set_mic_mute(v ? 1 : 0) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("mic_mute"));
-        }
-    }
-
-    /* ── Quiet hours ────────────────────────────────────────────── */
-    cJSON *qon = cJSON_GetObjectItem(req_json, "quiet_on");
-    if (cJSON_IsNumber(qon) || cJSON_IsBool(qon)) {
-        int v = cJSON_IsBool(qon) ? cJSON_IsTrue(qon) : (int)qon->valuedouble;
-        if (tab5_settings_set_quiet_on(v ? 1 : 0) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_on"));
-        }
-    }
-    cJSON *qs = cJSON_GetObjectItem(req_json, "quiet_start");
-    if (cJSON_IsNumber(qs)) {
-        int v = (int)qs->valuedouble;
-        if (v >= 0 && v <= 23 &&
-            tab5_settings_set_quiet_start((uint8_t)v) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_start"));
-        }
-    }
-    cJSON *qe = cJSON_GetObjectItem(req_json, "quiet_end");
-    if (cJSON_IsNumber(qe)) {
-        int v = (int)qe->valuedouble;
-        if (v >= 0 && v <= 23 &&
-            tab5_settings_set_quiet_end((uint8_t)v) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_end"));
-        }
-    }
-
-    /* Audit U2 (#206): auto-rotate POST setter for testability — also
-     * triggers ui_core_apply_auto_rotation so the new value takes
-     * effect immediately. */
-    cJSON *ar = cJSON_GetObjectItem(req_json, "auto_rot");
-    if (cJSON_IsNumber(ar) || cJSON_IsBool(ar)) {
-        int v = cJSON_IsBool(ar) ? cJSON_IsTrue(ar) : (int)ar->valuedouble;
-        if (tab5_settings_set_auto_rotate(v ? 1 : 0) == ESP_OK) {
-            extern void ui_core_apply_auto_rotation(bool enabled);
-            ui_core_apply_auto_rotation(v != 0);
-            cJSON_AddItemToArray(updated, cJSON_CreateString("auto_rot"));
-        }
-    }
-
-    /* #260: camera rotation POST setter for testability. */
-    cJSON *cr = cJSON_GetObjectItem(req_json, "cam_rot");
-    if (cJSON_IsNumber(cr)) {
-        int v = (int)cr->valuedouble;
-        if (v >= 0 && v <= 3 &&
-            tab5_settings_set_cam_rotation((uint8_t)v) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("cam_rot"));
-        }
-    }
-
-    /* ── Voice / AI ─────────────────────────────────────────────── */
-    cJSON *vm = cJSON_GetObjectItem(req_json, "voice_mode");
-    if (cJSON_IsNumber(vm)) {
-        int v = (int)vm->valuedouble;
-        /* TT #317 Phase 5: vmode=4 added for VMODE_LOCAL_ONBOARD (K144). */
-        if (v >= 0 && v <= 4 && tab5_settings_set_voice_mode((uint8_t)v) == ESP_OK) {
-           cJSON_AddItemToArray(updated, cJSON_CreateString("voice_mode"));
-        }
-    }
-    cJSON *lm = cJSON_GetObjectItem(req_json, "llm_model");
-    if (cJSON_IsString(lm) && lm->valuestring) {
-        if (tab5_settings_set_llm_model(lm->valuestring) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("llm_model"));
-        }
-    }
-    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");
-    if (cJSON_IsString(sid) && sid->valuestring) {
-        if (tab5_settings_set_session_id(sid->valuestring) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("session_id"));
-        }
-    }
-
-    cJSON *cmode = cJSON_GetObjectItem(req_json, "conn_mode");
-    if (cJSON_IsNumber(cmode)) {
-        int m = (int)cmode->valuedouble;
-        if (m >= 0 && m <= 2) {
-            if (tab5_settings_set_connection_mode((uint8_t)m) == ESP_OK) {
-                cJSON_AddItemToArray(updated, cJSON_CreateString("conn_mode"));
-                /* U21 (#206): re-target the live WS URI so a remote
-                 * change to "Internet Only"/"Local Only" lands without
-                 * waiting for the user to power-cycle. */
-                extern void voice_reapply_connection_mode(void);
-                voice_reapply_connection_mode();
-            }
-        }
-    }
-
-    /* v4·D Sovereign Halo mode dials — accept tiers and auto-resolve into
-     * voice_mode + llm_model. Calling /voice/reconnect after a tier
-     * change is optional but recommended -- Dragon picks up the new mode
-     * on the next config_update that follows. */
-    bool any_tier = false;
-    cJSON *it = cJSON_GetObjectItem(req_json, "int_tier");
-    if (cJSON_IsNumber(it)) {
-        int t = (int)it->valuedouble;
-        if (t >= 0 && t <= 2 && tab5_settings_set_int_tier((uint8_t)t) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("int_tier"));
-            any_tier = true;
-        }
-    }
-    cJSON *vt = cJSON_GetObjectItem(req_json, "voi_tier");
-    if (cJSON_IsNumber(vt)) {
-        int t = (int)vt->valuedouble;
-        if (t >= 0 && t <= 2 && tab5_settings_set_voi_tier((uint8_t)t) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("voi_tier"));
-            any_tier = true;
-        }
-    }
-    cJSON *at = cJSON_GetObjectItem(req_json, "aut_tier");
-    if (cJSON_IsNumber(at)) {
-        int t = (int)at->valuedouble;
-        if (t >= 0 && t <= 1 && tab5_settings_set_aut_tier((uint8_t)t) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("aut_tier"));
-            any_tier = true;
-        }
-    }
-
-    /* Phase 3e budget cap edit + spent reset (dev/debug knob) */
-    cJSON *cap = cJSON_GetObjectItem(req_json, "cap_mils");
-    if (cJSON_IsNumber(cap)) {
-        uint32_t v = (uint32_t)cap->valuedouble;
-        if (tab5_budget_set_cap_mils(v) == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("cap_mils"));
-        }
-    }
-    cJSON *reset = cJSON_GetObjectItem(req_json, "reset_spent");
-    if (cJSON_IsBool(reset) && cJSON_IsTrue(reset)) {
-        /* #148: actually zero today's spend via the new helper. */
-        if (tab5_budget_reset_spent() == ESP_OK) {
-            cJSON_AddItemToArray(updated, cJSON_CreateString("reset_spent"));
-        }
-    }
-    if (any_tier) {
-        /* Resolve the new tier triple and persist the derived voice_mode +
-         * llm_model. Leaves llm_model untouched when resolver doesn't pick
-         * a specific cloud model (ie Local, Hybrid, TinkerClaw modes). */
-        char model_out[64] = {0};
-        uint8_t new_mode = tab5_mode_resolve(
-            tab5_settings_get_int_tier(),
-            tab5_settings_get_voi_tier(),
-            tab5_settings_get_aut_tier(),
-            model_out, sizeof(model_out));
-        tab5_settings_set_voice_mode(new_mode);
-        cJSON_AddItemToArray(updated, cJSON_CreateString("voice_mode"));
-        cJSON_AddNumberToObject(resp, "resolved_voice_mode", new_mode);
-        if (model_out[0]) {
-            tab5_settings_set_llm_model(model_out);
-            cJSON_AddItemToArray(updated, cJSON_CreateString("llm_model"));
-            cJSON_AddStringToObject(resp, "resolved_llm_model", model_out);
-        }
-    }
-
-    cJSON_AddItemToObject(resp, "updated", updated);
-    char *out = cJSON_PrintUnformatted(resp);
-    cJSON_Delete(resp);
-    cJSON_Delete(req_json);
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, out);
-    free(out);
-    return ret;
-}
+/* ── /settings (GET + POST) family extracted to debug_server_settings.c
+ *    (Wave 23b, #332) — handlers + register live there now. ───────────── */
 
 /* ── /mode endpoint family extracted to debug_server_mode.c (Wave 23b, #332) ─ */
 
@@ -3271,38 +2903,8 @@ static esp_err_t ping_handler(httpd_req_t *req)
     return send_json_resp(req, root);
 }
 
-/* ── POST /nvs/erase?confirm=<token> ────────────────────────────── */
-/* Factory reset path.  Requires ?confirm=<first 8 chars of auth_tok>
- * as a guard against accidental triggering.  After erase, reboots. */
-static esp_err_t nvs_erase_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-    char q[64] = {0}, confirm[16] = {0};
-    httpd_req_get_url_query_str(req, q, sizeof(q));
-    httpd_query_key_value(q, "confirm", confirm, sizeof(confirm));
-
-    /* Expect first 8 chars of the auth token. */
-    char expected[9];
-    strncpy(expected, s_auth_token, 8);
-    expected[8] = '\0';
-    if (strncmp(confirm, expected, 8) != 0) {
-        cJSON *r = cJSON_CreateObject();
-        cJSON_AddStringToObject(r, "error",
-            "factory reset requires ?confirm=<first-8-chars-of-auth-token>");
-        return send_json_resp(req, r);
-    }
-    ESP_LOGW(TAG, "NVS erase requested via debug — rebooting in 500 ms");
-    tab5_debug_obs_event("nvs", "erase");
-    cJSON *r = cJSON_CreateObject();
-    cJSON_AddBoolToObject(r, "ok", true);
-    cJSON_AddStringToObject(r, "note", "erasing + rebooting");
-    send_json_resp(req, r);
-    vTaskDelay(pdMS_TO_TICKS(300));
-    nvs_flash_erase();
-    vTaskDelay(pdMS_TO_TICKS(200));
-    esp_restart();
-    return ESP_OK;  /* unreachable */
-}
+/* ── POST /nvs/erase family extracted to debug_server_settings.c
+ *    (Wave 23b, #332) — handler + register live there now. ─────────── */
 
 /* TT #328 Wave 12 — async banner trampoline for /debug/inject_error.
  * Fires on the LVGL thread; takes ownership of the heap-allocated
@@ -3631,14 +3233,10 @@ esp_err_t tab5_debug_server_init(void)
         .uri = "/sdcard", .method = HTTP_GET, .handler = sdcard_handler
     };
     /* #148: /wake removed (feature parked) — /info still reports state. */
-    const httpd_uri_t uri_settings_get = {
-        .uri = "/settings", .method = HTTP_GET, .handler = settings_get_handler
-    };
-    const httpd_uri_t uri_settings_set = {
-        .uri = "/settings", .method = HTTP_POST, .handler = settings_set_handler
-    };
-    /* Wave 23b (#332): /mode endpoint registered en-bloc via
-     * debug_server_mode_register() below. */
+    /* Wave 23b (#332): /settings GET+POST + /nvs/erase + /mode all
+     * registered en-bloc via the per-family extracted modules
+     * (debug_server_settings_register, debug_server_mode_register)
+     * below. */
     const httpd_uri_t uri_navigate = {
         .uri = "/navigate", .method = HTTP_POST, .handler = navigate_handler
     };
@@ -3740,7 +3338,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_chat_llm_done  = { .uri = "/chat/llm_done",  .method = HTTP_POST, .handler = chat_llm_done_handler };
     const httpd_uri_t uri_kb_layout      = { .uri = "/keyboard/layout",.method = HTTP_GET,  .handler = keyboard_layout_handler };
     const httpd_uri_t uri_net_ping       = { .uri = "/net/ping",       .method = HTTP_GET,  .handler = ping_handler };
-    const httpd_uri_t uri_nvs_erase      = { .uri = "/nvs/erase",      .method = HTTP_POST, .handler = nvs_erase_handler };
+    /* /nvs/erase registered en-bloc via debug_server_settings_register() below. */
     /* TT #328 Wave 12 — synthesize Wave 3 error.* obs events + their
      * banner/toast UX without needing real fault conditions.  Lets the
      * harness validate the persistent banner + tone-aware toast paths
@@ -3774,8 +3372,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_heap_trace_start);
     httpd_register_uri_handler(server, &uri_heap_trace_dump);
     httpd_register_uri_handler(server, &uri_sdcard);
-    httpd_register_uri_handler(server, &uri_settings_get);
-    httpd_register_uri_handler(server, &uri_settings_set);
+    /* Wave 23b (#332): /settings (GET+POST) + /nvs/erase registered en-bloc. */
+    debug_server_settings_register(server);
     /* Wave 23b (#332): /mode endpoint family registered en-bloc. */
     debug_server_mode_register(server);
     httpd_register_uri_handler(server, &uri_navigate);
@@ -3829,7 +3427,7 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_chat_llm_done);
     httpd_register_uri_handler(server, &uri_kb_layout);
     httpd_register_uri_handler(server, &uri_net_ping);
-    httpd_register_uri_handler(server, &uri_nvs_erase);
+    /* /nvs/erase registered via debug_server_settings_register() above. */
     httpd_register_uri_handler(server, &uri_inject_error);
     httpd_register_uri_handler(server, &uri_inject_audio);
     /* Wave 23b (#332): codec endpoint family registered en-bloc. */

--- a/main/debug_server_internal.h
+++ b/main/debug_server_internal.h
@@ -37,3 +37,11 @@ struct cJSON;
  * Used by ~57 handlers in debug_server.c and growing — each
  * per-family extract gains access without re-implementing. */
 esp_err_t tab5_debug_send_json_resp(httpd_req_t *req, struct cJSON *root);
+
+/* Factory-reset confirm-token check.  POST /nvs/erase?confirm=<token>
+ * requires the first 8 hex chars of the bearer auth token as a guard
+ * against accidental triggering.  Returns true iff `confirm` matches.
+ * The auth token itself is a file-static inside debug_server.c — this
+ * wrapper lets the settings family extract validate without leaking
+ * the secret through the internal header. */
+bool tab5_debug_check_factory_reset_confirm(const char *confirm);

--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -1,0 +1,448 @@
+/*
+ * debug_server_settings.c — /settings (GET + POST) and /nvs/erase.
+ *
+ * Wave 23b follow-up (#332): seventh per-family extract.  Three
+ * handlers + their factory-reset confirm guard moved verbatim from
+ * debug_server.c.  Only call-site changes are the standard
+ * `check_auth` → `tab5_debug_check_auth`, `send_json_resp` →
+ * `tab5_debug_send_json_resp`, and the auth-token-prefix compare
+ * which now goes through `tab5_debug_check_factory_reset_confirm`
+ * (added to debug_server_internal.h alongside this extract so the
+ * family doesn't need access to the file-static `s_auth_token`).
+ */
+
+#include "debug_server_settings.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "debug_obs.h"
+#include "debug_server_internal.h"
+#include "esp_heap_caps.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "mode_manager.h" /* tab5_mode_resolve */
+#include "nvs_flash.h"
+#include "settings.h" /* tab5_settings_*, tab5_budget_* */
+#include "ui_core.h"  /* ui_core_apply_auto_rotation (extern-declared at call site) */
+#include "voice.h"    /* voice_is_connected, voice_get_state, voice_reapply_connection_mode */
+
+static const char *TAG = "debug_settings";
+
+/* GET /settings — dump all NVS settings as JSON */
+static esp_err_t settings_get_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   /* #148: full NVS key coverage — was exposing only 10 of ~25 keys.
+    * wifi_pass + auth_tok are intentionally omitted (secrets).  Runtime
+    * state (voice_connected, voice_state) stays for backward compat. */
+   cJSON *root = cJSON_CreateObject();
+   char buf[96];
+
+   /* Network */
+   tab5_settings_get_wifi_ssid(buf, sizeof(buf));
+   cJSON_AddStringToObject(root, "wifi_ssid", buf);
+   tab5_settings_get_dragon_host(buf, sizeof(buf));
+   cJSON_AddStringToObject(root, "dragon_host", buf);
+   cJSON_AddNumberToObject(root, "dragon_port", tab5_settings_get_dragon_port());
+   cJSON_AddNumberToObject(root, "conn_mode", tab5_settings_get_connection_mode());
+   /* TT #328 Wave 8 — surface dragon_api_token presence (NOT the
+    * value, since /settings is bearer-auth on the Tab5 debug server
+    * itself but the token is sensitive Dragon-side credential).  The
+    * caller can verify the token is set without exposing it.  POST
+    * setters accept a "dragon_api_token" key to write. */
+   {
+      /* 96-byte buffer accommodates 64-char tokens + null + headroom
+       * for future-format tokens (UUIDs, JWT prefixes).  The 64-char
+       * cap on the writer is the meaningful limit, not the reader. */
+      char tok[96] = {0};
+      tab5_settings_get_dragon_api_token(tok, sizeof(tok));
+      cJSON_AddBoolToObject(root, "dragon_api_token_set", tok[0] != '\0');
+      cJSON_AddNumberToObject(root, "dragon_api_token_len", (double)strlen(tok));
+   }
+   /* TT #328 Wave 11 — starred-skills list.  Tool names are public
+    * via /api/v1/tools so exposing the list is fine + lets the
+    * harness verify the toggle round-trip via /settings GET. */
+   {
+      char stars[256] = {0};
+      tab5_settings_get_starred_skills(stars, sizeof(stars));
+      cJSON_AddStringToObject(root, "starred_skills", stars);
+   }
+
+   /* Hardware */
+   cJSON_AddNumberToObject(root, "brightness", tab5_settings_get_brightness());
+   cJSON_AddNumberToObject(root, "volume", tab5_settings_get_volume());
+   cJSON_AddNumberToObject(root, "mic_mute", tab5_settings_get_mic_mute());
+
+   /* Identity */
+   if (tab5_settings_get_device_id(buf, sizeof(buf)) == ESP_OK) {
+      cJSON_AddStringToObject(root, "device_id", buf);
+   }
+   if (tab5_settings_get_hardware_id(buf, sizeof(buf)) == ESP_OK) {
+      cJSON_AddStringToObject(root, "hardware_id", buf);
+   }
+   if (tab5_settings_get_session_id(buf, sizeof(buf)) == ESP_OK) {
+      cJSON_AddStringToObject(root, "session_id", buf);
+   }
+
+   /* Voice / AI */
+   cJSON_AddNumberToObject(root, "voice_mode", tab5_settings_get_voice_mode());
+   char model[64];
+   tab5_settings_get_llm_model(model, sizeof(model));
+   cJSON_AddStringToObject(root, "llm_model", model);
+   cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
+   cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
+   cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
+   cJSON_AddBoolToObject(root, "onboarded", tab5_settings_is_onboarded());
+
+   /* Quiet hours */
+   cJSON_AddNumberToObject(root, "quiet_on", tab5_settings_get_quiet_on());
+   cJSON_AddNumberToObject(root, "quiet_start", tab5_settings_get_quiet_start());
+   cJSON_AddNumberToObject(root, "quiet_end", tab5_settings_get_quiet_end());
+
+   /* Audit U2 (#206): auto-rotate persisted preference. */
+   cJSON_AddNumberToObject(root, "auto_rot", tab5_settings_get_auto_rotate());
+   /* #260: camera rotation persisted preference. */
+   cJSON_AddNumberToObject(root, "cam_rot", tab5_settings_get_cam_rotation());
+
+   /* Budget */
+   cJSON_AddNumberToObject(root, "spent_mils", (double)tab5_budget_get_today_mils());
+   cJSON_AddNumberToObject(root, "cap_mils", (double)tab5_budget_get_cap_mils());
+
+   /* Runtime state (handy for "dump everything once" callers) */
+   cJSON_AddBoolToObject(root, "voice_connected", voice_is_connected());
+   cJSON_AddNumberToObject(root, "voice_state", voice_get_state());
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* POST /settings — update NVS keys via JSON body.
+ * Accepts any combination of: wifi_ssid, wifi_pass, dragon_host, dragon_port,
+ * conn_mode, brightness, volume, mic_mute, quiet_on, quiet_start, quiet_end,
+ * voice_mode, llm_model, session_id, int_tier, voi_tier, aut_tier, cap_mils,
+ * reset_spent (bool).
+ *
+ * Returns: {"updated":[...], "skipped":[...], "resolved_voice_mode":N?, ...}
+ * Note: does NOT reconnect voice WS automatically — call /voice/reconnect after.
+ */
+static esp_err_t settings_set_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   /* #148: body cap bumped 512 → 2048 to fit a full key dump.
+    * Heap-allocated via PSRAM so the httpd task stack doesn't balloon. */
+   const size_t MAX_BODY = 2048;
+   int total = req->content_len;
+   if (total <= 0 || total > (int)MAX_BODY) {
+      httpd_resp_set_type(req, "application/json");
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "{\"error\":\"body 1..2048 bytes required\"}");
+      return ESP_OK;
+   }
+
+   char *body = heap_caps_malloc(total + 1, MALLOC_CAP_SPIRAM);
+   if (!body) {
+      httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "{\"error\":\"oom\"}");
+      return ESP_OK;
+   }
+   int received = 0;
+   while (received < total) {
+      int r = httpd_req_recv(req, body + received, total - received);
+      if (r <= 0) {
+         heap_caps_free(body);
+         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "{\"error\":\"recv failed\"}");
+         return ESP_OK;
+      }
+      received += r;
+   }
+   body[received] = '\0';
+
+   cJSON *req_json = cJSON_Parse(body);
+   heap_caps_free(body);
+   if (!req_json) {
+      httpd_resp_set_type(req, "application/json");
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "{\"error\":\"invalid JSON\"}");
+      return ESP_OK;
+   }
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON *updated = cJSON_CreateArray();
+
+   /* ── Network ────────────────────────────────────────────────── */
+   cJSON *ssid = cJSON_GetObjectItem(req_json, "wifi_ssid");
+   if (cJSON_IsString(ssid) && ssid->valuestring && strlen(ssid->valuestring) > 0) {
+      if (tab5_settings_set_wifi_ssid(ssid->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("wifi_ssid"));
+      }
+   }
+   cJSON *pass = cJSON_GetObjectItem(req_json, "wifi_pass");
+   if (cJSON_IsString(pass) && pass->valuestring) {
+      if (tab5_settings_set_wifi_pass(pass->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("wifi_pass"));
+      }
+   }
+   cJSON *host = cJSON_GetObjectItem(req_json, "dragon_host");
+   if (cJSON_IsString(host) && host->valuestring && strlen(host->valuestring) > 0) {
+      if (tab5_settings_set_dragon_host(host->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("dragon_host"));
+      }
+   }
+
+   cJSON *port = cJSON_GetObjectItem(req_json, "dragon_port");
+   if (cJSON_IsNumber(port)) {
+      int p = (int)port->valuedouble;
+      if (p > 0 && p < 65536) {
+         if (tab5_settings_set_dragon_port((uint16_t)p) == ESP_OK) {
+            cJSON_AddItemToArray(updated, cJSON_CreateString("dragon_port"));
+         }
+      }
+   }
+
+   /* TT #328 Wave 8 — Dragon REST API bearer token.  Empty string is
+    * valid (clears the token).  Length cap 64 is conservative for
+    * common secret formats (UUIDs, base64, hex). */
+   cJSON *tok = cJSON_GetObjectItem(req_json, "dragon_api_token");
+   if (cJSON_IsString(tok)) {
+      if (strlen(tok->valuestring) <= 64 && tab5_settings_set_dragon_api_token(tok->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("dragon_api_token"));
+      }
+   }
+
+   /* TT #328 Wave 11 — starred-skills list (comma-separated tool
+    * names).  Lets the test harness seed/clear the list; users
+    * normally toggle individual entries via tap on a skill card.
+    * Empty string clears.  Cap 240 chars (the NVS string write
+    * path is fine up to ~4 KB but 240 keeps the JSON tidy). */
+   cJSON *stars_in = cJSON_GetObjectItem(req_json, "starred_skills");
+   if (cJSON_IsString(stars_in)) {
+      if (strlen(stars_in->valuestring) <= 240 && tab5_settings_set_starred_skills(stars_in->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("starred_skills"));
+      }
+   }
+
+   /* ── Hardware ───────────────────────────────────────────────── */
+   cJSON *br = cJSON_GetObjectItem(req_json, "brightness");
+   if (cJSON_IsNumber(br)) {
+      int v = (int)br->valuedouble;
+      if (v >= 0 && v <= 100 && tab5_settings_set_brightness((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("brightness"));
+      }
+   }
+   cJSON *vol = cJSON_GetObjectItem(req_json, "volume");
+   if (cJSON_IsNumber(vol)) {
+      int v = (int)vol->valuedouble;
+      if (v >= 0 && v <= 100 && tab5_settings_set_volume((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("volume"));
+      }
+   }
+   cJSON *mic = cJSON_GetObjectItem(req_json, "mic_mute");
+   if (cJSON_IsNumber(mic) || cJSON_IsBool(mic)) {
+      int v = cJSON_IsBool(mic) ? cJSON_IsTrue(mic) : (int)mic->valuedouble;
+      if (tab5_settings_set_mic_mute(v ? 1 : 0) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("mic_mute"));
+      }
+   }
+
+   /* ── Quiet hours ────────────────────────────────────────────── */
+   cJSON *qon = cJSON_GetObjectItem(req_json, "quiet_on");
+   if (cJSON_IsNumber(qon) || cJSON_IsBool(qon)) {
+      int v = cJSON_IsBool(qon) ? cJSON_IsTrue(qon) : (int)qon->valuedouble;
+      if (tab5_settings_set_quiet_on(v ? 1 : 0) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_on"));
+      }
+   }
+   cJSON *qs = cJSON_GetObjectItem(req_json, "quiet_start");
+   if (cJSON_IsNumber(qs)) {
+      int v = (int)qs->valuedouble;
+      if (v >= 0 && v <= 23 && tab5_settings_set_quiet_start((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_start"));
+      }
+   }
+   cJSON *qe = cJSON_GetObjectItem(req_json, "quiet_end");
+   if (cJSON_IsNumber(qe)) {
+      int v = (int)qe->valuedouble;
+      if (v >= 0 && v <= 23 && tab5_settings_set_quiet_end((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_end"));
+      }
+   }
+
+   /* Audit U2 (#206): auto-rotate POST setter for testability — also
+    * triggers ui_core_apply_auto_rotation so the new value takes
+    * effect immediately. */
+   cJSON *ar = cJSON_GetObjectItem(req_json, "auto_rot");
+   if (cJSON_IsNumber(ar) || cJSON_IsBool(ar)) {
+      int v = cJSON_IsBool(ar) ? cJSON_IsTrue(ar) : (int)ar->valuedouble;
+      if (tab5_settings_set_auto_rotate(v ? 1 : 0) == ESP_OK) {
+         extern void ui_core_apply_auto_rotation(bool enabled);
+         ui_core_apply_auto_rotation(v != 0);
+         cJSON_AddItemToArray(updated, cJSON_CreateString("auto_rot"));
+      }
+   }
+
+   /* #260: camera rotation POST setter for testability. */
+   cJSON *cr = cJSON_GetObjectItem(req_json, "cam_rot");
+   if (cJSON_IsNumber(cr)) {
+      int v = (int)cr->valuedouble;
+      if (v >= 0 && v <= 3 && tab5_settings_set_cam_rotation((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("cam_rot"));
+      }
+   }
+
+   /* ── Voice / AI ─────────────────────────────────────────────── */
+   cJSON *vm = cJSON_GetObjectItem(req_json, "voice_mode");
+   if (cJSON_IsNumber(vm)) {
+      int v = (int)vm->valuedouble;
+      /* TT #317 Phase 5: vmode=4 added for VMODE_LOCAL_ONBOARD (K144). */
+      if (v >= 0 && v <= 4 && tab5_settings_set_voice_mode((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("voice_mode"));
+      }
+   }
+   cJSON *lm = cJSON_GetObjectItem(req_json, "llm_model");
+   if (cJSON_IsString(lm) && lm->valuestring) {
+      if (tab5_settings_set_llm_model(lm->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("llm_model"));
+      }
+   }
+   cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");
+   if (cJSON_IsString(sid) && sid->valuestring) {
+      if (tab5_settings_set_session_id(sid->valuestring) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("session_id"));
+      }
+   }
+
+   cJSON *cmode = cJSON_GetObjectItem(req_json, "conn_mode");
+   if (cJSON_IsNumber(cmode)) {
+      int m = (int)cmode->valuedouble;
+      if (m >= 0 && m <= 2) {
+         if (tab5_settings_set_connection_mode((uint8_t)m) == ESP_OK) {
+            cJSON_AddItemToArray(updated, cJSON_CreateString("conn_mode"));
+            /* U21 (#206): re-target the live WS URI so a remote
+             * change to "Internet Only"/"Local Only" lands without
+             * waiting for the user to power-cycle. */
+            extern void voice_reapply_connection_mode(void);
+            voice_reapply_connection_mode();
+         }
+      }
+   }
+
+   /* v4·D Sovereign Halo mode dials — accept tiers and auto-resolve into
+    * voice_mode + llm_model. Calling /voice/reconnect after a tier
+    * change is optional but recommended -- Dragon picks up the new mode
+    * on the next config_update that follows. */
+   bool any_tier = false;
+   cJSON *it = cJSON_GetObjectItem(req_json, "int_tier");
+   if (cJSON_IsNumber(it)) {
+      int t = (int)it->valuedouble;
+      if (t >= 0 && t <= 2 && tab5_settings_set_int_tier((uint8_t)t) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("int_tier"));
+         any_tier = true;
+      }
+   }
+   cJSON *vt = cJSON_GetObjectItem(req_json, "voi_tier");
+   if (cJSON_IsNumber(vt)) {
+      int t = (int)vt->valuedouble;
+      if (t >= 0 && t <= 2 && tab5_settings_set_voi_tier((uint8_t)t) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("voi_tier"));
+         any_tier = true;
+      }
+   }
+   cJSON *at = cJSON_GetObjectItem(req_json, "aut_tier");
+   if (cJSON_IsNumber(at)) {
+      int t = (int)at->valuedouble;
+      if (t >= 0 && t <= 1 && tab5_settings_set_aut_tier((uint8_t)t) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("aut_tier"));
+         any_tier = true;
+      }
+   }
+
+   /* Phase 3e budget cap edit + spent reset (dev/debug knob) */
+   cJSON *cap = cJSON_GetObjectItem(req_json, "cap_mils");
+   if (cJSON_IsNumber(cap)) {
+      uint32_t v = (uint32_t)cap->valuedouble;
+      if (tab5_budget_set_cap_mils(v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("cap_mils"));
+      }
+   }
+   cJSON *reset = cJSON_GetObjectItem(req_json, "reset_spent");
+   if (cJSON_IsBool(reset) && cJSON_IsTrue(reset)) {
+      /* #148: actually zero today's spend via the new helper. */
+      if (tab5_budget_reset_spent() == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("reset_spent"));
+      }
+   }
+   if (any_tier) {
+      /* Resolve the new tier triple and persist the derived voice_mode +
+       * llm_model. Leaves llm_model untouched when resolver doesn't pick
+       * a specific cloud model (ie Local, Hybrid, TinkerClaw modes). */
+      char model_out[64] = {0};
+      uint8_t new_mode = tab5_mode_resolve(tab5_settings_get_int_tier(), tab5_settings_get_voi_tier(),
+                                           tab5_settings_get_aut_tier(), model_out, sizeof(model_out));
+      tab5_settings_set_voice_mode(new_mode);
+      cJSON_AddItemToArray(updated, cJSON_CreateString("voice_mode"));
+      cJSON_AddNumberToObject(resp, "resolved_voice_mode", new_mode);
+      if (model_out[0]) {
+         tab5_settings_set_llm_model(model_out);
+         cJSON_AddItemToArray(updated, cJSON_CreateString("llm_model"));
+         cJSON_AddStringToObject(resp, "resolved_llm_model", model_out);
+      }
+   }
+
+   cJSON_AddItemToObject(resp, "updated", updated);
+   char *out = cJSON_PrintUnformatted(resp);
+   cJSON_Delete(resp);
+   cJSON_Delete(req_json);
+
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+   esp_err_t ret = httpd_resp_sendstr(req, out);
+   free(out);
+   return ret;
+}
+
+/* ── POST /nvs/erase?confirm=<token> ────────────────────────────── */
+/* Factory reset path.  Requires ?confirm=<first 8 chars of auth_tok>
+ * as a guard against accidental triggering.  After erase, reboots. */
+static esp_err_t nvs_erase_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   char q[64] = {0}, confirm[16] = {0};
+   httpd_req_get_url_query_str(req, q, sizeof(q));
+   httpd_query_key_value(q, "confirm", confirm, sizeof(confirm));
+
+   if (!tab5_debug_check_factory_reset_confirm(confirm)) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "factory reset requires ?confirm=<first-8-chars-of-auth-token>");
+      return tab5_debug_send_json_resp(req, r);
+   }
+   ESP_LOGW(TAG, "NVS erase requested via debug — rebooting in 500 ms");
+   tab5_debug_obs_event("nvs", "erase");
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddBoolToObject(r, "ok", true);
+   cJSON_AddStringToObject(r, "note", "erasing + rebooting");
+   tab5_debug_send_json_resp(req, r);
+   vTaskDelay(pdMS_TO_TICKS(300));
+   nvs_flash_erase();
+   vTaskDelay(pdMS_TO_TICKS(200));
+   esp_restart();
+   return ESP_OK; /* unreachable */
+}
+
+void debug_server_settings_register(httpd_handle_t server) {
+   const httpd_uri_t uri_settings_get = {.uri = "/settings", .method = HTTP_GET, .handler = settings_get_handler};
+   const httpd_uri_t uri_settings_set = {.uri = "/settings", .method = HTTP_POST, .handler = settings_set_handler};
+   const httpd_uri_t uri_nvs_erase = {.uri = "/nvs/erase", .method = HTTP_POST, .handler = nvs_erase_handler};
+   httpd_register_uri_handler(server, &uri_settings_get);
+   httpd_register_uri_handler(server, &uri_settings_set);
+   httpd_register_uri_handler(server, &uri_nvs_erase);
+   ESP_LOGI(TAG, "Settings endpoint family registered (3 URIs)");
+}

--- a/main/debug_server_settings.h
+++ b/main/debug_server_settings.h
@@ -1,0 +1,30 @@
+/*
+ * debug_server_settings.h — settings + factory-reset endpoint family.
+ *
+ * Wave 23b follow-up (#332): seventh per-family extract from
+ * debug_server.c (after K144 #336, OTA #340, codec #341, voice #342,
+ * mode #344).  Largest single family by LOC (~400 LOC handlers + the
+ * factory-reset guard) — scoped tight to NVS-touching endpoints so
+ * the WiFi family (kick + scan + status) can extract independently.
+ *
+ * Endpoints owned by this module:
+ *   GET  /settings              — dump all NVS settings as JSON
+ *   POST /settings              — update one or more NVS keys via JSON body
+ *   POST /nvs/erase?confirm=... — factory reset (auth-token-prefix guarded)
+ *
+ * The settings_set handler is the largest single handler in the
+ * historical debug_server.c — 280 LOC of "if key present + valid +
+ * persisted, append to updated[] array" boilerplate covering every NVS
+ * key the harness needs to drive remotely.  Kept verbatim during the
+ * extract; the dial-resolver coupling to mode_manager + voice WS
+ * reapply is the only non-trivial branch and stays here since both
+ * helpers are already extern-declared at their call sites.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the settings + factory-reset endpoint family on `server`.
+ * Called from tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_settings_register(httpd_handle_t server);


### PR DESCRIPTION
## What

Closes the largest single remaining slice of the Wave 23b debug_server.c split (refs #332).  Three handlers move verbatim to a new `main/debug_server_settings.{c,h}`:

* `GET  /settings`              — dump all NVS settings as JSON
* `POST /settings`              — update one or more NVS keys via JSON body
* `POST /nvs/erase?confirm=...` — factory reset (auth-token-prefix guarded)

The `settings_set_handler` is the **largest single handler** in the historical `debug_server.c` (281 LOC of \"if key present + valid + persisted, append to updated[]\" boilerplate covering every NVS key the test harness needs to drive remotely).  Kept verbatim during the extract; the dial-resolver coupling to `mode_manager` + voice WS reapply is the only non-trivial branch and stays here since both helpers are already extern-declared at their call sites.

## Family map after this PR

| Family | File | Endpoints | Status |
|---|---|---|---|
| K144 | `debug_server_m5.c` | 4 | Wave 23b #336 |
| OTA | `debug_server_ota.c` | 2 | Wave 23b #340 |
| Codec | `debug_server_codec.c` | 1 | Wave 23b #341 |
| Voice | `debug_server_voice.c` | 4 | Wave 23b #342 (+#343 hotfix) |
| Mode | `debug_server_mode.c` | 1 | Wave 23b #344 |
| **Settings** | **`debug_server_settings.c`** | **3** | **this PR** |
| _everything else_ | `debug_server.c` | ~50 | next: camera, video/call, chat |

## Internal-header surface change

The `/nvs/erase` factory-reset guard compares `?confirm=<token>` against the first 8 chars of the file-static `s_auth_token`.  Rather than re-export the whole secret to the new family, this PR adds a single boolean comparison helper to `debug_server_internal.h`:

```c
bool tab5_debug_check_factory_reset_confirm(const char *confirm);
```

Implementation lives next to the existing internal shims in `debug_server.c` and uses `memcmp` on a fixed prefix length so we don't trip `-Werror=stringop-truncation` (which fires on `strncpy` when the copy length matches the destination buffer size — the same warning that the original inline call site avoided only because gcc looked at the surrounding context differently).

## debug_server.c shrink

* This PR: 3859 → 3458 LOC (−401, −10.4 %)
* Cumulative across the seven 23b family extracts: 4520 → 3458 (−1062, −23.5 %)

## Verification

### Build
```
tinkertab.bin binary size 0x27dc30 bytes. Smallest app partition is 0x300000 bytes. 0x823d0 bytes (17%) free.
```

+208 bytes vs prior main — cost of the new family register stub + the `strlen` check in the confirm helper.

### Live on hardware (Tab5 @ 192.168.1.90)
```
$ curl -s -H \"Authorization: Bearer \$TOKEN\" \\
    http://192.168.1.90:8080/settings | jq 'keys | length'
28

$ curl -s -H \"Authorization: Bearer \$TOKEN\" -X POST \\
    http://192.168.1.90:8080/settings -d '{\"brightness\":75}'
{\"updated\":[\"brightness\"]}

$ curl -s -H \"Authorization: Bearer \$TOKEN\" -X POST \\
    'http://192.168.1.90:8080/nvs/erase?confirm=wrongtok'
{\"error\":\"factory reset requires ?confirm=<first-8-chars-of-auth-token>\"}
```

### E2E
```
══════ story_smoke ══════
  14 PASS, 0 FAIL in 97s
```

### Format gate (replicates CI)
```
$ git-clang-format --binary clang-format-18 --diff origin/main \\
    -- 'main/*.c' 'main/*.h'
clang-format did not modify any files
```

## Behavior unchanged

No URL contracts change.  No NVS key writes change.  No dial-resolver behaviour changes.  Pure structural refactor — the bytes flowing through `settings_get_handler`, `settings_set_handler`, and `nvs_erase_handler` are identical to pre-extract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)