### PR TITLE
refactor(debug_server): extract /wifi/kick + /wifi/status family (Wave 23b · 8th family)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
-             "debug_server_settings.c"
+             "debug_server_settings.c" "debug_server_wifi.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -64,6 +64,7 @@
 #include "debug_server_ota.h"
 #include "debug_server_settings.h"
 #include "debug_server_voice.h"
+#include "debug_server_wifi.h"
 #include "widget.h" /* Audit C4 (#202): widget_store_evictions_total */
 #include "wifi.h"
 
@@ -1760,50 +1761,8 @@ static esp_err_t input_text_handler(httpd_req_t *req)
 }
 
 /* ── Wi-Fi kick endpoint (test harness) ──────────────────────────────── */
-/* POST /wifi/kick?mode=soft|hard|reboot — force the escalation tiers
- * from #146.  Used by the test harness to verify recovery paths without
- * waiting 2-3 min of actual flap.  mode=soft is safe; hard costs ~1-2 s
- * of downtime; reboot is self-explanatory. */
-#include "wifi.h"
-static esp_err_t wifi_kick_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    char query[64] = {0};
-    char mode[16]  = "soft";
-    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
-        httpd_query_key_value(query, "mode", mode, sizeof(mode));
-    }
-
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddStringToObject(root, "mode", mode);
-
-    if (strcmp(mode, "hard") == 0) {
-        esp_err_t r = tab5_wifi_hard_kick();
-        cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
-        if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
-    } else if (strcmp(mode, "reboot") == 0) {
-        cJSON_AddBoolToObject(root, "ok", true);
-        cJSON_AddStringToObject(root, "note", "rebooting in 100 ms");
-        char *json = cJSON_PrintUnformatted(root);
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_sendstr(req, json);
-        free(json);
-        cJSON_Delete(root);
-        vTaskDelay(pdMS_TO_TICKS(100));
-        esp_restart();
-        return ESP_OK;  /* unreachable */
-    } else {
-        tab5_wifi_kick();
-        cJSON_AddBoolToObject(root, "ok", true);
-    }
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_sendstr(req, json);
-    free(json);
-    return ESP_OK;
-}
+/* ── /wifi/kick + /wifi/status family extracted to debug_server_wifi.c
+ *    (Wave 23b, #332) — handlers + register live there now. ─────────── */
 
 /* ── Dictation endpoint ───────────────────────────────────────────────── */
 /* POST /dictation?action=start|stop — remote dictation driver for the
@@ -2398,39 +2357,7 @@ static esp_err_t voice_text_handler(httpd_req_t *req)
     return chat_handler(req);
 }
 
-
-/* ── GET /wifi/status ──────────────────────────────────────────── */
-static esp_err_t wifi_status_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "connected", tab5_wifi_connected());
-
-    char ip[20]; get_wifi_ip(ip, sizeof(ip));
-    cJSON_AddStringToObject(root, "ip", ip);
-
-    wifi_ap_record_t ap = {0};
-    esp_err_t r = esp_wifi_sta_get_ap_info(&ap);
-    if (r == ESP_OK) {
-        char bssid[18];
-        snprintf(bssid, sizeof(bssid), "%02x:%02x:%02x:%02x:%02x:%02x",
-                 ap.bssid[0], ap.bssid[1], ap.bssid[2],
-                 ap.bssid[3], ap.bssid[4], ap.bssid[5]);
-        cJSON_AddStringToObject(root, "ssid", (const char *)ap.ssid);
-        cJSON_AddStringToObject(root, "bssid", bssid);
-        cJSON_AddNumberToObject(root, "channel", ap.primary);
-        cJSON_AddNumberToObject(root, "rssi", ap.rssi);
-        const char *auths[] = {"open","wep","wpa_psk","wpa2_psk","wpa_wpa2_psk",
-                               "wpa2_enterprise","wpa3_psk","wpa2_wpa3_psk",
-                               "wapi_psk","owe","wpa3_enterprise","wpa3_ent_192"};
-        int am = (int)ap.authmode;
-        cJSON_AddStringToObject(root, "authmode",
-            (am >= 0 && am < (int)(sizeof(auths)/sizeof(auths[0]))) ? auths[am] : "?");
-    } else {
-        cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
-    }
-    return send_json_resp(req, root);
-}
+/* /wifi/status extracted to debug_server_wifi.c (Wave 23b, #332). */
 
 /* ── GET /battery ──────────────────────────────────────────────── */
 static esp_err_t battery_handler(httpd_req_t *req)
@@ -3306,9 +3233,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_dictation_get = {
         .uri = "/dictation", .method = HTTP_GET, .handler = dictation_handler
     };
-    const httpd_uri_t uri_wifi_kick = {
-        .uri = "/wifi/kick", .method = HTTP_POST, .handler = wifi_kick_handler
-    };
+    /* /wifi/kick registered en-bloc via debug_server_wifi_register() below. */
     const httpd_uri_t uri_selftest = {
         .uri = "/selftest", .method = HTTP_GET, .handler = selftest_handler
     };
@@ -3322,7 +3247,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_logs_tail      = { .uri = "/logs/tail",      .method = HTTP_GET,  .handler = logs_tail_handler };
     const httpd_uri_t uri_voice_text     = { .uri = "/voice/text",     .method = HTTP_POST, .handler = voice_text_handler };
     /* Wave 23b (#332): /voice/cancel + /voice/clear moved to debug_server_voice.c. */
-    const httpd_uri_t uri_wifi_status    = { .uri = "/wifi/status",    .method = HTTP_GET,  .handler = wifi_status_handler };
+    /* /wifi/status registered en-bloc via debug_server_wifi_register() below. */
     const httpd_uri_t uri_battery        = { .uri = "/battery",        .method = HTTP_GET,  .handler = battery_handler };
     const httpd_uri_t uri_disp_bright    = { .uri = "/display/brightness", .method = HTTP_POST, .handler = display_brightness_handler };
     const httpd_uri_t uri_audio_get      = { .uri = "/audio",          .method = HTTP_GET,  .handler = audio_handler };
@@ -3402,7 +3327,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_call_restore);
     httpd_register_uri_handler(server, &uri_dictation_post);
     httpd_register_uri_handler(server, &uri_dictation_get);
-    httpd_register_uri_handler(server, &uri_wifi_kick);
+    /* Wave 23b (#332): WiFi diagnostic + recovery family registered en-bloc. */
+    debug_server_wifi_register(server);
     httpd_register_uri_handler(server, &uri_selftest);
     httpd_register_uri_handler(server, &uri_heap);
     /* #149 PR β registrations. */
@@ -3410,8 +3336,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_logs_tail);
     httpd_register_uri_handler(server, &uri_voice_text);
     /* Wave 23b (#332): /voice/cancel + /voice/clear registered via
-     * debug_server_voice_register() above. */
-    httpd_register_uri_handler(server, &uri_wifi_status);
+     * debug_server_voice_register() above; /wifi/status registered via
+     * debug_server_wifi_register() above. */
     httpd_register_uri_handler(server, &uri_battery);
     httpd_register_uri_handler(server, &uri_disp_bright);
     httpd_register_uri_handler(server, &uri_audio_get);

--- a/main/debug_server_wifi.c
+++ b/main/debug_server_wifi.c
@@ -1,0 +1,135 @@
+/*
+ * debug_server_wifi.c — /wifi/status + /wifi/kick handlers.
+ *
+ * Wave 23b follow-up (#332): eighth per-family extract.  Two
+ * handlers + the local IP-read helper moved verbatim from
+ * debug_server.c.  Only call-site changes are the standard
+ * `check_auth` → `tab5_debug_check_auth` and `send_json_resp` →
+ * `tab5_debug_send_json_resp` substitutions.
+ *
+ * The original `get_wifi_ip` static helper is duplicated here under
+ * the same name (file-static, so no linker conflict) rather than
+ * promoted to debug_server_internal.h — `info_handler` in
+ * debug_server.c is its only other caller and the function is 13
+ * lines of pure netif lookups; the duplication cost is lower than
+ * the public-API surface it would otherwise demand.
+ */
+
+#include "debug_server_wifi.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "debug_server_internal.h"
+#include "esp_err.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "wifi.h" /* tab5_wifi_connected, tab5_wifi_kick, tab5_wifi_hard_kick */
+
+static const char *TAG = "debug_wifi";
+
+/* Local IP-read helper — duplicated from debug_server.c by design (see
+ * file header for rationale).  Keeps the family self-contained. */
+static esp_err_t get_wifi_ip(char *buf, size_t len) {
+   esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+   if (!netif) {
+      snprintf(buf, len, "0.0.0.0");
+      return ESP_FAIL;
+   }
+   esp_netif_ip_info_t ip;
+   if (esp_netif_get_ip_info(netif, &ip) == ESP_OK) {
+      snprintf(buf, len, IPSTR, IP2STR(&ip.ip));
+      return ESP_OK;
+   }
+   snprintf(buf, len, "0.0.0.0");
+   return ESP_FAIL;
+}
+
+/* POST /wifi/kick?mode=soft|hard|reboot — force the escalation tiers
+ * from #146.  Used by the test harness to verify recovery paths without
+ * waiting 2-3 min of actual flap.  mode=soft is safe; hard costs ~1-2 s
+ * of downtime; reboot is self-explanatory. */
+static esp_err_t wifi_kick_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   char query[64] = {0};
+   char mode[16] = "soft";
+   if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+      httpd_query_key_value(query, "mode", mode, sizeof(mode));
+   }
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "mode", mode);
+
+   if (strcmp(mode, "hard") == 0) {
+      esp_err_t r = tab5_wifi_hard_kick();
+      cJSON_AddBoolToObject(root, "ok", r == ESP_OK);
+      if (r != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+   } else if (strcmp(mode, "reboot") == 0) {
+      cJSON_AddBoolToObject(root, "ok", true);
+      cJSON_AddStringToObject(root, "note", "rebooting in 100 ms");
+      char *json = cJSON_PrintUnformatted(root);
+      httpd_resp_set_type(req, "application/json");
+      httpd_resp_sendstr(req, json);
+      free(json);
+      cJSON_Delete(root);
+      vTaskDelay(pdMS_TO_TICKS(100));
+      esp_restart();
+      return ESP_OK; /* unreachable */
+   } else {
+      tab5_wifi_kick();
+      cJSON_AddBoolToObject(root, "ok", true);
+   }
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_sendstr(req, json);
+   free(json);
+   return ESP_OK;
+}
+
+/* ── GET /wifi/status ──────────────────────────────────────────── */
+static esp_err_t wifi_status_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "connected", tab5_wifi_connected());
+
+   char ip[20];
+   get_wifi_ip(ip, sizeof(ip));
+   cJSON_AddStringToObject(root, "ip", ip);
+
+   wifi_ap_record_t ap = {0};
+   esp_err_t r = esp_wifi_sta_get_ap_info(&ap);
+   if (r == ESP_OK) {
+      char bssid[18];
+      snprintf(bssid, sizeof(bssid), "%02x:%02x:%02x:%02x:%02x:%02x", ap.bssid[0], ap.bssid[1], ap.bssid[2],
+               ap.bssid[3], ap.bssid[4], ap.bssid[5]);
+      cJSON_AddStringToObject(root, "ssid", (const char *)ap.ssid);
+      cJSON_AddStringToObject(root, "bssid", bssid);
+      cJSON_AddNumberToObject(root, "channel", ap.primary);
+      cJSON_AddNumberToObject(root, "rssi", ap.rssi);
+      const char *auths[] = {"open",     "wep",           "wpa_psk",  "wpa2_psk", "wpa_wpa2_psk",    "wpa2_enterprise",
+                             "wpa3_psk", "wpa2_wpa3_psk", "wapi_psk", "owe",      "wpa3_enterprise", "wpa3_ent_192"};
+      int am = (int)ap.authmode;
+      cJSON_AddStringToObject(root, "authmode",
+                              (am >= 0 && am < (int)(sizeof(auths) / sizeof(auths[0]))) ? auths[am] : "?");
+   } else {
+      cJSON_AddStringToObject(root, "error", esp_err_to_name(r));
+   }
+   return tab5_debug_send_json_resp(req, root);
+}
+
+void debug_server_wifi_register(httpd_handle_t server) {
+   const httpd_uri_t uri_wifi_kick = {.uri = "/wifi/kick", .method = HTTP_POST, .handler = wifi_kick_handler};
+   const httpd_uri_t uri_wifi_status = {.uri = "/wifi/status", .method = HTTP_GET, .handler = wifi_status_handler};
+   httpd_register_uri_handler(server, &uri_wifi_kick);
+   httpd_register_uri_handler(server, &uri_wifi_status);
+   ESP_LOGI(TAG, "WiFi endpoint family registered (2 URIs)");
+}

--- a/main/debug_server_wifi.h
+++ b/main/debug_server_wifi.h
@@ -1,0 +1,29 @@
+/*
+ * debug_server_wifi.h — WiFi diagnostic + recovery endpoint family.
+ *
+ * Wave 23b follow-up (#332): eighth per-family extract from
+ * debug_server.c (after K144 #336, OTA #340, codec #341, voice #342,
+ * mode #344, settings #346).  Two small handlers extracted as a unit
+ * since they share the WiFi diagnostic surface (status read + recovery
+ * kick) and live next to each other in the URI map.
+ *
+ * Endpoints owned by this module:
+ *   GET  /wifi/status                   — connection state + AP info snapshot
+ *   POST /wifi/kick?mode=soft|hard|reboot — escalation tiers from #146,
+ *                                           drives the test-harness recovery
+ *                                           paths without waiting for real flap
+ *
+ * The /info handler in debug_server.c also reads `tab5_wifi_connected`
+ * + the netif IP — it keeps its own private copy of the small
+ * `get_wifi_ip` helper rather than going through this header, since
+ * those two read-only callers don't justify a public surface for the
+ * helper.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the WiFi diagnostic + recovery endpoint family on `server`.
+ * Called from tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_wifi_register(httpd_handle_t server);


### PR DESCRIPTION
## What

Eighth per-family extract from `debug_server.c` (refs #332).  Two small handlers move verbatim to a new `main/debug_server_wifi.{c,h}`:

* `GET  /wifi/status`                   — connection state + AP info snapshot
* `POST /wifi/kick?mode=soft|hard|reboot` — escalation tiers from #146 (test-harness recovery driver)

## Helper duplication (intentional)

The local `get_wifi_ip` helper (13-line netif lookup) is **duplicated** into the family file rather than promoted to `debug_server_internal.h`.  The `info_handler` in `debug_server.c` is its only other caller, and the function is pure read-only netif lookups — the duplication cost is lower than the public-API surface it would otherwise demand on every consumer of the internal header.  If a third caller appears, promote then.

## debug_server.c shrink

| Metric | Value |
|---|---|
| This PR | 3458 → 3384 LOC (−74, −2.1 %) |
| Cumulative across 8 family extracts | 4520 → 3384 (−1136, −25.1 %) |

## Verification

### Build
\`\`\`
tinkertab.bin binary size 0x27dcf0 bytes. Smallest app partition is 0x300000 bytes. 0x82310 bytes (17%) free.
\`\`\`
+192 B vs prior main — cost of the new family register stub.

### Live on hardware
\`\`\`
\$ curl -s -H \"Authorization: Bearer \$TOKEN\" http://192.168.1.90:8080/wifi/status | jq .
{
  \"connected\": true,
  \"ip\": \"192.168.1.90\",
  \"ssid\": \"Sawaya-2.4G\",
  \"bssid\": \"a0:95:7f:7c:16:8d\",
  \"channel\": 12,
  \"rssi\": -32,
  \"authmode\": \"wpa_wpa2_psk\"
}
\`\`\`

`/wifi/kick?mode=soft` drops the response (handler tears down WiFi mid-response — pre-extract behaviour, not a regression); device returns to LAN within ~5 s and serves `/wifi/status` normally.

### E2E
\`\`\`
══════ story_smoke ══════
  14 PASS, 0 FAIL in 177s
\`\`\`

### Format gate (replicates CI)
\`\`\`
\$ git-clang-format --binary clang-format-18 --diff origin/main -- 'main/*.c' 'main/*.h'
clang-format did not modify any files
\`\`\`

## Family map after this PR

| Family | File | Endpoints | Wave 23b PR |
|---|---|---|---|
| K144 | debug_server_m5.c | 4 | #336 |
| OTA | debug_server_ota.c | 2 | #340 |
| Codec | debug_server_codec.c | 1 | #341 |
| Voice | debug_server_voice.c | 4 | #342 (+#343 hotfix) |
| Mode | debug_server_mode.c | 1 | #344 |
| Settings | debug_server_settings.c | 3 | #346 |
| **WiFi** | **debug_server_wifi.c** | **2** | **this PR** |

## Behavior unchanged

No URL contracts change.  No WiFi semantics change.  Pure structural refactor — bytes flowing through both handlers are identical to pre-extract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)