### PR TITLE
refactor(debug_server): extract /dictation family (Wave 23b · 9th family)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
              "voice.c" "voice_codec.c" "voice_video.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
-             "debug_server_settings.c" "debug_server_wifi.c"
+             "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -58,6 +58,7 @@
 #include "voice.h"
 /* Wave 23b (#332): per-family endpoint extracts + auth shim. */
 #include "debug_server_codec.h"
+#include "debug_server_dictation.h"
 #include "debug_server_internal.h"
 #include "debug_server_m5.h"
 #include "debug_server_mode.h"
@@ -1764,49 +1765,8 @@ static esp_err_t input_text_handler(httpd_req_t *req)
 /* ── /wifi/kick + /wifi/status family extracted to debug_server_wifi.c
  *    (Wave 23b, #332) — handlers + register live there now. ─────────── */
 
-/* ── Dictation endpoint ───────────────────────────────────────────────── */
-/* POST /dictation?action=start|stop — remote dictation driver for the
- * long-duration pipeline tests (5 / 10 / 30 min).  GET also returns the
- * current accumulated transcript so the test harness can snapshot it
- * mid-run.  Long-press mic is the user-facing trigger; this endpoint
- * is the automation equivalent. */
-static esp_err_t dictation_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    char query[128] = {0};
-    char action[16] = {0};
-    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
-        httpd_query_key_value(query, "action", action, sizeof(action));
-    }
-
-    cJSON *root = cJSON_CreateObject();
-    if (req->method == HTTP_POST && strcmp(action, "start") == 0) {
-        esp_err_t err = voice_start_dictation();
-        cJSON_AddBoolToObject(root, "ok", err == ESP_OK);
-        cJSON_AddStringToObject(root, "action", "start");
-        if (err != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
-    } else if (req->method == HTTP_POST && strcmp(action, "stop") == 0) {
-        esp_err_t err = voice_stop_listening();
-        cJSON_AddBoolToObject(root, "ok", err == ESP_OK);
-        cJSON_AddStringToObject(root, "action", "stop");
-        if (err != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
-    } else {
-        /* GET — snapshot of current transcript + state */
-        cJSON_AddBoolToObject(root, "ok", true);
-        cJSON_AddStringToObject(root, "action", "status");
-    }
-    const char *txt = voice_get_dictation_text();
-    cJSON_AddStringToObject(root, "transcript", txt ? txt : "");
-    cJSON_AddNumberToObject(root, "transcript_len", txt ? (int)strlen(txt) : 0);
-    cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_sendstr(req, json);
-    free(json);
-    return ESP_OK;
-}
+/* ── /dictation family extracted to debug_server_dictation.c
+ *    (Wave 23b, #332). ─────────────────────────────────────────── */
 
 /* ── Voice state endpoint ─────────────────────────────────────────────── */
 
@@ -3227,12 +3187,7 @@ esp_err_t tab5_debug_server_init(void)
     const httpd_uri_t uri_call_restore = {
         .uri = "/call/restore",     .method = HTTP_POST, .handler = call_restore_handler
     };
-    const httpd_uri_t uri_dictation_post = {
-        .uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler
-    };
-    const httpd_uri_t uri_dictation_get = {
-        .uri = "/dictation", .method = HTTP_GET, .handler = dictation_handler
-    };
+    /* /dictation (POST + GET) registered en-bloc via debug_server_dictation_register() below. */
     /* /wifi/kick registered en-bloc via debug_server_wifi_register() below. */
     const httpd_uri_t uri_selftest = {
         .uri = "/selftest", .method = HTTP_GET, .handler = selftest_handler
@@ -3325,8 +3280,8 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_call_unmute);
     httpd_register_uri_handler(server, &uri_call_minimize);
     httpd_register_uri_handler(server, &uri_call_restore);
-    httpd_register_uri_handler(server, &uri_dictation_post);
-    httpd_register_uri_handler(server, &uri_dictation_get);
+    /* Wave 23b (#332): /dictation family registered en-bloc. */
+    debug_server_dictation_register(server);
     /* Wave 23b (#332): WiFi diagnostic + recovery family registered en-bloc. */
     debug_server_wifi_register(server);
     httpd_register_uri_handler(server, &uri_selftest);

--- a/main/debug_server_dictation.c
+++ b/main/debug_server_dictation.c
@@ -1,0 +1,73 @@
+/*
+ * debug_server_dictation.c — POST /dictation + GET /dictation handlers.
+ *
+ * Wave 23b follow-up (#332): ninth per-family extract.  Single
+ * handler moved verbatim from debug_server.c.  Only call-site changes
+ * are the standard `check_auth` → `tab5_debug_check_auth` substitution
+ * (no send_json_resp use — the handler builds the response inline).
+ */
+
+#include "debug_server_dictation.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "debug_server_internal.h"
+#include "esp_err.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "voice.h" /* voice_start_dictation, voice_stop_listening, voice_get_dictation_text, voice_get_state */
+
+static const char *TAG = "debug_dictation";
+
+/* ── Dictation endpoint ───────────────────────────────────────────────── */
+/* POST /dictation?action=start|stop — remote dictation driver for the
+ * long-duration pipeline tests (5 / 10 / 30 min).  GET also returns the
+ * current accumulated transcript so the test harness can snapshot it
+ * mid-run.  Long-press mic is the user-facing trigger; this endpoint
+ * is the automation equivalent. */
+static esp_err_t dictation_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   char query[128] = {0};
+   char action[16] = {0};
+   if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+      httpd_query_key_value(query, "action", action, sizeof(action));
+   }
+
+   cJSON *root = cJSON_CreateObject();
+   if (req->method == HTTP_POST && strcmp(action, "start") == 0) {
+      esp_err_t err = voice_start_dictation();
+      cJSON_AddBoolToObject(root, "ok", err == ESP_OK);
+      cJSON_AddStringToObject(root, "action", "start");
+      if (err != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+   } else if (req->method == HTTP_POST && strcmp(action, "stop") == 0) {
+      esp_err_t err = voice_stop_listening();
+      cJSON_AddBoolToObject(root, "ok", err == ESP_OK);
+      cJSON_AddStringToObject(root, "action", "stop");
+      if (err != ESP_OK) cJSON_AddStringToObject(root, "error", esp_err_to_name(err));
+   } else {
+      /* GET — snapshot of current transcript + state */
+      cJSON_AddBoolToObject(root, "ok", true);
+      cJSON_AddStringToObject(root, "action", "status");
+   }
+   const char *txt = voice_get_dictation_text();
+   cJSON_AddStringToObject(root, "transcript", txt ? txt : "");
+   cJSON_AddNumberToObject(root, "transcript_len", txt ? (int)strlen(txt) : 0);
+   cJSON_AddNumberToObject(root, "state", (int)voice_get_state());
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_sendstr(req, json);
+   free(json);
+   return ESP_OK;
+}
+
+void debug_server_dictation_register(httpd_handle_t server) {
+   const httpd_uri_t uri_dictation_post = {.uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler};
+   const httpd_uri_t uri_dictation_get = {.uri = "/dictation", .method = HTTP_GET, .handler = dictation_handler};
+   httpd_register_uri_handler(server, &uri_dictation_post);
+   httpd_register_uri_handler(server, &uri_dictation_get);
+   ESP_LOGI(TAG, "Dictation endpoint family registered (2 URIs, 1 handler)");
+}

--- a/main/debug_server_dictation.h
+++ b/main/debug_server_dictation.h
@@ -1,0 +1,26 @@
+/*
+ * debug_server_dictation.h — /dictation remote-driver endpoint family.
+ *
+ * Wave 23b follow-up (#332): ninth per-family extract from
+ * debug_server.c (after K144 #336, OTA #340, codec #341, voice #342,
+ * mode #344, settings #346, WiFi #347).  Tiny self-contained extract
+ * — single handler hung off two URI methods, voice.h dependencies
+ * only.
+ *
+ * Endpoints owned by this module:
+ *   POST /dictation?action=start  — begin dictation pipeline
+ *   POST /dictation?action=stop   — stop + flush accumulated transcript
+ *   GET  /dictation               — snapshot transcript + voice state
+ *
+ * The handler is the automation equivalent of the long-press-mic
+ * gesture and is exercised by the long-duration (5/10/30 min)
+ * dictation pipeline tests in tests/e2e/.
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the dictation endpoint family on `server`.
+ * Called from tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_dictation_register(httpd_handle_t server);


### PR DESCRIPTION
## What

Ninth per-family extract from `debug_server.c` (refs #332).  **Tiniest extract yet** — single handler hung off two URI methods, `voice.h` dependencies only.  Total moved: 37 LOC handler + 2 URI registrations.

Endpoints owned by the new `main/debug_server_dictation.{c,h}`:

* `POST /dictation?action=start`  — begin dictation pipeline
* `POST /dictation?action=stop`   — stop + flush accumulated transcript
* `GET  /dictation`               — snapshot transcript + voice state

The handler is the automation equivalent of the long-press-mic gesture and is exercised by the long-duration (5/10/30 min) dictation pipeline tests in `tests/e2e/`.

## debug_server.c shrink

| Metric | Value |
|---|---|
| This PR | 3384 → 3339 LOC (−45, −1.3 %) |
| Cumulative across 9 family extracts | 4520 → 3339 (−1181, −26.1 %) |

## Verification

### Build
\`\`\`
tinkertab.bin binary size 0x27dd00 bytes. Smallest app partition is 0x300000 bytes. (17% free)
\`\`\`

### Live on hardware (192.168.1.90)
\`\`\`
\$ curl -s -H \"Authorization: Bearer \$TOKEN\" http://192.168.1.90:8080/dictation | jq .
{
  \"ok\": true,
  \"action\": \"status\",
  \"transcript\": \"\",
  \"transcript_len\": 0,
  \"state\": 2
}
\`\`\`

### E2E
\`\`\`
══════ story_smoke ══════
  14 PASS, 0 FAIL in 101s
\`\`\`

### Format gate (replicates CI)
\`\`\`
\$ git-clang-format --binary clang-format-18 --diff origin/main -- 'main/*.c' 'main/*.h'
clang-format did not modify any files
\`\`\`

## Family map after this PR

| # | Family | File | URIs | PR |
|---|---|---|---|---|
| 1 | K144 | debug_server_m5.c | 4 | #336 |
| 2 | OTA | debug_server_ota.c | 2 | #340 |
| 3 | Codec | debug_server_codec.c | 1 | #341 |
| 4 | Voice | debug_server_voice.c | 4 | #342 (+#343) |
| 5 | Mode | debug_server_mode.c | 1 | #344 |
| 6 | Settings | debug_server_settings.c | 3 | #346 |
| 7 | WiFi | debug_server_wifi.c | 2 | #347 |
| **8** | **Dictation** | **debug_server_dictation.c** | **2** | **this PR** |

## Behavior unchanged

No URL contracts change.  No dictation lifecycle change.  Pure structural refactor — bytes flowing through `dictation_handler` are identical to pre-extract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)