### PR TITLE
refactor(voice): extract receipt + budget + cap-downgrade to voice_billing.{c,h} (SRP-3)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "mode_manager.c"
+             "voice.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"

--- a/main/voice.c
+++ b/main/voice.c
@@ -54,6 +54,7 @@
 #include "ui_home.h" /* TT #317 Phase 4: ui_home_show_toast for failover UX */
 #include "ui_notes.h"
 #include "ui_voice.h"
+#include "voice_billing.h"   /* SOLID-audit SRP-3: receipt + budget + cap-downgrade */
 #include "voice_codec.h"     /* #262: OPUS encode/decode wrapper */
 #include "voice_m5_llm.h"    /* TT #317 Phase 4: K144 LLM Module failover */
 #include "voice_video.h"     /* #266: live JPEG streaming */
@@ -308,11 +309,11 @@ static char s_llm_text[MAX_TRANSCRIPT_LEN]   = {0};
 static char s_queued_text[MAX_TRANSCRIPT_LEN] = {0};
 static bool s_queue_pending = false;
 
-/* v4·D Phase 3b: cached per-turn receipt from Dragon. */
-static int  s_last_receipt_mils       = 0;
-static int  s_last_receipt_prompt_tok = 0;
-static int  s_last_receipt_compl_tok  = 0;
-static char s_last_receipt_model[64]  = {0};
+/* v4·D Phase 3b: per-turn receipt cache moved to voice_billing.c
+ * (SOLID-audit SRP-3 extract).  The pre-extract `s_last_receipt_*`
+ * statics here were write-only — never read from anywhere — so they
+ * are not preserved on the way over.  Add a public accessor on
+ * voice_billing.h if a future caller needs them. */
 
 /* v4·D Phase 4b: cached vision capability from Dragon (camera screen). */
 static bool s_vision_capable   = false;
@@ -365,51 +366,9 @@ static void voice_build_local_uri(char *out, size_t out_cap,
                                    const char *host, uint16_t port);
 
 // ---------------------------------------------------------------------------
-// Deferred receipt attach — hops from voice WS rx task onto LVGL thread so
-// it queues AFTER ui_chat_push_message("assistant", …) from llm_done.
+// Deferred receipt attach: extracted to voice_billing.c (SOLID-audit SRP-3).
+// Public callers (TinkerClaw bypass etc.) use voice_billing.h directly.
 // ---------------------------------------------------------------------------
-typedef struct {
-    uint32_t mils;
-    uint16_t ptok;
-    uint16_t ctok;
-    bool     retried;
-    char     model_short[16];
-} receipt_attach_async_t;
-
-static void receipt_attach_async_cb(void *arg)
-{
-    receipt_attach_async_t *r = (receipt_attach_async_t *)arg;
-    if (!r) return;
-    extern int  chat_store_attach_receipt_ex(uint32_t, uint16_t, uint16_t,
-                                              const char *, bool);
-    extern void ui_chat_refresh_receipts(void);
-    chat_store_attach_receipt_ex(r->mils, r->ptok, r->ctok,
-                                  r->model_short, r->retried);
-    ui_chat_refresh_receipts();
-    free(r);
-}
-
-void voice_defer_receipt_attach(uint32_t mils,
-                                uint16_t ptok, uint16_t ctok,
-                                const char *model_short, bool retried)
-{
-    receipt_attach_async_t *r = calloc(1, sizeof(*r));
-    if (!r) {
-        /* Wave 14 W14-M08: log the drop so "my cost tracking is off"
-         * bug reports have a trail. */
-        ESP_LOGW(TAG, "voice_defer_receipt_attach OOM — dropped receipt (mils=%lu)",
-                 (unsigned long)mils);
-        return;
-    }
-    r->mils    = mils;
-    r->ptok    = ptok;
-    r->ctok    = ctok;
-    r->retried = retried;
-    if (model_short) {
-        snprintf(r->model_short, sizeof(r->model_short), "%s", model_short);
-    }
-    tab5_lv_async_call(receipt_attach_async_cb, r);
-}
 
 // ---------------------------------------------------------------------------
 // State machine
@@ -1304,111 +1263,18 @@ static void handle_text_message(const char *data, int len)
             voice_set_state(VOICE_STATE_READY, "llm_done");
         }
     } else if (strcmp(type_str, "receipt") == 0) {
-        /* v4·D Phase 3b: Dragon emits a receipt after each LLM turn on
-         * the cloud path.  Logged here for now; rendering the stamp
-         * beneath the chat bubble is a follow-up that lives in
-         * chat_msg_view.c when the store grows a receipt field.  Cost
-         * is in mils (1/1000 USD cent) so divide by 100000 for dollars
-         * or 1000 for cents. */
-        const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, "model"));
-        cJSON *ptok = cJSON_GetObjectItem(root, "prompt_tokens");
-        cJSON *ctok = cJSON_GetObjectItem(root, "completion_tokens");
-        cJSON *mils = cJSON_GetObjectItem(root, "cost_mils");
-        int pt = cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0;
-        int ct = cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0;
-        int m  = cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0;
-        ESP_LOGI(TAG, "Receipt: model=%s tok=%d+%d cost=%d mils ($%d.%05d)",
-                 model ? model : "?", pt, ct, m, m / 100000, m % 100000);
-        /* Cache for UI consumption. Accessed via voice_get_last_receipt(). */
-        s_last_receipt_mils       = m;
-        s_last_receipt_prompt_tok = pt;
-        s_last_receipt_compl_tok  = ct;
-        snprintf(s_last_receipt_model, sizeof(s_last_receipt_model),
-                 "%s", model ? model : "");
-        /* Phase 3c: accumulate into the daily spend counter. NVS write is
-         * serialised by the settings mutex; this runs in the voice WS rx
-         * task so the LVGL thread won't block. */
-        if (m > 0) {
-            tab5_budget_accumulate((uint32_t)m);
-            uint32_t spent = tab5_budget_get_today_mils();
-            uint32_t cap   = tab5_budget_get_cap_mils();
-            ESP_LOGI(TAG, "Budget: today=%lu mils / cap=%lu mils",
-                     (unsigned long)spent, (unsigned long)cap);
-            /* Nudge home to redraw its live-line spend readout. */
-            extern void ui_home_update_status(void);
-            tab5_lv_async_call((lv_async_cb_t)ui_home_update_status, NULL);
-            /* TT #328 Wave 1 — also refresh the chat-header spend badge
-             * so a turn that flipped the chip from dim → amber → red
-             * shows up the moment the receipt lands. */
-            extern void ui_chat_refresh_spend(void);
-            ui_chat_refresh_spend();
-
-            /* Phase 3e auto-downgrade: once spent >= cap AND we're in a
-             * cloud-cost-bearing mode (1=Hybrid or 2=Full Cloud), flip
-             * back to Local (voice_mode=0) + notify Dragon + surface a
-             * toast so the user knows why their next turn is free.
-             * Agent (mode 3) goes via TinkerClaw which has its own
-             * billing -- we don't auto-change it here. */
-            if (cap > 0 && spent >= cap) {
-                uint8_t cur = tab5_settings_get_voice_mode();
-                if (cur == 1 || cur == 2) {
-                    ESP_LOGW(TAG, "Budget cap reached -- auto-downgrading %d -> 0 (Local)", cur);
-                    tab5_settings_set_voice_mode(0);
-                    /* Clear llm_model override so Dragon reverts to local.
-                     * Leaving the NVS llm_model alone keeps the user's
-                     * cloud preference for when they raise the cap. */
-                    char lm[64] = {0};
-                    tab5_settings_get_llm_model(lm, sizeof(lm));
-                    /* G7-F: tag this downgrade so Dragon speaks a short TTS
-                     * alert -- the user hears the switch even with the screen
-                     * off. */
-                    voice_send_config_update_ex(0, lm, "cap_downgrade");
-                    /* Also reset the three Sovereign tiers so the mode
-                     * sheet visually reflects the downgrade. */
-                    tab5_settings_set_int_tier(0);
-                    tab5_settings_set_voi_tier(0);
-                    extern void ui_home_show_toast(const char *text);
-                    tab5_lv_async_call((lv_async_cb_t)ui_home_show_toast,
-                                  (void *)"Budget cap hit — Local mode");
-                }
-            }
-        }
-        /* Phase 3d + 4a: attach the receipt to the most-recent assistant
-         * bubble in the chat store so chat_msg_view can render a per-turn
-         * stamp.  Attach regardless of cost_mils so LOCAL turns (Ollama
-         * qwen3, cost=0) also get a "qwen3 · FREE" stamp -- engine-used
-         * transparency on every bubble, not just billable ones. */
-        cJSON *retried_j = cJSON_GetObjectItem(root, "retried");
-        bool retried = cJSON_IsTrue(retried_j);
-        /* v4·D audit P1 fix: always stamp the bubble, even when model is
-         * missing -- a blank model still tells the user the turn finished
-         * and the cost was zero.  Previously the null/empty-model path
-         * silently swallowed the receipt and the user never saw any
-         * stamp on a local turn that Dragon forgot to name. */
-        {
-            char short_model[16] = {0};
-            const char *mp = (model && model[0]) ? model : "local";
-            const char *slash = strchr(mp, '/');
-            const char *tail = slash ? slash + 1 : mp;
-            const char *hyphen = strchr(tail, '-');  /* skip vendor prefix "claude-" */
-            const char *start = hyphen ? hyphen + 1 : tail;
-            snprintf(short_model, sizeof(short_model), "%s", start);
-            /* Defer the attach onto the LVGL thread.  ui_chat_push_message
-             * ("assistant", …) from llm_done enqueues via lv_async_call a
-             * few ms before this handler runs; if we attach synchronously
-             * here (on the voice WS rx task) the assistant bubble is not
-             * yet in chat_store, attach returns -1, and the stamp is
-             * silently dropped.  Queuing via lv_async_call after the push
-             * preserves FIFO order — push lands first, attach lands
-             * second — and both run on the LVGL thread. */
-            extern void voice_defer_receipt_attach(uint32_t mils,
-                                                    uint16_t ptok,
-                                                    uint16_t ctok,
-                                                    const char *model_short,
-                                                    bool retried);
-            voice_defer_receipt_attach((uint32_t)m, (uint16_t)pt,
-                                        (uint16_t)ct, short_model, retried);
-        }
+       /* SOLID-audit SRP-3 (2026-05-03): receipt accounting + cap-downgrade
+        * policy + chat-bubble stamp deferral all moved to voice_billing.c.
+        * Voice.c parses the JSON fields and hands them in typed; the
+        * billing module owns the rest of the chain. */
+       const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, "model"));
+       cJSON *ptok = cJSON_GetObjectItem(root, "prompt_tokens");
+       cJSON *ctok = cJSON_GetObjectItem(root, "completion_tokens");
+       cJSON *mils = cJSON_GetObjectItem(root, "cost_mils");
+       cJSON *retried_j = cJSON_GetObjectItem(root, "retried");
+       voice_billing_record_receipt(model, cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0,
+                                    cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0,
+                                    cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0, cJSON_IsTrue(retried_j));
     } else if (strcmp(type_str, "text_update") == 0) {
         const char *text = cJSON_GetStringValue(cJSON_GetObjectItem(root, "text"));
         if (text) {

--- a/main/voice_billing.c
+++ b/main/voice_billing.c
@@ -1,0 +1,143 @@
+/*
+ * voice_billing.c — receipt + budget + cap-downgrade implementation.
+ *
+ * 2026-05-03 SOLID audit SRP-3 extract from voice.c.  Verbatim move
+ * of the receipt-verb branch + the deferred-attach machinery; only
+ * call-site changes are header includes replacing the prior extern
+ * decls inside voice.c.
+ */
+
+#include "voice_billing.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chat_msg_store.h" /* chat_store_attach_receipt_ex */
+#include "esp_log.h"
+#include "settings.h" /* tab5_settings_*, tab5_budget_* */
+#include "ui_chat.h"  /* ui_chat_refresh_receipts, ui_chat_refresh_spend */
+#include "ui_core.h"  /* tab5_lv_async_call (#258) */
+#include "ui_home.h"  /* ui_home_update_status, ui_home_show_toast */
+#include "voice.h"    /* voice_send_config_update_ex */
+
+static const char *TAG = "voice_billing";
+
+/* ── Deferred receipt attach ─────────────────────────────────────────── */
+/* Hops from voice WS rx task onto LVGL thread so it queues AFTER
+ * ui_chat_push_message("assistant", ...) from llm_done. */
+typedef struct {
+   uint32_t mils;
+   uint16_t ptok;
+   uint16_t ctok;
+   bool retried;
+   char model_short[16];
+} receipt_attach_async_t;
+
+static void receipt_attach_async_cb(void *arg) {
+   receipt_attach_async_t *r = (receipt_attach_async_t *)arg;
+   if (!r) return;
+   chat_store_attach_receipt_ex(r->mils, r->ptok, r->ctok, r->model_short, r->retried);
+   ui_chat_refresh_receipts();
+   free(r);
+}
+
+void voice_billing_defer_receipt_attach_async(uint32_t mils, uint16_t ptok, uint16_t ctok, const char *model_short,
+                                              bool retried) {
+   receipt_attach_async_t *r = calloc(1, sizeof(*r));
+   if (!r) {
+      /* Wave 14 W14-M08: log the drop so "my cost tracking is off"
+       * bug reports have a trail. */
+      ESP_LOGW(TAG, "voice_billing_defer_receipt_attach OOM — dropped receipt (mils=%lu)", (unsigned long)mils);
+      return;
+   }
+   r->mils = mils;
+   r->ptok = ptok;
+   r->ctok = ctok;
+   r->retried = retried;
+   if (model_short) {
+      snprintf(r->model_short, sizeof(r->model_short), "%s", model_short);
+   }
+   tab5_lv_async_call(receipt_attach_async_cb, r);
+}
+
+/* ── /receipt WS verb handler ─────────────────────────────────────── */
+
+void voice_billing_record_receipt(const char *model, int pt, int ct, int m, bool retried) {
+   ESP_LOGI(TAG, "Receipt: model=%s tok=%d+%d cost=%d mils ($%d.%05d)", model ? model : "?", pt, ct, m, m / 100000,
+            m % 100000);
+
+   /* Phase 3c: accumulate into the daily spend counter. NVS write is
+    * serialised by the settings mutex; this runs in the voice WS rx
+    * task so the LVGL thread won't block. */
+   if (m > 0) {
+      tab5_budget_accumulate((uint32_t)m);
+      uint32_t spent = tab5_budget_get_today_mils();
+      uint32_t cap = tab5_budget_get_cap_mils();
+      ESP_LOGI(TAG, "Budget: today=%lu mils / cap=%lu mils", (unsigned long)spent, (unsigned long)cap);
+
+      /* Nudge home to redraw its live-line spend readout. */
+      tab5_lv_async_call((lv_async_cb_t)ui_home_update_status, NULL);
+      /* TT #328 Wave 1 — also refresh the chat-header spend badge
+       * so a turn that flipped the chip from dim → amber → red
+       * shows up the moment the receipt lands. */
+      ui_chat_refresh_spend();
+
+      /* Phase 3e auto-downgrade: once spent >= cap AND we're in a
+       * cloud-cost-bearing mode (1=Hybrid or 2=Full Cloud), flip
+       * back to Local (voice_mode=0) + notify Dragon + surface a
+       * toast so the user knows why their next turn is free.
+       * Agent (mode 3) goes via TinkerClaw which has its own
+       * billing -- we don't auto-change it here. */
+      if (cap > 0 && spent >= cap) {
+         uint8_t cur = tab5_settings_get_voice_mode();
+         if (cur == 1 || cur == 2) {
+            ESP_LOGW(TAG, "Budget cap reached -- auto-downgrading %d -> 0 (Local)", cur);
+            tab5_settings_set_voice_mode(0);
+            /* Clear llm_model override so Dragon reverts to local.
+             * Leaving the NVS llm_model alone keeps the user's
+             * cloud preference for when they raise the cap. */
+            char lm[64] = {0};
+            tab5_settings_get_llm_model(lm, sizeof(lm));
+            /* G7-F: tag this downgrade so Dragon speaks a short TTS
+             * alert -- the user hears the switch even with the screen
+             * off. */
+            voice_send_config_update_ex(0, lm, "cap_downgrade");
+            /* Also reset the three Sovereign tiers so the mode
+             * sheet visually reflects the downgrade. */
+            tab5_settings_set_int_tier(0);
+            tab5_settings_set_voi_tier(0);
+            tab5_lv_async_call((lv_async_cb_t)ui_home_show_toast, (void *)"Budget cap hit — Local mode");
+         }
+      }
+   }
+
+   /* Phase 3d + 4a: attach the receipt to the most-recent assistant
+    * bubble in the chat store so chat_msg_view can render a per-turn
+    * stamp.  Attach regardless of cost_mils so LOCAL turns (Ollama
+    * qwen3, cost=0) also get a "qwen3 · FREE" stamp -- engine-used
+    * transparency on every bubble, not just billable ones.
+    *
+    * v4·D audit P1 fix: always stamp the bubble, even when model is
+    * missing -- a blank model still tells the user the turn finished
+    * and the cost was zero.  Previously the null/empty-model path
+    * silently swallowed the receipt and the user never saw any
+    * stamp on a local turn that Dragon forgot to name. */
+   char short_model[16] = {0};
+   const char *mp = (model && model[0]) ? model : "local";
+   const char *slash = strchr(mp, '/');
+   const char *tail = slash ? slash + 1 : mp;
+   const char *hyphen = strchr(tail, '-'); /* skip vendor prefix "claude-" */
+   const char *start = hyphen ? hyphen + 1 : tail;
+   snprintf(short_model, sizeof(short_model), "%s", start);
+   /* Defer the attach onto the LVGL thread.  ui_chat_push_message
+    * ("assistant", ...) from llm_done enqueues via lv_async_call a
+    * few ms before this handler runs; if we attach synchronously
+    * here (on the voice WS rx task) the assistant bubble is not
+    * yet in chat_store, attach returns -1, and the stamp is
+    * silently dropped.  Queuing via lv_async_call after the push
+    * preserves FIFO order — push lands first, attach lands
+    * second — and both run on the LVGL thread. */
+   voice_billing_defer_receipt_attach_async((uint32_t)m, (uint16_t)pt, (uint16_t)ct, short_model, retried);
+}

--- a/main/voice_billing.h
+++ b/main/voice_billing.h
@@ -1,0 +1,74 @@
+/*
+ * voice_billing.h — receipt + budget + cap-downgrade module.
+ *
+ * 2026-05-03 SOLID audit (SRP-3 / P1, see docs/AUDIT-solid-2026-05-03.md):
+ * voice.c's `handle_text_message()` had 110 LOC of receipt-handling logic
+ * inside the WS verb dispatch — token accounting, NVS budget accumulate,
+ * UI refresh hops, and the cap-triggered auto-downgrade rule, all
+ * tangled with the WS frame parser.  Extra ~40 LOC of
+ * `voice_defer_receipt_attach` machinery + last_receipt_* statics
+ * compounded the SRP violation.
+ *
+ * Billing policy (cap-triggered mode downgrade, "Hybrid+Cloud → Local;
+ * Agent unchanged") is a different axis of change than "Dragon sent
+ * me a receipt frame" — extending to "warn at 80% before downgrade"
+ * shouldn't force an edit deep inside the WS dispatcher.  Pulling
+ * the chain into voice_billing.{c,h} gives policy + receipt rendering
+ * a single home.
+ *
+ * Endpoints owned by this module:
+ *   * `voice_billing_record_receipt` — entry point called from voice.c's
+ *     receipt-verb branch.  Owns NVS write, UI refresh, cap-policy.
+ *   * `voice_billing_defer_receipt_attach_async` — async LVGL-thread
+ *     hop for the chat-bubble receipt stamp.  Stays public because
+ *     other receipt-emitting paths (TinkerClaw bypass, possible
+ *     future skill-emitted receipts) may need to call it directly.
+ *
+ * The `s_last_receipt_*` statics in the pre-extract voice.c were
+ * write-only — never read from anywhere — so they are NOT preserved
+ * here.  If a future caller needs the cached receipt, add a public
+ * `voice_billing_get_last_receipt(...)` accessor.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Forward decl — keep this header self-sufficient without dragging in
+ * cJSON.h on every consumer just for the prototype. */
+struct cJSON;
+
+/* Process a "receipt" WS frame from Dragon.  Owns the full chain:
+ *   - log the receipt to ESP_LOGI
+ *   - if cost_mils > 0: accumulate into the daily NVS budget
+ *   - nudge home + chat UI to re-render their spend chips
+ *   - if spent >= cap AND voice_mode is Hybrid (1) or Cloud (2):
+ *     auto-downgrade to Local (0), notify Dragon via
+ *     voice_send_config_update_ex(0, llm, "cap_downgrade"), reset the
+ *     int_tier + voi_tier dials, surface a "Budget cap hit" toast
+ *   - regardless of cost: defer-attach a per-bubble receipt stamp via
+ *     voice_billing_defer_receipt_attach_async() so chat_msg_view can
+ *     render "claude-haiku · $0.0042" (or "local · FREE") below the
+ *     last assistant bubble.
+ *
+ * Caller (voice.c WS dispatcher) parses the JSON fields out of `root`
+ * and hands them in typed.  This keeps cJSON dependency on the WS
+ * parser side and lets the billing module stay testable without a
+ * cJSON mock.
+ */
+void voice_billing_record_receipt(const char *model_id, int prompt_tok, int compl_tok, int cost_mils, bool retried);
+
+/* Async LVGL-thread hop for the per-bubble receipt stamp.  Pre-extract
+ * this lived in voice.c as `voice_defer_receipt_attach`; same shape,
+ * same semantics — just in its proper home now.
+ *
+ * Dragon's `llm_done` path enqueues `ui_chat_push_message("assistant",
+ * ...)` via lv_async_call ~ms before the WS rx task receives the
+ * receipt.  If this attached synchronously on the rx task, the
+ * assistant bubble wouldn't yet be in chat_store and the stamp would
+ * silently drop.  Queuing via lv_async_call after the push preserves
+ * FIFO order — push lands first, attach lands second — both on the
+ * LVGL thread. */
+void voice_billing_defer_receipt_attach_async(uint32_t mils, uint16_t prompt_tok, uint16_t compl_tok,
+                                              const char *model_short, bool retried);


### PR DESCRIPTION
## What

Closes audit **SRP-3** (P1). Pulls 110 LOC of receipt-handling logic out of voice.c's `handle_text_message()` WS verb dispatcher into a new `main/voice_billing.{c,h}` module that owns:

* The `receipt` WS verb chain — log, NVS budget accumulate, UI refresh hops.
* The cap-triggered auto-downgrade rule (Hybrid+Cloud → Local; Agent unchanged; toast).
* The deferred chat-bubble receipt-stamp attach (renamed `voice_billing_defer_receipt_attach_async` for namespace clarity).

The audit's complaint: billing policy ("warn at 80% before downgrade", "different policy per user") is a different axis of change than \"Dragon sent me a receipt frame\". Pre-fix, extending the policy required editing a 110-LOC block buried inside the WS dispatcher. Post-fix, voice.c just does JSON unmarshalling and hands typed values into `voice_billing_record_receipt(model, pt, ct, mils, retried)`.

## What got dropped on the way over

Four `s_last_receipt_mils/_prompt_tok/_compl_tok/_model` statics were write-only in the pre-extract code — never read from any caller in the tree. The comment claimed \"Accessed via voice_get_last_receipt()\" but `voice_get_last_receipt()` doesn't exist. Pure dead state — not preserved on the way over. If a future caller needs them, add a `voice_billing_get_last_receipt(...)` accessor.

## voice.c receipt branch shrink

110 LOC → 14 LOC of pure JSON parse + typed call:

\`\`\`c
} else if (strcmp(type_str, \"receipt\") == 0) {
    const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, \"model\"));
    cJSON *ptok = cJSON_GetObjectItem(root, \"prompt_tokens\");
    cJSON *ctok = cJSON_GetObjectItem(root, \"completion_tokens\");
    cJSON *mils = cJSON_GetObjectItem(root, \"cost_mils\");
    cJSON *retried_j = cJSON_GetObjectItem(root, \"retried\");
    voice_billing_record_receipt(
        model,
        cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0,
        cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0,
        cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0,
        cJSON_IsTrue(retried_j));
}
\`\`\`

cJSON dependency stays on the WS parser side. The billing module is now testable without a cJSON mock.

## voice.c shrink

| Metric | Value |
|---|---|
| This PR | 4001 → 3867 LOC (−134, −3.4 %) |
| Cumulative voice.c shrink (Wave 23b) | 4251 → 3867 (−384, −9.0 %) |

Combined with the 9 debug_server family extracts (4520 → 3339), the C tree is materially leaner.

## Verification

### Build
\`\`\`
tinkertab.bin binary size 0x27df00 bytes. Smallest app partition is 0x300000 bytes. (17% free)
\`\`\`

### E2E
\`\`\`
══════ story_smoke ══════
  14 PASS, 0 FAIL in 90s
\`\`\`

Step 7 (chat → llm_done) exercises the receipt path on a Local-mode turn — `cost_mils=0` so the budget-accumulate branch correctly stays as no-op, but `voice_billing_record_receipt` was called and the chat-bubble stamp deferred.

### Format gate (replicates CI)
\`\`\`
\$ git-clang-format --binary clang-format-18 --diff origin/main -- 'main/*.c' 'main/*.h'
clang-format did not modify any files
\`\`\`

## Risk

Verbatim move; behaviour is bit-for-bit identical to pre-extract. The cap-downgrade auto-policy is NOT exercised live in this smoke (would need a Cloud-mode + cap-exceed scenario), but the code is a copy from pre-extract so the risk is bounded to \"function never called\" — which the smoke + the `voice_billing` ESP_LOGI message would surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)