### PR TITLE
refactor(voice): extract voice_ws_proto.{c,h} (closes #353, refs #331)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "mode_manager.c"
+             "voice.c" "voice_ws_proto.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"

--- a/main/voice.c
+++ b/main/voice.c
@@ -59,6 +59,7 @@
 #include "voice_m5_llm.h"    /* TT #317 Phase 4: K144 LLM Module failover */
 #include "voice_video.h"     /* #266: live JPEG streaming */
 #include "voice_widget_ws.h" /* SOLID-audit SRP-2: widget WS verb dispatch */
+#include "voice_ws_proto.h"  /* TT #331 Wave 23 SRP-A1: WS proto layer */
 #include "widget.h"
 #include "wifi.h"
 
@@ -191,12 +192,15 @@ static SemaphoreHandle_t s_state_mutex = NULL;
 static volatile uint32_t s_session_gen = 0;
 
 // WebSocket client (esp_websocket_client managed component)
-/* Wave 14 W14-M03: volatile because s_ws is written on Core 1's WS
+/* Wave 14 W14-M03: volatile because g_voice_ws is written on Core 1's WS
  * task (connect/disconnect) and read on Core 0's LVGL thread
  * (voice_send_text, voice_start_listening, async_connect_task poll).
  * Without volatile the compiler may cache the load across a
- * disconnect and use-after-free the freed WS client. */
-static esp_websocket_client_handle_t volatile s_ws = NULL;
+ * disconnect and use-after-free the freed WS client.
+ * Wave 23 SRP-A1 (TT #331): promoted from static so voice_ws_proto.c
+ * can reach the handle without per-call getter churn.  Declared in
+ * voice.h. */
+esp_websocket_client_handle_t volatile g_voice_ws = NULL;
 
 // Dragon connection info (last-known, updated on each connect)
 static char     s_dragon_host[64] = {0};
@@ -330,8 +334,9 @@ static volatile float s_current_rms       = 0.0f;
 static char           s_dictation_title[128]   = {0};
 static char           s_dictation_summary[512] = {0};
 
-// Drop counter for audio frames lost under back-pressure (US-C04)
-static int s_audio_drop_count = 0;
+/* Drop counter for audio frames lost under back-pressure (US-C04) was
+ * moved to voice_ws_proto.c alongside voice_ws_send_binary (the only
+ * writer). */
 
 /* TT #327 Wave 4b: K144 failover state + autonomous chain were extracted
  * into main/voice_onboard.{c,h}.  voice.c only needs the WS-down grace
@@ -358,12 +363,9 @@ static void handle_text_message(const char *data, int len);
 static void playback_buf_reset(void);
 static size_t playback_buf_write(const int16_t *data, size_t samples);
 static size_t playback_buf_read(int16_t *data, size_t max_samples);
-static esp_err_t voice_ws_send_text(const char *msg);
-static esp_err_t voice_ws_send_register(void);
-static void voice_ws_event_handler(void *arg, esp_event_base_t base,
-                                    int32_t event_id, void *event_data);
-static void voice_build_local_uri(char *out, size_t out_cap,
-                                   const char *host, uint16_t port);
+/* TT #331 Wave 23: voice_ws_send_text + voice_ws_send_register +
+ * voice_ws_event_handler + voice_build_local_uri were moved to
+ * voice_ws_proto.c.  Their prototypes live in voice_ws_proto.h. */
 
 // ---------------------------------------------------------------------------
 // Deferred receipt attach: extracted to voice_billing.c (SOLID-audit SRP-3).
@@ -520,156 +522,10 @@ void voice_reset_activity_timestamp(void)
 }
 
 // ---------------------------------------------------------------------------
-// WebSocket send helpers (wrapping esp_websocket_client_send_*)
+// WebSocket send helpers + device registration: extracted to voice_ws_proto.c
+// (TT #331 Wave 23 SRP-A1).  voice.c now consumes voice_ws_send_text /
+// voice_ws_send_binary / voice_ws_send_register via voice_ws_proto.h.
 // ---------------------------------------------------------------------------
-static esp_err_t voice_ws_send_text(const char *msg)
-{
-    if (!s_ws) return ESP_ERR_INVALID_STATE;
-    if (!esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
-    if (!msg) return ESP_ERR_INVALID_ARG;
-
-    size_t len = strlen(msg);
-    /* Wave 14 W14-L02: bound the size_t→int cast.  Realistic messages
-     * are <256 bytes but an unchecked cast would silently truncate on
-     * an accidental >2 GB string (e.g. a corrupted LLM response
-     * flowing through text_update). */
-    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
-    int w = esp_websocket_client_send_text(s_ws, msg, (int)len, pdMS_TO_TICKS(1000));
-    if (w < 0) {
-        ESP_LOGW(TAG, "WS text send failed (%zu bytes)", len);
-        return ESP_FAIL;
-    }
-    return ESP_OK;
-}
-
-static esp_err_t voice_ws_send_binary(const void *data, size_t len)
-{
-    if (!s_ws) return ESP_ERR_INVALID_STATE;
-    if (!esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
-    if (!data) return ESP_ERR_INVALID_ARG;
-    /* W14-L02: same bound as text. */
-    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
-
-    /* Short 100 ms timeout — we drop frames under pressure rather than
-     * block the mic task. If WiFi stalls, I2S DMA would overflow. */
-    int w = esp_websocket_client_send_bin(s_ws, (const char *)data, (int)len,
-                                          pdMS_TO_TICKS(100));
-    if (w < 0) {
-        s_audio_drop_count++;
-        if (s_audio_drop_count % 10 == 1) {
-            ESP_LOGW(TAG, "WS binary send dropped — %d frames lost", s_audio_drop_count);
-        }
-        return ESP_ERR_TIMEOUT;
-    }
-    if (s_audio_drop_count > 0) {
-        ESP_LOGI(TAG, "WS binary send recovered after %d drops", s_audio_drop_count);
-        s_audio_drop_count = 0;
-    }
-    return ESP_OK;
-}
-
-/* #266: thin public wrapper for voice_video.c (and any future binary
- * sender).  Behavior is identical to voice_ws_send_binary — same
- * 100 ms send timeout, same drop accounting. */
-esp_err_t voice_ws_send_binary_public(const void *data, size_t len)
-{
-    return voice_ws_send_binary(data, len);
-}
-
-// ---------------------------------------------------------------------------
-// Device registration — sent as FIRST text frame from the CONNECTED handler.
-// This is the #76 fix: register is sent from inside the event handler, AFTER
-// the client's event task is running and ready to dispatch the server's
-// session_start reply. The legacy code sent register synchronously before
-// spawning the receive task, which opened a 50–500ms window where Dragon's
-// reply arrived while nothing was draining the SDIO RX buffer.
-// ---------------------------------------------------------------------------
-static esp_err_t voice_ws_send_register(void)
-{
-    char device_id[16]   = {0};
-    char hardware_id[20] = {0};
-    char session_id[64]  = {0};
-
-    tab5_settings_get_device_id(device_id, sizeof(device_id));
-    tab5_settings_get_hardware_id(hardware_id, sizeof(hardware_id));
-    tab5_settings_get_session_id(session_id, sizeof(session_id));
-
-    cJSON *root = cJSON_CreateObject();
-    if (!root) return ESP_ERR_NO_MEM;
-
-    cJSON_AddStringToObject(root, "type", "register");
-    cJSON_AddStringToObject(root, "device_id", device_id);
-    cJSON_AddStringToObject(root, "hardware_id", hardware_id);
-    cJSON_AddStringToObject(root, "name", "Tab5");
-    cJSON_AddStringToObject(root, "firmware_ver", TAB5_FIRMWARE_VER);
-    cJSON_AddStringToObject(root, "platform", TAB5_PLATFORM);
-
-    if (session_id[0] != '\0') {
-        cJSON_AddStringToObject(root, "session_id", session_id);
-    } else {
-        cJSON_AddNullToObject(root, "session_id");
-    }
-
-    cJSON *caps = cJSON_AddObjectToObject(root, "capabilities");
-    cJSON_AddBoolToObject(caps, "mic", true);
-    cJSON_AddBoolToObject(caps, "speaker", true);
-    cJSON_AddBoolToObject(caps, "screen", true);
-    cJSON_AddBoolToObject(caps, "camera", true);
-    cJSON_AddBoolToObject(caps, "sd_card", true);
-    cJSON_AddBoolToObject(caps, "touch", true);
-    /* #266: live JPEG video uplink.  Tab5 sends per-frame binary WS
-     * frames prefixed with the "VID0" 4-byte magic + 4-byte length.
-     * Dragon detects the magic to route video vs audio. */
-    cJSON_AddBoolToObject(caps, "video_send", true);
-    cJSON_AddBoolToObject(caps, "video_recv", true);   /* #268 Phase 3B */
-    cJSON_AddNumberToObject(caps, "video_max_fps", 10);
-    cJSON_AddNumberToObject(caps, "video_format", 0);  /* 0 = JPEG */
-    /* #262: advertise audio codec support.  Dragon picks one and replies
-     * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
-     * until Dragon switches it.  Per-direction so the broken uplink
-     * encoder (#262 follow-up: silk_NSQ_c crashes on this build) doesn't
-     * starve the working downlink decoder; until the encoder ships,
-     * advertise opus only on the downlink. */
-    cJSON *acodecs = cJSON_AddArrayToObject(caps, "audio_codec");
-    cJSON_AddItemToArray(acodecs, cJSON_CreateString("pcm"));
-#if VOICE_CODEC_OPUS_UPLINK_ENABLED
-    cJSON_AddItemToArray(acodecs, cJSON_CreateString("opus"));
-#endif
-    cJSON *acodecs_dl = cJSON_AddArrayToObject(caps, "audio_downlink_codec");
-    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("pcm"));
-    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("opus"));
-    /* v4·D audit P0 fix: widget_capability was spec-only -- now wired.
-     * Skills can downgrade widget content for low-end clients (smaller
-     * list, lower image res).  Match the actual Tab5 limits we've
-     * built out across widget_store.c / ui_home.c. */
-    cJSON *widgets = cJSON_AddObjectToObject(caps, "widgets");
-    cJSON *types = cJSON_AddArrayToObject(widgets, "types");
-    cJSON_AddItemToArray(types, cJSON_CreateString("live"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("card"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("list"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("chart"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("media"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("prompt"));
-    cJSON_AddNumberToObject(widgets, "list_max_items", 5);
-    cJSON_AddNumberToObject(widgets, "chart_max_points", 12);
-    cJSON_AddNumberToObject(widgets, "prompt_max_choices", 3);
-    cJSON_AddNumberToObject(widgets, "screen_w", 720);
-    cJSON_AddNumberToObject(widgets, "screen_h", 1280);
-    cJSON_AddNumberToObject(widgets, "media_max_w", 660);
-    cJSON_AddNumberToObject(widgets, "media_max_h", 440);
-    cJSON_AddNumberToObject(widgets, "action_rate_per_sec", 4);
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    if (!json) return ESP_ERR_NO_MEM;
-
-    ESP_LOGI(TAG, "Sending register: device=%s hw=%s session=%s",
-             device_id, hardware_id, session_id[0] ? session_id : "(new)");
-
-    esp_err_t err = voice_ws_send_text(json);
-    cJSON_free(json);
-    return err;
-}
 
 // ---------------------------------------------------------------------------
 // US-C02: Generation-guarded async call wrappers.
@@ -697,9 +553,9 @@ typedef struct {
 static void _voice_stop_ws_worker_fn(void *arg)
 {
     (void)arg;
-    if (s_ws) {
+    if (g_voice_ws) {
         ESP_LOGW(TAG, "device_evicted worker: stopping WS client now");
-        esp_websocket_client_stop(s_ws);
+        esp_websocket_client_stop(g_voice_ws);
     }
 }
 
@@ -713,10 +569,10 @@ static void _voice_stop_ws_worker_fn(void *arg)
 static void _voice_auth_fail_stop_worker_fn(void *arg)
 {
     (void)arg;
-    if (s_ws) {
+    if (g_voice_ws) {
         ESP_LOGW(TAG, "auth_failed worker: stopping WS after %d consecutive 401s",
                  s_auth_fail_cnt);
-        esp_websocket_client_stop(s_ws);
+        esp_websocket_client_stop(g_voice_ws);
     }
 }
 
@@ -1074,7 +930,7 @@ static void handle_text_message(const char *data, int len)
             /* FATAL → existing caption path. */
             playback_buf_reset();
             tab5_audio_speaker_enable(false);
-            bool connected = (s_ws != NULL) && esp_websocket_client_is_connected(s_ws);
+            bool connected = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
             voice_set_state(connected ? VOICE_STATE_READY : VOICE_STATE_IDLE, err_buf);
 
             /* device_evicted: don't loop the eviction.  Stop the WS
@@ -1088,7 +944,7 @@ static void handle_text_message(const char *data, int len)
              * stopped from websocket task" and no-ops).  Hop to the
              * shared worker queue (task_worker.{c,h}) so the stop
              * runs on a non-WS task. */
-            if (strcmp(code_src, "device_evicted") == 0 && s_ws) {
+            if (strcmp(code_src, "device_evicted") == 0 && g_voice_ws) {
                 ESP_LOGW(TAG, "device_evicted: scheduling WS stop to prevent reconnect loop");
                 s_disconnecting = true;
                 tab5_worker_enqueue(_voice_stop_ws_worker_fn, NULL,
@@ -1628,7 +1484,7 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
          * long-running healthy session doesn't get hit with a 30 s
          * delay on its first blip. */
         s_connect_attempt = 0;
-        esp_websocket_client_set_reconnect_timeout(s_ws, WS_CLIENT_BACKOFF_MIN_MS);
+        esp_websocket_client_set_reconnect_timeout(g_voice_ws, WS_CLIENT_BACKOFF_MIN_MS);
 
         esp_err_t reg_err = voice_ws_send_register();
         if (reg_err != ESP_OK) {
@@ -1685,7 +1541,7 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
             ESP_LOGI(TAG, "WS: reconnect attempt=%d backoff=%lums (exp=%lums)",
                      s_connect_attempt, (unsigned long)delay_ms,
                      (unsigned long)exp_ms);
-            esp_websocket_client_set_reconnect_timeout(s_ws, delay_ms);
+            esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
         }
         /* #146: WS-level escalation.  If Wi-Fi probes claim we're fine
          * (probe task still sees lan=1/ngrok=1) but the voice WS keeps
@@ -1756,7 +1612,7 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
          * that Tab5 is actively trying, not dead.  The managed WS
          * client's auto-reconnect picks up the new timeout. */
         ESP_LOGI(TAG, "WS: CLOSED — scheduling reconnect");
-        if (s_ws && !s_disconnecting) {
+        if (g_voice_ws && !s_disconnecting) {
             s_connect_attempt++;
             int shift = s_connect_attempt - 1;
             if (shift < 0) shift = 0;
@@ -1768,7 +1624,7 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
             uint32_t delay_ms = half + jitter;
             ESP_LOGI(TAG, "WS: CLOSED reconnect attempt=%d backoff=%lums",
                      s_connect_attempt, (unsigned long)delay_ms);
-            esp_websocket_client_set_reconnect_timeout(s_ws, delay_ms);
+            esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
             if (tab5_wifi_connected()) {
                 voice_set_state(VOICE_STATE_RECONNECTING, "closed");
             } else {
@@ -1852,7 +1708,7 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
             if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
             uint32_t half = exp_ms / 2;
             uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
-            esp_websocket_client_set_reconnect_timeout(s_ws, half + jitter);
+            esp_websocket_client_set_reconnect_timeout(g_voice_ws, half + jitter);
         }
 
         /* γ3-Tab5 (issue #198): 401 specifically means auth failed —
@@ -1922,12 +1778,12 @@ static void voice_ws_event_handler(void *arg, esp_event_base_t base,
                 /* set_uri requires a stopped client. The client is
                  * currently between reconnect attempts; stop+set+start
                  * to force it onto the new URI immediately. */
-                esp_websocket_client_stop(s_ws);
-                esp_websocket_client_set_uri(s_ws, ngrok_uri);
+                esp_websocket_client_stop(g_voice_ws);
+                esp_websocket_client_set_uri(g_voice_ws, ngrok_uri);
                 strncpy(s_dragon_host, TAB5_NGROK_HOST, sizeof(s_dragon_host) - 1);
                 s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
                 s_dragon_port = TAB5_NGROK_PORT;
-                esp_websocket_client_start(s_ws);
+                esp_websocket_client_start(g_voice_ws);
             }
         }
         break;
@@ -2002,7 +1858,7 @@ static void mic_capture_task(void *arg)
     int cal_count = 0;
     float dictation_threshold = DICTATION_SILENCE_THRESHOLD;
 
-    bool ws_live = (s_ws != NULL) && esp_websocket_client_is_connected(s_ws);
+    bool ws_live = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
 
     while (s_mic_running && (ws_live || s_voice_mode == VOICE_MODE_DICTATE || s_voice_mode == VOICE_MODE_CALL)) {
         esp_err_t err = tab5_mic_read(tdm_buf, MIC_TDM_SAMPLES, 100);
@@ -2057,7 +1913,7 @@ static void mic_capture_task(void *arg)
 
         /* Re-check connection each loop — esp_websocket_client may
          * have reconnected (or gone away) in the background. */
-        ws_live = (s_ws != NULL) && esp_websocket_client_is_connected(s_ws);
+        ws_live = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
 
         ui_notes_write_audio(mono_buf, out_idx);
 
@@ -2197,7 +2053,7 @@ static void mic_capture_task(void *arg)
 
     if (s_voice_mode == VOICE_MODE_DICTATE && had_speech
         && total_silence_frames >= DICTATION_AUTO_STOP_FRAMES
-        && s_ws && esp_websocket_client_is_connected(s_ws)) {
+        && g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
         voice_ws_send_text("{\"type\":\"stop\"}");
         voice_set_state(VOICE_STATE_PROCESSING, NULL);
     }
@@ -2587,15 +2443,15 @@ void voice_lan_probe_task(void *arg)
                      lan_host, (unsigned)(lan_port ? lan_port : 3502),
                      TAB5_VOICE_WS_PATH);
             ESP_LOGI(TAG, "Link probe: swapping ngrok -> LAN (%s)", lan_uri);
-            esp_websocket_client_stop(s_ws);
-            esp_websocket_client_set_uri(s_ws, lan_uri);
+            esp_websocket_client_stop(g_voice_ws);
+            esp_websocket_client_set_uri(g_voice_ws, lan_uri);
             strncpy(s_dragon_host, lan_host, sizeof(s_dragon_host) - 1);
             s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
             s_dragon_port = lan_port ? lan_port : 3502;
             s_using_ngrok = false;
             s_handshake_fail_cnt = 0;
             s_connect_attempt = 0;
-            esp_websocket_client_start(s_ws);
+            esp_websocket_client_start(g_voice_ws);
         }
     }
 }
@@ -2634,17 +2490,17 @@ static esp_err_t voice_ws_start_client(const char *dragon_host, uint16_t dragon_
 
     /* If client already exists, just re-target the URI.  The managed
      * component requires stop() before set_uri() when started. */
-    if (s_ws) {
+    if (g_voice_ws) {
         ESP_LOGI(TAG, "Re-using existing WS client; set_uri=%s", uri);
         if (s_started) {
-            esp_websocket_client_stop(s_ws);
+            esp_websocket_client_stop(g_voice_ws);
         }
-        esp_err_t ur = esp_websocket_client_set_uri(s_ws, uri);
+        esp_err_t ur = esp_websocket_client_set_uri(g_voice_ws, uri);
         if (ur != ESP_OK) {
             ESP_LOGE(TAG, "set_uri failed: %s", esp_err_to_name(ur));
             return ur;
         }
-        esp_err_t sr = esp_websocket_client_start(s_ws);
+        esp_err_t sr = esp_websocket_client_start(g_voice_ws);
         if (sr != ESP_OK) {
             ESP_LOGE(TAG, "client_start failed: %s", esp_err_to_name(sr));
             return sr;
@@ -2705,26 +2561,26 @@ static esp_err_t voice_ws_start_client(const char *dragon_host, uint16_t dragon_
         .crt_bundle_attach      = esp_crt_bundle_attach,
     };
 
-    s_ws = esp_websocket_client_init(&cfg);
-    if (!s_ws) {
+    g_voice_ws = esp_websocket_client_init(&cfg);
+    if (!g_voice_ws) {
         ESP_LOGE(TAG, "esp_websocket_client_init failed");
         return ESP_FAIL;
     }
 
-    esp_err_t er = esp_websocket_register_events(s_ws, WEBSOCKET_EVENT_ANY,
+    esp_err_t er = esp_websocket_register_events(g_voice_ws, WEBSOCKET_EVENT_ANY,
                                                   voice_ws_event_handler, NULL);
     if (er != ESP_OK) {
         ESP_LOGE(TAG, "register_events failed: %s", esp_err_to_name(er));
-        esp_websocket_client_destroy(s_ws);
-        s_ws = NULL;
+        esp_websocket_client_destroy(g_voice_ws);
+        g_voice_ws = NULL;
         return er;
     }
 
-    esp_err_t sr = esp_websocket_client_start(s_ws);
+    esp_err_t sr = esp_websocket_client_start(g_voice_ws);
     if (sr != ESP_OK) {
         ESP_LOGE(TAG, "client_start failed: %s", esp_err_to_name(sr));
-        esp_websocket_client_destroy(s_ws);
-        s_ws = NULL;
+        esp_websocket_client_destroy(g_voice_ws);
+        g_voice_ws = NULL;
         return sr;
     }
     s_started = true;
@@ -2742,7 +2598,7 @@ esp_err_t voice_connect(const char *dragon_host, uint16_t dragon_port)
         ESP_LOGW(TAG, "Disconnect in progress — refusing connect");
         return ESP_ERR_INVALID_STATE;
     }
-    if (s_ws && esp_websocket_client_is_connected(s_ws)) {
+    if (g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
         ESP_LOGW(TAG, "Already connected");
         return ESP_OK;
     }
@@ -2815,7 +2671,7 @@ esp_err_t voice_connect_async(const char *dragon_host, uint16_t dragon_port, boo
       ESP_LOGW(TAG, "Disconnect in progress — refusing async connect");
       return ESP_ERR_INVALID_STATE;
    }
-   if (s_ws && esp_websocket_client_is_connected(s_ws)) {
+   if (g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
       ESP_LOGW(TAG, "Already connected");
       if (auto_listen) {
          return voice_start_listening();
@@ -2872,7 +2728,7 @@ esp_err_t voice_start_listening(void)
       return voice_onboard_chain_start();
    }
 
-    bool ws_live = s_ws && esp_websocket_client_is_connected(s_ws);
+    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
     /* Wave 13 H1: snapshot state once under the mutex so the log and the
      * guard below see the same value, and neither races the WS RX callback. */
     voice_state_t cur_state = voice_get_state();
@@ -2921,7 +2777,7 @@ esp_err_t voice_start_listening(void)
 
 esp_err_t voice_start_dictation(void)
 {
-    bool ws_live = s_ws && esp_websocket_client_is_connected(s_ws);
+    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
     if (!s_initialized) {
        ESP_LOGE(TAG, "Not initialized");
        return ESP_ERR_INVALID_STATE;
@@ -3030,7 +2886,7 @@ voice_mode_t voice_get_mode(void)
  * voice_video_start_call which calls us here. */
 esp_err_t voice_call_audio_start(void)
 {
-    bool ws_live = s_ws && esp_websocket_client_is_connected(s_ws);
+    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
     if (!s_initialized || !ws_live) {
         ESP_LOGE(TAG, "voice_call_audio_start: not connected");
         return ESP_ERR_INVALID_STATE;
@@ -3107,7 +2963,7 @@ const char *voice_get_dictation_text(void)
 
 esp_err_t voice_clear_history(void)
 {
-    if (!s_ws || !esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
+    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
     ESP_LOGI(TAG, "Clearing conversation history on Dragon");
     return voice_ws_send_text("{\"type\":\"clear\"}");
 }
@@ -3133,7 +2989,7 @@ esp_err_t voice_stop_listening(void)
     * also flips state from LISTENING → RECONNECTING after 2-3 s
     * while the mic continues to write SD chunks, so the s_state
     * check below has to accept BOTH states for the offline path. */
-   bool offline_dictate = (s_voice_mode == VOICE_MODE_DICTATE) && !(s_ws && esp_websocket_client_is_connected(s_ws));
+   bool offline_dictate = (s_voice_mode == VOICE_MODE_DICTATE) && !(g_voice_ws && esp_websocket_client_is_connected(g_voice_ws));
 
    if (offline_dictate) {
       /* Permissive — mic is running, recording valid, stop should
@@ -3216,7 +3072,7 @@ esp_err_t voice_cancel(void)
     playback_buf_reset();
     tab5_audio_speaker_enable(false);
 
-    bool ws_live = s_ws && esp_websocket_client_is_connected(s_ws);
+    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
     if (ws_live) {
         voice_ws_send_text("{\"type\":\"cancel\"}");
     }
@@ -3277,8 +3133,8 @@ esp_err_t voice_disconnect(void)
      * future voice_connect/_async calls can set_uri + start without
      * re-creating everything. Destroy happens never in practice — the
      * client lives for the lifetime of the process. */
-    if (s_ws && s_started) {
-        esp_websocket_client_stop(s_ws);
+    if (g_voice_ws && s_started) {
+        esp_websocket_client_stop(g_voice_ws);
         s_started = false;
     }
 
@@ -3401,7 +3257,7 @@ esp_err_t voice_send_text(const char *text)
        return fe;
     }
 
-    if (!s_ws || !esp_websocket_client_is_connected(s_ws)) {
+    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) {
        /* TT #317 Phase 4: WS unreachable — try the K144 failover when
         * the user is in Local mode and the K144 is warm.  Falling back
         * to ESP_ERR_INVALID_STATE if any precondition fails preserves
@@ -3479,7 +3335,7 @@ esp_err_t voice_send_widget_action(const char *card_id, const char *event,
                                    const char *payload_json)
 {
     if (!card_id || !event) return ESP_ERR_INVALID_ARG;
-    if (!s_ws || !esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
+    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
 
     /* Rate limit: 4/sec max (see docs/WIDGETS.md §11). */
     static uint32_t s_action_bucket = 4;
@@ -3518,7 +3374,7 @@ esp_err_t voice_send_widget_action(const char *card_id, const char *event,
 esp_err_t voice_send_config_update_ex(int voice_mode, const char *llm_model,
                                       const char *reason)
 {
-    if (!s_ws || !esp_websocket_client_is_connected(s_ws)) return ESP_ERR_INVALID_STATE;
+    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
 
     cJSON *msg = cJSON_CreateObject();
     cJSON_AddStringToObject(msg, "type", "config_update");
@@ -3642,13 +3498,13 @@ void voice_force_reconnect(void)
 {
     /* Stop + start: the managed client will immediately re-attempt the
      * connect handshake, bypassing any pending reconnect_timeout_ms delay. */
-    if (!s_initialized || !s_ws) {
+    if (!s_initialized || !g_voice_ws) {
         ESP_LOGW(TAG, "voice_force_reconnect: client not ready");
         return;
     }
     ESP_LOGI(TAG, "Force reconnect");
-    esp_websocket_client_stop(s_ws);
-    esp_websocket_client_start(s_ws);
+    esp_websocket_client_stop(g_voice_ws);
+    esp_websocket_client_start(g_voice_ws);
     s_started = true;
 }
 
@@ -3792,9 +3648,9 @@ static void upload_chat_image_job(void *arg)
     char *txt = cJSON_PrintUnformatted(frame);
     cJSON_Delete(frame);
     if (!txt) return;
-    if (s_ws && esp_websocket_client_is_connected(s_ws)) {
+    if (g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
         size_t txtlen = strlen(txt);
-        esp_websocket_client_send_text(s_ws, txt, (int)txtlen,
+        esp_websocket_client_send_text(g_voice_ws, txt, (int)txtlen,
                                        portMAX_DELAY);
         ESP_LOGI(TAG, "user_image: announced media_id=%s", media_id);
     } else {
@@ -3825,7 +3681,7 @@ void voice_upload_chat_image(const char *filepath)
  * stop-set_uri-start dance. */
 void voice_reapply_connection_mode(void)
 {
-    if (!s_initialized || !s_ws) {
+    if (!s_initialized || !g_voice_ws) {
         ESP_LOGW(TAG, "reapply_connection_mode: client not ready");
         return;
     }
@@ -3842,5 +3698,5 @@ void voice_reapply_connection_mode(void)
 
 bool voice_is_connected(void)
 {
-    return s_ws && esp_websocket_client_is_connected(s_ws);
+    return g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
 }

--- a/main/voice.c
+++ b/main/voice.c
@@ -282,7 +282,7 @@ static SemaphoreHandle_t s_play_mutex    = NULL;
  * with headroom and matches the call-audio (AUD0) path's pre-existing
  * "max_out ≤ UPSAMPLE_BUF_CAPACITY" check shape. */
 #define UPSAMPLE_BUF_CAPACITY (8192 * 2) /* samples — 32 KB PSRAM */
-static int16_t          *s_upsample_buf  = NULL;
+int16_t                 *s_upsample_buf  = NULL;
 
 // Last transcript from Dragon STT
 char s_transcript[MAX_TRANSCRIPT_LEN] = {0};
@@ -343,7 +343,7 @@ static void mic_capture_task(void *arg);
 static void playback_drain_task(void *arg);
 /* handle_text_message → voice_ws_proto_handle_text (voice_ws_proto.h, TT #331). */
 /* voice_playback_buf_reset is now public — see voice.h */
-static size_t playback_buf_write(const int16_t *data, size_t samples);
+/* voice_playback_buf_write is now public — see voice.h */
 static size_t playback_buf_read(int16_t *data, size_t max_samples);
 /* TT #331 Wave 23: voice_ws_send_text + voice_ws_send_register +
  * voice_ws_event_handler + voice_build_local_uri were moved to
@@ -457,7 +457,7 @@ void voice_playback_buf_reset(void)
     xSemaphoreGive(s_play_mutex);
 }
 
-static size_t playback_buf_write(const int16_t *data, size_t samples)
+size_t voice_playback_buf_write(const int16_t *data, size_t samples)
 {
     xSemaphoreTake(s_play_mutex, portMAX_DELAY);
 
@@ -530,107 +530,10 @@ void voice_reset_activity_timestamp(void)
 
 
 // ---------------------------------------------------------------------------
-// Binary frame handling (TTS audio from Dragon) — called from event handler.
-// Dragon sends PCM int16 mono at 16kHz; I2S TX runs at 48kHz, so we upsample
-// 1:3 before writing to the playback ring buffer. Playback drain task
-// handles I2S writes.
+// Binary frame handling (voice_ws_proto_handle_binary): extracted to
+// voice_ws_proto.c (TT #331 Wave 23 SRP-A1, Task 1.7).
 // ---------------------------------------------------------------------------
-static size_t upsample_16k_to_48k(const int16_t *in, size_t in_samples,
-                                    int16_t *out, size_t out_capacity)
-{
-    size_t out_idx = 0;
-    for (size_t i = 0; i < in_samples && out_idx + UPSAMPLE_RATIO <= out_capacity; i++) {
-        int16_t curr = in[i];
-        int16_t next = (i + 1 < in_samples) ? in[i + 1] : curr;
-        for (int j = 0; j < UPSAMPLE_RATIO; j++) {
-            out[out_idx++] = (int16_t)(curr + (int32_t)(next - curr) * j / UPSAMPLE_RATIO);
-        }
-    }
-    return out_idx;
-}
 
-void handle_binary_message(const char *data, int len)
-{
-    /* #268: video frames carry the 4-byte "VID0" magic.  Route them
-     * to voice_video before any audio-state checks — video plays
-     * regardless of voice state (unlike TTS, which only plays in
-     * SPEAKING/PROCESSING).  Audio frames (no magic) fall through. */
-    if (voice_video_peek_downlink_magic(data, (size_t)len)) {
-        voice_video_on_downlink_frame((const uint8_t *)data, (size_t)len);
-        return;
-    }
-
-    /* #272 Phase 3E: call-audio frames carry the 4-byte "AUD0" magic.
-     * Strip the header + write the int16 PCM body straight to the
-     * playback buffer with the same upsample 16k->48k as TTS.  No
-     * state guards — call audio plays even when voice is READY. */
-    if (voice_codec_peek_call_audio_magic(data, (size_t)len)) {
-        const uint8_t *body = NULL;
-        size_t body_len = 0;
-        if (voice_codec_unpack_call_audio((const uint8_t *)data, (size_t)len,
-                                          &body, &body_len) && body_len >= 2 &&
-            s_upsample_buf) {
-            tab5_audio_speaker_enable(true);
-            const size_t in_samples = body_len / sizeof(int16_t);
-            const size_t max_out    = in_samples * UPSAMPLE_RATIO;
-            if (max_out <= UPSAMPLE_BUF_CAPACITY) {
-                size_t out_n = upsample_16k_to_48k((const int16_t *)body, in_samples,
-                                                    s_upsample_buf, max_out);
-                playback_buf_write(s_upsample_buf, out_n);
-            }
-        }
-        return;
-    }
-
-    /* v4·D audit P0 fix: snapshot s_state under the mutex so we never
-     * race with voice_set_state on another task.  The checks below
-     * formerly read s_state twice without locking -- second read could
-     * see a newer value mid-TTS-frame. */
-    voice_state_t cur;
-    if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-    cur = s_state;
-    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-
-
-    if (cur != VOICE_STATE_SPEAKING && cur != VOICE_STATE_PROCESSING) {
-        return;
-    }
-    if (cur == VOICE_STATE_PROCESSING) {
-        voice_playback_buf_reset();
-        voice_set_state(VOICE_STATE_SPEAKING, NULL);
-    }
-
-    /* #262: decode through voice_codec.  PCM is a memcpy-shaped passthrough
-     * (out_samples == in_samples), keeping the existing upsample 16k->48k
-     * path unchanged.  OPUS produces variable-length PCM (typ 320 samples
-     * per 20 ms packet) which then upsamples the same way. */
-    if (!s_upsample_buf) {
-        ESP_LOGW(TAG, "handle_binary: upsample_buf not initialized");
-        return;
-    }
-
-    /* Decode straight into a temp area in s_upsample_buf, low half;
-     * upsample reads from there and writes to the high half.
-     * Splitting avoids an extra malloc per chunk. */
-    int16_t *dec_pcm = s_upsample_buf;                          /* low half */
-    int16_t *up_out  = s_upsample_buf + (UPSAMPLE_BUF_CAPACITY / 2);  /* high half */
-    size_t dec_cap   = UPSAMPLE_BUF_CAPACITY / 2;
-    size_t in_samples = 0;
-    if (voice_codec_decode_downlink((const uint8_t *)data, (size_t)len,
-                                    dec_pcm, dec_cap, &in_samples) != ESP_OK ||
-        in_samples == 0) {
-        ESP_LOGW(TAG, "handle_binary: codec decode failed (len=%d)", len);
-        return;
-    }
-    size_t max_out = in_samples * UPSAMPLE_RATIO;
-    if (max_out > dec_cap) {
-        ESP_LOGW(TAG, "handle_binary: upsample would exceed half-buf — truncating");
-        max_out = dec_cap;
-    }
-    size_t out_samples = upsample_16k_to_48k(dec_pcm, in_samples,
-                                              up_out, max_out);
-    playback_buf_write(up_out, out_samples);
-}
 
 // ---------------------------------------------------------------------------
 // WebSocket event handler + URI helper: extracted to voice_ws_proto.c

--- a/main/voice.c
+++ b/main/voice.c
@@ -3331,45 +3331,9 @@ esp_err_t voice_send_text(const char *text)
     return ret;
 }
 
-esp_err_t voice_send_widget_action(const char *card_id, const char *event,
-                                   const char *payload_json)
-{
-    if (!card_id || !event) return ESP_ERR_INVALID_ARG;
-    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
-
-    /* Rate limit: 4/sec max (see docs/WIDGETS.md §11). */
-    static uint32_t s_action_bucket = 4;
-    static uint32_t s_action_tick   = 0;
-    uint32_t now = lv_tick_get();
-    if (now - s_action_tick >= 1000) {
-        s_action_bucket = 4;
-        s_action_tick = now;
-    }
-    if (s_action_bucket == 0) {
-        ESP_LOGW(TAG, "widget_action rate-limited (card=%s event=%s)", card_id, event);
-        return ESP_ERR_INVALID_STATE;
-    }
-    s_action_bucket--;
-
-    cJSON *msg = cJSON_CreateObject();
-    cJSON_AddStringToObject(msg, "type", "widget_action");
-    cJSON_AddStringToObject(msg, "card_id", card_id);
-    cJSON_AddStringToObject(msg, "event", event);
-    if (payload_json && payload_json[0]) {
-        cJSON *p = cJSON_Parse(payload_json);
-        if (p) cJSON_AddItemToObject(msg, "payload", p);
-    }
-    char *json = cJSON_PrintUnformatted(msg);
-    cJSON_Delete(msg);
-    if (!json) return ESP_ERR_NO_MEM;
-
-    esp_err_t ret = voice_ws_send_text(json);
-    cJSON_free(json);
-    if (ret == ESP_OK) {
-        ESP_LOGI(TAG, "widget_action: %s → %s", card_id, event);
-    }
-    return ret;
-}
+/* voice_send_widget_action moved to voice_ws_proto.c (TT #331 Wave 23
+ * SRP-A1) — pure WS-proto concern: builds a JSON frame + calls
+ * voice_ws_send_text. */
 
 esp_err_t voice_send_config_update_ex(int voice_mode, const char *llm_model,
                                       const char *reason)

--- a/main/voice.c
+++ b/main/voice.c
@@ -185,25 +185,26 @@ volatile uint32_t s_session_gen = 0;
 esp_websocket_client_handle_t volatile g_voice_ws = NULL;
 
 // Dragon connection info (last-known, updated on each connect)
-char     s_dragon_host[64] = {0};
-uint16_t s_dragon_port     = TAB5_VOICE_PORT;
+char s_dragon_host[64] = {0};
+uint16_t s_dragon_port = TAB5_VOICE_PORT;
 
 // Connection tracking
-volatile bool s_initialized        = false;
+volatile bool s_initialized = false;
 static volatile bool s_started            = false;  /* esp_websocket_client_start() has been called */
-volatile bool s_disconnecting      = false;  /* US-C21: guard against connect-during-disconnect race */
-volatile int  s_handshake_fail_cnt = 0;      /* consecutive handshake failures — trigger ngrok fallback in auto mode */
-volatile int  s_auth_fail_cnt      = 0;      /* γ3-Tab5 (issue #198): consecutive 401s — trigger stop-retry after WS_AUTH_FAIL_THRESHOLD */
+volatile bool s_disconnecting = false;              /* US-C21: guard against connect-during-disconnect race */
+volatile int s_handshake_fail_cnt = 0; /* consecutive handshake failures — trigger ngrok fallback in auto mode */
+volatile int s_auth_fail_cnt =
+    0; /* γ3-Tab5 (issue #198): consecutive 401s — trigger stop-retry after WS_AUTH_FAIL_THRESHOLD */
 /* v4·D connectivity audit T1.1: reconnect backoff state.  Counts
  * attempts since the last successful CONNECTED event.  Applied via
  * esp_websocket_client_set_reconnect_timeout inside the ERROR /
  * DISCONNECTED handlers; reset on CONNECTED.  */
-volatile int  s_connect_attempt   = 0;
+volatile int s_connect_attempt = 0;
 /* v4·D connectivity audit T1.3: link health published by probe task. */
 static volatile bool s_lan_tcp_ok        = false;
 static volatile bool s_ngrok_tcp_ok      = false;
 static volatile uint32_t s_last_probe_ms = 0;
-volatile bool s_using_ngrok        = false;  /* true once we've switched to the ngrok URI */
+volatile bool s_using_ngrok = false; /* true once we've switched to the ngrok URI */
 
 // Mic capture task
 static TaskHandle_t  s_mic_task    = NULL;
@@ -248,8 +249,8 @@ static void async_connect_task(void *arg);
 // Playback drain task — pulls from ring buffer, blocks on i2s_channel_write
 static TaskHandle_t      s_play_task    = NULL;
 static volatile bool     s_play_running = false;
-volatile bool     s_tts_done     = false;  // set by tts_end, drain task transitions to READY
-SemaphoreHandle_t s_play_sem     = NULL;   // signalled when data is written to ring buf
+volatile bool s_tts_done = false;     // set by tts_end, drain task transitions to READY
+SemaphoreHandle_t s_play_sem = NULL;  // signalled when data is written to ring buf
 
 // Playback ring buffer — allocated in PSRAM
 static int16_t          *s_play_buf      = NULL;
@@ -282,12 +283,12 @@ static SemaphoreHandle_t s_play_mutex    = NULL;
  * with headroom and matches the call-audio (AUD0) path's pre-existing
  * "max_out ≤ UPSAMPLE_BUF_CAPACITY" check shape. */
 #define UPSAMPLE_BUF_CAPACITY (8192 * 2) /* samples — 32 KB PSRAM */
-int16_t                 *s_upsample_buf  = NULL;
+int16_t *s_upsample_buf = NULL;
 
 // Last transcript from Dragon STT
 char s_transcript[MAX_TRANSCRIPT_LEN] = {0};
-char s_stt_text[MAX_TRANSCRIPT_LEN]   = {0};
-char s_llm_text[MAX_TRANSCRIPT_LEN]   = {0};
+char s_stt_text[MAX_TRANSCRIPT_LEN] = {0};
+char s_llm_text[MAX_TRANSCRIPT_LEN] = {0};
 
 /* v4·D Gauntlet G1: single-slot queued-turn buffer.  When voice_send_text
  * is invoked while the pipeline is busy, the new text is stashed here
@@ -302,8 +303,8 @@ static bool s_queue_pending = false;
  * voice_billing.h if a future caller needs them. */
 
 /* v4·D Phase 4b: cached vision capability from Dragon (camera screen). */
-bool s_vision_capable   = false;
-int  s_vision_per_frame_mils = 0;
+bool s_vision_capable = false;
+int s_vision_per_frame_mils = 0;
 char s_vision_model[64] = {0};
 
 // Dictation mode
@@ -311,10 +312,10 @@ static voice_mode_t   s_voice_mode        = VOICE_MODE_ASK;
 /* #280: in-call mute flag (definition near other state; the body
  * lives next to voice_call_audio_set_muted/_is_muted further down). */
 static volatile bool s_call_muted = false;
-char          *s_dictation_text    = NULL;  /* PSRAM-allocated, DICTATION_TEXT_SIZE */
+char *s_dictation_text = NULL; /* PSRAM-allocated, DICTATION_TEXT_SIZE */
 static volatile float s_current_rms       = 0.0f;
-char           s_dictation_title[128]   = {0};
-char           s_dictation_summary[512] = {0};
+char s_dictation_title[128] = {0};
+char s_dictation_summary[512] = {0};
 
 /* Drop counter for audio frames lost under back-pressure (US-C04) was
  * moved to voice_ws_proto.c alongside voice_ws_send_binary (the only
@@ -448,38 +449,35 @@ static void _drain_queued_text_job(void *arg)
 // ---------------------------------------------------------------------------
 // Playback ring buffer
 // ---------------------------------------------------------------------------
-void voice_playback_buf_reset(void)
-{
-    xSemaphoreTake(s_play_mutex, portMAX_DELAY);
-    s_play_wr = 0;
-    s_play_rd = 0;
-    s_play_count = 0;
-    xSemaphoreGive(s_play_mutex);
+void voice_playback_buf_reset(void) {
+   xSemaphoreTake(s_play_mutex, portMAX_DELAY);
+   s_play_wr = 0;
+   s_play_rd = 0;
+   s_play_count = 0;
+   xSemaphoreGive(s_play_mutex);
 }
 
-size_t voice_playback_buf_write(const int16_t *data, size_t samples)
-{
-    xSemaphoreTake(s_play_mutex, portMAX_DELAY);
+size_t voice_playback_buf_write(const int16_t *data, size_t samples) {
+   xSemaphoreTake(s_play_mutex, portMAX_DELAY);
 
-    size_t written = 0;
-    while (written < samples && s_play_count < PLAY_BUF_CAPACITY) {
-        s_play_buf[s_play_wr] = data[written];
-        s_play_wr = (s_play_wr + 1) % PLAY_BUF_CAPACITY;
-        s_play_count++;
-        written++;
-    }
+   size_t written = 0;
+   while (written < samples && s_play_count < PLAY_BUF_CAPACITY) {
+      s_play_buf[s_play_wr] = data[written];
+      s_play_wr = (s_play_wr + 1) % PLAY_BUF_CAPACITY;
+      s_play_count++;
+      written++;
+   }
 
-    xSemaphoreGive(s_play_mutex);
+   xSemaphoreGive(s_play_mutex);
 
-    if (written < samples) {
-        ESP_LOGW(TAG, "Playback buffer overflow, dropped %zu samples",
-                 samples - written);
-    }
+   if (written < samples) {
+      ESP_LOGW(TAG, "Playback buffer overflow, dropped %zu samples", samples - written);
+   }
 
-    if (written > 0 && s_play_sem) {
-        xSemaphoreGive(s_play_sem);
-    }
-    return written;
+   if (written > 0 && s_play_sem) {
+      xSemaphoreGive(s_play_sem);
+   }
+   return written;
 }
 
 static size_t playback_buf_read(int16_t *data, size_t max_samples)
@@ -528,19 +526,16 @@ void voice_reset_activity_timestamp(void)
 // s_dictation_summary, s_vision_capable, s_vision_per_frame_mils, s_vision_model.
 // ---------------------------------------------------------------------------
 
-
 // ---------------------------------------------------------------------------
 // Binary frame handling (voice_ws_proto_handle_binary): extracted to
 // voice_ws_proto.c (TT #331 Wave 23 SRP-A1, Task 1.7).
 // ---------------------------------------------------------------------------
-
 
 // ---------------------------------------------------------------------------
 // WebSocket event handler + URI helper: extracted to voice_ws_proto.c
 // (TT #331 Wave 23 SRP-A1, Tasks 1.6/1.8/1.9 combined for dep-closure).
 // Statics promoted to extern for cross-TU access (see voice.h).
 // ---------------------------------------------------------------------------
-
 
 // ---------------------------------------------------------------------------
 // Mic capture task — reads 4-ch TDM at 48kHz, extracts MIC1, downsamples
@@ -790,11 +785,10 @@ static void mic_capture_task(void *arg)
      * reuses them across sessions.  They're freed only at process
      * shutdown (which never happens on the firmware side). */
 
-    if (s_voice_mode == VOICE_MODE_DICTATE && had_speech
-        && total_silence_frames >= DICTATION_AUTO_STOP_FRAMES
-        && g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
-        voice_ws_send_text("{\"type\":\"stop\"}");
-        voice_set_state(VOICE_STATE_PROCESSING, NULL);
+    if (s_voice_mode == VOICE_MODE_DICTATE && had_speech && total_silence_frames >= DICTATION_AUTO_STOP_FRAMES &&
+        g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
+       voice_ws_send_text("{\"type\":\"stop\"}");
+       voice_set_state(VOICE_STATE_PROCESSING, NULL);
     }
 
     ESP_LOGI(TAG, "Mic session end (frames=%d) — back to idle",
@@ -1219,33 +1213,33 @@ static esp_err_t voice_ws_start_client(const char *dragon_host, uint16_t dragon_
         s_dragon_port = TAB5_NGROK_PORT;
         s_using_ngrok = true;
     } else {
-        voice_ws_proto_build_local_uri(uri, sizeof(uri), dragon_host, dragon_port);
-        strncpy(s_dragon_host, dragon_host, sizeof(s_dragon_host) - 1);
-        s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
-        s_dragon_port = dragon_port;
-        s_using_ngrok = false;
+       voice_ws_proto_build_local_uri(uri, sizeof(uri), dragon_host, dragon_port);
+       strncpy(s_dragon_host, dragon_host, sizeof(s_dragon_host) - 1);
+       s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
+       s_dragon_port = dragon_port;
+       s_using_ngrok = false;
     }
     s_handshake_fail_cnt = 0;
 
     /* If client already exists, just re-target the URI.  The managed
      * component requires stop() before set_uri() when started. */
     if (g_voice_ws) {
-        ESP_LOGI(TAG, "Re-using existing WS client; set_uri=%s", uri);
-        if (s_started) {
-            esp_websocket_client_stop(g_voice_ws);
-        }
-        esp_err_t ur = esp_websocket_client_set_uri(g_voice_ws, uri);
-        if (ur != ESP_OK) {
-            ESP_LOGE(TAG, "set_uri failed: %s", esp_err_to_name(ur));
-            return ur;
-        }
-        esp_err_t sr = esp_websocket_client_start(g_voice_ws);
-        if (sr != ESP_OK) {
-            ESP_LOGE(TAG, "client_start failed: %s", esp_err_to_name(sr));
-            return sr;
-        }
-        s_started = true;
-        return ESP_OK;
+       ESP_LOGI(TAG, "Re-using existing WS client; set_uri=%s", uri);
+       if (s_started) {
+          esp_websocket_client_stop(g_voice_ws);
+       }
+       esp_err_t ur = esp_websocket_client_set_uri(g_voice_ws, uri);
+       if (ur != ESP_OK) {
+          ESP_LOGE(TAG, "set_uri failed: %s", esp_err_to_name(ur));
+          return ur;
+       }
+       esp_err_t sr = esp_websocket_client_start(g_voice_ws);
+       if (sr != ESP_OK) {
+          ESP_LOGE(TAG, "client_start failed: %s", esp_err_to_name(sr));
+          return sr;
+       }
+       s_started = true;
+       return ESP_OK;
     }
 
     /* Wave 14 W14-C04: attach `Authorization: Bearer <token>` to the
@@ -1302,12 +1296,11 @@ static esp_err_t voice_ws_start_client(const char *dragon_host, uint16_t dragon_
 
     g_voice_ws = esp_websocket_client_init(&cfg);
     if (!g_voice_ws) {
-        ESP_LOGE(TAG, "esp_websocket_client_init failed");
-        return ESP_FAIL;
+       ESP_LOGE(TAG, "esp_websocket_client_init failed");
+       return ESP_FAIL;
     }
 
-    esp_err_t er = esp_websocket_register_events(g_voice_ws, WEBSOCKET_EVENT_ANY,
-                                                  voice_ws_proto_event_handler, NULL);
+    esp_err_t er = esp_websocket_register_events(g_voice_ws, WEBSOCKET_EVENT_ANY, voice_ws_proto_event_handler, NULL);
     if (er != ESP_OK) {
         ESP_LOGE(TAG, "register_events failed: %s", esp_err_to_name(er));
         esp_websocket_client_destroy(g_voice_ws);
@@ -1338,8 +1331,8 @@ esp_err_t voice_connect(const char *dragon_host, uint16_t dragon_port)
         return ESP_ERR_INVALID_STATE;
     }
     if (g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
-        ESP_LOGW(TAG, "Already connected");
-        return ESP_OK;
+       ESP_LOGW(TAG, "Already connected");
+       return ESP_OK;
     }
 
     if (s_state != VOICE_STATE_IDLE && s_state != VOICE_STATE_CONNECTING) {
@@ -1467,18 +1460,17 @@ esp_err_t voice_start_listening(void)
       return voice_onboard_chain_start();
    }
 
-    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
-    /* Wave 13 H1: snapshot state once under the mutex so the log and the
-     * guard below see the same value, and neither races the WS RX callback. */
-    voice_state_t cur_state = voice_get_state();
-    ESP_LOGI(TAG, "voice_start_listening: initialized=%d, ws_live=%d, state=%d",
-             s_initialized, ws_live, cur_state);
+   bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
+   /* Wave 13 H1: snapshot state once under the mutex so the log and the
+    * guard below see the same value, and neither races the WS RX callback. */
+   voice_state_t cur_state = voice_get_state();
+   ESP_LOGI(TAG, "voice_start_listening: initialized=%d, ws_live=%d, state=%d", s_initialized, ws_live, cur_state);
 
-    if (tab5_settings_get_mic_mute()) {
-       ESP_LOGW(TAG, "voice_start_listening: mic is muted, refusing");
-       ui_home_show_toast("Mic is muted -- unmute in Settings");
-       return ESP_ERR_INVALID_STATE;
-    }
+   if (tab5_settings_get_mic_mute()) {
+      ESP_LOGW(TAG, "voice_start_listening: mic is muted, refusing");
+      ui_home_show_toast("Mic is muted -- unmute in Settings");
+      return ESP_ERR_INVALID_STATE;
+   }
 
     if (!s_initialized || !ws_live) {
         ESP_LOGE(TAG, "Not connected (initialized=%d, ws_live=%d)",
@@ -1516,11 +1508,11 @@ esp_err_t voice_start_listening(void)
 
 esp_err_t voice_start_dictation(void)
 {
-    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
-    if (!s_initialized) {
-       ESP_LOGE(TAG, "Not initialized");
-       return ESP_ERR_INVALID_STATE;
-    }
+   bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
+   if (!s_initialized) {
+      ESP_LOGE(TAG, "Not initialized");
+      return ESP_ERR_INVALID_STATE;
+   }
     /* TT #328 Wave 9 — when WS is up, require READY state (existing
      * behaviour).  When WS is DOWN (offline-fallback path), accept
      * READY or IDLE or RECONNECTING since those are all valid
@@ -1625,11 +1617,11 @@ voice_mode_t voice_get_mode(void)
  * voice_video_start_call which calls us here. */
 esp_err_t voice_call_audio_start(void)
 {
-    bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
-    if (!s_initialized || !ws_live) {
-        ESP_LOGE(TAG, "voice_call_audio_start: not connected");
-        return ESP_ERR_INVALID_STATE;
-    }
+   bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
+   if (!s_initialized || !ws_live) {
+      ESP_LOGE(TAG, "voice_call_audio_start: not connected");
+      return ESP_ERR_INVALID_STATE;
+   }
     /* #284: persistent task pattern — `s_mic_task != NULL` is now
      * always true after voice_init (one task lives forever), so the
      * old guard would always block.  Gate on s_mic_running only. */
@@ -1702,9 +1694,9 @@ const char *voice_get_dictation_text(void)
 
 esp_err_t voice_clear_history(void)
 {
-    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
-    ESP_LOGI(TAG, "Clearing conversation history on Dragon");
-    return voice_ws_send_text("{\"type\":\"clear\"}");
+   if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+   ESP_LOGI(TAG, "Clearing conversation history on Dragon");
+   return voice_ws_send_text("{\"type\":\"clear\"}");
 }
 
 esp_err_t voice_stop_listening(void)
@@ -1728,7 +1720,8 @@ esp_err_t voice_stop_listening(void)
     * also flips state from LISTENING → RECONNECTING after 2-3 s
     * while the mic continues to write SD chunks, so the s_state
     * check below has to accept BOTH states for the offline path. */
-   bool offline_dictate = (s_voice_mode == VOICE_MODE_DICTATE) && !(g_voice_ws && esp_websocket_client_is_connected(g_voice_ws));
+   bool offline_dictate =
+       (s_voice_mode == VOICE_MODE_DICTATE) && !(g_voice_ws && esp_websocket_client_is_connected(g_voice_ws));
 
    if (offline_dictate) {
       /* Permissive — mic is running, recording valid, stop should
@@ -1873,8 +1866,8 @@ esp_err_t voice_disconnect(void)
      * re-creating everything. Destroy happens never in practice — the
      * client lives for the lifetime of the process. */
     if (g_voice_ws && s_started) {
-        esp_websocket_client_stop(g_voice_ws);
-        s_started = false;
+       esp_websocket_client_stop(g_voice_ws);
+       s_started = false;
     }
 
     voice_playback_buf_reset();
@@ -2077,15 +2070,15 @@ esp_err_t voice_send_text(const char *text)
 esp_err_t voice_send_config_update_ex(int voice_mode, const char *llm_model,
                                       const char *reason)
 {
-    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+   if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
 
-    cJSON *msg = cJSON_CreateObject();
-    cJSON_AddStringToObject(msg, "type", "config_update");
-    cJSON_AddNumberToObject(msg, "voice_mode", voice_mode);
-    cJSON_AddBoolToObject(msg, "cloud_mode", voice_mode >= 1);
-    if (voice_mode == 2 && llm_model && llm_model[0]) {
-        cJSON_AddStringToObject(msg, "llm_model", llm_model);
-    }
+   cJSON *msg = cJSON_CreateObject();
+   cJSON_AddStringToObject(msg, "type", "config_update");
+   cJSON_AddNumberToObject(msg, "voice_mode", voice_mode);
+   cJSON_AddBoolToObject(msg, "cloud_mode", voice_mode >= 1);
+   if (voice_mode == 2 && llm_model && llm_model[0]) {
+      cJSON_AddStringToObject(msg, "llm_model", llm_model);
+   }
     if (reason && reason[0]) {
         cJSON_AddStringToObject(msg, "reason", reason);
     }
@@ -2202,8 +2195,8 @@ void voice_force_reconnect(void)
     /* Stop + start: the managed client will immediately re-attempt the
      * connect handshake, bypassing any pending reconnect_timeout_ms delay. */
     if (!s_initialized || !g_voice_ws) {
-        ESP_LOGW(TAG, "voice_force_reconnect: client not ready");
-        return;
+       ESP_LOGW(TAG, "voice_force_reconnect: client not ready");
+       return;
     }
     ESP_LOGI(TAG, "Force reconnect");
     esp_websocket_client_stop(g_voice_ws);
@@ -2352,12 +2345,11 @@ static void upload_chat_image_job(void *arg)
     cJSON_Delete(frame);
     if (!txt) return;
     if (g_voice_ws && esp_websocket_client_is_connected(g_voice_ws)) {
-        size_t txtlen = strlen(txt);
-        esp_websocket_client_send_text(g_voice_ws, txt, (int)txtlen,
-                                       portMAX_DELAY);
-        ESP_LOGI(TAG, "user_image: announced media_id=%s", media_id);
+       size_t txtlen = strlen(txt);
+       esp_websocket_client_send_text(g_voice_ws, txt, (int)txtlen, portMAX_DELAY);
+       ESP_LOGI(TAG, "user_image: announced media_id=%s", media_id);
     } else {
-        ESP_LOGW(TAG, "user_image: WS not connected, skipping announce");
+       ESP_LOGW(TAG, "user_image: WS not connected, skipping announce");
     }
     free(txt);
 }
@@ -2384,10 +2376,10 @@ void voice_upload_chat_image(const char *filepath)
  * stop-set_uri-start dance. */
 void voice_reapply_connection_mode(void)
 {
-    if (!s_initialized || !g_voice_ws) {
-        ESP_LOGW(TAG, "reapply_connection_mode: client not ready");
-        return;
-    }
+   if (!s_initialized || !g_voice_ws) {
+      ESP_LOGW(TAG, "reapply_connection_mode: client not ready");
+      return;
+   }
     char host[64] = {0};
     tab5_settings_get_dragon_host(host, sizeof(host));
     if (!host[0]) {
@@ -2399,7 +2391,4 @@ void voice_reapply_connection_mode(void)
     voice_ws_start_client(host, port);
 }
 
-bool voice_is_connected(void)
-{
-    return g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
-}
+bool voice_is_connected(void) { return g_voice_ws && esp_websocket_client_is_connected(g_voice_ws); }

--- a/main/voice.c
+++ b/main/voice.c
@@ -111,29 +111,10 @@ static const char *TAG = "tab5_voice";
  * us from killing the session while Ollama is genuinely thinking. */
 #define WS_CLIENT_PONG_SEC     180
 
-/* v4·D connectivity audit T1.1: exponential backoff + full jitter on
- * WS reconnect.  Formula per the audit:
- *   exp = min(BACKOFF_CAP_MS, BACKOFF_MIN_MS << min(attempt, 5))
- *   delay = esp_random() % (exp/2) + exp/2   // full jitter [exp/2, exp)
- * attempt resets to 0 on WEBSOCKET_EVENT_CONNECTED.
- * Before: fixed 2 s reconnect -> thundering herd on Dragon reboot. */
-#define WS_CLIENT_BACKOFF_MIN_MS 1000
-#define WS_CLIENT_BACKOFF_CAP_MS 30000
-
-// Ngrok fallback is attempted after this many consecutive failed handshakes
-// against the local LAN URI (only in conn_mode=0 "auto").
-// Raised from 2 to 4 per connectivity audit: co-boot with Dragon almost
-// always fails the first 2 LAN handshakes while Dragon is still loading
-// Moonshine/Piper/Ollama -- raising the threshold stops us from
-// immediately pinning to ngrok on a simple server restart.
-#define NGROK_FALLBACK_THRESHOLD 4
-
-/* γ3-Tab5 (issue #198): stop retrying after this many consecutive
- * 401 handshake failures.  3 is tight enough that a misconfigured
- * device doesn't burn battery / log noise / ngrok bandwidth, but
- * loose enough to absorb a transient 401 during a token-rotation
- * race on Dragon restart. */
-#define WS_AUTH_FAIL_THRESHOLD 3
+/* WS_CLIENT_BACKOFF_MIN_MS, WS_CLIENT_BACKOFF_CAP_MS,
+ * NGROK_FALLBACK_THRESHOLD, WS_AUTH_FAIL_THRESHOLD moved to
+ * voice_ws_proto.c (TT #331 Wave 23 SRP-A1) — only the event handler
+ * inside that TU consumes them. */
 
 // Mic capture task — needs room for AFE feed buffer (960 int16 = 1.9KB)
 // + TDM diagnostics + OPUS encoder (silk_Encode is the heavy consumer,
@@ -167,8 +148,7 @@ static const char *TAG = "tab5_voice";
 #define PLAY_TASK_PRIORITY     9
 #define PLAY_TASK_CORE         1
 
-// Max transcript length
-#define MAX_TRANSCRIPT_LEN     2048
+/* MAX_TRANSCRIPT_LEN moved to voice.h (TT #331 Wave 23 SRP-A1). */
 
 // Dictation mode constants
 #define DICTATION_SILENCE_THRESHOLD  800
@@ -176,7 +156,7 @@ static const char *TAG = "tab5_voice";
 #define DICTATION_AUTO_STOP_FRAMES   250
 #define DICTATION_WARN_3S_FRAMES     150
 #define DICTATION_WARN_4S_FRAMES     200
-#define DICTATION_TEXT_SIZE          65536
+/* DICTATION_TEXT_SIZE moved to voice.h (TT #331 Wave 23 SRP-A1). */
 #define MAX_RECORD_FRAMES_ASK        1500
 
 // ---------------------------------------------------------------------------
@@ -184,12 +164,14 @@ static const char *TAG = "tab5_voice";
 // ---------------------------------------------------------------------------
 static voice_state_t     s_state = VOICE_STATE_IDLE;
 static voice_state_cb_t  s_state_cb = NULL;
-static SemaphoreHandle_t s_state_mutex = NULL;
+/* TT #331 Wave 23 SRP-A1: promoted to non-static so voice_ws_proto.c
+ * can take/give the lock from inside the JSON RX dispatcher. */
+SemaphoreHandle_t s_state_mutex = NULL;
 
 // US-C02: Session generation counter — monotonically increasing.
 // Every lv_async_call from voice tasks captures this value; the callback
 // checks it against the current generation and silently drops stale calls.
-static volatile uint32_t s_session_gen = 0;
+volatile uint32_t s_session_gen = 0;
 
 // WebSocket client (esp_websocket_client managed component)
 /* Wave 14 W14-M03: volatile because g_voice_ws is written on Core 1's WS
@@ -203,25 +185,25 @@ static volatile uint32_t s_session_gen = 0;
 esp_websocket_client_handle_t volatile g_voice_ws = NULL;
 
 // Dragon connection info (last-known, updated on each connect)
-static char     s_dragon_host[64] = {0};
-static uint16_t s_dragon_port     = TAB5_VOICE_PORT;
+char     s_dragon_host[64] = {0};
+uint16_t s_dragon_port     = TAB5_VOICE_PORT;
 
 // Connection tracking
-static volatile bool s_initialized        = false;
+volatile bool s_initialized        = false;
 static volatile bool s_started            = false;  /* esp_websocket_client_start() has been called */
-static volatile bool s_disconnecting      = false;  /* US-C21: guard against connect-during-disconnect race */
-static volatile int  s_handshake_fail_cnt = 0;      /* consecutive handshake failures — trigger ngrok fallback in auto mode */
-static volatile int  s_auth_fail_cnt      = 0;      /* γ3-Tab5 (issue #198): consecutive 401s — trigger stop-retry after WS_AUTH_FAIL_THRESHOLD */
+volatile bool s_disconnecting      = false;  /* US-C21: guard against connect-during-disconnect race */
+volatile int  s_handshake_fail_cnt = 0;      /* consecutive handshake failures — trigger ngrok fallback in auto mode */
+volatile int  s_auth_fail_cnt      = 0;      /* γ3-Tab5 (issue #198): consecutive 401s — trigger stop-retry after WS_AUTH_FAIL_THRESHOLD */
 /* v4·D connectivity audit T1.1: reconnect backoff state.  Counts
  * attempts since the last successful CONNECTED event.  Applied via
  * esp_websocket_client_set_reconnect_timeout inside the ERROR /
  * DISCONNECTED handlers; reset on CONNECTED.  */
-static volatile int  s_connect_attempt   = 0;
+volatile int  s_connect_attempt   = 0;
 /* v4·D connectivity audit T1.3: link health published by probe task. */
 static volatile bool s_lan_tcp_ok        = false;
 static volatile bool s_ngrok_tcp_ok      = false;
 static volatile uint32_t s_last_probe_ms = 0;
-static volatile bool s_using_ngrok        = false;  /* true once we've switched to the ngrok URI */
+volatile bool s_using_ngrok        = false;  /* true once we've switched to the ngrok URI */
 
 // Mic capture task
 static TaskHandle_t  s_mic_task    = NULL;
@@ -266,8 +248,8 @@ static void async_connect_task(void *arg);
 // Playback drain task — pulls from ring buffer, blocks on i2s_channel_write
 static TaskHandle_t      s_play_task    = NULL;
 static volatile bool     s_play_running = false;
-static volatile bool     s_tts_done     = false;  // set by tts_end, drain task transitions to READY
-static SemaphoreHandle_t s_play_sem     = NULL;   // signalled when data is written to ring buf
+volatile bool     s_tts_done     = false;  // set by tts_end, drain task transitions to READY
+SemaphoreHandle_t s_play_sem     = NULL;   // signalled when data is written to ring buf
 
 // Playback ring buffer — allocated in PSRAM
 static int16_t          *s_play_buf      = NULL;
@@ -303,9 +285,9 @@ static SemaphoreHandle_t s_play_mutex    = NULL;
 static int16_t          *s_upsample_buf  = NULL;
 
 // Last transcript from Dragon STT
-static char s_transcript[MAX_TRANSCRIPT_LEN] = {0};
-static char s_stt_text[MAX_TRANSCRIPT_LEN]   = {0};
-static char s_llm_text[MAX_TRANSCRIPT_LEN]   = {0};
+char s_transcript[MAX_TRANSCRIPT_LEN] = {0};
+char s_stt_text[MAX_TRANSCRIPT_LEN]   = {0};
+char s_llm_text[MAX_TRANSCRIPT_LEN]   = {0};
 
 /* v4·D Gauntlet G1: single-slot queued-turn buffer.  When voice_send_text
  * is invoked while the pipeline is busy, the new text is stashed here
@@ -320,19 +302,19 @@ static bool s_queue_pending = false;
  * voice_billing.h if a future caller needs them. */
 
 /* v4·D Phase 4b: cached vision capability from Dragon (camera screen). */
-static bool s_vision_capable   = false;
-static int  s_vision_per_frame_mils = 0;
-static char s_vision_model[64] = {0};
+bool s_vision_capable   = false;
+int  s_vision_per_frame_mils = 0;
+char s_vision_model[64] = {0};
 
 // Dictation mode
 static voice_mode_t   s_voice_mode        = VOICE_MODE_ASK;
 /* #280: in-call mute flag (definition near other state; the body
  * lives next to voice_call_audio_set_muted/_is_muted further down). */
 static volatile bool s_call_muted = false;
-static char          *s_dictation_text    = NULL;  /* PSRAM-allocated, DICTATION_TEXT_SIZE */
+char          *s_dictation_text    = NULL;  /* PSRAM-allocated, DICTATION_TEXT_SIZE */
 static volatile float s_current_rms       = 0.0f;
-static char           s_dictation_title[128]   = {0};
-static char           s_dictation_summary[512] = {0};
+char           s_dictation_title[128]   = {0};
+char           s_dictation_summary[512] = {0};
 
 /* Drop counter for audio frames lost under back-pressure (US-C04) was
  * moved to voice_ws_proto.c alongside voice_ws_send_binary (the only
@@ -343,13 +325,13 @@ static char           s_dictation_summary[512] = {0};
  * window for the Local-mode-failover routing decision (see
  * voice_send_text below) and a forward declaration for voice_onboard's
  * public API. */
-static int64_t s_ws_last_alive_us = 0;
+int64_t s_ws_last_alive_us = 0;
 #define M5_FAILOVER_GRACE_MS 30000 /* WS down this long before vmode=0 routes to K144 */
 
 #include "voice_onboard.h"
 
 // Activity timestamp shared with stop_listening for response timeout
-static volatile int64_t s_last_activity_us = 0;
+volatile int64_t s_last_activity_us = 0;
 
 // ---------------------------------------------------------------------------
 // Forward declarations
@@ -359,8 +341,8 @@ static volatile int64_t s_last_activity_us = 0;
 static void _drain_queued_text_job(void *arg);   /* #133 */
 static void mic_capture_task(void *arg);
 static void playback_drain_task(void *arg);
-static void handle_text_message(const char *data, int len);
-static void playback_buf_reset(void);
+/* handle_text_message → voice_ws_proto_handle_text (voice_ws_proto.h, TT #331). */
+/* voice_playback_buf_reset is now public — see voice.h */
 static size_t playback_buf_write(const int16_t *data, size_t samples);
 static size_t playback_buf_read(int16_t *data, size_t max_samples);
 /* TT #331 Wave 23: voice_ws_send_text + voice_ws_send_register +
@@ -466,7 +448,7 @@ static void _drain_queued_text_job(void *arg)
 // ---------------------------------------------------------------------------
 // Playback ring buffer
 // ---------------------------------------------------------------------------
-static void playback_buf_reset(void)
+void voice_playback_buf_reset(void)
 {
     xSemaphoreTake(s_play_mutex, portMAX_DELAY);
     s_play_wr = 0;
@@ -528,810 +510,24 @@ void voice_reset_activity_timestamp(void)
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// US-C02: Generation-guarded async call wrappers.
-// ---------------------------------------------------------------------------
-typedef struct {
-    uint32_t gen;
-    char    *text;
-} voice_async_toast_t;
-
-typedef struct {
-    uint32_t gen;
-} voice_async_badge_t;
-
-/* γ2-H8 (issue #196): worker to stop the WS client off the WS task.
- * esp_websocket_client_stop() rejects calls from inside the WS task
- * itself (logs "Client cannot be stopped from websocket task" and
- * no-ops).  This worker runs on the shared task_worker queue, so
- * the stop happens on a different task and actually takes effect.
- *
- * Triggered when Tab5 receives a `device_evicted` error frame —
- * another device claimed our slot, and auto-reconnect would just
- * trigger another eviction.  s_disconnecting was already set in
- * the WS handler so the WEBSOCKET_EVENT_DISCONNECTED branch won't
- * try to reconnect when the stop completes. */
-static void _voice_stop_ws_worker_fn(void *arg)
-{
-    (void)arg;
-    if (g_voice_ws) {
-        ESP_LOGW(TAG, "device_evicted worker: stopping WS client now");
-        esp_websocket_client_stop(g_voice_ws);
-    }
-}
-
-/* γ3-Tab5 (issue #198): worker for the auth-failed stop path.
- * Same task-hop pattern as _voice_stop_ws_worker_fn — must run
- * off the WS task or esp_websocket_client_stop() no-ops.
- * Separate function (not shared with the eviction worker) so the
- * ESP_LOG line clearly identifies WHICH path triggered the stop —
- * makes ops triage on a misconfigured-token device much easier
- * than a generic "stop_ws" trace. */
-static void _voice_auth_fail_stop_worker_fn(void *arg)
-{
-    (void)arg;
-    if (g_voice_ws) {
-        ESP_LOGW(TAG, "auth_failed worker: stopping WS after %d consecutive 401s",
-                 s_auth_fail_cnt);
-        esp_websocket_client_stop(g_voice_ws);
-    }
-}
-
-static void async_show_toast_cb(void *arg)
-{
-    voice_async_toast_t *t = (voice_async_toast_t *)arg;
-    if (!t) return;
-    if (t->gen == s_session_gen && t->text) {
-       ui_home_show_toast(t->text);
-    } else if (t->text) {
-       ESP_LOGD(TAG, "Stale async toast dropped (gen %lu vs %lu)", (unsigned long)t->gen, (unsigned long)s_session_gen);
-    }
-    free(t->text);
-    free(t);
-}
-
-static void async_refresh_badge_cb(void *arg)
-{
-    voice_async_badge_t *b = (voice_async_badge_t *)arg;
-    if (!b) return;
-    if (b->gen == s_session_gen) {
-       ui_home_refresh_mode_badge();
-    } else {
-       ESP_LOGD(TAG, "Stale async badge refresh dropped (gen %lu vs %lu)", (unsigned long)b->gen,
-                (unsigned long)s_session_gen);
-    }
-    free(b);
-}
-
-static void voice_async_toast(char *text)
-{
-    voice_async_toast_t *t = malloc(sizeof(voice_async_toast_t));
-    if (!t) {
-        /* Wave 14 W14-M08: log the silent-drop so ops can see we
-         * squeezed internal SRAM and a user-facing toast never reached
-         * LVGL. */
-        ESP_LOGW(TAG, "voice_async_toast OOM — dropping toast (text=%.40s)",
-                 text ? text : "");
-        free(text);
-        return;
-    }
-    t->gen = s_session_gen;
-    t->text = text;
-    tab5_lv_async_call(async_show_toast_cb, t);
-}
-
-/* TT #328 Wave 3 — async fire of ui_home_show_error_banner from voice WS
- * task.  Persistent error banner survives across the 2-3 s toast lifetime
- * so the user can't miss a fatal-state notification (auth lockout, device
- * eviction, etc).  static-string variant: caller must pass a string literal
- * or otherwise outlives the call (no malloc/free shuttle). */
-typedef struct {
-   const char *text; /* MUST outlive the async dispatch */
-} voice_banner_async_t;
-
-static void async_show_error_banner_cb(void *arg) {
-   voice_banner_async_t *b = (voice_banner_async_t *)arg;
-   if (!b) return;
-   if (b->text) {
-      ui_home_show_error_banner(b->text, NULL /* non-dismissable */);
-   }
-   free(b);
-}
-
-static void voice_async_error_banner(const char *static_text) {
-   if (!static_text) return;
-   voice_banner_async_t *b = malloc(sizeof(*b));
-   if (!b) {
-      ESP_LOGW(TAG, "voice_async_error_banner OOM — banner dropped");
-      return;
-   }
-   b->text = static_text;
-   tab5_lv_async_call(async_show_error_banner_cb, b);
-}
-
-/* TT #328 Wave 2 — dynamic-string banner variant.  Dragon-side error
- * messages (config_update.error, transient `error` frames with
- * non-static strings) need a heap-owned copy so the WS rx task can
- * safely return before LVGL processes the async call.  Strdups into
- * a heap-owned struct, the cb shows the banner + frees both.  Pass
- * `dismissable=true` to allow user-tap dismiss (the standard recovery
- * path); `false` for system-cleared-only banners. */
-typedef struct {
-   char *text; /* heap, freed in cb after lvgl reads it */
-   bool dismissable;
-} voice_banner_dyn_t;
-
-static void async_dismiss_banner_cb(void) {
-   /* Wave 2: tap-to-dismiss handler.  ui_home_show_error_banner installs
-    * us as the cb when dismissable=true; firing means the user
-    * acknowledged so we just clear. */
-   ui_home_clear_error_banner();
-}
-
-static void async_show_error_banner_dyn_cb(void *arg) {
-   voice_banner_dyn_t *b = (voice_banner_dyn_t *)arg;
-   if (!b) return;
-   if (b->text) {
-      ui_home_show_error_banner(b->text, b->dismissable ? async_dismiss_banner_cb : NULL);
-      free(b->text);
-   }
-   free(b);
-}
-
-static void voice_async_error_banner_dyn(const char *text, bool dismissable) {
-   if (!text || !text[0]) return;
-   voice_banner_dyn_t *b = heap_caps_malloc(sizeof(*b), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-   if (!b) {
-      ESP_LOGW(TAG, "voice_async_error_banner_dyn OOM (struct) — banner dropped");
-      return;
-   }
-   size_t len = strlen(text) + 1;
-   b->text = heap_caps_malloc(len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-   if (!b->text) {
-      ESP_LOGW(TAG, "voice_async_error_banner_dyn OOM (text) — banner dropped");
-      free(b);
-      return;
-   }
-   memcpy(b->text, text, len);
-   b->dismissable = dismissable;
-   tab5_lv_async_call(async_show_error_banner_dyn_cb, b);
-}
-
-/* TT #328 Wave 2 — recovery-aware banner state.  When config_update.error
- * fires we mark the fallback banner active; on the next successful
- * llm_done we auto-clear it (recovery signal).  Volatile because the
- * flag is written from the WS rx task and read from llm_done handling
- * on the same task — no contention, but the compiler might reorder
- * across the lv_async_call boundary otherwise. */
-static volatile bool s_fallback_banner_active = false;
-
-static void async_clear_banner_cb(void *arg) {
-   (void)arg;
-   ui_home_clear_error_banner();
-}
-
-static void voice_async_refresh_badge(void)
-{
-    voice_async_badge_t *b = malloc(sizeof(voice_async_badge_t));
-    if (!b) {
-        ESP_LOGW(TAG, "voice_async_refresh_badge OOM — badge will lag a tick");
-        return;
-    }
-    b->gen = s_session_gen;
-    tab5_lv_async_call(async_refresh_badge_cb, b);
-}
-
-// ---------------------------------------------------------------------------
-// JSON message handling (Dragon -> Tab5)
+// JSON RX dispatcher + UI-async helpers + worker-fn machinery: extracted to
+// voice_ws_proto.c (TT #331 Wave 23 SRP-A1, Task 1.6).
+//
+// Moved out of voice.c:
+//   - voice_async_toast_t / voice_async_badge_t / voice_banner_async_t / voice_banner_dyn_t typedefs
+//   - _voice_stop_ws_worker_fn / _voice_auth_fail_stop_worker_fn (γ2-H8 / γ3-Tab5)
+//   - async_show_toast_cb / async_refresh_badge_cb / voice_async_toast / voice_async_refresh_badge
+//   - async_show_error_banner_cb / voice_async_error_banner / voice_async_error_banner_dyn
+//   - async_dismiss_banner_cb / async_clear_banner_cb / s_fallback_banner_active
+//   - voice_debug_inject_text (public; declared in voice.h, defined in voice_ws_proto.c)
+//   - handle_text_message (now voice_ws_proto_handle_text in voice_ws_proto.h)
+//
+// Statics promoted out of voice.c via externs in voice.h: s_state_mutex,
+// s_session_gen, s_disconnecting, s_auth_fail_cnt, s_play_sem, s_tts_done,
+// s_transcript, s_stt_text, s_llm_text, s_dictation_text, s_dictation_title,
+// s_dictation_summary, s_vision_capable, s_vision_per_frame_mils, s_vision_model.
 // ---------------------------------------------------------------------------
 
-/* TT #328 Wave 2 — debug entry-point exposed via voice.h so the e2e
- * harness can fire synthetic WS frames into the dispatcher without
- * needing Dragon to misbehave.  Tiny wrapper, no validation beyond
- * the len > 0 guard — the JSON parser inside handle_text_message
- * already rejects malformed input. */
-void voice_debug_inject_text(const char *data, int len) {
-   if (!data || len <= 0) return;
-   handle_text_message(data, len);
-}
-
-static void handle_text_message(const char *data, int len)
-{
-    cJSON *root = cJSON_ParseWithLength(data, len);
-    if (!root) {
-        ESP_LOGW(TAG, "Failed to parse JSON: %.*s", len, data);
-        return;
-    }
-
-    cJSON *type = cJSON_GetObjectItem(root, "type");
-    if (!cJSON_IsString(type)) {
-        ESP_LOGW(TAG, "JSON missing 'type': %.*s", len, data);
-        cJSON_Delete(root);
-        return;
-    }
-
-    const char *type_str = type->valuestring;
-
-    if (strcmp(type_str, "stt_partial") == 0) {
-        cJSON *text = cJSON_GetObjectItem(root, "text");
-        /* U12 (#206): regardless of dictation mode, surface the partial
-         * as a live caption above the chat input pill.  No-op when chat
-         * is closed (s_input is NULL inside ui_chat). */
-        if (cJSON_IsString(text) && text->valuestring) {
-            ui_chat_show_partial(text->valuestring);
-        }
-        if (cJSON_IsString(text) && text->valuestring && s_voice_mode == VOICE_MODE_DICTATE
-            && s_dictation_text) {
-            /* v4·D audit P1 fix: use bounded copy instead of unchecked
-             * strcat.  Previously the guard compared cur+add+2 against
-             * the buffer size, but under mutex-less concurrent writes
-             * cur_len could change between the check and the strcat.
-             * Take the state mutex and re-bound with snprintf so an
-             * overflow is impossible. */
-            if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-            size_t cur_len = strlen(s_dictation_text);
-            size_t remaining = (cur_len + 1 < DICTATION_TEXT_SIZE)
-                               ? (DICTATION_TEXT_SIZE - cur_len - 1) : 0;
-            if (remaining > 1) {
-                const char *sep = (cur_len > 0) ? " " : "";
-                snprintf(s_dictation_text + cur_len, remaining,
-                         "%s%s", sep, text->valuestring);
-            }
-            if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-            ESP_LOGI(TAG, "STT partial: \"%s\" (total %u chars)",
-                     text->valuestring, (unsigned)strlen(s_dictation_text));
-            voice_set_state(VOICE_STATE_LISTENING, s_dictation_text);
-        }
-    } else if (strcmp(type_str, "stt") == 0) {
-        cJSON *text = cJSON_GetObjectItem(root, "text");
-        /* U12 (#206): final STT result lands as a real chat bubble — clear
-         * the live partial caption so it doesn't linger above the pill. */
-        ui_chat_show_partial(NULL);
-        if (cJSON_IsString(text) && text->valuestring) {
-            if (s_voice_mode == VOICE_MODE_DICTATE) {
-                if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-                strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
-                s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
-                if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-                ESP_LOGI(TAG, "Dictation complete: %u chars", (unsigned)strlen(text->valuestring));
-                voice_set_state(VOICE_STATE_READY, "dictation_done");
-            } else {
-                if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-                strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
-                s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
-                strncpy(s_transcript, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
-                s_transcript[MAX_TRANSCRIPT_LEN - 1] = '\0';
-                s_llm_text[0] = '\0';
-                if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-                ESP_LOGI(TAG, "STT: \"%s\"", s_stt_text);
-                ui_chat_push_message("user", text->valuestring);
-                voice_set_state(VOICE_STATE_PROCESSING, s_stt_text);
-            }
-        }
-    } else if (strcmp(type_str, "tts_start") == 0) {
-        /* Audit #80 DMA leak hunt (wave 9): log heap state at the 5
-         * interesting boundaries of a chat turn (llm_done, tts_start,
-         * tts_end, media, text_update) so we can diff which stage leaks.
-         * Heap caps are DMA-capable internal SRAM — same pool the WiFi
-         * Rx ring needs to stay alive. */
-        ESP_LOGI(TAG, "TTS start — preparing playback | heap_dma_free=%u largest=%u",
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
-        tab5_audio_speaker_enable(true);
-        playback_buf_reset();
-        voice_set_state(VOICE_STATE_SPEAKING, NULL);
-    } else if (strcmp(type_str, "tts_end") == 0) {
-        ESP_LOGI(TAG, "TTS end — drain task will finish playback | heap_dma_free=%u largest=%u",
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
-        s_tts_done = true;
-        if (s_play_sem) xSemaphoreGive(s_play_sem);
-    } else if (strcmp(type_str, "llm") == 0) {
-        /* TinkerBox #91 follow-up (#193): ignore late llm tokens that
-         * arrive after a cancel.  Tab5 transitions to READY locally on
-         * cancel-send (see voice_cancel below); Dragon now actually
-         * interrupts the LLM stream within ~1 ms (was ~65 s pre-#91),
-         * but tokens already in TCP flight at cancel-time still arrive
-         * a few hundred ms later.  Without this guard, the unconditional
-         * voice_set_state below pulls the orb back into PROCESSING with
-         * the partial cancelled response text — the cancel APPEARS to
-         * not have worked from the user's perspective.
-         *
-         * Honor llm tokens only when the user is actively waiting for a
-         * turn (PROCESSING or SPEAKING).  All other states (READY after
-         * cancel, IDLE on disconnect, LISTENING when a new mic recording
-         * already started) mean the previous turn is no longer the user's
-         * focus and any late tokens belong to a turn they cancelled.
-         */
-        voice_state_t cur_for_llm = voice_get_state();
-        if (cur_for_llm != VOICE_STATE_PROCESSING && cur_for_llm != VOICE_STATE_SPEAKING) {
-            ESP_LOGD(TAG, "llm token ignored — state=%d (post-cancel late arrival)",
-                     cur_for_llm);
-            cJSON_Delete(root);
-            return;
-        }
-        cJSON *text = cJSON_GetObjectItem(root, "text");
-        if (cJSON_IsString(text) && text->valuestring) {
-            if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-            size_t llm_len = strlen(s_llm_text);
-            size_t add_len = strlen(text->valuestring);
-            if (llm_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
-                strcat(s_llm_text, text->valuestring);
-            }
-            size_t cur_len = strlen(s_transcript);
-            if (cur_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
-                strcat(s_transcript, text->valuestring);
-            }
-            if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-            ESP_LOGD(TAG, "LLM token: \"%s\"", text->valuestring);
-            voice_set_state(VOICE_STATE_PROCESSING, s_llm_text);
-        }
-    } else if (strcmp(type_str, "cancel_ack") == 0) {
-        /* TinkerBox #91: server-side confirmation that cancel landed.
-         * Today we just log it — the state machine already transitioned
-         * to READY when voice_cancel was called, and the llm-token
-         * guard above handles the late-arrival grace window.
-         * If we ever add a "definitely no more late tokens, safe to
-         * resume" semantic, this is where it would slot in. */
-        cJSON *cancelled = cJSON_GetObjectItem(root, "cancelled");
-        int n = cJSON_IsArray(cancelled) ? cJSON_GetArraySize(cancelled) : 0;
-        ESP_LOGI(TAG, "cancel_ack: cancelled=%d slot(s)", n);
-    } else if (strcmp(type_str, "error") == 0) {
-        /* γ2-H8 (issue #196): route Dragon error frames by severity.
-         *
-         * Pre-fix every {"type":"error"} frame landed in the voice-
-         * overlay caption regardless of what went wrong — a recoverable
-         * STT-empty toast and an unrecoverable session-invalid banner
-         * both ended up in the same place.  Dragon's γ1 taxonomy
-         * (TinkerBox PR #102) added structured `severity` ("transient"
-         * vs "fatal") and `scope` fields; this handler honours them:
-         *
-         *   - TRANSIENT → non-blocking ui_home_show_toast(), stay in
-         *     READY.  User can keep talking.
-         *   - FATAL → existing voice-state caption path (more
-         *     permanent surface).  Reset playback + speaker since a
-         *     fatal error means we shouldn't keep half-playing TTS.
-         *
-         * Special case: code="device_evicted" (TinkerBox γ2-M5, PR
-         * #109) means another device claimed our slot.  Auto-reconnect
-         * would just trigger an eviction loop, so we set the
-         * disconnect guard + stop the WS client.  User must
-         * power-cycle or re-launch via the debug endpoint.
-         */
-        cJSON *msg       = cJSON_GetObjectItem(root, "message");
-        cJSON *severity  = cJSON_GetObjectItem(root, "severity");
-        cJSON *code      = cJSON_GetObjectItem(root, "code");
-        const char *err_src  = cJSON_IsString(msg) ? msg->valuestring : "unknown";
-        /* Default to "fatal" for unknown / pre-γ1 frames — safer to
-         * surface in caption (more visible) than to silently toast.
-         * Tab5 is forward-compatible with future severity values too:
-         * anything not "transient" routes to caption. */
-        const char *sev_src  = cJSON_IsString(severity) ? severity->valuestring : "fatal";
-        const char *code_src = cJSON_IsString(code) ? code->valuestring : "";
-        ESP_LOGE(TAG, "Dragon error [%s/%s]: %s", sev_src, code_src, err_src);
-
-        char err_buf[128];
-        strncpy(err_buf, err_src, sizeof(err_buf) - 1);
-        err_buf[sizeof(err_buf) - 1] = '\0';
-
-        bool is_transient = (strcmp(sev_src, "transient") == 0);
-
-        if (is_transient) {
-            /* TRANSIENT → toast via the existing voice_async_toast()
-             * helper.  This handler runs on the WS task, NOT the LVGL
-             * task — voice_async_toast() takes ownership of a strdup'd
-             * buffer, queues it via lv_async_call, and stamps the
-             * session_gen so a stale toast from a prior connection
-             * doesn't surface after a reconnect. */
-            char *toast_copy = strdup(err_buf);
-            if (toast_copy) {
-                voice_async_toast(toast_copy);
-            }
-        } else {
-            /* FATAL → existing caption path. */
-            playback_buf_reset();
-            tab5_audio_speaker_enable(false);
-            bool connected = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
-            voice_set_state(connected ? VOICE_STATE_READY : VOICE_STATE_IDLE, err_buf);
-
-            /* device_evicted: don't loop the eviction.  Stop the WS
-             * client + set the disconnect guard so the
-             * WEBSOCKET_EVENT_DISCONNECTED handler doesn't try to
-             * reconnect.  User regains connectivity via power-cycle
-             * or the /voice/reconnect debug endpoint.
-             *
-             * IMPORTANT: esp_websocket_client_stop() rejects calls
-             * from the WS task itself (logs "Client cannot be
-             * stopped from websocket task" and no-ops).  Hop to the
-             * shared worker queue (task_worker.{c,h}) so the stop
-             * runs on a non-WS task. */
-            if (strcmp(code_src, "device_evicted") == 0 && g_voice_ws) {
-                ESP_LOGW(TAG, "device_evicted: scheduling WS stop to prevent reconnect loop");
-                s_disconnecting = true;
-                tab5_worker_enqueue(_voice_stop_ws_worker_fn, NULL,
-                                    "device_evicted_stop");
-            }
-        }
-    } else if (strcmp(type_str, "session_start") == 0) {
-        cJSON *sid = cJSON_GetObjectItem(root, "session_id");
-        if (cJSON_IsString(sid) && sid->valuestring) {
-            tab5_settings_set_session_id(sid->valuestring);
-            ESP_LOGI(TAG, "Session: %s", sid->valuestring);
-        }
-        cJSON *resumed = cJSON_GetObjectItem(root, "resumed");
-        cJSON *msg_cnt = cJSON_GetObjectItem(root, "message_count");
-        ESP_LOGI(TAG, "session_start: resumed=%s messages=%d",
-                 (cJSON_IsTrue(resumed) ? "yes" : "no"),
-                 cJSON_IsNumber(msg_cnt) ? msg_cnt->valueint : 0);
-
-        if (s_state == VOICE_STATE_CONNECTING) {
-            voice_set_state(VOICE_STATE_READY, NULL);
-            ESP_LOGI(TAG, "Connected to Dragon voice server");
-
-            uint8_t saved_mode = tab5_settings_get_voice_mode();
-            char saved_model[64] = {0};
-            tab5_settings_get_llm_model(saved_model, sizeof(saved_model));
-            ESP_LOGI(TAG, "Restoring voice_mode=%d model='%s' on reconnect",
-                     saved_mode, saved_model[0] ? saved_model : "(default)");
-            voice_send_config_update((int)saved_mode,
-                                     saved_model[0] ? saved_model : NULL);
-
-            ui_notes_sync_pending();
-        }
-    } else if (strcmp(type_str, "session_messages") == 0) {
-        /* Audit C8/K15 (2026-04-20): Dragon replays the tail of session
-         * messages on a resumed connect.  Rehydrate chat_store so the
-         * user sees their conversation after a reconnect.  Pushed via
-         * ui_chat_push_message which is thread-safe + lv_async_call'd. */
-        cJSON *items = cJSON_GetObjectItem(root, "items");
-        if (cJSON_IsArray(items)) {
-            int n = cJSON_GetArraySize(items);
-            ESP_LOGI(TAG, "session_messages replay: %d items", n);
-            for (int i = 0; i < n; i++) {
-                cJSON *m = cJSON_GetArrayItem(items, i);
-                if (!m) continue;
-                const char *role = cJSON_GetStringValue(
-                    cJSON_GetObjectItem(m, "role"));
-                const char *content = cJSON_GetStringValue(
-                    cJSON_GetObjectItem(m, "content"));
-                if (!role || !content || !content[0]) continue;
-                /* Skip system/tool rows — chat UI only renders
-                 * user/assistant today. */
-                if (strcmp(role, "user") != 0 &&
-                    strcmp(role, "assistant") != 0) continue;
-                ui_chat_push_message(role, content);
-            }
-        }
-    } else if (strcmp(type_str, "dictation_postprocessing") == 0) {
-        /* TinkerBox#94 H4: Dragon spawned the title+summary LLM call after
-         * `stt`.  Pre-fix the user stared at the bare transcript for
-         * 10-20 s with no signal that more was coming.  Show a status
-         * caption so the wait feels intentional. */
-        ESP_LOGI(TAG, "Dictation post-process started");
-        voice_set_state(VOICE_STATE_PROCESSING, "Generating summary...");
-    } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
-        /* TinkerBox#94 H4: LLM failed or wasn't available.  Note already
-         * saved (the transcript landed via the prior `stt` event); user
-         * just doesn't get an auto-generated title/summary.  Clear the
-         * "Generating summary..." caption and toast the friendly
-         * message. */
-        cJSON *msg = cJSON_GetObjectItem(root, "message");
-        const char *m = cJSON_IsString(msg) ? msg->valuestring
-                                            : "Note saved — summary unavailable";
-        ESP_LOGW(TAG, "Dictation post-process error: %s", m);
-        char buf[160];
-        strncpy(buf, m, sizeof(buf) - 1);
-        buf[sizeof(buf) - 1] = '\0';
-        voice_async_toast(strdup(buf));
-        voice_set_state(VOICE_STATE_READY, "dictation_done");
-    } else if (strcmp(type_str, "dictation_postprocessing_cancelled") == 0) {
-       /* TinkerBox#94 H4: a NEW dictation superseded the prior in-flight
-        * post-process.  The new dictation will emit its own
-        * `dictation_postprocessing` event a few ms later — silently log
-        * here so we don't fight the new caption.
-        *
-        * TT #328 Wave 2 (audit error-surfacing) — the original handler
-        * was log-only, but on the cancellation-WITHOUT-followup path
-        * (Dragon shut down, user disconnected mid-dictation, failover
-        * race) the user is left staring at "Generating summary..."
-        * forever because no dictation_postprocessing comes to override
-        * it.  Reset to READY so the caption clears; if a legitimate
-        * follow-up _postprocessing fires it'll re-set the caption a
-        * few ms later anyway, no UI flicker visible. */
-       ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
-       voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
-    } else if (strcmp(type_str, "dictation_summary") == 0) {
-        cJSON *title = cJSON_GetObjectItem(root, "title");
-        cJSON *summary = cJSON_GetObjectItem(root, "summary");
-        if (cJSON_IsString(title)) {
-            strncpy(s_dictation_title, title->valuestring, sizeof(s_dictation_title) - 1);
-            s_dictation_title[sizeof(s_dictation_title) - 1] = '\0';
-        }
-        if (cJSON_IsString(summary)) {
-            strncpy(s_dictation_summary, summary->valuestring, sizeof(s_dictation_summary) - 1);
-            s_dictation_summary[sizeof(s_dictation_summary) - 1] = '\0';
-        }
-        ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
-        voice_set_state(VOICE_STATE_READY, "dictation_summary");
-    } else if (strcmp(type_str, "note_created") == 0) {
-        cJSON *nid = cJSON_GetObjectItem(root, "note_id");
-        cJSON *ntitle = cJSON_GetObjectItem(root, "title");
-        ESP_LOGI(TAG, "Dragon auto-created note: id=%s title=\"%s\"",
-                 cJSON_IsString(nid) ? nid->valuestring : "?",
-                 cJSON_IsString(ntitle) ? ntitle->valuestring : "?");
-    } else if (strcmp(type_str, "llm_done") == 0) {
-        cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
-        ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u",
-                 cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
-        /* TT #328 Wave 2 — recovery hook.  The fallback banner that fires
-         * on config_update.error sticks until the user dismisses or until
-         * a successful turn comes back through.  llm_done is the
-         * canonical "things are working again" signal — clear it here so
-         * the user sees the "things are back to normal" state without
-         * having to manually tap the banner. */
-        if (s_fallback_banner_active) {
-           ESP_LOGI(TAG, "Wave 2: clearing fallback banner (recovery via llm_done)");
-           s_fallback_banner_active = false;
-           tab5_lv_async_call(async_clear_banner_cb, NULL);
-        }
-        /* #293: emit obs event for e2e harness. */
-        {
-           char latency_str[24];
-           snprintf(latency_str, sizeof(latency_str), "%.0f", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0);
-           tab5_debug_obs_event("chat.llm_done", latency_str);
-        }
-        /* Prefer the full text field in llm_done (TC bypass uses it)
-         * falling back to the accumulated streamed tokens. */
-        cJSON *full = cJSON_GetObjectItem(root, "text");
-        const char *bubble_text = s_llm_text;
-        if (cJSON_IsString(full) && full->valuestring && full->valuestring[0]) {
-            bubble_text = full->valuestring;
-        }
-        if (bubble_text && bubble_text[0]) {
-            /* #78 + #160: defensive Tab5-side scrub of any <tool>...</tool>
-             * + <args>...</args> markers that survived Dragon's
-             * server-side stripper.  Without this the user sometimes
-             * sees raw "<tool>recall</tool><args>{\"query\":...}</args>"
-             * land as a chat bubble (caught by the audit screenshot in
-             * #160).  The strip handles the bubble destined for chat;
-             * s_llm_text continues to hold the raw text in case other
-             * paths need it. */
-            char clean[MAX_TRANSCRIPT_LEN];
-            md_strip_tool_markers(bubble_text, clean, sizeof(clean));
-            if (clean[0]) {
-                ui_chat_push_message("assistant", clean);
-            }
-        }
-        /* v4·D TC polish: if no TTS is coming (TC bypass never sends
-         * tts_start -- gateway is text-only), transition to READY
-         * directly.  Without this, state sits in PROCESSING forever
-         * after a TC text turn, chat input pill stays on "Thinking...",
-         * voice overlay stays blocked. */
-        if (s_state == VOICE_STATE_PROCESSING) {
-            voice_set_state(VOICE_STATE_READY, "llm_done");
-        }
-    } else if (strcmp(type_str, "receipt") == 0) {
-       /* SOLID-audit SRP-3 (2026-05-03): receipt accounting + cap-downgrade
-        * policy + chat-bubble stamp deferral all moved to voice_billing.c.
-        * Voice.c parses the JSON fields and hands them in typed; the
-        * billing module owns the rest of the chain. */
-       const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, "model"));
-       cJSON *ptok = cJSON_GetObjectItem(root, "prompt_tokens");
-       cJSON *ctok = cJSON_GetObjectItem(root, "completion_tokens");
-       cJSON *mils = cJSON_GetObjectItem(root, "cost_mils");
-       cJSON *retried_j = cJSON_GetObjectItem(root, "retried");
-       voice_billing_record_receipt(model, cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0,
-                                    cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0,
-                                    cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0, cJSON_IsTrue(retried_j));
-    } else if (strcmp(type_str, "text_update") == 0) {
-        const char *text = cJSON_GetStringValue(cJSON_GetObjectItem(root, "text"));
-        if (text) {
-            ESP_LOGI(TAG, "Text update: replacing last AI message");
-            ui_chat_update_last_message(text);
-        }
-    } else if (strcmp(type_str, "vision_capability") == 0) {
-        /* v4·D Phase 4b: Dragon advertises which model (if any) can see a
-         * camera frame.  Cached for ui_camera to render its violet chip.
-         * Empty/zero on local-only or non-vision models.  Triggered via
-         * Dragon's config_update ACK path so it lands whenever mode
-         * changes. */
-        cJSON *can = cJSON_GetObjectItem(root, "can_see");
-        cJSON *mdl = cJSON_GetObjectItem(root, "model");
-        cJSON *fpm = cJSON_GetObjectItem(root, "per_frame_mils");
-        s_vision_capable = cJSON_IsTrue(can);
-        s_vision_per_frame_mils = cJSON_IsNumber(fpm) ? (int)fpm->valuedouble : 0;
-        const char *m = (cJSON_IsString(mdl) && mdl->valuestring) ? mdl->valuestring : "";
-        snprintf(s_vision_model, sizeof(s_vision_model), "%s", m);
-        ESP_LOGI(TAG, "Vision capability: %s (model=%s, per_frame=%d mils)",
-                 s_vision_capable ? "YES" : "no",
-                 s_vision_model[0] ? s_vision_model : "none",
-                 s_vision_per_frame_mils);
-    } else if (strcmp(type_str, "pong") == 0) {
-        /* Dragon-level JSON pong — logged only. WS-level ping/pong is
-         * handled automatically by esp_websocket_client (pingpong_timeout_sec). */
-        ESP_LOGD(TAG, "App-level pong");
-    } else if (strcmp(type_str, "config_update") == 0) {
-        cJSON *error = cJSON_GetObjectItem(root, "error");
-        if (cJSON_IsString(error) && error->valuestring[0]) {
-            ESP_LOGW(TAG, "Config update error from Dragon: %s", error->valuestring);
-            /* TT #317 Phase 5: don't clobber a Tab5-only ONBOARD pick. */
-            if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
-               tab5_settings_set_voice_mode(0);
-            }
-            voice_async_refresh_badge();
-            {
-                size_t elen = strlen(error->valuestring);
-                if (elen > 80) elen = 80;
-                char *toast_msg = malloc(elen + 1);
-                if (toast_msg) {
-                    memcpy(toast_msg, error->valuestring, elen);
-                    toast_msg[elen] = '\0';
-                    voice_async_toast(toast_msg);
-                }
-            }
-            /* TT #328 Wave 2 (audit error-surfacing) — toast was the
-             * only surface; auto-dismissed in 3 s.  Users glancing
-             * away missed the fact that they got auto-downgraded to
-             * Local + lost cloud STT/TTS quality.  Pair the toast
-             * with a persistent dismissable error banner that sits
-             * until the user acknowledges OR until the next
-             * successful llm_done auto-clears it (recovery signal). */
-            voice_async_error_banner_dyn(error->valuestring, true /* dismissable */);
-            s_fallback_banner_active = true;
-            voice_set_state(VOICE_STATE_READY, error->valuestring);
-        }
-        cJSON *vmode = cJSON_GetObjectItem(root, "voice_mode");
-        if (!cJSON_IsNumber(vmode)) {
-            cJSON *config_obj = cJSON_GetObjectItem(root, "config");
-            if (config_obj) {
-                vmode = cJSON_GetObjectItem(config_obj, "voice_mode");
-            }
-        }
-        if (cJSON_IsNumber(vmode)) {
-            uint8_t mode = (uint8_t)vmode->valueint;
-            /* TT #317 Phase 5: ONBOARD is Tab5-side-only.  Dragon never
-             * knows about it — its ACK always echoes 0/1/2/3.  If user
-             * has set ONBOARD locally, ignore Dragon's echo. */
-            if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
-               tab5_settings_set_voice_mode(mode);
-               ESP_LOGI(TAG, "Config update: voice_mode=%d (persisted)", mode);
-            } else {
-               ESP_LOGD(TAG, "Config update: ignoring Dragon vmode=%d (we're in ONBOARD)", mode);
-            }
-            voice_async_refresh_badge();
-        }
-        cJSON *config = cJSON_GetObjectItem(root, "config");
-        bool applied_cloud = false;
-        if (config) {
-            cJSON *cloud = cJSON_GetObjectItem(config, "cloud_mode");
-            if (cJSON_IsBool(cloud)) {
-                bool is_cloud = cJSON_IsTrue(cloud);
-                if (!cJSON_IsNumber(vmode)) {
-                    tab5_settings_set_voice_mode(is_cloud ? 1 : 0);
-                    voice_async_refresh_badge();
-                    applied_cloud = true;
-                }
-            }
-        }
-        /* #262: codec negotiation reply.  Dragon picks one of the
-         * codecs Tab5 advertised in `register` and tells us via
-         * config_update.audio_codec.  Two flavours so it can choose
-         * uplink (mic) and downlink (TTS) independently:
-         *   - audio_codec        : applies to both (legacy / shorthand)
-         *   - audio_uplink_codec : mic only
-         *   - audio_downlink_codec: TTS only
-         * Unrecognized strings fall back to PCM. */
-        cJSON *acu = cJSON_GetObjectItem(root, "audio_uplink_codec");
-        cJSON *acd = cJSON_GetObjectItem(root, "audio_downlink_codec");
-        cJSON *ac  = cJSON_GetObjectItem(root, "audio_codec");
-        if (cJSON_IsString(acu)) {
-            voice_codec_set_uplink(voice_codec_from_name(acu->valuestring));
-        } else if (cJSON_IsString(ac)) {
-            voice_codec_set_uplink(voice_codec_from_name(ac->valuestring));
-        }
-        if (cJSON_IsString(acd)) {
-            voice_codec_set_downlink(voice_codec_from_name(acd->valuestring));
-        } else if (cJSON_IsString(ac)) {
-            voice_codec_set_downlink(voice_codec_from_name(ac->valuestring));
-        }
-        /* Wave 14 W14-L03: if neither voice_mode nor cloud_mode was
-         * present, the handler used to exit silently and Tab5 would
-         * disagree with Dragon about the active mode with no trace.
-         * Log at DEBUG so it's visible via /log without spamming INFO. */
-        if (!cJSON_IsNumber(vmode) && !applied_cloud &&
-            !cJSON_IsString(error)) {
-            ESP_LOGD(TAG, "config_update received with no voice_mode/"
-                         "cloud_mode/error field — no-op");
-        }
-    } else if (strcmp(type_str, "tool_call") == 0) {
-        cJSON *tool = cJSON_GetObjectItem(root, "tool");
-        const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
-        ESP_LOGI(TAG, "Tool call: %s", tool_name);
-
-        const char *status_text = "Thinking...";
-        if (strcmp(tool_name, "web_search") == 0) {
-            status_text = "Searching the web...";
-        } else if (strcmp(tool_name, "remember") == 0 || strcmp(tool_name, "memory_store") == 0) {
-            status_text = "Remembering...";
-        } else if (strcmp(tool_name, "memory_search") == 0 || strcmp(tool_name, "recall") == 0) {
-            status_text = "Recalling...";
-        } else if (strcmp(tool_name, "browser") == 0 || strcmp(tool_name, "browse") == 0) {
-            status_text = "Browsing...";
-        } else if (strcmp(tool_name, "calculator") == 0 || strcmp(tool_name, "math") == 0) {
-            status_text = "Calculating...";
-        } else {
-            status_text = "Using tools...";
-        }
-        voice_set_state(VOICE_STATE_PROCESSING, status_text);
-        /* Tab5 audit D5: also push a system bubble so the user can see
-         * tool activity in chat (not just on the voice overlay label).
-         * CLAUDE.md's "thinking + tool indicator bubbles" claim was wired
-         * only to the overlay-state string previously. */
-        ui_chat_push_system(status_text);
-        /* U7+U8 (#206): record activity so the agents/focus surfaces
-         * can render real history instead of the v5 demo rows. */
-        tool_log_push_call(tool_name, status_text);
-    } else if (strcmp(type_str, "tool_result") == 0) {
-        cJSON *tool = cJSON_GetObjectItem(root, "tool");
-        cJSON *exec_ms = cJSON_GetObjectItem(root, "execution_ms");
-        const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
-        double ms = cJSON_IsNumber(exec_ms) ? exec_ms->valuedouble : 0.0;
-        ESP_LOGI(TAG, "Tool result: %s (%.0fms)", tool_name, ms);
-        voice_set_state(VOICE_STATE_PROCESSING, "Thinking...");
-        /* Tab5 audit D5: close the loop with a completion bubble so the
-         * chat timeline shows what ran + how long it took. */
-        char done_buf[80];
-        snprintf(done_buf, sizeof(done_buf), "%s done (%.0fms)",
-                 tool_name, ms);
-        ui_chat_push_system(done_buf);
-        /* U7+U8 (#206): mark the tool_log entry done so the
-         * agents/focus surfaces can show "DONE  •  234 ms". */
-        tool_log_push_result(tool_name, (uint32_t)ms);
-    } else if (strcmp(type_str, "media") == 0) {
-        const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
-        const char *mtype = cJSON_GetStringValue(cJSON_GetObjectItem(root, "media_type"));
-        cJSON *w_item = cJSON_GetObjectItem(root, "width");
-        cJSON *h_item = cJSON_GetObjectItem(root, "height");
-        int w = cJSON_IsNumber(w_item) ? (int)w_item->valuedouble : 0;
-        int h = cJSON_IsNumber(h_item) ? (int)h_item->valuedouble : 0;
-        const char *alt = cJSON_GetStringValue(cJSON_GetObjectItem(root, "alt"));
-        if (url) {
-            ESP_LOGI(TAG, "Media: %s %dx%d", mtype ? mtype : "image", w, h);
-            ui_chat_push_media(url, mtype, w, h, alt);
-        }
-    } else if (strcmp(type_str, "card") == 0) {
-        const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
-        const char *sub = cJSON_GetStringValue(cJSON_GetObjectItem(root, "subtitle"));
-        const char *img = cJSON_GetStringValue(cJSON_GetObjectItem(root, "image_url"));
-        const char *desc = cJSON_GetStringValue(cJSON_GetObjectItem(root, "description"));
-        if (title) {
-            ESP_LOGI(TAG, "Card: %s", title);
-            ui_chat_push_card(title, sub, img, desc);
-        }
-        /* Wave 23b SOLID-audit SRP-2: nine widget WS verbs (widget_card,
-         * widget_live, widget_live_update, widget_list, widget_chart,
-         * widget_media, widget_prompt, widget_live_dismiss, widget_dismiss)
-         * extracted to voice_widget_ws.{c,h}.  Returns true iff the verb
-         * was recognized + handled; false falls through to the unknown-
-         * verb log below. */
-    } else if (voice_widget_ws_dispatch(type_str, root)) {
-       /* widget verb handled inside voice_widget_ws.c */
-    } else if (strcmp(type_str, "audio_clip") == 0) {
-       const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
-       cJSON *dur_item = cJSON_GetObjectItem(root, "duration_s");
-       float dur = cJSON_IsNumber(dur_item) ? (float)dur_item->valuedouble : 0.0f;
-       const char *label = cJSON_GetStringValue(cJSON_GetObjectItem(root, "label"));
-       if (url) {
-          ESP_LOGI(TAG, "Audio clip: %s (%.1fs)", label ? label : "", dur);
-          ui_chat_push_audio_clip(url, dur, label);
-       }
-    } else {
-       ESP_LOGW(TAG, "Unknown message type: %s (full: %.*s)", type_str, len, data);
-    }
-
-    cJSON_Delete(root);
-}
 
 // ---------------------------------------------------------------------------
 // Binary frame handling (TTS audio from Dragon) — called from event handler.
@@ -1353,7 +549,7 @@ static size_t upsample_16k_to_48k(const int16_t *in, size_t in_samples,
     return out_idx;
 }
 
-static void handle_binary_message(const char *data, int len)
+void handle_binary_message(const char *data, int len)
 {
     /* #268: video frames carry the 4-byte "VID0" magic.  Route them
      * to voice_video before any audio-state checks — video plays
@@ -1400,7 +596,7 @@ static void handle_binary_message(const char *data, int len)
         return;
     }
     if (cur == VOICE_STATE_PROCESSING) {
-        playback_buf_reset();
+        voice_playback_buf_reset();
         voice_set_state(VOICE_STATE_SPEAKING, NULL);
     }
 
@@ -1437,371 +633,11 @@ static void handle_binary_message(const char *data, int len)
 }
 
 // ---------------------------------------------------------------------------
-// WebSocket event handler (runs on esp_websocket_client's internal task)
+// WebSocket event handler + URI helper: extracted to voice_ws_proto.c
+// (TT #331 Wave 23 SRP-A1, Tasks 1.6/1.8/1.9 combined for dep-closure).
+// Statics promoted to extern for cross-TU access (see voice.h).
 // ---------------------------------------------------------------------------
-static void voice_ws_event_handler(void *arg, esp_event_base_t base,
-                                    int32_t event_id, void *event_data)
-{
-    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
 
-    switch ((esp_websocket_event_id_t)event_id) {
-    case WEBSOCKET_EVENT_BEFORE_CONNECT:
-        ESP_LOGI(TAG, "WS: BEFORE_CONNECT (host=%s%s)",
-                 s_dragon_host, s_using_ngrok ? " [ngrok]" : "");
-        voice_set_state(VOICE_STATE_CONNECTING, s_dragon_host);
-        break;
-
-    case WEBSOCKET_EVENT_CONNECTED: {
-        ESP_LOGI(TAG, "WS: CONNECTED — sending register frame");
-        /* #293: emit obs event for e2e harness. */
-        tab5_debug_obs_event("ws.connect", "");
-        /* TT #317 Phase 4: stamp WS-alive so the K144 failover gate can
-         * measure how long Dragon's been down before engaging. */
-        s_ws_last_alive_us = esp_timer_get_time();
-        /* TT #317 Phase 5: if a K144 failover engaged during the down
-         * period, surface "Dragon reconnected" so the user knows the
-         * next turn is back on the cloud/LAN brain.  Wave 4b: the flag
-         * lives in voice_onboard now; consume_engagement_flag returns
-         * true once and clears, so the toast fires exactly once per
-         * disconnect cycle. */
-        if (voice_onboard_consume_engagement_flag()) {
-           ESP_LOGI(TAG, "WS reconnected after K144 failover — toast 'Dragon reconnected'");
-           if (tab5_ui_try_lock(100)) {
-              ui_home_show_toast("Dragon reconnected");
-              tab5_ui_unlock();
-           }
-        }
-        /* US-C02: bump session gen on every successful connect. */
-        s_session_gen++;
-        s_handshake_fail_cnt = 0;
-        /* γ3-Tab5 (issue #198): clear the auth-fail counter on a
-         * successful connect so a transient 401 (e.g. a token-rotation
-         * race during Dragon restart) doesn't get sticky after Dragon
-         * recovers.  Only a sustained run of 401s should trip the
-         * stop-retry — recovery must self-heal. */
-        s_auth_fail_cnt = 0;
-        /* T1.1: reset backoff state on every successful connect so a
-         * long-running healthy session doesn't get hit with a 30 s
-         * delay on its first blip. */
-        s_connect_attempt = 0;
-        esp_websocket_client_set_reconnect_timeout(g_voice_ws, WS_CLIENT_BACKOFF_MIN_MS);
-
-        esp_err_t reg_err = voice_ws_send_register();
-        if (reg_err != ESP_OK) {
-            ESP_LOGE(TAG, "WS: register send failed (%s)", esp_err_to_name(reg_err));
-            /* Let auto-reconnect re-attempt. */
-        }
-        /* Don't set READY yet — wait for Dragon's session_start reply so
-         * we know the backend pipeline is fully up. Keep state CONNECTING
-         * until session_start arrives (~6s model load on first boot). */
-        break;
-    }
-
-    case WEBSOCKET_EVENT_DISCONNECTED:
-        ESP_LOGW(TAG, "WS: DISCONNECTED");
-        { tab5_debug_obs_event("ws.disconnect", ""); }
-        /* Flush playback so we don't keep speaking into a dead pipe. */
-        playback_buf_reset();
-        tab5_audio_speaker_enable(false);
-        /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice
-         * state was PROCESSING or SPEAKING), surface a toast so the user
-         * knows why the reply stopped.  Previously a mid-turn Dragon
-         * crash was silent — just a frozen overlay + no answer.  The
-         * home status-bar pill already picks up RECONNECTING via
-         * voice_get_degraded_reason(), so the toast is a short-lived
-         * orient-the-user signal, not the permanent indicator.
-         *
-         * Wave 7 F5 completion (2026-04-21): also pulse the halo orb
-         * rose for ~2.5 s so the visual signal matches the audit spec
-         * ("toast + rose orb pulse"). Toast alone was easy to miss if
-         * the user was looking at the chat area rather than the home
-         * card. ui_home_pulse_orb_alert reverts to the mode-default
-         * orb paint via an LVGL one-shot timer. */
-        {
-            voice_state_t cur = s_state;
-            if ((cur == VOICE_STATE_PROCESSING || cur == VOICE_STATE_SPEAKING) && !s_disconnecting) {
-               tab5_lv_async_call((lv_async_cb_t)ui_home_show_toast, (void *)"Dragon dropped mid-turn - reconnecting");
-               tab5_lv_async_call((lv_async_cb_t)ui_home_pulse_orb_alert, NULL);
-            }
-        }
-        /* T1.1: bump attempt counter + apply exponential-with-full-jitter
-         * backoff to the client's reconnect timer.  Prevents thundering
-         * herd if multiple Tab5s share the same Dragon + avoids 2 s
-         * hammering against a server that's 20 s into its restart. */
-        s_connect_attempt++;
-        {
-            int shift = s_connect_attempt - 1;
-            if (shift < 0) shift = 0;
-            if (shift > 5) shift = 5;
-            uint32_t exp_ms = WS_CLIENT_BACKOFF_MIN_MS << shift;
-            if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
-            uint32_t half = exp_ms / 2;
-            uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
-            uint32_t delay_ms = half + jitter;    /* [exp/2, exp) */
-            ESP_LOGI(TAG, "WS: reconnect attempt=%d backoff=%lums (exp=%lums)",
-                     s_connect_attempt, (unsigned long)delay_ms,
-                     (unsigned long)exp_ms);
-            esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
-        }
-        /* #146: WS-level escalation.  If Wi-Fi probes claim we're fine
-         * (probe task still sees lan=1/ngrok=1) but the voice WS keeps
-         * failing to connect, the Wi-Fi chip's TCP-stack state is bad.
-         * The probe is a one-shot SYN; the WS handshake needs more
-         * buffers + TLS-path + full RX pipeline.  After WS_KICK_THRESHOLD
-         * consecutive failed attempts (~2 min of retry), hard-kick the
-         * stack.  Don't do this on attempt 1-4 — those are normal
-         * transient failures (Dragon restart, brief AP hiccup). */
-        #define WS_KICK_THRESHOLD 5
-        if (s_connect_attempt == WS_KICK_THRESHOLD) {
-            ESP_LOGW(TAG, "WS: %d failed attempts — escalating to hard-kick "
-                          "(stack may be wedged despite probe success)",
-                     s_connect_attempt);
-            esp_err_t kr = tab5_wifi_hard_kick();
-            if (kr != ESP_OK) {
-                /* ESP-Hosted's Wi-Fi slave chip doesn't always recover
-                 * from stop/start without a host-side reboot (observed:
-                 * esp_wifi_start returns ESP_FAIL repeatedly).  Don't
-                 * burn another 5 attempts — reboot now. */
-                ESP_LOGE(TAG, "WS: hard-kick failed (%s) — controlled reboot",
-                         esp_err_to_name(kr));
-                vTaskDelay(pdMS_TO_TICKS(100));
-                esp_restart();
-                /* unreachable */
-            }
-            /* Reset the counter so we give it another 5 tries after the
-             * successful hard kick before escalating again.  If 10
-             * failures in a row, the link-probe zombie path catches it. */
-            s_connect_attempt = 0;
-        }
-        /* T1.2: RECONNECTING while a backoff is queued + WiFi is up.
-         * IDLE only when WiFi is genuinely down or user stopped voice. */
-        {
-            bool wifi_up = tab5_wifi_connected();
-            if (s_initialized && !s_disconnecting && wifi_up) {
-                voice_set_state(VOICE_STATE_RECONNECTING, "backoff");
-            } else {
-                voice_set_state(VOICE_STATE_IDLE, "disconnected");
-            }
-        }
-        /* v4·D audit P0 fix: ngrok fallback was one-way.  Clear the flag
-         * + reset the fail counter so the NEXT successful connection
-         * gets a chance to land on LAN.  The actual URI swap is deferred
-         * to voice_try_lan_probe() which runs off the WS event task. */
-        if (s_using_ngrok && tab5_settings_get_connection_mode() == 0) {
-            s_handshake_fail_cnt = 0;
-            /* Leave s_using_ngrok alone here: we only reset it once the
-             * external LAN probe succeeds (heap_watchdog periodic hook).
-             * Clearing it here without swapping the client URI would be
-             * a lie, and swapping the URI inside the event task has
-             * shown to wedge the client.  Next sprint: add a proper
-             * probe task that pings LAN and schedules the swap via
-             * lv_async_call on success. */
-        }
-        break;
-
-    case WEBSOCKET_EVENT_CLOSED:
-        /* closes #110: was voice_set_state(IDLE, "closed") with NO
-         * reconnect scheduled — if Dragon sends a graceful WS close
-         * frame (restart, idle timeout, etc.) Tab5 parked in IDLE
-         * forever until the user hit /voice/reconnect manually.
-         * DISCONNECTED re-armed the reconnect timer; CLOSED did not.
-         *
-         * Mirror the DISCONNECTED path: bump attempt, apply
-         * exponential-with-full-jitter backoff, transition to
-         * RECONNECTING when Wi-Fi is up so the state bar reflects
-         * that Tab5 is actively trying, not dead.  The managed WS
-         * client's auto-reconnect picks up the new timeout. */
-        ESP_LOGI(TAG, "WS: CLOSED — scheduling reconnect");
-        if (g_voice_ws && !s_disconnecting) {
-            s_connect_attempt++;
-            int shift = s_connect_attempt - 1;
-            if (shift < 0) shift = 0;
-            if (shift > 5) shift = 5;
-            uint32_t exp_ms = WS_CLIENT_BACKOFF_MIN_MS << shift;
-            if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
-            uint32_t half = exp_ms / 2;
-            uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
-            uint32_t delay_ms = half + jitter;
-            ESP_LOGI(TAG, "WS: CLOSED reconnect attempt=%d backoff=%lums",
-                     s_connect_attempt, (unsigned long)delay_ms);
-            esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
-            if (tab5_wifi_connected()) {
-                voice_set_state(VOICE_STATE_RECONNECTING, "closed");
-            } else {
-                voice_set_state(VOICE_STATE_IDLE, "closed-nowifi");
-            }
-        } else {
-            voice_set_state(VOICE_STATE_IDLE, "closed");
-        }
-        break;
-
-    case WEBSOCKET_EVENT_DATA:
-        if (!data) break;
-        s_last_activity_us = esp_timer_get_time();
-        if (data->op_code == WS_TRANSPORT_OPCODES_TEXT && data->data_len > 0) {
-            ESP_LOGI(TAG, "WS recv text (%d bytes): %.*s", data->data_len,
-                     data->data_len > 200 ? 200 : data->data_len, data->data_ptr);
-            handle_text_message(data->data_ptr, data->data_len);
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_BINARY && data->data_len > 0) {
-            /* #268: large binary frames (e.g. Phase 3B video JPEGs >32 KB)
-             * arrive in fragments — esp_websocket_client splits them at
-             * WS_CLIENT_BUFFER_SIZE.  Reassemble using payload_len +
-             * payload_offset before dispatching to handle_binary_message
-             * so the magic-byte sniff sees the whole frame.  Audio
-             * (PCM/OPUS) is single-fragment so the fast path skips
-             * reassembly. */
-            const int frag_total = data->payload_len;
-            const int frag_off   = data->payload_offset;
-            const int frag_len   = data->data_len;
-            if (frag_total <= 0 || frag_total == frag_len) {
-                /* Single-fragment frame — current behavior. */
-                handle_binary_message(data->data_ptr, frag_len);
-            } else {
-                /* Multi-fragment frame.  Lazy-init reassembly buffer
-                 * in PSRAM, sized to the same ceiling voice_video uses. */
-                static uint8_t *s_rx_reasm_buf = NULL;
-                static int      s_rx_reasm_cap = 96 * 1024;
-                if (!s_rx_reasm_buf) {
-                    s_rx_reasm_buf = heap_caps_malloc(
-                        s_rx_reasm_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-                }
-                if (!s_rx_reasm_buf) {
-                    ESP_LOGW(TAG, "rx-reasm OOM (%d B); dropping frag", s_rx_reasm_cap);
-                    break;
-                }
-                if (frag_total > s_rx_reasm_cap) {
-                    ESP_LOGW(TAG, "rx-reasm: payload %d > cap %d; dropping", frag_total, s_rx_reasm_cap);
-                    break;
-                }
-                if (frag_off + frag_len > frag_total) {
-                    ESP_LOGW(TAG, "rx-reasm: bad frag off=%d len=%d total=%d",
-                             frag_off, frag_len, frag_total);
-                    break;
-                }
-                memcpy(s_rx_reasm_buf + frag_off, data->data_ptr, frag_len);
-                if (frag_off + frag_len == frag_total) {
-                    handle_binary_message((const char *)s_rx_reasm_buf, frag_total);
-                }
-            }
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_PING) {
-            ESP_LOGD(TAG, "WS recv PING — client auto-pongs");
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_PONG) {
-            ESP_LOGD(TAG, "WS recv PONG");
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_CLOSE) {
-            ESP_LOGI(TAG, "WS recv CLOSE frame");
-        }
-        break;
-
-    case WEBSOCKET_EVENT_ERROR: {
-        int status = data ? data->error_handle.esp_ws_handshake_status_code : 0;
-        esp_websocket_error_type_t et = data ? data->error_handle.error_type : WEBSOCKET_ERROR_TYPE_NONE;
-        ESP_LOGW(TAG, "WS: ERROR (type=%d, handshake_status=%d, sock_errno=%d)",
-                 (int)et, status,
-                 data ? data->error_handle.esp_transport_sock_errno : 0);
-        /* T1.1: apply the same backoff on error as on disconnect so
-         * a handshake-fail loop doesn't pin at 2 s forever. */
-        {
-            int shift = s_connect_attempt;
-            if (shift < 0) shift = 0;
-            if (shift > 5) shift = 5;
-            uint32_t exp_ms = WS_CLIENT_BACKOFF_MIN_MS << shift;
-            if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
-            uint32_t half = exp_ms / 2;
-            uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
-            esp_websocket_client_set_reconnect_timeout(g_voice_ws, half + jitter);
-        }
-
-        /* γ3-Tab5 (issue #198): 401 specifically means auth failed —
-         * burning the auth-fail counter every retry will pin the
-         * device against ngrok forever (wrong-token devices used to
-         * loop 401s on both LAN and ngrok endpoints, eating battery
-         * + ngrok bandwidth + log storage).  After WS_AUTH_FAIL_THRESHOLD
-         * consecutive 401s, stop the WS client + show a toast pointing
-         * at Settings.  s_auth_fail_cnt resets on a successful CONNECT
-         * so a transient 401 (token-rotation race during Dragon
-         * restart) doesn't get sticky after recovery.
-         *
-         * Filter on status alone — NOT on
-         * `et == WEBSOCKET_ERROR_TYPE_HANDSHAKE`.  Empirically (live
-         * test on real device against PROD :3502 with rotated token)
-         * a clean 401 from Dragon arrives as `et=1`
-         * (WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT) because the underlying
-         * TCP transport completed successfully — the 401 happens at
-         * the application layer.  Gating on HANDSHAKE here meant the
-         * counter never incremented and the loop ran forever. */
-        if (status == 401) {
-            s_auth_fail_cnt++;
-            ESP_LOGW(TAG, "WS: 401 auth_failed (count=%d/%d)",
-                     s_auth_fail_cnt, WS_AUTH_FAIL_THRESHOLD);
-            if (s_auth_fail_cnt >= WS_AUTH_FAIL_THRESHOLD && !s_disconnecting) {
-                ESP_LOGE(TAG, "WS: %d consecutive 401s — stopping retry loop",
-                         s_auth_fail_cnt);
-                s_disconnecting = true;
-                /* Hop to worker task — esp_websocket_client_stop()
-                 * rejects calls from the WS task itself.  Same pattern
-                 * as the γ2-H8 device_evicted handler. */
-                tab5_worker_enqueue(_voice_auth_fail_stop_worker_fn, NULL,
-                                    "auth_failed_stop");
-                /* TT #328 Wave 3 P0 #15 — pre-Wave-3 this was a 2.2 s toast.
-                 * After 5 silent retries the user got a single transient
-                 * notice they could easily miss.  Upgraded to a persistent
-                 * error banner that stays until they tap it (and presumably
-                 * jump to Settings to fix the token).  Also fires the
-                 * error.auth obs event so /events surfaces the lockout. */
-                tab5_debug_obs_event("error.auth", "ws_401_stop");
-                char *toast = strdup("Invalid Dragon token — check Settings");
-                if (toast) {
-                    voice_async_toast(toast);
-                }
-                voice_async_error_banner(
-                    "Dragon rejected your token (401). Reconnect paused — "
-                    "open Settings → Network to update.");
-                break;
-            }
-        }
-
-        /* Handshake failure → try ngrok fallback (only in conn_mode=auto,
-         * only while still on local URI, after NGROK_FALLBACK_THRESHOLD fails). */
-        if (et == WEBSOCKET_ERROR_TYPE_HANDSHAKE && status != 101) {
-            s_handshake_fail_cnt++;
-            uint8_t conn_mode = tab5_settings_get_connection_mode();
-            if (conn_mode == 0 && !s_using_ngrok
-                && s_handshake_fail_cnt >= NGROK_FALLBACK_THRESHOLD) {
-                char ngrok_uri[128];
-                snprintf(ngrok_uri, sizeof(ngrok_uri),
-                         "wss://%s:%d%s",
-                         TAB5_NGROK_HOST, TAB5_NGROK_PORT, TAB5_VOICE_WS_PATH);
-                ESP_LOGW(TAG, "WS: handshake failed %d× — falling back to %s",
-                         s_handshake_fail_cnt, ngrok_uri);
-                s_using_ngrok = true;
-                s_handshake_fail_cnt = 0;
-                /* set_uri requires a stopped client. The client is
-                 * currently between reconnect attempts; stop+set+start
-                 * to force it onto the new URI immediately. */
-                esp_websocket_client_stop(g_voice_ws);
-                esp_websocket_client_set_uri(g_voice_ws, ngrok_uri);
-                strncpy(s_dragon_host, TAB5_NGROK_HOST, sizeof(s_dragon_host) - 1);
-                s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
-                s_dragon_port = TAB5_NGROK_PORT;
-                esp_websocket_client_start(g_voice_ws);
-            }
-        }
-        break;
-    }
-
-    default:
-        break;
-    }
-}
-
-// ---------------------------------------------------------------------------
-// URI helpers
-// ---------------------------------------------------------------------------
-static void voice_build_local_uri(char *out, size_t out_cap,
-                                   const char *host, uint16_t port)
-{
-    snprintf(out, out_cap, "ws://%s:%u%s", host, (unsigned)port, TAB5_VOICE_WS_PATH);
-}
 
 // ---------------------------------------------------------------------------
 // Mic capture task — reads 4-ch TDM at 48kHz, extracts MIC1, downsamples
@@ -2210,7 +1046,7 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
         return ESP_ERR_NO_MEM;
     }
 
-    playback_buf_reset();
+    voice_playback_buf_reset();
     s_transcript[0] = '\0';
 
     /* Spawn the playback drain task once, at init — it sleeps on s_play_sem
@@ -2480,7 +1316,7 @@ static esp_err_t voice_ws_start_client(const char *dragon_host, uint16_t dragon_
         s_dragon_port = TAB5_NGROK_PORT;
         s_using_ngrok = true;
     } else {
-        voice_build_local_uri(uri, sizeof(uri), dragon_host, dragon_port);
+        voice_ws_proto_build_local_uri(uri, sizeof(uri), dragon_host, dragon_port);
         strncpy(s_dragon_host, dragon_host, sizeof(s_dragon_host) - 1);
         s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
         s_dragon_port = dragon_port;
@@ -2568,7 +1404,7 @@ static esp_err_t voice_ws_start_client(const char *dragon_host, uint16_t dragon_
     }
 
     esp_err_t er = esp_websocket_register_events(g_voice_ws, WEBSOCKET_EVENT_ANY,
-                                                  voice_ws_event_handler, NULL);
+                                                  voice_ws_proto_event_handler, NULL);
     if (er != ESP_OK) {
         ESP_LOGE(TAG, "register_events failed: %s", esp_err_to_name(er));
         esp_websocket_client_destroy(g_voice_ws);
@@ -3069,7 +1905,7 @@ esp_err_t voice_cancel(void)
         }
     }
 
-    playback_buf_reset();
+    voice_playback_buf_reset();
     tab5_audio_speaker_enable(false);
 
     bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
@@ -3138,7 +1974,7 @@ esp_err_t voice_disconnect(void)
         s_started = false;
     }
 
-    playback_buf_reset();
+    voice_playback_buf_reset();
     voice_set_state(VOICE_STATE_IDLE, NULL);
 
     s_disconnecting = false;

--- a/main/voice.h
+++ b/main/voice.h
@@ -54,11 +54,13 @@ extern char                  s_vision_model[64];
 #define MAX_TRANSCRIPT_LEN     2048
 #define DICTATION_TEXT_SIZE    65536
 
-/* TT #331 Wave 23 SRP-A1: voice_ws_proto.c calls this from the JSON RX
- * dispatcher (tts_start clears the playback ring before new TTS audio).
- * Implementation stays in voice.c next to the playback ring buffer it
- * resets — this is just the public-API exposure for cross-TU access. */
-void voice_playback_buf_reset(void);
+/* TT #331 Wave 23 SRP-A1: voice_ws_proto.c calls these from the JSON RX
+ * dispatcher (tts_start clears the playback ring before new TTS audio)
+ * and the binary RX dispatcher (writes upsampled PCM into the ring).
+ * Implementations stay in voice.c next to the playback ring buffer they
+ * touch — these are just the public-API exposures for cross-TU access. */
+void   voice_playback_buf_reset(void);
+size_t voice_playback_buf_write(const int16_t *data, size_t samples);
 
 /* Additional voice-subsystem statics the WS event handler needs.
  * Declared as voice_ws_proto.c-local externs (not in voice.h) to keep

--- a/main/voice.h
+++ b/main/voice.h
@@ -24,6 +24,56 @@
  * WS task (connect/disconnect) and read on Core 0's LVGL thread. */
 extern esp_websocket_client_handle_t volatile g_voice_ws;
 
+/* TT #331 Wave 23 (SRP-A1) — additional voice-subsystem statics promoted
+ * out of voice.c so voice_ws_proto.c can read/write them.  Names kept
+ * with the legacy `s_` prefix to minimise diff churn across the rename
+ * surface; they are now non-static and shared inside the voice
+ * subsystem.  All declared/initialised in voice.c, used in
+ * voice_ws_proto.c.
+ *
+ * SemaphoreHandle_t externs (s_state_mutex, s_play_sem) are declared
+ * directly in the consuming TU (voice_ws_proto.c) to avoid pulling
+ * <freertos/semphr.h> into voice.h's public surface. */
+extern volatile bool         s_disconnecting;               /* US-C21 connect/disconnect guard */
+extern volatile int          s_auth_fail_cnt;               /* γ3 401 retry threshold */
+extern volatile uint32_t     s_session_gen;                 /* US-C02 async-call gen guard */
+extern volatile bool         s_tts_done;                    /* set by tts_end RX, read by playback drain */
+extern char                 *s_dictation_text;              /* PSRAM, DICTATION_TEXT_SIZE */
+extern char                  s_dictation_title[128];
+extern char                  s_dictation_summary[512];
+extern char                  s_transcript[];
+extern char                  s_stt_text[];
+extern char                  s_llm_text[];
+extern bool                  s_vision_capable;
+extern int                   s_vision_per_frame_mils;
+extern char                  s_vision_model[64];
+
+/* TT #331 Wave 23 SRP-A1: promoted from voice.c so voice_ws_proto.c can
+ * size its (transient) buffer copies + write into the shared transcript
+ * arrays.  Sizes match the voice.c internal definitions. */
+#define MAX_TRANSCRIPT_LEN     2048
+#define DICTATION_TEXT_SIZE    65536
+
+/* TT #331 Wave 23 SRP-A1: voice_ws_proto.c calls this from the JSON RX
+ * dispatcher (tts_start clears the playback ring before new TTS audio).
+ * Implementation stays in voice.c next to the playback ring buffer it
+ * resets — this is just the public-API exposure for cross-TU access. */
+void voice_playback_buf_reset(void);
+
+/* Additional voice-subsystem statics the WS event handler needs.
+ * Declared as voice_ws_proto.c-local externs (not in voice.h) to keep
+ * the public voice.h surface narrow and to dodge the collision with
+ * ui_voice.c's own `s_initialized`. */
+extern volatile int      s_handshake_fail_cnt;
+extern volatile int      s_connect_attempt;
+extern volatile bool     s_using_ngrok;
+extern volatile int64_t  s_last_activity_us;
+extern int64_t           s_ws_last_alive_us;
+extern char              s_dragon_host[64];
+extern uint16_t          s_dragon_port;
+/* (s_rx_reasm_buf + _cap are FUNCTION-LOCAL statics inside the WS event
+ *  handler — they move with it, no extern needed.) */
+
 // Voice states
 typedef enum {
     VOICE_STATE_IDLE,          // Not connected and not trying (WiFi down / user disabled)

--- a/main/voice.h
+++ b/main/voice.h
@@ -14,8 +14,15 @@
 #pragma once
 
 #include "esp_err.h"
+#include "esp_websocket_client.h"   /* g_voice_ws extern below (TT #331 Wave 23) */
 #include <stdbool.h>
 #include <stdint.h>
+
+/* TT #331 Wave 23 (SRP-A1): the WS client handle was promoted from
+ * static in voice.c so voice_ws_proto.c can read/use it without
+ * per-call getter churn.  volatile because it's written on Core 1's
+ * WS task (connect/disconnect) and read on Core 0's LVGL thread. */
+extern esp_websocket_client_handle_t volatile g_voice_ws;
 
 // Voice states
 typedef enum {

--- a/main/voice.h
+++ b/main/voice.h
@@ -13,10 +13,11 @@
  */
 #pragma once
 
-#include "esp_err.h"
-#include "esp_websocket_client.h"   /* g_voice_ws extern below (TT #331 Wave 23) */
 #include <stdbool.h>
 #include <stdint.h>
+
+#include "esp_err.h"
+#include "esp_websocket_client.h" /* g_voice_ws extern below (TT #331 Wave 23) */
 
 /* TT #331 Wave 23 (SRP-A1): the WS client handle was promoted from
  * static in voice.c so voice_ws_proto.c can read/use it without
@@ -34,45 +35,45 @@ extern esp_websocket_client_handle_t volatile g_voice_ws;
  * SemaphoreHandle_t externs (s_state_mutex, s_play_sem) are declared
  * directly in the consuming TU (voice_ws_proto.c) to avoid pulling
  * <freertos/semphr.h> into voice.h's public surface. */
-extern volatile bool         s_disconnecting;               /* US-C21 connect/disconnect guard */
-extern volatile int          s_auth_fail_cnt;               /* γ3 401 retry threshold */
-extern volatile uint32_t     s_session_gen;                 /* US-C02 async-call gen guard */
-extern volatile bool         s_tts_done;                    /* set by tts_end RX, read by playback drain */
-extern char                 *s_dictation_text;              /* PSRAM, DICTATION_TEXT_SIZE */
-extern char                  s_dictation_title[128];
-extern char                  s_dictation_summary[512];
-extern char                  s_transcript[];
-extern char                  s_stt_text[];
-extern char                  s_llm_text[];
-extern bool                  s_vision_capable;
-extern int                   s_vision_per_frame_mils;
-extern char                  s_vision_model[64];
+extern volatile bool s_disconnecting;   /* US-C21 connect/disconnect guard */
+extern volatile int s_auth_fail_cnt;    /* γ3 401 retry threshold */
+extern volatile uint32_t s_session_gen; /* US-C02 async-call gen guard */
+extern volatile bool s_tts_done;        /* set by tts_end RX, read by playback drain */
+extern char *s_dictation_text;          /* PSRAM, DICTATION_TEXT_SIZE */
+extern char s_dictation_title[128];
+extern char s_dictation_summary[512];
+extern char s_transcript[];
+extern char s_stt_text[];
+extern char s_llm_text[];
+extern bool s_vision_capable;
+extern int s_vision_per_frame_mils;
+extern char s_vision_model[64];
 
 /* TT #331 Wave 23 SRP-A1: promoted from voice.c so voice_ws_proto.c can
  * size its (transient) buffer copies + write into the shared transcript
  * arrays.  Sizes match the voice.c internal definitions. */
-#define MAX_TRANSCRIPT_LEN     2048
-#define DICTATION_TEXT_SIZE    65536
+#define MAX_TRANSCRIPT_LEN 2048
+#define DICTATION_TEXT_SIZE 65536
 
 /* TT #331 Wave 23 SRP-A1: voice_ws_proto.c calls these from the JSON RX
  * dispatcher (tts_start clears the playback ring before new TTS audio)
  * and the binary RX dispatcher (writes upsampled PCM into the ring).
  * Implementations stay in voice.c next to the playback ring buffer they
  * touch — these are just the public-API exposures for cross-TU access. */
-void   voice_playback_buf_reset(void);
+void voice_playback_buf_reset(void);
 size_t voice_playback_buf_write(const int16_t *data, size_t samples);
 
 /* Additional voice-subsystem statics the WS event handler needs.
  * Declared as voice_ws_proto.c-local externs (not in voice.h) to keep
  * the public voice.h surface narrow and to dodge the collision with
  * ui_voice.c's own `s_initialized`. */
-extern volatile int      s_handshake_fail_cnt;
-extern volatile int      s_connect_attempt;
-extern volatile bool     s_using_ngrok;
-extern volatile int64_t  s_last_activity_us;
-extern int64_t           s_ws_last_alive_us;
-extern char              s_dragon_host[64];
-extern uint16_t          s_dragon_port;
+extern volatile int s_handshake_fail_cnt;
+extern volatile int s_connect_attempt;
+extern volatile bool s_using_ngrok;
+extern volatile int64_t s_last_activity_us;
+extern int64_t s_ws_last_alive_us;
+extern char s_dragon_host[64];
+extern uint16_t s_dragon_port;
 /* (s_rx_reasm_buf + _cap are FUNCTION-LOCAL statics inside the WS event
  *  handler — they move with it, no extern needed.) */
 

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -7,39 +7,38 @@
  */
 #include "voice_ws_proto.h"
 
-#include "voice.h"   /* g_voice_ws extern + voice_set_state */
-
-#include <limits.h>  /* INT_MAX (W14-L02 send-bound check) */
+#include <limits.h> /* INT_MAX (W14-L02 send-bound check) */
 #include <string.h>
 
-#include "audio.h"            /* tab5_audio_speaker_enable on tts_start */
-#include "wifi.h"             /* tab5_wifi_hard_kick / tab5_wifi_connected */
+#include "audio.h" /* tab5_audio_speaker_enable on tts_start */
 #include "cJSON.h"
-#include "chat_msg_store.h"   /* tool indicator bubbles */
+#include "chat_msg_store.h" /* tool indicator bubbles */
 #include "config.h"
-#include "debug_obs.h"        /* tab5_debug_obs_event */
+#include "debug_obs.h" /* tab5_debug_obs_event */
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "esp_websocket_client.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/semphr.h"  /* s_state_mutex / s_play_sem externs below */
+#include "freertos/semphr.h" /* s_state_mutex / s_play_sem externs below */
 #include "freertos/task.h"
-#include "lvgl.h"             /* lv_tick_get for the widget_action rate limiter */
-#include "md_strip.h"         /* md_strip_tool_markers on llm streaming */
+#include "lvgl.h"     /* lv_tick_get for the widget_action rate limiter */
+#include "md_strip.h" /* md_strip_tool_markers on llm streaming */
 #include "settings.h"
-#include "task_worker.h"      /* tab5_worker_enqueue for stop-WS workers */
-#include "tool_log.h"         /* tool_log_push_call / _push_result */
+#include "task_worker.h" /* tab5_worker_enqueue for stop-WS workers */
+#include "tool_log.h"    /* tool_log_push_call / _push_result */
 #include "ui_chat.h"
-#include "ui_core.h"          /* tab5_lv_async_call */
+#include "ui_core.h" /* tab5_lv_async_call */
 #include "ui_home.h"
 #include "ui_notes.h"
-#include "voice_billing.h"    /* receipt + budget */
-#include "voice_codec.h"      /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
-#include "voice_onboard.h"    /* K144 failover hooks */
-#include "voice_video.h"      /* VID0 magic peek + downlink decode */
-#include "voice_widget_ws.h"  /* widget_* WS dispatch */
-#include "widget.h"           /* widget_live_update / widget_live_dismiss */
+#include "voice.h"           /* g_voice_ws extern + voice_set_state */
+#include "voice_billing.h"   /* receipt + budget */
+#include "voice_codec.h"     /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+#include "voice_onboard.h"   /* K144 failover hooks */
+#include "voice_video.h"     /* VID0 magic peek + downlink decode */
+#include "voice_widget_ws.h" /* widget_* WS dispatch */
+#include "widget.h"          /* widget_live_update / widget_live_dismiss */
+#include "wifi.h"            /* tab5_wifi_hard_kick / tab5_wifi_connected */
 
 static const char *TAG = "tab5_voice_ws";
 
@@ -82,59 +81,53 @@ extern volatile bool s_initialized;
 // ---------------------------------------------------------------------------
 // WebSocket send helpers (wrapping esp_websocket_client_send_*)
 // ---------------------------------------------------------------------------
-esp_err_t voice_ws_send_text(const char *msg)
-{
-    if (!g_voice_ws) return ESP_ERR_INVALID_STATE;
-    if (!esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
-    if (!msg) return ESP_ERR_INVALID_ARG;
+esp_err_t voice_ws_send_text(const char *msg) {
+   if (!g_voice_ws) return ESP_ERR_INVALID_STATE;
+   if (!esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+   if (!msg) return ESP_ERR_INVALID_ARG;
 
-    size_t len = strlen(msg);
-    /* Wave 14 W14-L02: bound the size_t→int cast.  Realistic messages
-     * are <256 bytes but an unchecked cast would silently truncate on
-     * an accidental >2 GB string (e.g. a corrupted LLM response
-     * flowing through text_update). */
-    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
-    int w = esp_websocket_client_send_text(g_voice_ws, msg, (int)len, pdMS_TO_TICKS(1000));
-    if (w < 0) {
-        ESP_LOGW(TAG, "WS text send failed (%zu bytes)", len);
-        return ESP_FAIL;
-    }
-    return ESP_OK;
+   size_t len = strlen(msg);
+   /* Wave 14 W14-L02: bound the size_t→int cast.  Realistic messages
+    * are <256 bytes but an unchecked cast would silently truncate on
+    * an accidental >2 GB string (e.g. a corrupted LLM response
+    * flowing through text_update). */
+   if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
+   int w = esp_websocket_client_send_text(g_voice_ws, msg, (int)len, pdMS_TO_TICKS(1000));
+   if (w < 0) {
+      ESP_LOGW(TAG, "WS text send failed (%zu bytes)", len);
+      return ESP_FAIL;
+   }
+   return ESP_OK;
 }
 
-esp_err_t voice_ws_send_binary(const void *data, size_t len)
-{
-    if (!g_voice_ws) return ESP_ERR_INVALID_STATE;
-    if (!esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
-    if (!data) return ESP_ERR_INVALID_ARG;
-    /* W14-L02: same bound as text. */
-    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
+esp_err_t voice_ws_send_binary(const void *data, size_t len) {
+   if (!g_voice_ws) return ESP_ERR_INVALID_STATE;
+   if (!esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+   if (!data) return ESP_ERR_INVALID_ARG;
+   /* W14-L02: same bound as text. */
+   if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
 
-    /* Short 100 ms timeout — we drop frames under pressure rather than
-     * block the mic task. If WiFi stalls, I2S DMA would overflow. */
-    int w = esp_websocket_client_send_bin(g_voice_ws, (const char *)data, (int)len,
-                                          pdMS_TO_TICKS(100));
-    if (w < 0) {
-        s_audio_drop_count++;
-        if (s_audio_drop_count % 10 == 1) {
-            ESP_LOGW(TAG, "WS binary send dropped — %d frames lost", s_audio_drop_count);
-        }
-        return ESP_ERR_TIMEOUT;
-    }
-    if (s_audio_drop_count > 0) {
-        ESP_LOGI(TAG, "WS binary send recovered after %d drops", s_audio_drop_count);
-        s_audio_drop_count = 0;
-    }
-    return ESP_OK;
+   /* Short 100 ms timeout — we drop frames under pressure rather than
+    * block the mic task. If WiFi stalls, I2S DMA would overflow. */
+   int w = esp_websocket_client_send_bin(g_voice_ws, (const char *)data, (int)len, pdMS_TO_TICKS(100));
+   if (w < 0) {
+      s_audio_drop_count++;
+      if (s_audio_drop_count % 10 == 1) {
+         ESP_LOGW(TAG, "WS binary send dropped — %d frames lost", s_audio_drop_count);
+      }
+      return ESP_ERR_TIMEOUT;
+   }
+   if (s_audio_drop_count > 0) {
+      ESP_LOGI(TAG, "WS binary send recovered after %d drops", s_audio_drop_count);
+      s_audio_drop_count = 0;
+   }
+   return ESP_OK;
 }
 
 /* #266: thin public wrapper for voice_video.c (and any future binary
  * sender).  Behavior is identical to voice_ws_send_binary — same
  * 100 ms send timeout, same drop accounting. */
-esp_err_t voice_ws_send_binary_public(const void *data, size_t len)
-{
-    return voice_ws_send_binary(data, len);
-}
+esp_err_t voice_ws_send_binary_public(const void *data, size_t len) { return voice_ws_send_binary(data, len); }
 
 // ---------------------------------------------------------------------------
 // Device registration — sent as FIRST text frame from the CONNECTED handler.
@@ -144,91 +137,90 @@ esp_err_t voice_ws_send_binary_public(const void *data, size_t len)
 // spawning the receive task, which opened a 50–500ms window where Dragon's
 // reply arrived while nothing was draining the SDIO RX buffer.
 // ---------------------------------------------------------------------------
-esp_err_t voice_ws_send_register(void)
-{
-    char device_id[16]   = {0};
-    char hardware_id[20] = {0};
-    char session_id[64]  = {0};
+esp_err_t voice_ws_send_register(void) {
+   char device_id[16] = {0};
+   char hardware_id[20] = {0};
+   char session_id[64] = {0};
 
-    tab5_settings_get_device_id(device_id, sizeof(device_id));
-    tab5_settings_get_hardware_id(hardware_id, sizeof(hardware_id));
-    tab5_settings_get_session_id(session_id, sizeof(session_id));
+   tab5_settings_get_device_id(device_id, sizeof(device_id));
+   tab5_settings_get_hardware_id(hardware_id, sizeof(hardware_id));
+   tab5_settings_get_session_id(session_id, sizeof(session_id));
 
-    cJSON *root = cJSON_CreateObject();
-    if (!root) return ESP_ERR_NO_MEM;
+   cJSON *root = cJSON_CreateObject();
+   if (!root) return ESP_ERR_NO_MEM;
 
-    cJSON_AddStringToObject(root, "type", "register");
-    cJSON_AddStringToObject(root, "device_id", device_id);
-    cJSON_AddStringToObject(root, "hardware_id", hardware_id);
-    cJSON_AddStringToObject(root, "name", "Tab5");
-    cJSON_AddStringToObject(root, "firmware_ver", TAB5_FIRMWARE_VER);
-    cJSON_AddStringToObject(root, "platform", TAB5_PLATFORM);
+   cJSON_AddStringToObject(root, "type", "register");
+   cJSON_AddStringToObject(root, "device_id", device_id);
+   cJSON_AddStringToObject(root, "hardware_id", hardware_id);
+   cJSON_AddStringToObject(root, "name", "Tab5");
+   cJSON_AddStringToObject(root, "firmware_ver", TAB5_FIRMWARE_VER);
+   cJSON_AddStringToObject(root, "platform", TAB5_PLATFORM);
 
-    if (session_id[0] != '\0') {
-        cJSON_AddStringToObject(root, "session_id", session_id);
-    } else {
-        cJSON_AddNullToObject(root, "session_id");
-    }
+   if (session_id[0] != '\0') {
+      cJSON_AddStringToObject(root, "session_id", session_id);
+   } else {
+      cJSON_AddNullToObject(root, "session_id");
+   }
 
-    cJSON *caps = cJSON_AddObjectToObject(root, "capabilities");
-    cJSON_AddBoolToObject(caps, "mic", true);
-    cJSON_AddBoolToObject(caps, "speaker", true);
-    cJSON_AddBoolToObject(caps, "screen", true);
-    cJSON_AddBoolToObject(caps, "camera", true);
-    cJSON_AddBoolToObject(caps, "sd_card", true);
-    cJSON_AddBoolToObject(caps, "touch", true);
-    /* #266: live JPEG video uplink.  Tab5 sends per-frame binary WS
-     * frames prefixed with the "VID0" 4-byte magic + 4-byte length.
-     * Dragon detects the magic to route video vs audio. */
-    cJSON_AddBoolToObject(caps, "video_send", true);
-    cJSON_AddBoolToObject(caps, "video_recv", true);   /* #268 Phase 3B */
-    cJSON_AddNumberToObject(caps, "video_max_fps", 10);
-    cJSON_AddNumberToObject(caps, "video_format", 0);  /* 0 = JPEG */
-    /* #262: advertise audio codec support.  Dragon picks one and replies
-     * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
-     * until Dragon switches it.  Per-direction so the broken uplink
-     * encoder (#262 follow-up: silk_NSQ_c crashes on this build) doesn't
-     * starve the working downlink decoder; until the encoder ships,
-     * advertise opus only on the downlink. */
-    cJSON *acodecs = cJSON_AddArrayToObject(caps, "audio_codec");
-    cJSON_AddItemToArray(acodecs, cJSON_CreateString("pcm"));
+   cJSON *caps = cJSON_AddObjectToObject(root, "capabilities");
+   cJSON_AddBoolToObject(caps, "mic", true);
+   cJSON_AddBoolToObject(caps, "speaker", true);
+   cJSON_AddBoolToObject(caps, "screen", true);
+   cJSON_AddBoolToObject(caps, "camera", true);
+   cJSON_AddBoolToObject(caps, "sd_card", true);
+   cJSON_AddBoolToObject(caps, "touch", true);
+   /* #266: live JPEG video uplink.  Tab5 sends per-frame binary WS
+    * frames prefixed with the "VID0" 4-byte magic + 4-byte length.
+    * Dragon detects the magic to route video vs audio. */
+   cJSON_AddBoolToObject(caps, "video_send", true);
+   cJSON_AddBoolToObject(caps, "video_recv", true); /* #268 Phase 3B */
+   cJSON_AddNumberToObject(caps, "video_max_fps", 10);
+   cJSON_AddNumberToObject(caps, "video_format", 0); /* 0 = JPEG */
+   /* #262: advertise audio codec support.  Dragon picks one and replies
+    * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
+    * until Dragon switches it.  Per-direction so the broken uplink
+    * encoder (#262 follow-up: silk_NSQ_c crashes on this build) doesn't
+    * starve the working downlink decoder; until the encoder ships,
+    * advertise opus only on the downlink. */
+   cJSON *acodecs = cJSON_AddArrayToObject(caps, "audio_codec");
+   cJSON_AddItemToArray(acodecs, cJSON_CreateString("pcm"));
 #if VOICE_CODEC_OPUS_UPLINK_ENABLED
-    cJSON_AddItemToArray(acodecs, cJSON_CreateString("opus"));
+   cJSON_AddItemToArray(acodecs, cJSON_CreateString("opus"));
 #endif
-    cJSON *acodecs_dl = cJSON_AddArrayToObject(caps, "audio_downlink_codec");
-    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("pcm"));
-    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("opus"));
-    /* v4·D audit P0 fix: widget_capability was spec-only -- now wired.
-     * Skills can downgrade widget content for low-end clients (smaller
-     * list, lower image res).  Match the actual Tab5 limits we've
-     * built out across widget_store.c / ui_home.c. */
-    cJSON *widgets = cJSON_AddObjectToObject(caps, "widgets");
-    cJSON *types = cJSON_AddArrayToObject(widgets, "types");
-    cJSON_AddItemToArray(types, cJSON_CreateString("live"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("card"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("list"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("chart"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("media"));
-    cJSON_AddItemToArray(types, cJSON_CreateString("prompt"));
-    cJSON_AddNumberToObject(widgets, "list_max_items", 5);
-    cJSON_AddNumberToObject(widgets, "chart_max_points", 12);
-    cJSON_AddNumberToObject(widgets, "prompt_max_choices", 3);
-    cJSON_AddNumberToObject(widgets, "screen_w", 720);
-    cJSON_AddNumberToObject(widgets, "screen_h", 1280);
-    cJSON_AddNumberToObject(widgets, "media_max_w", 660);
-    cJSON_AddNumberToObject(widgets, "media_max_h", 440);
-    cJSON_AddNumberToObject(widgets, "action_rate_per_sec", 4);
+   cJSON *acodecs_dl = cJSON_AddArrayToObject(caps, "audio_downlink_codec");
+   cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("pcm"));
+   cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("opus"));
+   /* v4·D audit P0 fix: widget_capability was spec-only -- now wired.
+    * Skills can downgrade widget content for low-end clients (smaller
+    * list, lower image res).  Match the actual Tab5 limits we've
+    * built out across widget_store.c / ui_home.c. */
+   cJSON *widgets = cJSON_AddObjectToObject(caps, "widgets");
+   cJSON *types = cJSON_AddArrayToObject(widgets, "types");
+   cJSON_AddItemToArray(types, cJSON_CreateString("live"));
+   cJSON_AddItemToArray(types, cJSON_CreateString("card"));
+   cJSON_AddItemToArray(types, cJSON_CreateString("list"));
+   cJSON_AddItemToArray(types, cJSON_CreateString("chart"));
+   cJSON_AddItemToArray(types, cJSON_CreateString("media"));
+   cJSON_AddItemToArray(types, cJSON_CreateString("prompt"));
+   cJSON_AddNumberToObject(widgets, "list_max_items", 5);
+   cJSON_AddNumberToObject(widgets, "chart_max_points", 12);
+   cJSON_AddNumberToObject(widgets, "prompt_max_choices", 3);
+   cJSON_AddNumberToObject(widgets, "screen_w", 720);
+   cJSON_AddNumberToObject(widgets, "screen_h", 1280);
+   cJSON_AddNumberToObject(widgets, "media_max_w", 660);
+   cJSON_AddNumberToObject(widgets, "media_max_h", 440);
+   cJSON_AddNumberToObject(widgets, "action_rate_per_sec", 4);
 
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    if (!json) return ESP_ERR_NO_MEM;
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!json) return ESP_ERR_NO_MEM;
 
-    ESP_LOGI(TAG, "Sending register: device=%s hw=%s session=%s",
-             device_id, hardware_id, session_id[0] ? session_id : "(new)");
+   ESP_LOGI(TAG, "Sending register: device=%s hw=%s session=%s", device_id, hardware_id,
+            session_id[0] ? session_id : "(new)");
 
-    esp_err_t err = voice_ws_send_text(json);
-    cJSON_free(json);
-    return err;
+   esp_err_t err = voice_ws_send_text(json);
+   cJSON_free(json);
+   return err;
 }
 
 // ---------------------------------------------------------------------------
@@ -236,44 +228,42 @@ esp_err_t voice_ws_send_register(void)
 // JSON frame, rate-limits, sends via voice_ws_send_text.  Pre-extract this
 // lived inline in voice.c at the bottom of the public-API section.
 // ---------------------------------------------------------------------------
-esp_err_t voice_send_widget_action(const char *card_id, const char *event,
-                                   const char *payload_json)
-{
-    if (!card_id || !event) return ESP_ERR_INVALID_ARG;
-    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+esp_err_t voice_send_widget_action(const char *card_id, const char *event, const char *payload_json) {
+   if (!card_id || !event) return ESP_ERR_INVALID_ARG;
+   if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
 
-    /* Rate limit: 4/sec max (see docs/WIDGETS.md §11). */
-    static uint32_t s_action_bucket = 4;
-    static uint32_t s_action_tick   = 0;
-    uint32_t now = lv_tick_get();
-    if (now - s_action_tick >= 1000) {
-        s_action_bucket = 4;
-        s_action_tick = now;
-    }
-    if (s_action_bucket == 0) {
-        ESP_LOGW(TAG, "widget_action rate-limited (card=%s event=%s)", card_id, event);
-        return ESP_ERR_INVALID_STATE;
-    }
-    s_action_bucket--;
+   /* Rate limit: 4/sec max (see docs/WIDGETS.md §11). */
+   static uint32_t s_action_bucket = 4;
+   static uint32_t s_action_tick = 0;
+   uint32_t now = lv_tick_get();
+   if (now - s_action_tick >= 1000) {
+      s_action_bucket = 4;
+      s_action_tick = now;
+   }
+   if (s_action_bucket == 0) {
+      ESP_LOGW(TAG, "widget_action rate-limited (card=%s event=%s)", card_id, event);
+      return ESP_ERR_INVALID_STATE;
+   }
+   s_action_bucket--;
 
-    cJSON *msg = cJSON_CreateObject();
-    cJSON_AddStringToObject(msg, "type", "widget_action");
-    cJSON_AddStringToObject(msg, "card_id", card_id);
-    cJSON_AddStringToObject(msg, "event", event);
-    if (payload_json && payload_json[0]) {
-        cJSON *p = cJSON_Parse(payload_json);
-        if (p) cJSON_AddItemToObject(msg, "payload", p);
-    }
-    char *json = cJSON_PrintUnformatted(msg);
-    cJSON_Delete(msg);
-    if (!json) return ESP_ERR_NO_MEM;
+   cJSON *msg = cJSON_CreateObject();
+   cJSON_AddStringToObject(msg, "type", "widget_action");
+   cJSON_AddStringToObject(msg, "card_id", card_id);
+   cJSON_AddStringToObject(msg, "event", event);
+   if (payload_json && payload_json[0]) {
+      cJSON *p = cJSON_Parse(payload_json);
+      if (p) cJSON_AddItemToObject(msg, "payload", p);
+   }
+   char *json = cJSON_PrintUnformatted(msg);
+   cJSON_Delete(msg);
+   if (!json) return ESP_ERR_NO_MEM;
 
-    esp_err_t ret = voice_ws_send_text(json);
-    cJSON_free(json);
-    if (ret == ESP_OK) {
-        ESP_LOGI(TAG, "widget_action: %s → %s", card_id, event);
-    }
-    return ret;
+   esp_err_t ret = voice_ws_send_text(json);
+   cJSON_free(json);
+   if (ret == ESP_OK) {
+      ESP_LOGI(TAG, "widget_action: %s → %s", card_id, event);
+   }
+   return ret;
 }
 
 // ---------------------------------------------------------------------------
@@ -287,12 +277,12 @@ esp_err_t voice_send_widget_action(const char *card_id, const char *event,
 // US-C02: Generation-guarded async call wrappers.
 // ---------------------------------------------------------------------------
 typedef struct {
-    uint32_t gen;
-    char    *text;
+   uint32_t gen;
+   char *text;
 } voice_async_toast_t;
 
 typedef struct {
-    uint32_t gen;
+   uint32_t gen;
 } voice_async_badge_t;
 
 /* γ2-H8 (issue #196): worker to stop the WS client off the WS task.
@@ -306,13 +296,12 @@ typedef struct {
  * trigger another eviction.  s_disconnecting was already set in
  * the WS handler so the WEBSOCKET_EVENT_DISCONNECTED branch won't
  * try to reconnect when the stop completes. */
-static void _voice_stop_ws_worker_fn(void *arg)
-{
-    (void)arg;
-    if (g_voice_ws) {
-        ESP_LOGW(TAG, "device_evicted worker: stopping WS client now");
-        esp_websocket_client_stop(g_voice_ws);
-    }
+static void _voice_stop_ws_worker_fn(void *arg) {
+   (void)arg;
+   if (g_voice_ws) {
+      ESP_LOGW(TAG, "device_evicted worker: stopping WS client now");
+      esp_websocket_client_stop(g_voice_ws);
+   }
 }
 
 /* γ3-Tab5 (issue #198): worker for the auth-failed stop path.
@@ -322,57 +311,51 @@ static void _voice_stop_ws_worker_fn(void *arg)
  * ESP_LOG line clearly identifies WHICH path triggered the stop —
  * makes ops triage on a misconfigured-token device much easier
  * than a generic "stop_ws" trace. */
-static void _voice_auth_fail_stop_worker_fn(void *arg)
-{
-    (void)arg;
-    if (g_voice_ws) {
-        ESP_LOGW(TAG, "auth_failed worker: stopping WS after %d consecutive 401s",
-                 s_auth_fail_cnt);
-        esp_websocket_client_stop(g_voice_ws);
-    }
+static void _voice_auth_fail_stop_worker_fn(void *arg) {
+   (void)arg;
+   if (g_voice_ws) {
+      ESP_LOGW(TAG, "auth_failed worker: stopping WS after %d consecutive 401s", s_auth_fail_cnt);
+      esp_websocket_client_stop(g_voice_ws);
+   }
 }
 
-static void async_show_toast_cb(void *arg)
-{
-    voice_async_toast_t *t = (voice_async_toast_t *)arg;
-    if (!t) return;
-    if (t->gen == s_session_gen && t->text) {
-       ui_home_show_toast(t->text);
-    } else if (t->text) {
-       ESP_LOGD(TAG, "Stale async toast dropped (gen %lu vs %lu)", (unsigned long)t->gen, (unsigned long)s_session_gen);
-    }
-    free(t->text);
-    free(t);
+static void async_show_toast_cb(void *arg) {
+   voice_async_toast_t *t = (voice_async_toast_t *)arg;
+   if (!t) return;
+   if (t->gen == s_session_gen && t->text) {
+      ui_home_show_toast(t->text);
+   } else if (t->text) {
+      ESP_LOGD(TAG, "Stale async toast dropped (gen %lu vs %lu)", (unsigned long)t->gen, (unsigned long)s_session_gen);
+   }
+   free(t->text);
+   free(t);
 }
 
-static void async_refresh_badge_cb(void *arg)
-{
-    voice_async_badge_t *b = (voice_async_badge_t *)arg;
-    if (!b) return;
-    if (b->gen == s_session_gen) {
-       ui_home_refresh_mode_badge();
-    } else {
-       ESP_LOGD(TAG, "Stale async badge refresh dropped (gen %lu vs %lu)", (unsigned long)b->gen,
-                (unsigned long)s_session_gen);
-    }
-    free(b);
+static void async_refresh_badge_cb(void *arg) {
+   voice_async_badge_t *b = (voice_async_badge_t *)arg;
+   if (!b) return;
+   if (b->gen == s_session_gen) {
+      ui_home_refresh_mode_badge();
+   } else {
+      ESP_LOGD(TAG, "Stale async badge refresh dropped (gen %lu vs %lu)", (unsigned long)b->gen,
+               (unsigned long)s_session_gen);
+   }
+   free(b);
 }
 
-void voice_async_toast(char *text)
-{
-    voice_async_toast_t *t = malloc(sizeof(voice_async_toast_t));
-    if (!t) {
-        /* Wave 14 W14-M08: log the silent-drop so ops can see we
-         * squeezed internal SRAM and a user-facing toast never reached
-         * LVGL. */
-        ESP_LOGW(TAG, "voice_async_toast OOM — dropping toast (text=%.40s)",
-                 text ? text : "");
-        free(text);
-        return;
-    }
-    t->gen = s_session_gen;
-    t->text = text;
-    tab5_lv_async_call(async_show_toast_cb, t);
+void voice_async_toast(char *text) {
+   voice_async_toast_t *t = malloc(sizeof(voice_async_toast_t));
+   if (!t) {
+      /* Wave 14 W14-M08: log the silent-drop so ops can see we
+       * squeezed internal SRAM and a user-facing toast never reached
+       * LVGL. */
+      ESP_LOGW(TAG, "voice_async_toast OOM — dropping toast (text=%.40s)", text ? text : "");
+      free(text);
+      return;
+   }
+   t->gen = s_session_gen;
+   t->text = text;
+   tab5_lv_async_call(async_show_toast_cb, t);
 }
 
 /* TT #328 Wave 3 — async fire of ui_home_show_error_banner from voice WS
@@ -465,15 +448,14 @@ static void async_clear_banner_cb(void *arg) {
    ui_home_clear_error_banner();
 }
 
-static void voice_async_refresh_badge(void)
-{
-    voice_async_badge_t *b = malloc(sizeof(voice_async_badge_t));
-    if (!b) {
-        ESP_LOGW(TAG, "voice_async_refresh_badge OOM — badge will lag a tick");
-        return;
-    }
-    b->gen = s_session_gen;
-    tab5_lv_async_call(async_refresh_badge_cb, b);
+static void voice_async_refresh_badge(void) {
+   voice_async_badge_t *b = malloc(sizeof(voice_async_badge_t));
+   if (!b) {
+      ESP_LOGW(TAG, "voice_async_refresh_badge OOM — badge will lag a tick");
+      return;
+   }
+   b->gen = s_session_gen;
+   tab5_lv_async_call(async_refresh_badge_cb, b);
 }
 
 // ---------------------------------------------------------------------------
@@ -491,612 +473,593 @@ void voice_debug_inject_text(const char *data, int len) {
 }
 
 /* TT #331 Wave 23 SRP-A1: was static void handle_text_message — promoted + renamed for the voice_ws_proto layer. */
-void voice_ws_proto_handle_text(const char *data, int len)
-{
-    cJSON *root = cJSON_ParseWithLength(data, len);
-    if (!root) {
-        ESP_LOGW(TAG, "Failed to parse JSON: %.*s", len, data);
-        return;
-    }
+void voice_ws_proto_handle_text(const char *data, int len) {
+   cJSON *root = cJSON_ParseWithLength(data, len);
+   if (!root) {
+      ESP_LOGW(TAG, "Failed to parse JSON: %.*s", len, data);
+      return;
+   }
 
-    cJSON *type = cJSON_GetObjectItem(root, "type");
-    if (!cJSON_IsString(type)) {
-        ESP_LOGW(TAG, "JSON missing 'type': %.*s", len, data);
-        cJSON_Delete(root);
-        return;
-    }
+   cJSON *type = cJSON_GetObjectItem(root, "type");
+   if (!cJSON_IsString(type)) {
+      ESP_LOGW(TAG, "JSON missing 'type': %.*s", len, data);
+      cJSON_Delete(root);
+      return;
+   }
 
-    const char *type_str = type->valuestring;
+   const char *type_str = type->valuestring;
 
-    if (strcmp(type_str, "stt_partial") == 0) {
-        cJSON *text = cJSON_GetObjectItem(root, "text");
-        /* U12 (#206): regardless of dictation mode, surface the partial
-         * as a live caption above the chat input pill.  No-op when chat
-         * is closed (s_input is NULL inside ui_chat). */
-        if (cJSON_IsString(text) && text->valuestring) {
-            ui_chat_show_partial(text->valuestring);
-        }
-        if (cJSON_IsString(text) && text->valuestring && voice_get_mode() == VOICE_MODE_DICTATE
-            && s_dictation_text) {
-            /* v4·D audit P1 fix: use bounded copy instead of unchecked
-             * strcat.  Previously the guard compared cur+add+2 against
-             * the buffer size, but under mutex-less concurrent writes
-             * cur_len could change between the check and the strcat.
-             * Take the state mutex and re-bound with snprintf so an
-             * overflow is impossible. */
+   if (strcmp(type_str, "stt_partial") == 0) {
+      cJSON *text = cJSON_GetObjectItem(root, "text");
+      /* U12 (#206): regardless of dictation mode, surface the partial
+       * as a live caption above the chat input pill.  No-op when chat
+       * is closed (s_input is NULL inside ui_chat). */
+      if (cJSON_IsString(text) && text->valuestring) {
+         ui_chat_show_partial(text->valuestring);
+      }
+      if (cJSON_IsString(text) && text->valuestring && voice_get_mode() == VOICE_MODE_DICTATE && s_dictation_text) {
+         /* v4·D audit P1 fix: use bounded copy instead of unchecked
+          * strcat.  Previously the guard compared cur+add+2 against
+          * the buffer size, but under mutex-less concurrent writes
+          * cur_len could change between the check and the strcat.
+          * Take the state mutex and re-bound with snprintf so an
+          * overflow is impossible. */
+         if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+         size_t cur_len = strlen(s_dictation_text);
+         size_t remaining = (cur_len + 1 < DICTATION_TEXT_SIZE) ? (DICTATION_TEXT_SIZE - cur_len - 1) : 0;
+         if (remaining > 1) {
+            const char *sep = (cur_len > 0) ? " " : "";
+            snprintf(s_dictation_text + cur_len, remaining, "%s%s", sep, text->valuestring);
+         }
+         if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+         ESP_LOGI(TAG, "STT partial: \"%s\" (total %u chars)", text->valuestring, (unsigned)strlen(s_dictation_text));
+         voice_set_state(VOICE_STATE_LISTENING, s_dictation_text);
+      }
+   } else if (strcmp(type_str, "stt") == 0) {
+      cJSON *text = cJSON_GetObjectItem(root, "text");
+      /* U12 (#206): final STT result lands as a real chat bubble — clear
+       * the live partial caption so it doesn't linger above the pill. */
+      ui_chat_show_partial(NULL);
+      if (cJSON_IsString(text) && text->valuestring) {
+         if (voice_get_mode() == VOICE_MODE_DICTATE) {
             if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-            size_t cur_len = strlen(s_dictation_text);
-            size_t remaining = (cur_len + 1 < DICTATION_TEXT_SIZE)
-                               ? (DICTATION_TEXT_SIZE - cur_len - 1) : 0;
-            if (remaining > 1) {
-                const char *sep = (cur_len > 0) ? " " : "";
-                snprintf(s_dictation_text + cur_len, remaining,
-                         "%s%s", sep, text->valuestring);
-            }
+            strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
+            s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
             if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-            ESP_LOGI(TAG, "STT partial: \"%s\" (total %u chars)",
-                     text->valuestring, (unsigned)strlen(s_dictation_text));
-            voice_set_state(VOICE_STATE_LISTENING, s_dictation_text);
-        }
-    } else if (strcmp(type_str, "stt") == 0) {
-        cJSON *text = cJSON_GetObjectItem(root, "text");
-        /* U12 (#206): final STT result lands as a real chat bubble — clear
-         * the live partial caption so it doesn't linger above the pill. */
-        ui_chat_show_partial(NULL);
-        if (cJSON_IsString(text) && text->valuestring) {
-            if (voice_get_mode() == VOICE_MODE_DICTATE) {
-                if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-                strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
-                s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
-                if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-                ESP_LOGI(TAG, "Dictation complete: %u chars", (unsigned)strlen(text->valuestring));
-                voice_set_state(VOICE_STATE_READY, "dictation_done");
-            } else {
-                if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-                strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
-                s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
-                strncpy(s_transcript, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
-                s_transcript[MAX_TRANSCRIPT_LEN - 1] = '\0';
-                s_llm_text[0] = '\0';
-                if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-                ESP_LOGI(TAG, "STT: \"%s\"", s_stt_text);
-                ui_chat_push_message("user", text->valuestring);
-                voice_set_state(VOICE_STATE_PROCESSING, s_stt_text);
-            }
-        }
-    } else if (strcmp(type_str, "tts_start") == 0) {
-        /* Audit #80 DMA leak hunt (wave 9): log heap state at the 5
-         * interesting boundaries of a chat turn (llm_done, tts_start,
-         * tts_end, media, text_update) so we can diff which stage leaks.
-         * Heap caps are DMA-capable internal SRAM — same pool the WiFi
-         * Rx ring needs to stay alive. */
-        ESP_LOGI(TAG, "TTS start — preparing playback | heap_dma_free=%u largest=%u",
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
-        tab5_audio_speaker_enable(true);
-        voice_playback_buf_reset();
-        voice_set_state(VOICE_STATE_SPEAKING, NULL);
-    } else if (strcmp(type_str, "tts_end") == 0) {
-        ESP_LOGI(TAG, "TTS end — drain task will finish playback | heap_dma_free=%u largest=%u",
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
-        s_tts_done = true;
-        if (s_play_sem) xSemaphoreGive(s_play_sem);
-    } else if (strcmp(type_str, "llm") == 0) {
-        /* TinkerBox #91 follow-up (#193): ignore late llm tokens that
-         * arrive after a cancel.  Tab5 transitions to READY locally on
-         * cancel-send (see voice_cancel below); Dragon now actually
-         * interrupts the LLM stream within ~1 ms (was ~65 s pre-#91),
-         * but tokens already in TCP flight at cancel-time still arrive
-         * a few hundred ms later.  Without this guard, the unconditional
-         * voice_set_state below pulls the orb back into PROCESSING with
-         * the partial cancelled response text — the cancel APPEARS to
-         * not have worked from the user's perspective.
-         *
-         * Honor llm tokens only when the user is actively waiting for a
-         * turn (PROCESSING or SPEAKING).  All other states (READY after
-         * cancel, IDLE on disconnect, LISTENING when a new mic recording
-         * already started) mean the previous turn is no longer the user's
-         * focus and any late tokens belong to a turn they cancelled.
-         */
-        voice_state_t cur_for_llm = voice_get_state();
-        if (cur_for_llm != VOICE_STATE_PROCESSING && cur_for_llm != VOICE_STATE_SPEAKING) {
-            ESP_LOGD(TAG, "llm token ignored — state=%d (post-cancel late arrival)",
-                     cur_for_llm);
-            cJSON_Delete(root);
-            return;
-        }
-        cJSON *text = cJSON_GetObjectItem(root, "text");
-        if (cJSON_IsString(text) && text->valuestring) {
+            ESP_LOGI(TAG, "Dictation complete: %u chars", (unsigned)strlen(text->valuestring));
+            voice_set_state(VOICE_STATE_READY, "dictation_done");
+         } else {
             if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-            size_t llm_len = strlen(s_llm_text);
-            size_t add_len = strlen(text->valuestring);
-            if (llm_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
-                strcat(s_llm_text, text->valuestring);
-            }
-            size_t cur_len = strlen(s_transcript);
-            if (cur_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
-                strcat(s_transcript, text->valuestring);
-            }
+            strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
+            s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
+            strncpy(s_transcript, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
+            s_transcript[MAX_TRANSCRIPT_LEN - 1] = '\0';
+            s_llm_text[0] = '\0';
             if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-            ESP_LOGD(TAG, "LLM token: \"%s\"", text->valuestring);
-            voice_set_state(VOICE_STATE_PROCESSING, s_llm_text);
-        }
-    } else if (strcmp(type_str, "cancel_ack") == 0) {
-        /* TinkerBox #91: server-side confirmation that cancel landed.
-         * Today we just log it — the state machine already transitioned
-         * to READY when voice_cancel was called, and the llm-token
-         * guard above handles the late-arrival grace window.
-         * If we ever add a "definitely no more late tokens, safe to
-         * resume" semantic, this is where it would slot in. */
-        cJSON *cancelled = cJSON_GetObjectItem(root, "cancelled");
-        int n = cJSON_IsArray(cancelled) ? cJSON_GetArraySize(cancelled) : 0;
-        ESP_LOGI(TAG, "cancel_ack: cancelled=%d slot(s)", n);
-    } else if (strcmp(type_str, "error") == 0) {
-        /* γ2-H8 (issue #196): route Dragon error frames by severity.
-         *
-         * Pre-fix every {"type":"error"} frame landed in the voice-
-         * overlay caption regardless of what went wrong — a recoverable
-         * STT-empty toast and an unrecoverable session-invalid banner
-         * both ended up in the same place.  Dragon's γ1 taxonomy
-         * (TinkerBox PR #102) added structured `severity` ("transient"
-         * vs "fatal") and `scope` fields; this handler honours them:
-         *
-         *   - TRANSIENT → non-blocking ui_home_show_toast(), stay in
-         *     READY.  User can keep talking.
-         *   - FATAL → existing voice-state caption path (more
-         *     permanent surface).  Reset playback + speaker since a
-         *     fatal error means we shouldn't keep half-playing TTS.
-         *
-         * Special case: code="device_evicted" (TinkerBox γ2-M5, PR
-         * #109) means another device claimed our slot.  Auto-reconnect
-         * would just trigger an eviction loop, so we set the
-         * disconnect guard + stop the WS client.  User must
-         * power-cycle or re-launch via the debug endpoint.
-         */
-        cJSON *msg       = cJSON_GetObjectItem(root, "message");
-        cJSON *severity  = cJSON_GetObjectItem(root, "severity");
-        cJSON *code      = cJSON_GetObjectItem(root, "code");
-        const char *err_src  = cJSON_IsString(msg) ? msg->valuestring : "unknown";
-        /* Default to "fatal" for unknown / pre-γ1 frames — safer to
-         * surface in caption (more visible) than to silently toast.
-         * Tab5 is forward-compatible with future severity values too:
-         * anything not "transient" routes to caption. */
-        const char *sev_src  = cJSON_IsString(severity) ? severity->valuestring : "fatal";
-        const char *code_src = cJSON_IsString(code) ? code->valuestring : "";
-        ESP_LOGE(TAG, "Dragon error [%s/%s]: %s", sev_src, code_src, err_src);
+            ESP_LOGI(TAG, "STT: \"%s\"", s_stt_text);
+            ui_chat_push_message("user", text->valuestring);
+            voice_set_state(VOICE_STATE_PROCESSING, s_stt_text);
+         }
+      }
+   } else if (strcmp(type_str, "tts_start") == 0) {
+      /* Audit #80 DMA leak hunt (wave 9): log heap state at the 5
+       * interesting boundaries of a chat turn (llm_done, tts_start,
+       * tts_end, media, text_update) so we can diff which stage leaks.
+       * Heap caps are DMA-capable internal SRAM — same pool the WiFi
+       * Rx ring needs to stay alive. */
+      ESP_LOGI(TAG, "TTS start — preparing playback | heap_dma_free=%u largest=%u",
+               (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
+               (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+      tab5_audio_speaker_enable(true);
+      voice_playback_buf_reset();
+      voice_set_state(VOICE_STATE_SPEAKING, NULL);
+   } else if (strcmp(type_str, "tts_end") == 0) {
+      ESP_LOGI(TAG, "TTS end — drain task will finish playback | heap_dma_free=%u largest=%u",
+               (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
+               (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+      s_tts_done = true;
+      if (s_play_sem) xSemaphoreGive(s_play_sem);
+   } else if (strcmp(type_str, "llm") == 0) {
+      /* TinkerBox #91 follow-up (#193): ignore late llm tokens that
+       * arrive after a cancel.  Tab5 transitions to READY locally on
+       * cancel-send (see voice_cancel below); Dragon now actually
+       * interrupts the LLM stream within ~1 ms (was ~65 s pre-#91),
+       * but tokens already in TCP flight at cancel-time still arrive
+       * a few hundred ms later.  Without this guard, the unconditional
+       * voice_set_state below pulls the orb back into PROCESSING with
+       * the partial cancelled response text — the cancel APPEARS to
+       * not have worked from the user's perspective.
+       *
+       * Honor llm tokens only when the user is actively waiting for a
+       * turn (PROCESSING or SPEAKING).  All other states (READY after
+       * cancel, IDLE on disconnect, LISTENING when a new mic recording
+       * already started) mean the previous turn is no longer the user's
+       * focus and any late tokens belong to a turn they cancelled.
+       */
+      voice_state_t cur_for_llm = voice_get_state();
+      if (cur_for_llm != VOICE_STATE_PROCESSING && cur_for_llm != VOICE_STATE_SPEAKING) {
+         ESP_LOGD(TAG, "llm token ignored — state=%d (post-cancel late arrival)", cur_for_llm);
+         cJSON_Delete(root);
+         return;
+      }
+      cJSON *text = cJSON_GetObjectItem(root, "text");
+      if (cJSON_IsString(text) && text->valuestring) {
+         if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+         size_t llm_len = strlen(s_llm_text);
+         size_t add_len = strlen(text->valuestring);
+         if (llm_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
+            strcat(s_llm_text, text->valuestring);
+         }
+         size_t cur_len = strlen(s_transcript);
+         if (cur_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
+            strcat(s_transcript, text->valuestring);
+         }
+         if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+         ESP_LOGD(TAG, "LLM token: \"%s\"", text->valuestring);
+         voice_set_state(VOICE_STATE_PROCESSING, s_llm_text);
+      }
+   } else if (strcmp(type_str, "cancel_ack") == 0) {
+      /* TinkerBox #91: server-side confirmation that cancel landed.
+       * Today we just log it — the state machine already transitioned
+       * to READY when voice_cancel was called, and the llm-token
+       * guard above handles the late-arrival grace window.
+       * If we ever add a "definitely no more late tokens, safe to
+       * resume" semantic, this is where it would slot in. */
+      cJSON *cancelled = cJSON_GetObjectItem(root, "cancelled");
+      int n = cJSON_IsArray(cancelled) ? cJSON_GetArraySize(cancelled) : 0;
+      ESP_LOGI(TAG, "cancel_ack: cancelled=%d slot(s)", n);
+   } else if (strcmp(type_str, "error") == 0) {
+      /* γ2-H8 (issue #196): route Dragon error frames by severity.
+       *
+       * Pre-fix every {"type":"error"} frame landed in the voice-
+       * overlay caption regardless of what went wrong — a recoverable
+       * STT-empty toast and an unrecoverable session-invalid banner
+       * both ended up in the same place.  Dragon's γ1 taxonomy
+       * (TinkerBox PR #102) added structured `severity` ("transient"
+       * vs "fatal") and `scope` fields; this handler honours them:
+       *
+       *   - TRANSIENT → non-blocking ui_home_show_toast(), stay in
+       *     READY.  User can keep talking.
+       *   - FATAL → existing voice-state caption path (more
+       *     permanent surface).  Reset playback + speaker since a
+       *     fatal error means we shouldn't keep half-playing TTS.
+       *
+       * Special case: code="device_evicted" (TinkerBox γ2-M5, PR
+       * #109) means another device claimed our slot.  Auto-reconnect
+       * would just trigger an eviction loop, so we set the
+       * disconnect guard + stop the WS client.  User must
+       * power-cycle or re-launch via the debug endpoint.
+       */
+      cJSON *msg = cJSON_GetObjectItem(root, "message");
+      cJSON *severity = cJSON_GetObjectItem(root, "severity");
+      cJSON *code = cJSON_GetObjectItem(root, "code");
+      const char *err_src = cJSON_IsString(msg) ? msg->valuestring : "unknown";
+      /* Default to "fatal" for unknown / pre-γ1 frames — safer to
+       * surface in caption (more visible) than to silently toast.
+       * Tab5 is forward-compatible with future severity values too:
+       * anything not "transient" routes to caption. */
+      const char *sev_src = cJSON_IsString(severity) ? severity->valuestring : "fatal";
+      const char *code_src = cJSON_IsString(code) ? code->valuestring : "";
+      ESP_LOGE(TAG, "Dragon error [%s/%s]: %s", sev_src, code_src, err_src);
 
-        char err_buf[128];
-        strncpy(err_buf, err_src, sizeof(err_buf) - 1);
-        err_buf[sizeof(err_buf) - 1] = '\0';
+      char err_buf[128];
+      strncpy(err_buf, err_src, sizeof(err_buf) - 1);
+      err_buf[sizeof(err_buf) - 1] = '\0';
 
-        bool is_transient = (strcmp(sev_src, "transient") == 0);
+      bool is_transient = (strcmp(sev_src, "transient") == 0);
 
-        if (is_transient) {
-            /* TRANSIENT → toast via the existing voice_async_toast()
-             * helper.  This handler runs on the WS task, NOT the LVGL
-             * task — voice_async_toast() takes ownership of a strdup'd
-             * buffer, queues it via lv_async_call, and stamps the
-             * session_gen so a stale toast from a prior connection
-             * doesn't surface after a reconnect. */
-            char *toast_copy = strdup(err_buf);
-            if (toast_copy) {
-                voice_async_toast(toast_copy);
-            }
-        } else {
-            /* FATAL → existing caption path. */
-            voice_playback_buf_reset();
-            tab5_audio_speaker_enable(false);
-            bool connected = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
-            voice_set_state(connected ? VOICE_STATE_READY : VOICE_STATE_IDLE, err_buf);
+      if (is_transient) {
+         /* TRANSIENT → toast via the existing voice_async_toast()
+          * helper.  This handler runs on the WS task, NOT the LVGL
+          * task — voice_async_toast() takes ownership of a strdup'd
+          * buffer, queues it via lv_async_call, and stamps the
+          * session_gen so a stale toast from a prior connection
+          * doesn't surface after a reconnect. */
+         char *toast_copy = strdup(err_buf);
+         if (toast_copy) {
+            voice_async_toast(toast_copy);
+         }
+      } else {
+         /* FATAL → existing caption path. */
+         voice_playback_buf_reset();
+         tab5_audio_speaker_enable(false);
+         bool connected = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
+         voice_set_state(connected ? VOICE_STATE_READY : VOICE_STATE_IDLE, err_buf);
 
-            /* device_evicted: don't loop the eviction.  Stop the WS
-             * client + set the disconnect guard so the
-             * WEBSOCKET_EVENT_DISCONNECTED handler doesn't try to
-             * reconnect.  User regains connectivity via power-cycle
-             * or the /voice/reconnect debug endpoint.
-             *
-             * IMPORTANT: esp_websocket_client_stop() rejects calls
-             * from the WS task itself (logs "Client cannot be
-             * stopped from websocket task" and no-ops).  Hop to the
-             * shared worker queue (task_worker.{c,h}) so the stop
-             * runs on a non-WS task. */
-            if (strcmp(code_src, "device_evicted") == 0 && g_voice_ws) {
-                ESP_LOGW(TAG, "device_evicted: scheduling WS stop to prevent reconnect loop");
-                s_disconnecting = true;
-                tab5_worker_enqueue(_voice_stop_ws_worker_fn, NULL,
-                                    "device_evicted_stop");
-            }
-        }
-    } else if (strcmp(type_str, "session_start") == 0) {
-        cJSON *sid = cJSON_GetObjectItem(root, "session_id");
-        if (cJSON_IsString(sid) && sid->valuestring) {
-            tab5_settings_set_session_id(sid->valuestring);
-            ESP_LOGI(TAG, "Session: %s", sid->valuestring);
-        }
-        cJSON *resumed = cJSON_GetObjectItem(root, "resumed");
-        cJSON *msg_cnt = cJSON_GetObjectItem(root, "message_count");
-        ESP_LOGI(TAG, "session_start: resumed=%s messages=%d",
-                 (cJSON_IsTrue(resumed) ? "yes" : "no"),
-                 cJSON_IsNumber(msg_cnt) ? msg_cnt->valueint : 0);
+         /* device_evicted: don't loop the eviction.  Stop the WS
+          * client + set the disconnect guard so the
+          * WEBSOCKET_EVENT_DISCONNECTED handler doesn't try to
+          * reconnect.  User regains connectivity via power-cycle
+          * or the /voice/reconnect debug endpoint.
+          *
+          * IMPORTANT: esp_websocket_client_stop() rejects calls
+          * from the WS task itself (logs "Client cannot be
+          * stopped from websocket task" and no-ops).  Hop to the
+          * shared worker queue (task_worker.{c,h}) so the stop
+          * runs on a non-WS task. */
+         if (strcmp(code_src, "device_evicted") == 0 && g_voice_ws) {
+            ESP_LOGW(TAG, "device_evicted: scheduling WS stop to prevent reconnect loop");
+            s_disconnecting = true;
+            tab5_worker_enqueue(_voice_stop_ws_worker_fn, NULL, "device_evicted_stop");
+         }
+      }
+   } else if (strcmp(type_str, "session_start") == 0) {
+      cJSON *sid = cJSON_GetObjectItem(root, "session_id");
+      if (cJSON_IsString(sid) && sid->valuestring) {
+         tab5_settings_set_session_id(sid->valuestring);
+         ESP_LOGI(TAG, "Session: %s", sid->valuestring);
+      }
+      cJSON *resumed = cJSON_GetObjectItem(root, "resumed");
+      cJSON *msg_cnt = cJSON_GetObjectItem(root, "message_count");
+      ESP_LOGI(TAG, "session_start: resumed=%s messages=%d", (cJSON_IsTrue(resumed) ? "yes" : "no"),
+               cJSON_IsNumber(msg_cnt) ? msg_cnt->valueint : 0);
 
-        if (voice_get_state() == VOICE_STATE_CONNECTING) {
-            voice_set_state(VOICE_STATE_READY, NULL);
-            ESP_LOGI(TAG, "Connected to Dragon voice server");
+      if (voice_get_state() == VOICE_STATE_CONNECTING) {
+         voice_set_state(VOICE_STATE_READY, NULL);
+         ESP_LOGI(TAG, "Connected to Dragon voice server");
 
-            uint8_t saved_mode = tab5_settings_get_voice_mode();
-            char saved_model[64] = {0};
-            tab5_settings_get_llm_model(saved_model, sizeof(saved_model));
-            ESP_LOGI(TAG, "Restoring voice_mode=%d model='%s' on reconnect",
-                     saved_mode, saved_model[0] ? saved_model : "(default)");
-            voice_send_config_update((int)saved_mode,
-                                     saved_model[0] ? saved_model : NULL);
+         uint8_t saved_mode = tab5_settings_get_voice_mode();
+         char saved_model[64] = {0};
+         tab5_settings_get_llm_model(saved_model, sizeof(saved_model));
+         ESP_LOGI(TAG, "Restoring voice_mode=%d model='%s' on reconnect", saved_mode,
+                  saved_model[0] ? saved_model : "(default)");
+         voice_send_config_update((int)saved_mode, saved_model[0] ? saved_model : NULL);
 
-            ui_notes_sync_pending();
-        }
-    } else if (strcmp(type_str, "session_messages") == 0) {
-        /* Audit C8/K15 (2026-04-20): Dragon replays the tail of session
-         * messages on a resumed connect.  Rehydrate chat_store so the
-         * user sees their conversation after a reconnect.  Pushed via
-         * ui_chat_push_message which is thread-safe + lv_async_call'd. */
-        cJSON *items = cJSON_GetObjectItem(root, "items");
-        if (cJSON_IsArray(items)) {
-            int n = cJSON_GetArraySize(items);
-            ESP_LOGI(TAG, "session_messages replay: %d items", n);
-            for (int i = 0; i < n; i++) {
-                cJSON *m = cJSON_GetArrayItem(items, i);
-                if (!m) continue;
-                const char *role = cJSON_GetStringValue(
-                    cJSON_GetObjectItem(m, "role"));
-                const char *content = cJSON_GetStringValue(
-                    cJSON_GetObjectItem(m, "content"));
-                if (!role || !content || !content[0]) continue;
-                /* Skip system/tool rows — chat UI only renders
-                 * user/assistant today. */
-                if (strcmp(role, "user") != 0 &&
-                    strcmp(role, "assistant") != 0) continue;
-                ui_chat_push_message(role, content);
+         ui_notes_sync_pending();
+      }
+   } else if (strcmp(type_str, "session_messages") == 0) {
+      /* Audit C8/K15 (2026-04-20): Dragon replays the tail of session
+       * messages on a resumed connect.  Rehydrate chat_store so the
+       * user sees their conversation after a reconnect.  Pushed via
+       * ui_chat_push_message which is thread-safe + lv_async_call'd. */
+      cJSON *items = cJSON_GetObjectItem(root, "items");
+      if (cJSON_IsArray(items)) {
+         int n = cJSON_GetArraySize(items);
+         ESP_LOGI(TAG, "session_messages replay: %d items", n);
+         for (int i = 0; i < n; i++) {
+            cJSON *m = cJSON_GetArrayItem(items, i);
+            if (!m) continue;
+            const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(m, "role"));
+            const char *content = cJSON_GetStringValue(cJSON_GetObjectItem(m, "content"));
+            if (!role || !content || !content[0]) continue;
+            /* Skip system/tool rows — chat UI only renders
+             * user/assistant today. */
+            if (strcmp(role, "user") != 0 && strcmp(role, "assistant") != 0) continue;
+            ui_chat_push_message(role, content);
+         }
+      }
+   } else if (strcmp(type_str, "dictation_postprocessing") == 0) {
+      /* TinkerBox#94 H4: Dragon spawned the title+summary LLM call after
+       * `stt`.  Pre-fix the user stared at the bare transcript for
+       * 10-20 s with no signal that more was coming.  Show a status
+       * caption so the wait feels intentional. */
+      ESP_LOGI(TAG, "Dictation post-process started");
+      voice_set_state(VOICE_STATE_PROCESSING, "Generating summary...");
+   } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
+      /* TinkerBox#94 H4: LLM failed or wasn't available.  Note already
+       * saved (the transcript landed via the prior `stt` event); user
+       * just doesn't get an auto-generated title/summary.  Clear the
+       * "Generating summary..." caption and toast the friendly
+       * message. */
+      cJSON *msg = cJSON_GetObjectItem(root, "message");
+      const char *m = cJSON_IsString(msg) ? msg->valuestring : "Note saved — summary unavailable";
+      ESP_LOGW(TAG, "Dictation post-process error: %s", m);
+      char buf[160];
+      strncpy(buf, m, sizeof(buf) - 1);
+      buf[sizeof(buf) - 1] = '\0';
+      voice_async_toast(strdup(buf));
+      voice_set_state(VOICE_STATE_READY, "dictation_done");
+   } else if (strcmp(type_str, "dictation_postprocessing_cancelled") == 0) {
+      /* TinkerBox#94 H4: a NEW dictation superseded the prior in-flight
+       * post-process.  The new dictation will emit its own
+       * `dictation_postprocessing` event a few ms later — silently log
+       * here so we don't fight the new caption.
+       *
+       * TT #328 Wave 2 (audit error-surfacing) — the original handler
+       * was log-only, but on the cancellation-WITHOUT-followup path
+       * (Dragon shut down, user disconnected mid-dictation, failover
+       * race) the user is left staring at "Generating summary..."
+       * forever because no dictation_postprocessing comes to override
+       * it.  Reset to READY so the caption clears; if a legitimate
+       * follow-up _postprocessing fires it'll re-set the caption a
+       * few ms later anyway, no UI flicker visible. */
+      ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
+      voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
+   } else if (strcmp(type_str, "dictation_summary") == 0) {
+      cJSON *title = cJSON_GetObjectItem(root, "title");
+      cJSON *summary = cJSON_GetObjectItem(root, "summary");
+      if (cJSON_IsString(title)) {
+         strncpy(s_dictation_title, title->valuestring, sizeof(s_dictation_title) - 1);
+         s_dictation_title[sizeof(s_dictation_title) - 1] = '\0';
+      }
+      if (cJSON_IsString(summary)) {
+         strncpy(s_dictation_summary, summary->valuestring, sizeof(s_dictation_summary) - 1);
+         s_dictation_summary[sizeof(s_dictation_summary) - 1] = '\0';
+      }
+      ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
+      voice_set_state(VOICE_STATE_READY, "dictation_summary");
+   } else if (strcmp(type_str, "note_created") == 0) {
+      cJSON *nid = cJSON_GetObjectItem(root, "note_id");
+      cJSON *ntitle = cJSON_GetObjectItem(root, "title");
+      ESP_LOGI(TAG, "Dragon auto-created note: id=%s title=\"%s\"", cJSON_IsString(nid) ? nid->valuestring : "?",
+               cJSON_IsString(ntitle) ? ntitle->valuestring : "?");
+   } else if (strcmp(type_str, "llm_done") == 0) {
+      cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
+      ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,
+               (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
+               (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+      /* TT #328 Wave 2 — recovery hook.  The fallback banner that fires
+       * on config_update.error sticks until the user dismisses or until
+       * a successful turn comes back through.  llm_done is the
+       * canonical "things are working again" signal — clear it here so
+       * the user sees the "things are back to normal" state without
+       * having to manually tap the banner. */
+      if (s_fallback_banner_active) {
+         ESP_LOGI(TAG, "Wave 2: clearing fallback banner (recovery via llm_done)");
+         s_fallback_banner_active = false;
+         tab5_lv_async_call(async_clear_banner_cb, NULL);
+      }
+      /* #293: emit obs event for e2e harness. */
+      {
+         char latency_str[24];
+         snprintf(latency_str, sizeof(latency_str), "%.0f", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0);
+         tab5_debug_obs_event("chat.llm_done", latency_str);
+      }
+      /* Prefer the full text field in llm_done (TC bypass uses it)
+       * falling back to the accumulated streamed tokens. */
+      cJSON *full = cJSON_GetObjectItem(root, "text");
+      const char *bubble_text = s_llm_text;
+      if (cJSON_IsString(full) && full->valuestring && full->valuestring[0]) {
+         bubble_text = full->valuestring;
+      }
+      if (bubble_text && bubble_text[0]) {
+         /* #78 + #160: defensive Tab5-side scrub of any <tool>...</tool>
+          * + <args>...</args> markers that survived Dragon's
+          * server-side stripper.  Without this the user sometimes
+          * sees raw "<tool>recall</tool><args>{\"query\":...}</args>"
+          * land as a chat bubble (caught by the audit screenshot in
+          * #160).  The strip handles the bubble destined for chat;
+          * s_llm_text continues to hold the raw text in case other
+          * paths need it. */
+         char clean[MAX_TRANSCRIPT_LEN];
+         md_strip_tool_markers(bubble_text, clean, sizeof(clean));
+         if (clean[0]) {
+            ui_chat_push_message("assistant", clean);
+         }
+      }
+      /* v4·D TC polish: if no TTS is coming (TC bypass never sends
+       * tts_start -- gateway is text-only), transition to READY
+       * directly.  Without this, state sits in PROCESSING forever
+       * after a TC text turn, chat input pill stays on "Thinking...",
+       * voice overlay stays blocked. */
+      if (voice_get_state() == VOICE_STATE_PROCESSING) {
+         voice_set_state(VOICE_STATE_READY, "llm_done");
+      }
+   } else if (strcmp(type_str, "receipt") == 0) {
+      /* SOLID-audit SRP-3 (2026-05-03): receipt accounting + cap-downgrade
+       * policy + chat-bubble stamp deferral all moved to voice_billing.c.
+       * Voice.c parses the JSON fields and hands them in typed; the
+       * billing module owns the rest of the chain. */
+      const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, "model"));
+      cJSON *ptok = cJSON_GetObjectItem(root, "prompt_tokens");
+      cJSON *ctok = cJSON_GetObjectItem(root, "completion_tokens");
+      cJSON *mils = cJSON_GetObjectItem(root, "cost_mils");
+      cJSON *retried_j = cJSON_GetObjectItem(root, "retried");
+      voice_billing_record_receipt(model, cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0,
+                                   cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0,
+                                   cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0, cJSON_IsTrue(retried_j));
+   } else if (strcmp(type_str, "text_update") == 0) {
+      const char *text = cJSON_GetStringValue(cJSON_GetObjectItem(root, "text"));
+      if (text) {
+         ESP_LOGI(TAG, "Text update: replacing last AI message");
+         ui_chat_update_last_message(text);
+      }
+   } else if (strcmp(type_str, "vision_capability") == 0) {
+      /* v4·D Phase 4b: Dragon advertises which model (if any) can see a
+       * camera frame.  Cached for ui_camera to render its violet chip.
+       * Empty/zero on local-only or non-vision models.  Triggered via
+       * Dragon's config_update ACK path so it lands whenever mode
+       * changes. */
+      cJSON *can = cJSON_GetObjectItem(root, "can_see");
+      cJSON *mdl = cJSON_GetObjectItem(root, "model");
+      cJSON *fpm = cJSON_GetObjectItem(root, "per_frame_mils");
+      s_vision_capable = cJSON_IsTrue(can);
+      s_vision_per_frame_mils = cJSON_IsNumber(fpm) ? (int)fpm->valuedouble : 0;
+      const char *m = (cJSON_IsString(mdl) && mdl->valuestring) ? mdl->valuestring : "";
+      snprintf(s_vision_model, sizeof(s_vision_model), "%s", m);
+      ESP_LOGI(TAG, "Vision capability: %s (model=%s, per_frame=%d mils)", s_vision_capable ? "YES" : "no",
+               s_vision_model[0] ? s_vision_model : "none", s_vision_per_frame_mils);
+   } else if (strcmp(type_str, "pong") == 0) {
+      /* Dragon-level JSON pong — logged only. WS-level ping/pong is
+       * handled automatically by esp_websocket_client (pingpong_timeout_sec). */
+      ESP_LOGD(TAG, "App-level pong");
+   } else if (strcmp(type_str, "config_update") == 0) {
+      cJSON *error = cJSON_GetObjectItem(root, "error");
+      if (cJSON_IsString(error) && error->valuestring[0]) {
+         ESP_LOGW(TAG, "Config update error from Dragon: %s", error->valuestring);
+         /* TT #317 Phase 5: don't clobber a Tab5-only ONBOARD pick. */
+         if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
+            tab5_settings_set_voice_mode(0);
+         }
+         voice_async_refresh_badge();
+         {
+            size_t elen = strlen(error->valuestring);
+            if (elen > 80) elen = 80;
+            char *toast_msg = malloc(elen + 1);
+            if (toast_msg) {
+               memcpy(toast_msg, error->valuestring, elen);
+               toast_msg[elen] = '\0';
+               voice_async_toast(toast_msg);
             }
-        }
-    } else if (strcmp(type_str, "dictation_postprocessing") == 0) {
-        /* TinkerBox#94 H4: Dragon spawned the title+summary LLM call after
-         * `stt`.  Pre-fix the user stared at the bare transcript for
-         * 10-20 s with no signal that more was coming.  Show a status
-         * caption so the wait feels intentional. */
-        ESP_LOGI(TAG, "Dictation post-process started");
-        voice_set_state(VOICE_STATE_PROCESSING, "Generating summary...");
-    } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
-        /* TinkerBox#94 H4: LLM failed or wasn't available.  Note already
-         * saved (the transcript landed via the prior `stt` event); user
-         * just doesn't get an auto-generated title/summary.  Clear the
-         * "Generating summary..." caption and toast the friendly
-         * message. */
-        cJSON *msg = cJSON_GetObjectItem(root, "message");
-        const char *m = cJSON_IsString(msg) ? msg->valuestring
-                                            : "Note saved — summary unavailable";
-        ESP_LOGW(TAG, "Dictation post-process error: %s", m);
-        char buf[160];
-        strncpy(buf, m, sizeof(buf) - 1);
-        buf[sizeof(buf) - 1] = '\0';
-        voice_async_toast(strdup(buf));
-        voice_set_state(VOICE_STATE_READY, "dictation_done");
-    } else if (strcmp(type_str, "dictation_postprocessing_cancelled") == 0) {
-       /* TinkerBox#94 H4: a NEW dictation superseded the prior in-flight
-        * post-process.  The new dictation will emit its own
-        * `dictation_postprocessing` event a few ms later — silently log
-        * here so we don't fight the new caption.
-        *
-        * TT #328 Wave 2 (audit error-surfacing) — the original handler
-        * was log-only, but on the cancellation-WITHOUT-followup path
-        * (Dragon shut down, user disconnected mid-dictation, failover
-        * race) the user is left staring at "Generating summary..."
-        * forever because no dictation_postprocessing comes to override
-        * it.  Reset to READY so the caption clears; if a legitimate
-        * follow-up _postprocessing fires it'll re-set the caption a
-        * few ms later anyway, no UI flicker visible. */
-       ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
-       voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
-    } else if (strcmp(type_str, "dictation_summary") == 0) {
-        cJSON *title = cJSON_GetObjectItem(root, "title");
-        cJSON *summary = cJSON_GetObjectItem(root, "summary");
-        if (cJSON_IsString(title)) {
-            strncpy(s_dictation_title, title->valuestring, sizeof(s_dictation_title) - 1);
-            s_dictation_title[sizeof(s_dictation_title) - 1] = '\0';
-        }
-        if (cJSON_IsString(summary)) {
-            strncpy(s_dictation_summary, summary->valuestring, sizeof(s_dictation_summary) - 1);
-            s_dictation_summary[sizeof(s_dictation_summary) - 1] = '\0';
-        }
-        ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
-        voice_set_state(VOICE_STATE_READY, "dictation_summary");
-    } else if (strcmp(type_str, "note_created") == 0) {
-        cJSON *nid = cJSON_GetObjectItem(root, "note_id");
-        cJSON *ntitle = cJSON_GetObjectItem(root, "title");
-        ESP_LOGI(TAG, "Dragon auto-created note: id=%s title=\"%s\"",
-                 cJSON_IsString(nid) ? nid->valuestring : "?",
-                 cJSON_IsString(ntitle) ? ntitle->valuestring : "?");
-    } else if (strcmp(type_str, "llm_done") == 0) {
-        cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
-        ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u",
-                 cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,
-                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
-                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
-        /* TT #328 Wave 2 — recovery hook.  The fallback banner that fires
-         * on config_update.error sticks until the user dismisses or until
-         * a successful turn comes back through.  llm_done is the
-         * canonical "things are working again" signal — clear it here so
-         * the user sees the "things are back to normal" state without
-         * having to manually tap the banner. */
-        if (s_fallback_banner_active) {
-           ESP_LOGI(TAG, "Wave 2: clearing fallback banner (recovery via llm_done)");
-           s_fallback_banner_active = false;
-           tab5_lv_async_call(async_clear_banner_cb, NULL);
-        }
-        /* #293: emit obs event for e2e harness. */
-        {
-           char latency_str[24];
-           snprintf(latency_str, sizeof(latency_str), "%.0f", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0);
-           tab5_debug_obs_event("chat.llm_done", latency_str);
-        }
-        /* Prefer the full text field in llm_done (TC bypass uses it)
-         * falling back to the accumulated streamed tokens. */
-        cJSON *full = cJSON_GetObjectItem(root, "text");
-        const char *bubble_text = s_llm_text;
-        if (cJSON_IsString(full) && full->valuestring && full->valuestring[0]) {
-            bubble_text = full->valuestring;
-        }
-        if (bubble_text && bubble_text[0]) {
-            /* #78 + #160: defensive Tab5-side scrub of any <tool>...</tool>
-             * + <args>...</args> markers that survived Dragon's
-             * server-side stripper.  Without this the user sometimes
-             * sees raw "<tool>recall</tool><args>{\"query\":...}</args>"
-             * land as a chat bubble (caught by the audit screenshot in
-             * #160).  The strip handles the bubble destined for chat;
-             * s_llm_text continues to hold the raw text in case other
-             * paths need it. */
-            char clean[MAX_TRANSCRIPT_LEN];
-            md_strip_tool_markers(bubble_text, clean, sizeof(clean));
-            if (clean[0]) {
-                ui_chat_push_message("assistant", clean);
+         }
+         /* TT #328 Wave 2 (audit error-surfacing) — toast was the
+          * only surface; auto-dismissed in 3 s.  Users glancing
+          * away missed the fact that they got auto-downgraded to
+          * Local + lost cloud STT/TTS quality.  Pair the toast
+          * with a persistent dismissable error banner that sits
+          * until the user acknowledges OR until the next
+          * successful llm_done auto-clears it (recovery signal). */
+         voice_async_error_banner_dyn(error->valuestring, true /* dismissable */);
+         s_fallback_banner_active = true;
+         voice_set_state(VOICE_STATE_READY, error->valuestring);
+      }
+      cJSON *vmode = cJSON_GetObjectItem(root, "voice_mode");
+      if (!cJSON_IsNumber(vmode)) {
+         cJSON *config_obj = cJSON_GetObjectItem(root, "config");
+         if (config_obj) {
+            vmode = cJSON_GetObjectItem(config_obj, "voice_mode");
+         }
+      }
+      if (cJSON_IsNumber(vmode)) {
+         uint8_t mode = (uint8_t)vmode->valueint;
+         /* TT #317 Phase 5: ONBOARD is Tab5-side-only.  Dragon never
+          * knows about it — its ACK always echoes 0/1/2/3.  If user
+          * has set ONBOARD locally, ignore Dragon's echo. */
+         if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
+            tab5_settings_set_voice_mode(mode);
+            ESP_LOGI(TAG, "Config update: voice_mode=%d (persisted)", mode);
+         } else {
+            ESP_LOGD(TAG, "Config update: ignoring Dragon vmode=%d (we're in ONBOARD)", mode);
+         }
+         voice_async_refresh_badge();
+      }
+      cJSON *config = cJSON_GetObjectItem(root, "config");
+      bool applied_cloud = false;
+      if (config) {
+         cJSON *cloud = cJSON_GetObjectItem(config, "cloud_mode");
+         if (cJSON_IsBool(cloud)) {
+            bool is_cloud = cJSON_IsTrue(cloud);
+            if (!cJSON_IsNumber(vmode)) {
+               tab5_settings_set_voice_mode(is_cloud ? 1 : 0);
+               voice_async_refresh_badge();
+               applied_cloud = true;
             }
-        }
-        /* v4·D TC polish: if no TTS is coming (TC bypass never sends
-         * tts_start -- gateway is text-only), transition to READY
-         * directly.  Without this, state sits in PROCESSING forever
-         * after a TC text turn, chat input pill stays on "Thinking...",
-         * voice overlay stays blocked. */
-        if (voice_get_state() == VOICE_STATE_PROCESSING) {
-            voice_set_state(VOICE_STATE_READY, "llm_done");
-        }
-    } else if (strcmp(type_str, "receipt") == 0) {
-       /* SOLID-audit SRP-3 (2026-05-03): receipt accounting + cap-downgrade
-        * policy + chat-bubble stamp deferral all moved to voice_billing.c.
-        * Voice.c parses the JSON fields and hands them in typed; the
-        * billing module owns the rest of the chain. */
-       const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, "model"));
-       cJSON *ptok = cJSON_GetObjectItem(root, "prompt_tokens");
-       cJSON *ctok = cJSON_GetObjectItem(root, "completion_tokens");
-       cJSON *mils = cJSON_GetObjectItem(root, "cost_mils");
-       cJSON *retried_j = cJSON_GetObjectItem(root, "retried");
-       voice_billing_record_receipt(model, cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0,
-                                    cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0,
-                                    cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0, cJSON_IsTrue(retried_j));
-    } else if (strcmp(type_str, "text_update") == 0) {
-        const char *text = cJSON_GetStringValue(cJSON_GetObjectItem(root, "text"));
-        if (text) {
-            ESP_LOGI(TAG, "Text update: replacing last AI message");
-            ui_chat_update_last_message(text);
-        }
-    } else if (strcmp(type_str, "vision_capability") == 0) {
-        /* v4·D Phase 4b: Dragon advertises which model (if any) can see a
-         * camera frame.  Cached for ui_camera to render its violet chip.
-         * Empty/zero on local-only or non-vision models.  Triggered via
-         * Dragon's config_update ACK path so it lands whenever mode
-         * changes. */
-        cJSON *can = cJSON_GetObjectItem(root, "can_see");
-        cJSON *mdl = cJSON_GetObjectItem(root, "model");
-        cJSON *fpm = cJSON_GetObjectItem(root, "per_frame_mils");
-        s_vision_capable = cJSON_IsTrue(can);
-        s_vision_per_frame_mils = cJSON_IsNumber(fpm) ? (int)fpm->valuedouble : 0;
-        const char *m = (cJSON_IsString(mdl) && mdl->valuestring) ? mdl->valuestring : "";
-        snprintf(s_vision_model, sizeof(s_vision_model), "%s", m);
-        ESP_LOGI(TAG, "Vision capability: %s (model=%s, per_frame=%d mils)",
-                 s_vision_capable ? "YES" : "no",
-                 s_vision_model[0] ? s_vision_model : "none",
-                 s_vision_per_frame_mils);
-    } else if (strcmp(type_str, "pong") == 0) {
-        /* Dragon-level JSON pong — logged only. WS-level ping/pong is
-         * handled automatically by esp_websocket_client (pingpong_timeout_sec). */
-        ESP_LOGD(TAG, "App-level pong");
-    } else if (strcmp(type_str, "config_update") == 0) {
-        cJSON *error = cJSON_GetObjectItem(root, "error");
-        if (cJSON_IsString(error) && error->valuestring[0]) {
-            ESP_LOGW(TAG, "Config update error from Dragon: %s", error->valuestring);
-            /* TT #317 Phase 5: don't clobber a Tab5-only ONBOARD pick. */
-            if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
-               tab5_settings_set_voice_mode(0);
-            }
-            voice_async_refresh_badge();
-            {
-                size_t elen = strlen(error->valuestring);
-                if (elen > 80) elen = 80;
-                char *toast_msg = malloc(elen + 1);
-                if (toast_msg) {
-                    memcpy(toast_msg, error->valuestring, elen);
-                    toast_msg[elen] = '\0';
-                    voice_async_toast(toast_msg);
-                }
-            }
-            /* TT #328 Wave 2 (audit error-surfacing) — toast was the
-             * only surface; auto-dismissed in 3 s.  Users glancing
-             * away missed the fact that they got auto-downgraded to
-             * Local + lost cloud STT/TTS quality.  Pair the toast
-             * with a persistent dismissable error banner that sits
-             * until the user acknowledges OR until the next
-             * successful llm_done auto-clears it (recovery signal). */
-            voice_async_error_banner_dyn(error->valuestring, true /* dismissable */);
-            s_fallback_banner_active = true;
-            voice_set_state(VOICE_STATE_READY, error->valuestring);
-        }
-        cJSON *vmode = cJSON_GetObjectItem(root, "voice_mode");
-        if (!cJSON_IsNumber(vmode)) {
-            cJSON *config_obj = cJSON_GetObjectItem(root, "config");
-            if (config_obj) {
-                vmode = cJSON_GetObjectItem(config_obj, "voice_mode");
-            }
-        }
-        if (cJSON_IsNumber(vmode)) {
-            uint8_t mode = (uint8_t)vmode->valueint;
-            /* TT #317 Phase 5: ONBOARD is Tab5-side-only.  Dragon never
-             * knows about it — its ACK always echoes 0/1/2/3.  If user
-             * has set ONBOARD locally, ignore Dragon's echo. */
-            if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
-               tab5_settings_set_voice_mode(mode);
-               ESP_LOGI(TAG, "Config update: voice_mode=%d (persisted)", mode);
-            } else {
-               ESP_LOGD(TAG, "Config update: ignoring Dragon vmode=%d (we're in ONBOARD)", mode);
-            }
-            voice_async_refresh_badge();
-        }
-        cJSON *config = cJSON_GetObjectItem(root, "config");
-        bool applied_cloud = false;
-        if (config) {
-            cJSON *cloud = cJSON_GetObjectItem(config, "cloud_mode");
-            if (cJSON_IsBool(cloud)) {
-                bool is_cloud = cJSON_IsTrue(cloud);
-                if (!cJSON_IsNumber(vmode)) {
-                    tab5_settings_set_voice_mode(is_cloud ? 1 : 0);
-                    voice_async_refresh_badge();
-                    applied_cloud = true;
-                }
-            }
-        }
-        /* #262: codec negotiation reply.  Dragon picks one of the
-         * codecs Tab5 advertised in `register` and tells us via
-         * config_update.audio_codec.  Two flavours so it can choose
-         * uplink (mic) and downlink (TTS) independently:
-         *   - audio_codec        : applies to both (legacy / shorthand)
-         *   - audio_uplink_codec : mic only
-         *   - audio_downlink_codec: TTS only
-         * Unrecognized strings fall back to PCM. */
-        cJSON *acu = cJSON_GetObjectItem(root, "audio_uplink_codec");
-        cJSON *acd = cJSON_GetObjectItem(root, "audio_downlink_codec");
-        cJSON *ac  = cJSON_GetObjectItem(root, "audio_codec");
-        if (cJSON_IsString(acu)) {
-            voice_codec_set_uplink(voice_codec_from_name(acu->valuestring));
-        } else if (cJSON_IsString(ac)) {
-            voice_codec_set_uplink(voice_codec_from_name(ac->valuestring));
-        }
-        if (cJSON_IsString(acd)) {
-            voice_codec_set_downlink(voice_codec_from_name(acd->valuestring));
-        } else if (cJSON_IsString(ac)) {
-            voice_codec_set_downlink(voice_codec_from_name(ac->valuestring));
-        }
-        /* Wave 14 W14-L03: if neither voice_mode nor cloud_mode was
-         * present, the handler used to exit silently and Tab5 would
-         * disagree with Dragon about the active mode with no trace.
-         * Log at DEBUG so it's visible via /log without spamming INFO. */
-        if (!cJSON_IsNumber(vmode) && !applied_cloud &&
-            !cJSON_IsString(error)) {
-            ESP_LOGD(TAG, "config_update received with no voice_mode/"
-                         "cloud_mode/error field — no-op");
-        }
-    } else if (strcmp(type_str, "tool_call") == 0) {
-        cJSON *tool = cJSON_GetObjectItem(root, "tool");
-        const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
-        ESP_LOGI(TAG, "Tool call: %s", tool_name);
+         }
+      }
+      /* #262: codec negotiation reply.  Dragon picks one of the
+       * codecs Tab5 advertised in `register` and tells us via
+       * config_update.audio_codec.  Two flavours so it can choose
+       * uplink (mic) and downlink (TTS) independently:
+       *   - audio_codec        : applies to both (legacy / shorthand)
+       *   - audio_uplink_codec : mic only
+       *   - audio_downlink_codec: TTS only
+       * Unrecognized strings fall back to PCM. */
+      cJSON *acu = cJSON_GetObjectItem(root, "audio_uplink_codec");
+      cJSON *acd = cJSON_GetObjectItem(root, "audio_downlink_codec");
+      cJSON *ac = cJSON_GetObjectItem(root, "audio_codec");
+      if (cJSON_IsString(acu)) {
+         voice_codec_set_uplink(voice_codec_from_name(acu->valuestring));
+      } else if (cJSON_IsString(ac)) {
+         voice_codec_set_uplink(voice_codec_from_name(ac->valuestring));
+      }
+      if (cJSON_IsString(acd)) {
+         voice_codec_set_downlink(voice_codec_from_name(acd->valuestring));
+      } else if (cJSON_IsString(ac)) {
+         voice_codec_set_downlink(voice_codec_from_name(ac->valuestring));
+      }
+      /* Wave 14 W14-L03: if neither voice_mode nor cloud_mode was
+       * present, the handler used to exit silently and Tab5 would
+       * disagree with Dragon about the active mode with no trace.
+       * Log at DEBUG so it's visible via /log without spamming INFO. */
+      if (!cJSON_IsNumber(vmode) && !applied_cloud && !cJSON_IsString(error)) {
+         ESP_LOGD(TAG,
+                  "config_update received with no voice_mode/"
+                  "cloud_mode/error field — no-op");
+      }
+   } else if (strcmp(type_str, "tool_call") == 0) {
+      cJSON *tool = cJSON_GetObjectItem(root, "tool");
+      const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
+      ESP_LOGI(TAG, "Tool call: %s", tool_name);
 
-        const char *status_text = "Thinking...";
-        if (strcmp(tool_name, "web_search") == 0) {
-            status_text = "Searching the web...";
-        } else if (strcmp(tool_name, "remember") == 0 || strcmp(tool_name, "memory_store") == 0) {
-            status_text = "Remembering...";
-        } else if (strcmp(tool_name, "memory_search") == 0 || strcmp(tool_name, "recall") == 0) {
-            status_text = "Recalling...";
-        } else if (strcmp(tool_name, "browser") == 0 || strcmp(tool_name, "browse") == 0) {
-            status_text = "Browsing...";
-        } else if (strcmp(tool_name, "calculator") == 0 || strcmp(tool_name, "math") == 0) {
-            status_text = "Calculating...";
-        } else {
-            status_text = "Using tools...";
-        }
-        voice_set_state(VOICE_STATE_PROCESSING, status_text);
-        /* Tab5 audit D5: also push a system bubble so the user can see
-         * tool activity in chat (not just on the voice overlay label).
-         * CLAUDE.md's "thinking + tool indicator bubbles" claim was wired
-         * only to the overlay-state string previously. */
-        ui_chat_push_system(status_text);
-        /* U7+U8 (#206): record activity so the agents/focus surfaces
-         * can render real history instead of the v5 demo rows. */
-        tool_log_push_call(tool_name, status_text);
-    } else if (strcmp(type_str, "tool_result") == 0) {
-        cJSON *tool = cJSON_GetObjectItem(root, "tool");
-        cJSON *exec_ms = cJSON_GetObjectItem(root, "execution_ms");
-        const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
-        double ms = cJSON_IsNumber(exec_ms) ? exec_ms->valuedouble : 0.0;
-        ESP_LOGI(TAG, "Tool result: %s (%.0fms)", tool_name, ms);
-        voice_set_state(VOICE_STATE_PROCESSING, "Thinking...");
-        /* Tab5 audit D5: close the loop with a completion bubble so the
-         * chat timeline shows what ran + how long it took. */
-        char done_buf[80];
-        snprintf(done_buf, sizeof(done_buf), "%s done (%.0fms)",
-                 tool_name, ms);
-        ui_chat_push_system(done_buf);
-        /* U7+U8 (#206): mark the tool_log entry done so the
-         * agents/focus surfaces can show "DONE  •  234 ms". */
-        tool_log_push_result(tool_name, (uint32_t)ms);
-    } else if (strcmp(type_str, "media") == 0) {
-        const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
-        const char *mtype = cJSON_GetStringValue(cJSON_GetObjectItem(root, "media_type"));
-        cJSON *w_item = cJSON_GetObjectItem(root, "width");
-        cJSON *h_item = cJSON_GetObjectItem(root, "height");
-        int w = cJSON_IsNumber(w_item) ? (int)w_item->valuedouble : 0;
-        int h = cJSON_IsNumber(h_item) ? (int)h_item->valuedouble : 0;
-        const char *alt = cJSON_GetStringValue(cJSON_GetObjectItem(root, "alt"));
-        if (url) {
-            ESP_LOGI(TAG, "Media: %s %dx%d", mtype ? mtype : "image", w, h);
-            ui_chat_push_media(url, mtype, w, h, alt);
-        }
-    } else if (strcmp(type_str, "card") == 0) {
-        const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
-        const char *sub = cJSON_GetStringValue(cJSON_GetObjectItem(root, "subtitle"));
-        const char *img = cJSON_GetStringValue(cJSON_GetObjectItem(root, "image_url"));
-        const char *desc = cJSON_GetStringValue(cJSON_GetObjectItem(root, "description"));
-        if (title) {
-            ESP_LOGI(TAG, "Card: %s", title);
-            ui_chat_push_card(title, sub, img, desc);
-        }
-        /* Wave 23b SOLID-audit SRP-2: nine widget WS verbs (widget_card,
-         * widget_live, widget_live_update, widget_list, widget_chart,
-         * widget_media, widget_prompt, widget_live_dismiss, widget_dismiss)
-         * extracted to voice_widget_ws.{c,h}.  Returns true iff the verb
-         * was recognized + handled; false falls through to the unknown-
-         * verb log below. */
-    } else if (voice_widget_ws_dispatch(type_str, root)) {
-       /* widget verb handled inside voice_widget_ws.c */
-    } else if (strcmp(type_str, "audio_clip") == 0) {
-       const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
-       cJSON *dur_item = cJSON_GetObjectItem(root, "duration_s");
-       float dur = cJSON_IsNumber(dur_item) ? (float)dur_item->valuedouble : 0.0f;
-       const char *label = cJSON_GetStringValue(cJSON_GetObjectItem(root, "label"));
-       if (url) {
-          ESP_LOGI(TAG, "Audio clip: %s (%.1fs)", label ? label : "", dur);
-          ui_chat_push_audio_clip(url, dur, label);
-       }
-    } else {
-       ESP_LOGW(TAG, "Unknown message type: %s (full: %.*s)", type_str, len, data);
-    }
+      const char *status_text = "Thinking...";
+      if (strcmp(tool_name, "web_search") == 0) {
+         status_text = "Searching the web...";
+      } else if (strcmp(tool_name, "remember") == 0 || strcmp(tool_name, "memory_store") == 0) {
+         status_text = "Remembering...";
+      } else if (strcmp(tool_name, "memory_search") == 0 || strcmp(tool_name, "recall") == 0) {
+         status_text = "Recalling...";
+      } else if (strcmp(tool_name, "browser") == 0 || strcmp(tool_name, "browse") == 0) {
+         status_text = "Browsing...";
+      } else if (strcmp(tool_name, "calculator") == 0 || strcmp(tool_name, "math") == 0) {
+         status_text = "Calculating...";
+      } else {
+         status_text = "Using tools...";
+      }
+      voice_set_state(VOICE_STATE_PROCESSING, status_text);
+      /* Tab5 audit D5: also push a system bubble so the user can see
+       * tool activity in chat (not just on the voice overlay label).
+       * CLAUDE.md's "thinking + tool indicator bubbles" claim was wired
+       * only to the overlay-state string previously. */
+      ui_chat_push_system(status_text);
+      /* U7+U8 (#206): record activity so the agents/focus surfaces
+       * can render real history instead of the v5 demo rows. */
+      tool_log_push_call(tool_name, status_text);
+   } else if (strcmp(type_str, "tool_result") == 0) {
+      cJSON *tool = cJSON_GetObjectItem(root, "tool");
+      cJSON *exec_ms = cJSON_GetObjectItem(root, "execution_ms");
+      const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
+      double ms = cJSON_IsNumber(exec_ms) ? exec_ms->valuedouble : 0.0;
+      ESP_LOGI(TAG, "Tool result: %s (%.0fms)", tool_name, ms);
+      voice_set_state(VOICE_STATE_PROCESSING, "Thinking...");
+      /* Tab5 audit D5: close the loop with a completion bubble so the
+       * chat timeline shows what ran + how long it took. */
+      char done_buf[80];
+      snprintf(done_buf, sizeof(done_buf), "%s done (%.0fms)", tool_name, ms);
+      ui_chat_push_system(done_buf);
+      /* U7+U8 (#206): mark the tool_log entry done so the
+       * agents/focus surfaces can show "DONE  •  234 ms". */
+      tool_log_push_result(tool_name, (uint32_t)ms);
+   } else if (strcmp(type_str, "media") == 0) {
+      const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
+      const char *mtype = cJSON_GetStringValue(cJSON_GetObjectItem(root, "media_type"));
+      cJSON *w_item = cJSON_GetObjectItem(root, "width");
+      cJSON *h_item = cJSON_GetObjectItem(root, "height");
+      int w = cJSON_IsNumber(w_item) ? (int)w_item->valuedouble : 0;
+      int h = cJSON_IsNumber(h_item) ? (int)h_item->valuedouble : 0;
+      const char *alt = cJSON_GetStringValue(cJSON_GetObjectItem(root, "alt"));
+      if (url) {
+         ESP_LOGI(TAG, "Media: %s %dx%d", mtype ? mtype : "image", w, h);
+         ui_chat_push_media(url, mtype, w, h, alt);
+      }
+   } else if (strcmp(type_str, "card") == 0) {
+      const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
+      const char *sub = cJSON_GetStringValue(cJSON_GetObjectItem(root, "subtitle"));
+      const char *img = cJSON_GetStringValue(cJSON_GetObjectItem(root, "image_url"));
+      const char *desc = cJSON_GetStringValue(cJSON_GetObjectItem(root, "description"));
+      if (title) {
+         ESP_LOGI(TAG, "Card: %s", title);
+         ui_chat_push_card(title, sub, img, desc);
+      }
+      /* Wave 23b SOLID-audit SRP-2: nine widget WS verbs (widget_card,
+       * widget_live, widget_live_update, widget_list, widget_chart,
+       * widget_media, widget_prompt, widget_live_dismiss, widget_dismiss)
+       * extracted to voice_widget_ws.{c,h}.  Returns true iff the verb
+       * was recognized + handled; false falls through to the unknown-
+       * verb log below. */
+   } else if (voice_widget_ws_dispatch(type_str, root)) {
+      /* widget verb handled inside voice_widget_ws.c */
+   } else if (strcmp(type_str, "audio_clip") == 0) {
+      const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
+      cJSON *dur_item = cJSON_GetObjectItem(root, "duration_s");
+      float dur = cJSON_IsNumber(dur_item) ? (float)dur_item->valuedouble : 0.0f;
+      const char *label = cJSON_GetStringValue(cJSON_GetObjectItem(root, "label"));
+      if (url) {
+         ESP_LOGI(TAG, "Audio clip: %s (%.1fs)", label ? label : "", dur);
+         ui_chat_push_audio_clip(url, dur, label);
+      }
+   } else {
+      ESP_LOGW(TAG, "Unknown message type: %s (full: %.*s)", type_str, len, data);
+   }
 
-    cJSON_Delete(root);
+   cJSON_Delete(root);
 }
-
 
 /* TT #331 Wave 23 SRP-A1: mirror voice.c's UPSAMPLE_* macros so
  * voice_ws_proto_handle_binary can size its half-buffers.  These MUST
  * match the voice.c definitions — the upsample buffer (s_upsample_buf,
  * allocated in voice_init) is sized by UPSAMPLE_BUF_CAPACITY there. */
-#define UPSAMPLE_RATIO          (TAB5_AUDIO_SAMPLE_RATE / TAB5_VOICE_SAMPLE_RATE)
-#define UPSAMPLE_BUF_CAPACITY   (8192 * 2)
+#define UPSAMPLE_RATIO (TAB5_AUDIO_SAMPLE_RATE / TAB5_VOICE_SAMPLE_RATE)
+#define UPSAMPLE_BUF_CAPACITY (8192 * 2)
 
 /* PSRAM upsample buffer — owned + allocated in voice.c voice_init,
  * referenced here from voice_ws_proto_handle_binary. */
@@ -1115,106 +1078,99 @@ extern int16_t *s_upsample_buf;
 // handles I2S writes.
 // ---------------------------------------------------------------------------
 /* TT #331 Wave 23 SRP-A1: was static — file-scope inside voice_ws_proto.c. */
-static size_t voice_ws_proto_upsample_16k_to_48k(const int16_t *in, size_t in_samples,
-                                    int16_t *out, size_t out_capacity)
-{
-    size_t out_idx = 0;
-    for (size_t i = 0; i < in_samples && out_idx + UPSAMPLE_RATIO <= out_capacity; i++) {
-        int16_t curr = in[i];
-        int16_t next = (i + 1 < in_samples) ? in[i + 1] : curr;
-        for (int j = 0; j < UPSAMPLE_RATIO; j++) {
-            out[out_idx++] = (int16_t)(curr + (int32_t)(next - curr) * j / UPSAMPLE_RATIO);
-        }
-    }
-    return out_idx;
+static size_t voice_ws_proto_upsample_16k_to_48k(const int16_t *in, size_t in_samples, int16_t *out,
+                                                 size_t out_capacity) {
+   size_t out_idx = 0;
+   for (size_t i = 0; i < in_samples && out_idx + UPSAMPLE_RATIO <= out_capacity; i++) {
+      int16_t curr = in[i];
+      int16_t next = (i + 1 < in_samples) ? in[i + 1] : curr;
+      for (int j = 0; j < UPSAMPLE_RATIO; j++) {
+         out[out_idx++] = (int16_t)(curr + (int32_t)(next - curr) * j / UPSAMPLE_RATIO);
+      }
+   }
+   return out_idx;
 }
 
 /* TT #331 Wave 23 SRP-A1: was handle_binary_message (non-static after task 1.6 promotion). */
-void voice_ws_proto_handle_binary(const char *data, int len)
-{
-    /* #268: video frames carry the 4-byte "VID0" magic.  Route them
-     * to voice_video before any audio-state checks — video plays
-     * regardless of voice state (unlike TTS, which only plays in
-     * SPEAKING/PROCESSING).  Audio frames (no magic) fall through. */
-    if (voice_video_peek_downlink_magic(data, (size_t)len)) {
-        voice_video_on_downlink_frame((const uint8_t *)data, (size_t)len);
-        return;
-    }
+void voice_ws_proto_handle_binary(const char *data, int len) {
+   /* #268: video frames carry the 4-byte "VID0" magic.  Route them
+    * to voice_video before any audio-state checks — video plays
+    * regardless of voice state (unlike TTS, which only plays in
+    * SPEAKING/PROCESSING).  Audio frames (no magic) fall through. */
+   if (voice_video_peek_downlink_magic(data, (size_t)len)) {
+      voice_video_on_downlink_frame((const uint8_t *)data, (size_t)len);
+      return;
+   }
 
-    /* #272 Phase 3E: call-audio frames carry the 4-byte "AUD0" magic.
-     * Strip the header + write the int16 PCM body straight to the
-     * playback buffer with the same upsample 16k->48k as TTS.  No
-     * state guards — call audio plays even when voice is READY. */
-    if (voice_codec_peek_call_audio_magic(data, (size_t)len)) {
-        const uint8_t *body = NULL;
-        size_t body_len = 0;
-        if (voice_codec_unpack_call_audio((const uint8_t *)data, (size_t)len,
-                                          &body, &body_len) && body_len >= 2 &&
-            s_upsample_buf) {
-            tab5_audio_speaker_enable(true);
-            const size_t in_samples = body_len / sizeof(int16_t);
-            const size_t max_out    = in_samples * UPSAMPLE_RATIO;
-            if (max_out <= UPSAMPLE_BUF_CAPACITY) {
-                size_t out_n = voice_ws_proto_upsample_16k_to_48k((const int16_t *)body, in_samples,
-                                                    s_upsample_buf, max_out);
-                voice_playback_buf_write(s_upsample_buf, out_n);
-            }
-        }
-        return;
-    }
+   /* #272 Phase 3E: call-audio frames carry the 4-byte "AUD0" magic.
+    * Strip the header + write the int16 PCM body straight to the
+    * playback buffer with the same upsample 16k->48k as TTS.  No
+    * state guards — call audio plays even when voice is READY. */
+   if (voice_codec_peek_call_audio_magic(data, (size_t)len)) {
+      const uint8_t *body = NULL;
+      size_t body_len = 0;
+      if (voice_codec_unpack_call_audio((const uint8_t *)data, (size_t)len, &body, &body_len) && body_len >= 2 &&
+          s_upsample_buf) {
+         tab5_audio_speaker_enable(true);
+         const size_t in_samples = body_len / sizeof(int16_t);
+         const size_t max_out = in_samples * UPSAMPLE_RATIO;
+         if (max_out <= UPSAMPLE_BUF_CAPACITY) {
+            size_t out_n =
+                voice_ws_proto_upsample_16k_to_48k((const int16_t *)body, in_samples, s_upsample_buf, max_out);
+            voice_playback_buf_write(s_upsample_buf, out_n);
+         }
+      }
+      return;
+   }
 
-    /* v4·D audit P0 fix: snapshot voice_get_state() so we never race
-     * with voice_set_state on another task.  The checks below formerly
-     * read s_state twice without locking — voice_get_state takes the
-     * state mutex internally so a single call is atomic.
-     *
-     * TT #331 Wave 23 SRP-A1: pre-extract this site held s_state_mutex
-     * directly while reading the static.  Re-locking around
-     * voice_get_state() (which takes the same non-recursive mutex)
-     * deadlocked → TASK_WDT reset.  Single getter call is the fix. */
-    voice_state_t cur = voice_get_state();
+   /* v4·D audit P0 fix: snapshot voice_get_state() so we never race
+    * with voice_set_state on another task.  The checks below formerly
+    * read s_state twice without locking — voice_get_state takes the
+    * state mutex internally so a single call is atomic.
+    *
+    * TT #331 Wave 23 SRP-A1: pre-extract this site held s_state_mutex
+    * directly while reading the static.  Re-locking around
+    * voice_get_state() (which takes the same non-recursive mutex)
+    * deadlocked → TASK_WDT reset.  Single getter call is the fix. */
+   voice_state_t cur = voice_get_state();
 
+   if (cur != VOICE_STATE_SPEAKING && cur != VOICE_STATE_PROCESSING) {
+      return;
+   }
+   if (cur == VOICE_STATE_PROCESSING) {
+      voice_playback_buf_reset();
+      voice_set_state(VOICE_STATE_SPEAKING, NULL);
+   }
 
-    if (cur != VOICE_STATE_SPEAKING && cur != VOICE_STATE_PROCESSING) {
-        return;
-    }
-    if (cur == VOICE_STATE_PROCESSING) {
-        voice_playback_buf_reset();
-        voice_set_state(VOICE_STATE_SPEAKING, NULL);
-    }
+   /* #262: decode through voice_codec.  PCM is a memcpy-shaped passthrough
+    * (out_samples == in_samples), keeping the existing upsample 16k->48k
+    * path unchanged.  OPUS produces variable-length PCM (typ 320 samples
+    * per 20 ms packet) which then upsamples the same way. */
+   if (!s_upsample_buf) {
+      ESP_LOGW(TAG, "handle_binary: upsample_buf not initialized");
+      return;
+   }
 
-    /* #262: decode through voice_codec.  PCM is a memcpy-shaped passthrough
-     * (out_samples == in_samples), keeping the existing upsample 16k->48k
-     * path unchanged.  OPUS produces variable-length PCM (typ 320 samples
-     * per 20 ms packet) which then upsamples the same way. */
-    if (!s_upsample_buf) {
-        ESP_LOGW(TAG, "handle_binary: upsample_buf not initialized");
-        return;
-    }
-
-    /* Decode straight into a temp area in s_upsample_buf, low half;
-     * upsample reads from there and writes to the high half.
-     * Splitting avoids an extra malloc per chunk. */
-    int16_t *dec_pcm = s_upsample_buf;                          /* low half */
-    int16_t *up_out  = s_upsample_buf + (UPSAMPLE_BUF_CAPACITY / 2);  /* high half */
-    size_t dec_cap   = UPSAMPLE_BUF_CAPACITY / 2;
-    size_t in_samples = 0;
-    if (voice_codec_decode_downlink((const uint8_t *)data, (size_t)len,
-                                    dec_pcm, dec_cap, &in_samples) != ESP_OK ||
-        in_samples == 0) {
-        ESP_LOGW(TAG, "handle_binary: codec decode failed (len=%d)", len);
-        return;
-    }
-    size_t max_out = in_samples * UPSAMPLE_RATIO;
-    if (max_out > dec_cap) {
-        ESP_LOGW(TAG, "handle_binary: upsample would exceed half-buf — truncating");
-        max_out = dec_cap;
-    }
-    size_t out_samples = voice_ws_proto_upsample_16k_to_48k(dec_pcm, in_samples,
-                                              up_out, max_out);
-    voice_playback_buf_write(up_out, out_samples);
+   /* Decode straight into a temp area in s_upsample_buf, low half;
+    * upsample reads from there and writes to the high half.
+    * Splitting avoids an extra malloc per chunk. */
+   int16_t *dec_pcm = s_upsample_buf;                              /* low half */
+   int16_t *up_out = s_upsample_buf + (UPSAMPLE_BUF_CAPACITY / 2); /* high half */
+   size_t dec_cap = UPSAMPLE_BUF_CAPACITY / 2;
+   size_t in_samples = 0;
+   if (voice_codec_decode_downlink((const uint8_t *)data, (size_t)len, dec_pcm, dec_cap, &in_samples) != ESP_OK ||
+       in_samples == 0) {
+      ESP_LOGW(TAG, "handle_binary: codec decode failed (len=%d)", len);
+      return;
+   }
+   size_t max_out = in_samples * UPSAMPLE_RATIO;
+   if (max_out > dec_cap) {
+      ESP_LOGW(TAG, "handle_binary: upsample would exceed half-buf — truncating");
+      max_out = dec_cap;
+   }
+   size_t out_samples = voice_ws_proto_upsample_16k_to_48k(dec_pcm, in_samples, up_out, max_out);
+   voice_playback_buf_write(up_out, out_samples);
 }
-
 
 // ---------------------------------------------------------------------------
 // Task 1.6/1.8/1.9: WebSocket event handler + URI helper.
@@ -1226,97 +1182,94 @@ void voice_ws_proto_handle_binary(const char *data, int len)
 /* TT #331 Wave 23 SRP-A1: was static void voice_ws_event_handler — promoted +
  * renamed for the voice_ws_proto layer.  Registered with
  * esp_websocket_register_events from voice_ws_start_client in voice.c. */
-void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
-                                  int32_t event_id, void *event_data)
-{
-    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t event_id, void *event_data) {
+   esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
 
-    switch ((esp_websocket_event_id_t)event_id) {
-    case WEBSOCKET_EVENT_BEFORE_CONNECT:
-        ESP_LOGI(TAG, "WS: BEFORE_CONNECT (host=%s%s)",
-                 s_dragon_host, s_using_ngrok ? " [ngrok]" : "");
-        voice_set_state(VOICE_STATE_CONNECTING, s_dragon_host);
-        break;
+   switch ((esp_websocket_event_id_t)event_id) {
+      case WEBSOCKET_EVENT_BEFORE_CONNECT:
+         ESP_LOGI(TAG, "WS: BEFORE_CONNECT (host=%s%s)", s_dragon_host, s_using_ngrok ? " [ngrok]" : "");
+         voice_set_state(VOICE_STATE_CONNECTING, s_dragon_host);
+         break;
 
-    case WEBSOCKET_EVENT_CONNECTED: {
-        ESP_LOGI(TAG, "WS: CONNECTED — sending register frame");
-        /* #293: emit obs event for e2e harness. */
-        tab5_debug_obs_event("ws.connect", "");
-        /* TT #317 Phase 4: stamp WS-alive so the K144 failover gate can
-         * measure how long Dragon's been down before engaging. */
-        s_ws_last_alive_us = esp_timer_get_time();
-        /* TT #317 Phase 5: if a K144 failover engaged during the down
-         * period, surface "Dragon reconnected" so the user knows the
-         * next turn is back on the cloud/LAN brain.  Wave 4b: the flag
-         * lives in voice_onboard now; consume_engagement_flag returns
-         * true once and clears, so the toast fires exactly once per
-         * disconnect cycle. */
-        if (voice_onboard_consume_engagement_flag()) {
-           ESP_LOGI(TAG, "WS reconnected after K144 failover — toast 'Dragon reconnected'");
-           if (tab5_ui_try_lock(100)) {
-              ui_home_show_toast("Dragon reconnected");
-              tab5_ui_unlock();
-           }
-        }
-        /* US-C02: bump session gen on every successful connect. */
-        s_session_gen++;
-        s_handshake_fail_cnt = 0;
-        /* γ3-Tab5 (issue #198): clear the auth-fail counter on a
-         * successful connect so a transient 401 (e.g. a token-rotation
-         * race during Dragon restart) doesn't get sticky after Dragon
-         * recovers.  Only a sustained run of 401s should trip the
-         * stop-retry — recovery must self-heal. */
-        s_auth_fail_cnt = 0;
-        /* T1.1: reset backoff state on every successful connect so a
-         * long-running healthy session doesn't get hit with a 30 s
-         * delay on its first blip. */
-        s_connect_attempt = 0;
-        esp_websocket_client_set_reconnect_timeout(g_voice_ws, WS_CLIENT_BACKOFF_MIN_MS);
+      case WEBSOCKET_EVENT_CONNECTED: {
+         ESP_LOGI(TAG, "WS: CONNECTED — sending register frame");
+         /* #293: emit obs event for e2e harness. */
+         tab5_debug_obs_event("ws.connect", "");
+         /* TT #317 Phase 4: stamp WS-alive so the K144 failover gate can
+          * measure how long Dragon's been down before engaging. */
+         s_ws_last_alive_us = esp_timer_get_time();
+         /* TT #317 Phase 5: if a K144 failover engaged during the down
+          * period, surface "Dragon reconnected" so the user knows the
+          * next turn is back on the cloud/LAN brain.  Wave 4b: the flag
+          * lives in voice_onboard now; consume_engagement_flag returns
+          * true once and clears, so the toast fires exactly once per
+          * disconnect cycle. */
+         if (voice_onboard_consume_engagement_flag()) {
+            ESP_LOGI(TAG, "WS reconnected after K144 failover — toast 'Dragon reconnected'");
+            if (tab5_ui_try_lock(100)) {
+               ui_home_show_toast("Dragon reconnected");
+               tab5_ui_unlock();
+            }
+         }
+         /* US-C02: bump session gen on every successful connect. */
+         s_session_gen++;
+         s_handshake_fail_cnt = 0;
+         /* γ3-Tab5 (issue #198): clear the auth-fail counter on a
+          * successful connect so a transient 401 (e.g. a token-rotation
+          * race during Dragon restart) doesn't get sticky after Dragon
+          * recovers.  Only a sustained run of 401s should trip the
+          * stop-retry — recovery must self-heal. */
+         s_auth_fail_cnt = 0;
+         /* T1.1: reset backoff state on every successful connect so a
+          * long-running healthy session doesn't get hit with a 30 s
+          * delay on its first blip. */
+         s_connect_attempt = 0;
+         esp_websocket_client_set_reconnect_timeout(g_voice_ws, WS_CLIENT_BACKOFF_MIN_MS);
 
-        esp_err_t reg_err = voice_ws_send_register();
-        if (reg_err != ESP_OK) {
+         esp_err_t reg_err = voice_ws_send_register();
+         if (reg_err != ESP_OK) {
             ESP_LOGE(TAG, "WS: register send failed (%s)", esp_err_to_name(reg_err));
             /* Let auto-reconnect re-attempt. */
-        }
-        /* Don't set READY yet — wait for Dragon's session_start reply so
-         * we know the backend pipeline is fully up. Keep state CONNECTING
-         * until session_start arrives (~6s model load on first boot). */
-        break;
-    }
+         }
+         /* Don't set READY yet — wait for Dragon's session_start reply so
+          * we know the backend pipeline is fully up. Keep state CONNECTING
+          * until session_start arrives (~6s model load on first boot). */
+         break;
+      }
 
-    case WEBSOCKET_EVENT_DISCONNECTED:
-        ESP_LOGW(TAG, "WS: DISCONNECTED");
-        { tab5_debug_obs_event("ws.disconnect", ""); }
-        /* Flush playback so we don't keep speaking into a dead pipe. */
-        voice_playback_buf_reset();
-        tab5_audio_speaker_enable(false);
-        /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice
-         * state was PROCESSING or SPEAKING), surface a toast so the user
-         * knows why the reply stopped.  Previously a mid-turn Dragon
-         * crash was silent — just a frozen overlay + no answer.  The
-         * home status-bar pill already picks up RECONNECTING via
-         * voice_get_degraded_reason(), so the toast is a short-lived
-         * orient-the-user signal, not the permanent indicator.
-         *
-         * Wave 7 F5 completion (2026-04-21): also pulse the halo orb
-         * rose for ~2.5 s so the visual signal matches the audit spec
-         * ("toast + rose orb pulse"). Toast alone was easy to miss if
-         * the user was looking at the chat area rather than the home
-         * card. ui_home_pulse_orb_alert reverts to the mode-default
-         * orb paint via an LVGL one-shot timer. */
-        {
+      case WEBSOCKET_EVENT_DISCONNECTED:
+         ESP_LOGW(TAG, "WS: DISCONNECTED");
+         { tab5_debug_obs_event("ws.disconnect", ""); }
+         /* Flush playback so we don't keep speaking into a dead pipe. */
+         voice_playback_buf_reset();
+         tab5_audio_speaker_enable(false);
+         /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice
+          * state was PROCESSING or SPEAKING), surface a toast so the user
+          * knows why the reply stopped.  Previously a mid-turn Dragon
+          * crash was silent — just a frozen overlay + no answer.  The
+          * home status-bar pill already picks up RECONNECTING via
+          * voice_get_degraded_reason(), so the toast is a short-lived
+          * orient-the-user signal, not the permanent indicator.
+          *
+          * Wave 7 F5 completion (2026-04-21): also pulse the halo orb
+          * rose for ~2.5 s so the visual signal matches the audit spec
+          * ("toast + rose orb pulse"). Toast alone was easy to miss if
+          * the user was looking at the chat area rather than the home
+          * card. ui_home_pulse_orb_alert reverts to the mode-default
+          * orb paint via an LVGL one-shot timer. */
+         {
             voice_state_t cur = voice_get_state();
             if ((cur == VOICE_STATE_PROCESSING || cur == VOICE_STATE_SPEAKING) && !s_disconnecting) {
                tab5_lv_async_call((lv_async_cb_t)ui_home_show_toast, (void *)"Dragon dropped mid-turn - reconnecting");
                tab5_lv_async_call((lv_async_cb_t)ui_home_pulse_orb_alert, NULL);
             }
-        }
-        /* T1.1: bump attempt counter + apply exponential-with-full-jitter
-         * backoff to the client's reconnect timer.  Prevents thundering
-         * herd if multiple Tab5s share the same Dragon + avoids 2 s
-         * hammering against a server that's 20 s into its restart. */
-        s_connect_attempt++;
-        {
+         }
+         /* T1.1: bump attempt counter + apply exponential-with-full-jitter
+          * backoff to the client's reconnect timer.  Prevents thundering
+          * herd if multiple Tab5s share the same Dragon + avoids 2 s
+          * hammering against a server that's 20 s into its restart. */
+         s_connect_attempt++;
+         {
             int shift = s_connect_attempt - 1;
             if (shift < 0) shift = 0;
             if (shift > 5) shift = 5;
@@ -1324,57 +1277,56 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
             if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
             uint32_t half = exp_ms / 2;
             uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
-            uint32_t delay_ms = half + jitter;    /* [exp/2, exp) */
-            ESP_LOGI(TAG, "WS: reconnect attempt=%d backoff=%lums (exp=%lums)",
-                     s_connect_attempt, (unsigned long)delay_ms,
-                     (unsigned long)exp_ms);
+            uint32_t delay_ms = half + jitter; /* [exp/2, exp) */
+            ESP_LOGI(TAG, "WS: reconnect attempt=%d backoff=%lums (exp=%lums)", s_connect_attempt,
+                     (unsigned long)delay_ms, (unsigned long)exp_ms);
             esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
-        }
-        /* #146: WS-level escalation.  If Wi-Fi probes claim we're fine
-         * (probe task still sees lan=1/ngrok=1) but the voice WS keeps
-         * failing to connect, the Wi-Fi chip's TCP-stack state is bad.
-         * The probe is a one-shot SYN; the WS handshake needs more
-         * buffers + TLS-path + full RX pipeline.  After WS_KICK_THRESHOLD
-         * consecutive failed attempts (~2 min of retry), hard-kick the
-         * stack.  Don't do this on attempt 1-4 — those are normal
-         * transient failures (Dragon restart, brief AP hiccup). */
-        #define WS_KICK_THRESHOLD 5
-        if (s_connect_attempt == WS_KICK_THRESHOLD) {
-            ESP_LOGW(TAG, "WS: %d failed attempts — escalating to hard-kick "
-                          "(stack may be wedged despite probe success)",
+         }
+/* #146: WS-level escalation.  If Wi-Fi probes claim we're fine
+ * (probe task still sees lan=1/ngrok=1) but the voice WS keeps
+ * failing to connect, the Wi-Fi chip's TCP-stack state is bad.
+ * The probe is a one-shot SYN; the WS handshake needs more
+ * buffers + TLS-path + full RX pipeline.  After WS_KICK_THRESHOLD
+ * consecutive failed attempts (~2 min of retry), hard-kick the
+ * stack.  Don't do this on attempt 1-4 — those are normal
+ * transient failures (Dragon restart, brief AP hiccup). */
+#define WS_KICK_THRESHOLD 5
+         if (s_connect_attempt == WS_KICK_THRESHOLD) {
+            ESP_LOGW(TAG,
+                     "WS: %d failed attempts — escalating to hard-kick "
+                     "(stack may be wedged despite probe success)",
                      s_connect_attempt);
             esp_err_t kr = tab5_wifi_hard_kick();
             if (kr != ESP_OK) {
-                /* ESP-Hosted's Wi-Fi slave chip doesn't always recover
-                 * from stop/start without a host-side reboot (observed:
-                 * esp_wifi_start returns ESP_FAIL repeatedly).  Don't
-                 * burn another 5 attempts — reboot now. */
-                ESP_LOGE(TAG, "WS: hard-kick failed (%s) — controlled reboot",
-                         esp_err_to_name(kr));
-                vTaskDelay(pdMS_TO_TICKS(100));
-                esp_restart();
-                /* unreachable */
+               /* ESP-Hosted's Wi-Fi slave chip doesn't always recover
+                * from stop/start without a host-side reboot (observed:
+                * esp_wifi_start returns ESP_FAIL repeatedly).  Don't
+                * burn another 5 attempts — reboot now. */
+               ESP_LOGE(TAG, "WS: hard-kick failed (%s) — controlled reboot", esp_err_to_name(kr));
+               vTaskDelay(pdMS_TO_TICKS(100));
+               esp_restart();
+               /* unreachable */
             }
             /* Reset the counter so we give it another 5 tries after the
              * successful hard kick before escalating again.  If 10
              * failures in a row, the link-probe zombie path catches it. */
             s_connect_attempt = 0;
-        }
-        /* T1.2: RECONNECTING while a backoff is queued + WiFi is up.
-         * IDLE only when WiFi is genuinely down or user stopped voice. */
-        {
+         }
+         /* T1.2: RECONNECTING while a backoff is queued + WiFi is up.
+          * IDLE only when WiFi is genuinely down or user stopped voice. */
+         {
             bool wifi_up = tab5_wifi_connected();
             if (s_initialized && !s_disconnecting && wifi_up) {
-                voice_set_state(VOICE_STATE_RECONNECTING, "backoff");
+               voice_set_state(VOICE_STATE_RECONNECTING, "backoff");
             } else {
-                voice_set_state(VOICE_STATE_IDLE, "disconnected");
+               voice_set_state(VOICE_STATE_IDLE, "disconnected");
             }
-        }
-        /* v4·D audit P0 fix: ngrok fallback was one-way.  Clear the flag
-         * + reset the fail counter so the NEXT successful connection
-         * gets a chance to land on LAN.  The actual URI swap is deferred
-         * to voice_try_lan_probe() which runs off the WS event task. */
-        if (s_using_ngrok && tab5_settings_get_connection_mode() == 0) {
+         }
+         /* v4·D audit P0 fix: ngrok fallback was one-way.  Clear the flag
+          * + reset the fail counter so the NEXT successful connection
+          * gets a chance to land on LAN.  The actual URI swap is deferred
+          * to voice_try_lan_probe() which runs off the WS event task. */
+         if (s_using_ngrok && tab5_settings_get_connection_mode() == 0) {
             s_handshake_fail_cnt = 0;
             /* Leave s_using_ngrok alone here: we only reset it once the
              * external LAN probe succeeds (heap_watchdog periodic hook).
@@ -1383,23 +1335,23 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
              * shown to wedge the client.  Next sprint: add a proper
              * probe task that pings LAN and schedules the swap via
              * lv_async_call on success. */
-        }
-        break;
+         }
+         break;
 
-    case WEBSOCKET_EVENT_CLOSED:
-        /* closes #110: was voice_set_state(IDLE, "closed") with NO
-         * reconnect scheduled — if Dragon sends a graceful WS close
-         * frame (restart, idle timeout, etc.) Tab5 parked in IDLE
-         * forever until the user hit /voice/reconnect manually.
-         * DISCONNECTED re-armed the reconnect timer; CLOSED did not.
-         *
-         * Mirror the DISCONNECTED path: bump attempt, apply
-         * exponential-with-full-jitter backoff, transition to
-         * RECONNECTING when Wi-Fi is up so the state bar reflects
-         * that Tab5 is actively trying, not dead.  The managed WS
-         * client's auto-reconnect picks up the new timeout. */
-        ESP_LOGI(TAG, "WS: CLOSED — scheduling reconnect");
-        if (g_voice_ws && !s_disconnecting) {
+      case WEBSOCKET_EVENT_CLOSED:
+         /* closes #110: was voice_set_state(IDLE, "closed") with NO
+          * reconnect scheduled — if Dragon sends a graceful WS close
+          * frame (restart, idle timeout, etc.) Tab5 parked in IDLE
+          * forever until the user hit /voice/reconnect manually.
+          * DISCONNECTED re-armed the reconnect timer; CLOSED did not.
+          *
+          * Mirror the DISCONNECTED path: bump attempt, apply
+          * exponential-with-full-jitter backoff, transition to
+          * RECONNECTING when Wi-Fi is up so the state bar reflects
+          * that Tab5 is actively trying, not dead.  The managed WS
+          * client's auto-reconnect picks up the new timeout. */
+         ESP_LOGI(TAG, "WS: CLOSED — scheduling reconnect");
+         if (g_voice_ws && !s_disconnecting) {
             s_connect_attempt++;
             int shift = s_connect_attempt - 1;
             if (shift < 0) shift = 0;
@@ -1409,27 +1361,26 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
             uint32_t half = exp_ms / 2;
             uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
             uint32_t delay_ms = half + jitter;
-            ESP_LOGI(TAG, "WS: CLOSED reconnect attempt=%d backoff=%lums",
-                     s_connect_attempt, (unsigned long)delay_ms);
+            ESP_LOGI(TAG, "WS: CLOSED reconnect attempt=%d backoff=%lums", s_connect_attempt, (unsigned long)delay_ms);
             esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
             if (tab5_wifi_connected()) {
-                voice_set_state(VOICE_STATE_RECONNECTING, "closed");
+               voice_set_state(VOICE_STATE_RECONNECTING, "closed");
             } else {
-                voice_set_state(VOICE_STATE_IDLE, "closed-nowifi");
+               voice_set_state(VOICE_STATE_IDLE, "closed-nowifi");
             }
-        } else {
+         } else {
             voice_set_state(VOICE_STATE_IDLE, "closed");
-        }
-        break;
+         }
+         break;
 
-    case WEBSOCKET_EVENT_DATA:
-        if (!data) break;
-        s_last_activity_us = esp_timer_get_time();
-        if (data->op_code == WS_TRANSPORT_OPCODES_TEXT && data->data_len > 0) {
-            ESP_LOGI(TAG, "WS recv text (%d bytes): %.*s", data->data_len,
-                     data->data_len > 200 ? 200 : data->data_len, data->data_ptr);
+      case WEBSOCKET_EVENT_DATA:
+         if (!data) break;
+         s_last_activity_us = esp_timer_get_time();
+         if (data->op_code == WS_TRANSPORT_OPCODES_TEXT && data->data_len > 0) {
+            ESP_LOGI(TAG, "WS recv text (%d bytes): %.*s", data->data_len, data->data_len > 200 ? 200 : data->data_len,
+                     data->data_ptr);
             voice_ws_proto_handle_text(data->data_ptr, data->data_len);
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_BINARY && data->data_len > 0) {
+         } else if (data->op_code == WS_TRANSPORT_OPCODES_BINARY && data->data_len > 0) {
             /* #268: large binary frames (e.g. Phase 3B video JPEGs >32 KB)
              * arrive in fragments — esp_websocket_client splits them at
              * WS_CLIENT_BUFFER_SIZE.  Reassemble using payload_len +
@@ -1438,56 +1389,53 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
              * (PCM/OPUS) is single-fragment so the fast path skips
              * reassembly. */
             const int frag_total = data->payload_len;
-            const int frag_off   = data->payload_offset;
-            const int frag_len   = data->data_len;
+            const int frag_off = data->payload_offset;
+            const int frag_len = data->data_len;
             if (frag_total <= 0 || frag_total == frag_len) {
-                /* Single-fragment frame — current behavior. */
-                voice_ws_proto_handle_binary(data->data_ptr, frag_len);
+               /* Single-fragment frame — current behavior. */
+               voice_ws_proto_handle_binary(data->data_ptr, frag_len);
             } else {
-                /* Multi-fragment frame.  Lazy-init reassembly buffer
-                 * in PSRAM, sized to the same ceiling voice_video uses. */
-                static uint8_t *s_rx_reasm_buf = NULL;
-                static int      s_rx_reasm_cap = 96 * 1024;
-                if (!s_rx_reasm_buf) {
-                    s_rx_reasm_buf = heap_caps_malloc(
-                        s_rx_reasm_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-                }
-                if (!s_rx_reasm_buf) {
-                    ESP_LOGW(TAG, "rx-reasm OOM (%d B); dropping frag", s_rx_reasm_cap);
-                    break;
-                }
-                if (frag_total > s_rx_reasm_cap) {
-                    ESP_LOGW(TAG, "rx-reasm: payload %d > cap %d; dropping", frag_total, s_rx_reasm_cap);
-                    break;
-                }
-                if (frag_off + frag_len > frag_total) {
-                    ESP_LOGW(TAG, "rx-reasm: bad frag off=%d len=%d total=%d",
-                             frag_off, frag_len, frag_total);
-                    break;
-                }
-                memcpy(s_rx_reasm_buf + frag_off, data->data_ptr, frag_len);
-                if (frag_off + frag_len == frag_total) {
-                    voice_ws_proto_handle_binary((const char *)s_rx_reasm_buf, frag_total);
-                }
+               /* Multi-fragment frame.  Lazy-init reassembly buffer
+                * in PSRAM, sized to the same ceiling voice_video uses. */
+               static uint8_t *s_rx_reasm_buf = NULL;
+               static int s_rx_reasm_cap = 96 * 1024;
+               if (!s_rx_reasm_buf) {
+                  s_rx_reasm_buf = heap_caps_malloc(s_rx_reasm_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+               }
+               if (!s_rx_reasm_buf) {
+                  ESP_LOGW(TAG, "rx-reasm OOM (%d B); dropping frag", s_rx_reasm_cap);
+                  break;
+               }
+               if (frag_total > s_rx_reasm_cap) {
+                  ESP_LOGW(TAG, "rx-reasm: payload %d > cap %d; dropping", frag_total, s_rx_reasm_cap);
+                  break;
+               }
+               if (frag_off + frag_len > frag_total) {
+                  ESP_LOGW(TAG, "rx-reasm: bad frag off=%d len=%d total=%d", frag_off, frag_len, frag_total);
+                  break;
+               }
+               memcpy(s_rx_reasm_buf + frag_off, data->data_ptr, frag_len);
+               if (frag_off + frag_len == frag_total) {
+                  voice_ws_proto_handle_binary((const char *)s_rx_reasm_buf, frag_total);
+               }
             }
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_PING) {
+         } else if (data->op_code == WS_TRANSPORT_OPCODES_PING) {
             ESP_LOGD(TAG, "WS recv PING — client auto-pongs");
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_PONG) {
+         } else if (data->op_code == WS_TRANSPORT_OPCODES_PONG) {
             ESP_LOGD(TAG, "WS recv PONG");
-        } else if (data->op_code == WS_TRANSPORT_OPCODES_CLOSE) {
+         } else if (data->op_code == WS_TRANSPORT_OPCODES_CLOSE) {
             ESP_LOGI(TAG, "WS recv CLOSE frame");
-        }
-        break;
+         }
+         break;
 
-    case WEBSOCKET_EVENT_ERROR: {
-        int status = data ? data->error_handle.esp_ws_handshake_status_code : 0;
-        esp_websocket_error_type_t et = data ? data->error_handle.error_type : WEBSOCKET_ERROR_TYPE_NONE;
-        ESP_LOGW(TAG, "WS: ERROR (type=%d, handshake_status=%d, sock_errno=%d)",
-                 (int)et, status,
-                 data ? data->error_handle.esp_transport_sock_errno : 0);
-        /* T1.1: apply the same backoff on error as on disconnect so
-         * a handshake-fail loop doesn't pin at 2 s forever. */
-        {
+      case WEBSOCKET_EVENT_ERROR: {
+         int status = data ? data->error_handle.esp_ws_handshake_status_code : 0;
+         esp_websocket_error_type_t et = data ? data->error_handle.error_type : WEBSOCKET_ERROR_TYPE_NONE;
+         ESP_LOGW(TAG, "WS: ERROR (type=%d, handshake_status=%d, sock_errno=%d)", (int)et, status,
+                  data ? data->error_handle.esp_transport_sock_errno : 0);
+         /* T1.1: apply the same backoff on error as on disconnect so
+          * a handshake-fail loop doesn't pin at 2 s forever. */
+         {
             int shift = s_connect_attempt;
             if (shift < 0) shift = 0;
             if (shift > 5) shift = 5;
@@ -1496,97 +1444,89 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
             uint32_t half = exp_ms / 2;
             uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
             esp_websocket_client_set_reconnect_timeout(g_voice_ws, half + jitter);
-        }
+         }
 
-        /* γ3-Tab5 (issue #198): 401 specifically means auth failed —
-         * burning the auth-fail counter every retry will pin the
-         * device against ngrok forever (wrong-token devices used to
-         * loop 401s on both LAN and ngrok endpoints, eating battery
-         * + ngrok bandwidth + log storage).  After WS_AUTH_FAIL_THRESHOLD
-         * consecutive 401s, stop the WS client + show a toast pointing
-         * at Settings.  s_auth_fail_cnt resets on a successful CONNECT
-         * so a transient 401 (token-rotation race during Dragon
-         * restart) doesn't get sticky after recovery.
-         *
-         * Filter on status alone — NOT on
-         * `et == WEBSOCKET_ERROR_TYPE_HANDSHAKE`.  Empirically (live
-         * test on real device against PROD :3502 with rotated token)
-         * a clean 401 from Dragon arrives as `et=1`
-         * (WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT) because the underlying
-         * TCP transport completed successfully — the 401 happens at
-         * the application layer.  Gating on HANDSHAKE here meant the
-         * counter never incremented and the loop ran forever. */
-        if (status == 401) {
+         /* γ3-Tab5 (issue #198): 401 specifically means auth failed —
+          * burning the auth-fail counter every retry will pin the
+          * device against ngrok forever (wrong-token devices used to
+          * loop 401s on both LAN and ngrok endpoints, eating battery
+          * + ngrok bandwidth + log storage).  After WS_AUTH_FAIL_THRESHOLD
+          * consecutive 401s, stop the WS client + show a toast pointing
+          * at Settings.  s_auth_fail_cnt resets on a successful CONNECT
+          * so a transient 401 (token-rotation race during Dragon
+          * restart) doesn't get sticky after recovery.
+          *
+          * Filter on status alone — NOT on
+          * `et == WEBSOCKET_ERROR_TYPE_HANDSHAKE`.  Empirically (live
+          * test on real device against PROD :3502 with rotated token)
+          * a clean 401 from Dragon arrives as `et=1`
+          * (WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT) because the underlying
+          * TCP transport completed successfully — the 401 happens at
+          * the application layer.  Gating on HANDSHAKE here meant the
+          * counter never incremented and the loop ran forever. */
+         if (status == 401) {
             s_auth_fail_cnt++;
-            ESP_LOGW(TAG, "WS: 401 auth_failed (count=%d/%d)",
-                     s_auth_fail_cnt, WS_AUTH_FAIL_THRESHOLD);
+            ESP_LOGW(TAG, "WS: 401 auth_failed (count=%d/%d)", s_auth_fail_cnt, WS_AUTH_FAIL_THRESHOLD);
             if (s_auth_fail_cnt >= WS_AUTH_FAIL_THRESHOLD && !s_disconnecting) {
-                ESP_LOGE(TAG, "WS: %d consecutive 401s — stopping retry loop",
-                         s_auth_fail_cnt);
-                s_disconnecting = true;
-                /* Hop to worker task — esp_websocket_client_stop()
-                 * rejects calls from the WS task itself.  Same pattern
-                 * as the γ2-H8 device_evicted handler. */
-                tab5_worker_enqueue(_voice_auth_fail_stop_worker_fn, NULL,
-                                    "auth_failed_stop");
-                /* TT #328 Wave 3 P0 #15 — pre-Wave-3 this was a 2.2 s toast.
-                 * After 5 silent retries the user got a single transient
-                 * notice they could easily miss.  Upgraded to a persistent
-                 * error banner that stays until they tap it (and presumably
-                 * jump to Settings to fix the token).  Also fires the
-                 * error.auth obs event so /events surfaces the lockout. */
-                tab5_debug_obs_event("error.auth", "ws_401_stop");
-                char *toast = strdup("Invalid Dragon token — check Settings");
-                if (toast) {
-                    voice_async_toast(toast);
-                }
-                voice_async_error_banner(
-                    "Dragon rejected your token (401). Reconnect paused — "
-                    "open Settings → Network to update.");
-                break;
+               ESP_LOGE(TAG, "WS: %d consecutive 401s — stopping retry loop", s_auth_fail_cnt);
+               s_disconnecting = true;
+               /* Hop to worker task — esp_websocket_client_stop()
+                * rejects calls from the WS task itself.  Same pattern
+                * as the γ2-H8 device_evicted handler. */
+               tab5_worker_enqueue(_voice_auth_fail_stop_worker_fn, NULL, "auth_failed_stop");
+               /* TT #328 Wave 3 P0 #15 — pre-Wave-3 this was a 2.2 s toast.
+                * After 5 silent retries the user got a single transient
+                * notice they could easily miss.  Upgraded to a persistent
+                * error banner that stays until they tap it (and presumably
+                * jump to Settings to fix the token).  Also fires the
+                * error.auth obs event so /events surfaces the lockout. */
+               tab5_debug_obs_event("error.auth", "ws_401_stop");
+               char *toast = strdup("Invalid Dragon token — check Settings");
+               if (toast) {
+                  voice_async_toast(toast);
+               }
+               voice_async_error_banner(
+                   "Dragon rejected your token (401). Reconnect paused — "
+                   "open Settings → Network to update.");
+               break;
             }
-        }
+         }
 
-        /* Handshake failure → try ngrok fallback (only in conn_mode=auto,
-         * only while still on local URI, after NGROK_FALLBACK_THRESHOLD fails). */
-        if (et == WEBSOCKET_ERROR_TYPE_HANDSHAKE && status != 101) {
+         /* Handshake failure → try ngrok fallback (only in conn_mode=auto,
+          * only while still on local URI, after NGROK_FALLBACK_THRESHOLD fails). */
+         if (et == WEBSOCKET_ERROR_TYPE_HANDSHAKE && status != 101) {
             s_handshake_fail_cnt++;
             uint8_t conn_mode = tab5_settings_get_connection_mode();
-            if (conn_mode == 0 && !s_using_ngrok
-                && s_handshake_fail_cnt >= NGROK_FALLBACK_THRESHOLD) {
-                char ngrok_uri[128];
-                snprintf(ngrok_uri, sizeof(ngrok_uri),
-                         "wss://%s:%d%s",
-                         TAB5_NGROK_HOST, TAB5_NGROK_PORT, TAB5_VOICE_WS_PATH);
-                ESP_LOGW(TAG, "WS: handshake failed %d× — falling back to %s",
-                         s_handshake_fail_cnt, ngrok_uri);
-                s_using_ngrok = true;
-                s_handshake_fail_cnt = 0;
-                /* set_uri requires a stopped client. The client is
-                 * currently between reconnect attempts; stop+set+start
-                 * to force it onto the new URI immediately. */
-                esp_websocket_client_stop(g_voice_ws);
-                esp_websocket_client_set_uri(g_voice_ws, ngrok_uri);
-                strncpy(s_dragon_host, TAB5_NGROK_HOST, sizeof(s_dragon_host) - 1);
-                s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
-                s_dragon_port = TAB5_NGROK_PORT;
-                esp_websocket_client_start(g_voice_ws);
+            if (conn_mode == 0 && !s_using_ngrok && s_handshake_fail_cnt >= NGROK_FALLBACK_THRESHOLD) {
+               char ngrok_uri[128];
+               snprintf(ngrok_uri, sizeof(ngrok_uri), "wss://%s:%d%s", TAB5_NGROK_HOST, TAB5_NGROK_PORT,
+                        TAB5_VOICE_WS_PATH);
+               ESP_LOGW(TAG, "WS: handshake failed %d× — falling back to %s", s_handshake_fail_cnt, ngrok_uri);
+               s_using_ngrok = true;
+               s_handshake_fail_cnt = 0;
+               /* set_uri requires a stopped client. The client is
+                * currently between reconnect attempts; stop+set+start
+                * to force it onto the new URI immediately. */
+               esp_websocket_client_stop(g_voice_ws);
+               esp_websocket_client_set_uri(g_voice_ws, ngrok_uri);
+               strncpy(s_dragon_host, TAB5_NGROK_HOST, sizeof(s_dragon_host) - 1);
+               s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
+               s_dragon_port = TAB5_NGROK_PORT;
+               esp_websocket_client_start(g_voice_ws);
             }
-        }
-        break;
-    }
+         }
+         break;
+      }
 
-    default:
-        break;
-    }
+      default:
+         break;
+   }
 }
 
 // ---------------------------------------------------------------------------
 // URI helpers
 // ---------------------------------------------------------------------------
 /* TT #331 Wave 23 SRP-A1: was static void voice_build_local_uri. */
-void voice_ws_proto_build_local_uri(char *out, size_t out_cap,
-                                    const char *host, uint16_t port)
-{
-    snprintf(out, out_cap, "ws://%s:%u%s", host, (unsigned)port, TAB5_VOICE_WS_PATH);
+void voice_ws_proto_build_local_uri(char *out, size_t out_cap, const char *host, uint16_t port) {
+   snprintf(out, out_cap, "ws://%s:%u%s", host, (unsigned)port, TAB5_VOICE_WS_PATH);
 }

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -1,0 +1,194 @@
+/**
+ * Voice WebSocket protocol layer (Tab5 ↔ Dragon) — implementation.
+ *
+ * Wave 23 SOLID-audit closure for TT #331 (extract A1).  See
+ * voice_ws_proto.h for the layer contract.  Pre-extract this all
+ * lived inline in voice.c at L525-1948.
+ */
+#include "voice_ws_proto.h"
+
+#include "voice.h"   /* g_voice_ws extern + voice_set_state */
+
+#include <limits.h>  /* INT_MAX (W14-L02 send-bound check) */
+#include <string.h>
+
+#include "cJSON.h"
+#include "config.h"
+#include "esp_log.h"
+#include "esp_websocket_client.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "settings.h"
+#include "voice_codec.h" /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+
+static const char *TAG = "tab5_voice_ws";
+
+/* US-C04: counter for audio frames dropped under WS back-pressure.
+ * Internal to voice_ws_send_binary; pre-extract this was a file-static
+ * in voice.c.  No external readers — kept here so the dropped-frame
+ * accounting stays colocated with the sender that increments it. */
+static int s_audio_drop_count = 0;
+
+// ---------------------------------------------------------------------------
+// WebSocket send helpers (wrapping esp_websocket_client_send_*)
+// ---------------------------------------------------------------------------
+esp_err_t voice_ws_send_text(const char *msg)
+{
+    if (!g_voice_ws) return ESP_ERR_INVALID_STATE;
+    if (!esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+    if (!msg) return ESP_ERR_INVALID_ARG;
+
+    size_t len = strlen(msg);
+    /* Wave 14 W14-L02: bound the size_t→int cast.  Realistic messages
+     * are <256 bytes but an unchecked cast would silently truncate on
+     * an accidental >2 GB string (e.g. a corrupted LLM response
+     * flowing through text_update). */
+    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
+    int w = esp_websocket_client_send_text(g_voice_ws, msg, (int)len, pdMS_TO_TICKS(1000));
+    if (w < 0) {
+        ESP_LOGW(TAG, "WS text send failed (%zu bytes)", len);
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t voice_ws_send_binary(const void *data, size_t len)
+{
+    if (!g_voice_ws) return ESP_ERR_INVALID_STATE;
+    if (!esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+    if (!data) return ESP_ERR_INVALID_ARG;
+    /* W14-L02: same bound as text. */
+    if (len > INT_MAX) return ESP_ERR_INVALID_ARG;
+
+    /* Short 100 ms timeout — we drop frames under pressure rather than
+     * block the mic task. If WiFi stalls, I2S DMA would overflow. */
+    int w = esp_websocket_client_send_bin(g_voice_ws, (const char *)data, (int)len,
+                                          pdMS_TO_TICKS(100));
+    if (w < 0) {
+        s_audio_drop_count++;
+        if (s_audio_drop_count % 10 == 1) {
+            ESP_LOGW(TAG, "WS binary send dropped — %d frames lost", s_audio_drop_count);
+        }
+        return ESP_ERR_TIMEOUT;
+    }
+    if (s_audio_drop_count > 0) {
+        ESP_LOGI(TAG, "WS binary send recovered after %d drops", s_audio_drop_count);
+        s_audio_drop_count = 0;
+    }
+    return ESP_OK;
+}
+
+/* #266: thin public wrapper for voice_video.c (and any future binary
+ * sender).  Behavior is identical to voice_ws_send_binary — same
+ * 100 ms send timeout, same drop accounting. */
+esp_err_t voice_ws_send_binary_public(const void *data, size_t len)
+{
+    return voice_ws_send_binary(data, len);
+}
+
+// ---------------------------------------------------------------------------
+// Device registration — sent as FIRST text frame from the CONNECTED handler.
+// This is the #76 fix: register is sent from inside the event handler, AFTER
+// the client's event task is running and ready to dispatch the server's
+// session_start reply. The legacy code sent register synchronously before
+// spawning the receive task, which opened a 50–500ms window where Dragon's
+// reply arrived while nothing was draining the SDIO RX buffer.
+// ---------------------------------------------------------------------------
+esp_err_t voice_ws_send_register(void)
+{
+    char device_id[16]   = {0};
+    char hardware_id[20] = {0};
+    char session_id[64]  = {0};
+
+    tab5_settings_get_device_id(device_id, sizeof(device_id));
+    tab5_settings_get_hardware_id(hardware_id, sizeof(hardware_id));
+    tab5_settings_get_session_id(session_id, sizeof(session_id));
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) return ESP_ERR_NO_MEM;
+
+    cJSON_AddStringToObject(root, "type", "register");
+    cJSON_AddStringToObject(root, "device_id", device_id);
+    cJSON_AddStringToObject(root, "hardware_id", hardware_id);
+    cJSON_AddStringToObject(root, "name", "Tab5");
+    cJSON_AddStringToObject(root, "firmware_ver", TAB5_FIRMWARE_VER);
+    cJSON_AddStringToObject(root, "platform", TAB5_PLATFORM);
+
+    if (session_id[0] != '\0') {
+        cJSON_AddStringToObject(root, "session_id", session_id);
+    } else {
+        cJSON_AddNullToObject(root, "session_id");
+    }
+
+    cJSON *caps = cJSON_AddObjectToObject(root, "capabilities");
+    cJSON_AddBoolToObject(caps, "mic", true);
+    cJSON_AddBoolToObject(caps, "speaker", true);
+    cJSON_AddBoolToObject(caps, "screen", true);
+    cJSON_AddBoolToObject(caps, "camera", true);
+    cJSON_AddBoolToObject(caps, "sd_card", true);
+    cJSON_AddBoolToObject(caps, "touch", true);
+    /* #266: live JPEG video uplink.  Tab5 sends per-frame binary WS
+     * frames prefixed with the "VID0" 4-byte magic + 4-byte length.
+     * Dragon detects the magic to route video vs audio. */
+    cJSON_AddBoolToObject(caps, "video_send", true);
+    cJSON_AddBoolToObject(caps, "video_recv", true);   /* #268 Phase 3B */
+    cJSON_AddNumberToObject(caps, "video_max_fps", 10);
+    cJSON_AddNumberToObject(caps, "video_format", 0);  /* 0 = JPEG */
+    /* #262: advertise audio codec support.  Dragon picks one and replies
+     * via config_update.audio_codec.  Tab5 stays on PCM (current behavior)
+     * until Dragon switches it.  Per-direction so the broken uplink
+     * encoder (#262 follow-up: silk_NSQ_c crashes on this build) doesn't
+     * starve the working downlink decoder; until the encoder ships,
+     * advertise opus only on the downlink. */
+    cJSON *acodecs = cJSON_AddArrayToObject(caps, "audio_codec");
+    cJSON_AddItemToArray(acodecs, cJSON_CreateString("pcm"));
+#if VOICE_CODEC_OPUS_UPLINK_ENABLED
+    cJSON_AddItemToArray(acodecs, cJSON_CreateString("opus"));
+#endif
+    cJSON *acodecs_dl = cJSON_AddArrayToObject(caps, "audio_downlink_codec");
+    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("pcm"));
+    cJSON_AddItemToArray(acodecs_dl, cJSON_CreateString("opus"));
+    /* v4·D audit P0 fix: widget_capability was spec-only -- now wired.
+     * Skills can downgrade widget content for low-end clients (smaller
+     * list, lower image res).  Match the actual Tab5 limits we've
+     * built out across widget_store.c / ui_home.c. */
+    cJSON *widgets = cJSON_AddObjectToObject(caps, "widgets");
+    cJSON *types = cJSON_AddArrayToObject(widgets, "types");
+    cJSON_AddItemToArray(types, cJSON_CreateString("live"));
+    cJSON_AddItemToArray(types, cJSON_CreateString("card"));
+    cJSON_AddItemToArray(types, cJSON_CreateString("list"));
+    cJSON_AddItemToArray(types, cJSON_CreateString("chart"));
+    cJSON_AddItemToArray(types, cJSON_CreateString("media"));
+    cJSON_AddItemToArray(types, cJSON_CreateString("prompt"));
+    cJSON_AddNumberToObject(widgets, "list_max_items", 5);
+    cJSON_AddNumberToObject(widgets, "chart_max_points", 12);
+    cJSON_AddNumberToObject(widgets, "prompt_max_choices", 3);
+    cJSON_AddNumberToObject(widgets, "screen_w", 720);
+    cJSON_AddNumberToObject(widgets, "screen_h", 1280);
+    cJSON_AddNumberToObject(widgets, "media_max_w", 660);
+    cJSON_AddNumberToObject(widgets, "media_max_h", 440);
+    cJSON_AddNumberToObject(widgets, "action_rate_per_sec", 4);
+
+    char *json = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!json) return ESP_ERR_NO_MEM;
+
+    ESP_LOGI(TAG, "Sending register: device=%s hw=%s session=%s",
+             device_id, hardware_id, session_id[0] ? session_id : "(new)");
+
+    esp_err_t err = voice_ws_send_text(json);
+    cJSON_free(json);
+    return err;
+}
+
+// ---------------------------------------------------------------------------
+// RX dispatchers — added in Tasks 1.6 / 1.7 / 1.8.
+// voice_ws_proto_handle_text   — moved from voice.c handle_text_message
+// voice_ws_proto_handle_binary — moved from voice.c handle_binary_message
+// voice_ws_proto_event_handler — moved from voice.c voice_ws_event_handler
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// URI helper — added in Task 1.9.
+// voice_ws_proto_build_local_uri — moved from voice.c voice_build_local_uri
+// ---------------------------------------------------------------------------

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -37,6 +37,7 @@
 #include "voice_billing.h"    /* receipt + budget */
 #include "voice_codec.h"      /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
 #include "voice_onboard.h"    /* K144 failover hooks */
+#include "voice_video.h"      /* VID0 magic peek + downlink decode */
 #include "voice_widget_ws.h"  /* widget_* WS dispatch */
 #include "widget.h"           /* widget_live_update / widget_live_dismiss */
 
@@ -1090,10 +1091,130 @@ void voice_ws_proto_handle_text(const char *data, int len)
 }
 
 
-/* Forward decl: handle_binary_message still lives in voice.c until
- * Task 1.7 moves it.  voice_ws_proto_event_handler dispatches binary
- * frames through this thunk for now. */
-extern void handle_binary_message(const char *data, int len);
+/* TT #331 Wave 23 SRP-A1: mirror voice.c's UPSAMPLE_* macros so
+ * voice_ws_proto_handle_binary can size its half-buffers.  These MUST
+ * match the voice.c definitions — the upsample buffer (s_upsample_buf,
+ * allocated in voice_init) is sized by UPSAMPLE_BUF_CAPACITY there. */
+#define UPSAMPLE_RATIO          (TAB5_AUDIO_SAMPLE_RATE / TAB5_VOICE_SAMPLE_RATE)
+#define UPSAMPLE_BUF_CAPACITY   (8192 * 2)
+
+/* PSRAM upsample buffer — owned + allocated in voice.c voice_init,
+ * referenced here from voice_ws_proto_handle_binary. */
+extern int16_t *s_upsample_buf;
+
+// ---------------------------------------------------------------------------
+// Task 1.7: Binary frame handling (voice_ws_proto_handle_binary).
+// Dragon sends PCM int16 mono at 16kHz; I2S TX runs at 48kHz, so we
+// upsample 1:3 before writing to the playback ring.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Binary frame handling (TTS audio from Dragon) — called from event handler.
+// Dragon sends PCM int16 mono at 16kHz; I2S TX runs at 48kHz, so we upsample
+// 1:3 before writing to the playback ring buffer. Playback drain task
+// handles I2S writes.
+// ---------------------------------------------------------------------------
+/* TT #331 Wave 23 SRP-A1: was static — file-scope inside voice_ws_proto.c. */
+static size_t voice_ws_proto_upsample_16k_to_48k(const int16_t *in, size_t in_samples,
+                                    int16_t *out, size_t out_capacity)
+{
+    size_t out_idx = 0;
+    for (size_t i = 0; i < in_samples && out_idx + UPSAMPLE_RATIO <= out_capacity; i++) {
+        int16_t curr = in[i];
+        int16_t next = (i + 1 < in_samples) ? in[i + 1] : curr;
+        for (int j = 0; j < UPSAMPLE_RATIO; j++) {
+            out[out_idx++] = (int16_t)(curr + (int32_t)(next - curr) * j / UPSAMPLE_RATIO);
+        }
+    }
+    return out_idx;
+}
+
+/* TT #331 Wave 23 SRP-A1: was handle_binary_message (non-static after task 1.6 promotion). */
+void voice_ws_proto_handle_binary(const char *data, int len)
+{
+    /* #268: video frames carry the 4-byte "VID0" magic.  Route them
+     * to voice_video before any audio-state checks — video plays
+     * regardless of voice state (unlike TTS, which only plays in
+     * SPEAKING/PROCESSING).  Audio frames (no magic) fall through. */
+    if (voice_video_peek_downlink_magic(data, (size_t)len)) {
+        voice_video_on_downlink_frame((const uint8_t *)data, (size_t)len);
+        return;
+    }
+
+    /* #272 Phase 3E: call-audio frames carry the 4-byte "AUD0" magic.
+     * Strip the header + write the int16 PCM body straight to the
+     * playback buffer with the same upsample 16k->48k as TTS.  No
+     * state guards — call audio plays even when voice is READY. */
+    if (voice_codec_peek_call_audio_magic(data, (size_t)len)) {
+        const uint8_t *body = NULL;
+        size_t body_len = 0;
+        if (voice_codec_unpack_call_audio((const uint8_t *)data, (size_t)len,
+                                          &body, &body_len) && body_len >= 2 &&
+            s_upsample_buf) {
+            tab5_audio_speaker_enable(true);
+            const size_t in_samples = body_len / sizeof(int16_t);
+            const size_t max_out    = in_samples * UPSAMPLE_RATIO;
+            if (max_out <= UPSAMPLE_BUF_CAPACITY) {
+                size_t out_n = voice_ws_proto_upsample_16k_to_48k((const int16_t *)body, in_samples,
+                                                    s_upsample_buf, max_out);
+                voice_playback_buf_write(s_upsample_buf, out_n);
+            }
+        }
+        return;
+    }
+
+    /* v4·D audit P0 fix: snapshot voice_get_state() so we never race
+     * with voice_set_state on another task.  The checks below formerly
+     * read s_state twice without locking — voice_get_state takes the
+     * state mutex internally so a single call is atomic.
+     *
+     * TT #331 Wave 23 SRP-A1: pre-extract this site held s_state_mutex
+     * directly while reading the static.  Re-locking around
+     * voice_get_state() (which takes the same non-recursive mutex)
+     * deadlocked → TASK_WDT reset.  Single getter call is the fix. */
+    voice_state_t cur = voice_get_state();
+
+
+    if (cur != VOICE_STATE_SPEAKING && cur != VOICE_STATE_PROCESSING) {
+        return;
+    }
+    if (cur == VOICE_STATE_PROCESSING) {
+        voice_playback_buf_reset();
+        voice_set_state(VOICE_STATE_SPEAKING, NULL);
+    }
+
+    /* #262: decode through voice_codec.  PCM is a memcpy-shaped passthrough
+     * (out_samples == in_samples), keeping the existing upsample 16k->48k
+     * path unchanged.  OPUS produces variable-length PCM (typ 320 samples
+     * per 20 ms packet) which then upsamples the same way. */
+    if (!s_upsample_buf) {
+        ESP_LOGW(TAG, "handle_binary: upsample_buf not initialized");
+        return;
+    }
+
+    /* Decode straight into a temp area in s_upsample_buf, low half;
+     * upsample reads from there and writes to the high half.
+     * Splitting avoids an extra malloc per chunk. */
+    int16_t *dec_pcm = s_upsample_buf;                          /* low half */
+    int16_t *up_out  = s_upsample_buf + (UPSAMPLE_BUF_CAPACITY / 2);  /* high half */
+    size_t dec_cap   = UPSAMPLE_BUF_CAPACITY / 2;
+    size_t in_samples = 0;
+    if (voice_codec_decode_downlink((const uint8_t *)data, (size_t)len,
+                                    dec_pcm, dec_cap, &in_samples) != ESP_OK ||
+        in_samples == 0) {
+        ESP_LOGW(TAG, "handle_binary: codec decode failed (len=%d)", len);
+        return;
+    }
+    size_t max_out = in_samples * UPSAMPLE_RATIO;
+    if (max_out > dec_cap) {
+        ESP_LOGW(TAG, "handle_binary: upsample would exceed half-buf — truncating");
+        max_out = dec_cap;
+    }
+    size_t out_samples = voice_ws_proto_upsample_16k_to_48k(dec_pcm, in_samples,
+                                              up_out, max_out);
+    voice_playback_buf_write(up_out, out_samples);
+}
+
 
 // ---------------------------------------------------------------------------
 // Task 1.6/1.8/1.9: WebSocket event handler + URI helper.
@@ -1321,7 +1442,7 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
             const int frag_len   = data->data_len;
             if (frag_total <= 0 || frag_total == frag_len) {
                 /* Single-fragment frame — current behavior. */
-                handle_binary_message(data->data_ptr, frag_len);
+                voice_ws_proto_handle_binary(data->data_ptr, frag_len);
             } else {
                 /* Multi-fragment frame.  Lazy-init reassembly buffer
                  * in PSRAM, sized to the same ceiling voice_video uses. */
@@ -1346,7 +1467,7 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
                 }
                 memcpy(s_rx_reasm_buf + frag_off, data->data_ptr, frag_len);
                 if (frag_off + frag_len == frag_total) {
-                    handle_binary_message((const char *)s_rx_reasm_buf, frag_total);
+                    voice_ws_proto_handle_binary((const char *)s_rx_reasm_buf, frag_total);
                 }
             }
         } else if (data->op_code == WS_TRANSPORT_OPCODES_PING) {

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -18,6 +18,7 @@
 #include "esp_websocket_client.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "lvgl.h"        /* lv_tick_get for the widget_action rate limiter */
 #include "settings.h"
 #include "voice_codec.h" /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
 
@@ -179,6 +180,51 @@ esp_err_t voice_ws_send_register(void)
     esp_err_t err = voice_ws_send_text(json);
     cJSON_free(json);
     return err;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound widget_action (Tab5 → Dragon).  Pure WS-proto concern: builds a
+// JSON frame, rate-limits, sends via voice_ws_send_text.  Pre-extract this
+// lived inline in voice.c at the bottom of the public-API section.
+// ---------------------------------------------------------------------------
+esp_err_t voice_send_widget_action(const char *card_id, const char *event,
+                                   const char *payload_json)
+{
+    if (!card_id || !event) return ESP_ERR_INVALID_ARG;
+    if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) return ESP_ERR_INVALID_STATE;
+
+    /* Rate limit: 4/sec max (see docs/WIDGETS.md §11). */
+    static uint32_t s_action_bucket = 4;
+    static uint32_t s_action_tick   = 0;
+    uint32_t now = lv_tick_get();
+    if (now - s_action_tick >= 1000) {
+        s_action_bucket = 4;
+        s_action_tick = now;
+    }
+    if (s_action_bucket == 0) {
+        ESP_LOGW(TAG, "widget_action rate-limited (card=%s event=%s)", card_id, event);
+        return ESP_ERR_INVALID_STATE;
+    }
+    s_action_bucket--;
+
+    cJSON *msg = cJSON_CreateObject();
+    cJSON_AddStringToObject(msg, "type", "widget_action");
+    cJSON_AddStringToObject(msg, "card_id", card_id);
+    cJSON_AddStringToObject(msg, "event", event);
+    if (payload_json && payload_json[0]) {
+        cJSON *p = cJSON_Parse(payload_json);
+        if (p) cJSON_AddItemToObject(msg, "payload", p);
+    }
+    char *json = cJSON_PrintUnformatted(msg);
+    cJSON_Delete(msg);
+    if (!json) return ESP_ERR_NO_MEM;
+
+    esp_err_t ret = voice_ws_send_text(json);
+    cJSON_free(json);
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "widget_action: %s → %s", card_id, event);
+    }
+    return ret;
 }
 
 // ---------------------------------------------------------------------------

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -12,15 +12,33 @@
 #include <limits.h>  /* INT_MAX (W14-L02 send-bound check) */
 #include <string.h>
 
+#include "audio.h"            /* tab5_audio_speaker_enable on tts_start */
+#include "wifi.h"             /* tab5_wifi_hard_kick / tab5_wifi_connected */
 #include "cJSON.h"
+#include "chat_msg_store.h"   /* tool indicator bubbles */
 #include "config.h"
+#include "debug_obs.h"        /* tab5_debug_obs_event */
+#include "esp_heap_caps.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "esp_websocket_client.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"  /* s_state_mutex / s_play_sem externs below */
 #include "freertos/task.h"
-#include "lvgl.h"        /* lv_tick_get for the widget_action rate limiter */
+#include "lvgl.h"             /* lv_tick_get for the widget_action rate limiter */
+#include "md_strip.h"         /* md_strip_tool_markers on llm streaming */
 #include "settings.h"
-#include "voice_codec.h" /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+#include "task_worker.h"      /* tab5_worker_enqueue for stop-WS workers */
+#include "tool_log.h"         /* tool_log_push_call / _push_result */
+#include "ui_chat.h"
+#include "ui_core.h"          /* tab5_lv_async_call */
+#include "ui_home.h"
+#include "ui_notes.h"
+#include "voice_billing.h"    /* receipt + budget */
+#include "voice_codec.h"      /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+#include "voice_onboard.h"    /* K144 failover hooks */
+#include "voice_widget_ws.h"  /* widget_* WS dispatch */
+#include "widget.h"           /* widget_live_update / widget_live_dismiss */
 
 static const char *TAG = "tab5_voice_ws";
 
@@ -29,6 +47,36 @@ static const char *TAG = "tab5_voice_ws";
  * in voice.c.  No external readers — kept here so the dropped-frame
  * accounting stays colocated with the sender that increments it. */
 static int s_audio_drop_count = 0;
+
+/* SemaphoreHandle_t externs — defined in voice.c, used by the JSON RX
+ * dispatcher + UI-async helpers below.  Declared here (not in voice.h)
+ * to keep <freertos/semphr.h> out of voice.h's public surface. */
+extern SemaphoreHandle_t s_state_mutex;
+extern SemaphoreHandle_t s_play_sem;
+
+/* TT #331 Wave 23 SRP-A1: voice.c's s_initialized was promoted to non-
+ * static for cross-TU access, but it stays out of voice.h to dodge the
+ * collision with ui_voice.c's local static of the same name.  Declared
+ * here so the WS event handler can guard async-call dispatches. */
+extern volatile bool s_initialized;
+
+/* WS event handler tunables — moved from voice.c.  Only this TU
+ * consumes them. */
+/* v4·D connectivity audit T1.1: exponential backoff + full jitter on
+ * WS reconnect.  Formula:
+ *   exp = min(BACKOFF_CAP_MS, BACKOFF_MIN_MS << min(attempt, 5))
+ *   delay = esp_random() % (exp/2) + exp/2
+ * attempt resets to 0 on WEBSOCKET_EVENT_CONNECTED. */
+#define WS_CLIENT_BACKOFF_MIN_MS 1000
+#define WS_CLIENT_BACKOFF_CAP_MS 30000
+
+/* Ngrok fallback after this many consecutive failed handshakes against
+ * the local LAN URI (only in conn_mode=0 "auto"). */
+#define NGROK_FALLBACK_THRESHOLD 4
+
+/* γ3-Tab5 (issue #198): stop retrying after this many consecutive
+ * 401 handshake failures. */
+#define WS_AUTH_FAIL_THRESHOLD 3
 
 // ---------------------------------------------------------------------------
 // WebSocket send helpers (wrapping esp_websocket_client_send_*)
@@ -228,13 +276,1196 @@ esp_err_t voice_send_widget_action(const char *card_id, const char *event,
 }
 
 // ---------------------------------------------------------------------------
-// RX dispatchers — added in Tasks 1.6 / 1.7 / 1.8.
-// voice_ws_proto_handle_text   — moved from voice.c handle_text_message
-// voice_ws_proto_handle_binary — moved from voice.c handle_binary_message
-// voice_ws_proto_event_handler — moved from voice.c voice_ws_event_handler
+// Task 1.6: UI-async helper machinery (toast / banner / badge dispatchers,
+// device-evicted + auth-fail stop workers) + JSON RX dispatcher
+// (voice_ws_proto_handle_text, formerly handle_text_message in voice.c).
+// voice_debug_inject_text is the public TT #328 Wave 2 e2e injection point.
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// URI helper — added in Task 1.9.
-// voice_ws_proto_build_local_uri — moved from voice.c voice_build_local_uri
+// US-C02: Generation-guarded async call wrappers.
 // ---------------------------------------------------------------------------
+typedef struct {
+    uint32_t gen;
+    char    *text;
+} voice_async_toast_t;
+
+typedef struct {
+    uint32_t gen;
+} voice_async_badge_t;
+
+/* γ2-H8 (issue #196): worker to stop the WS client off the WS task.
+ * esp_websocket_client_stop() rejects calls from inside the WS task
+ * itself (logs "Client cannot be stopped from websocket task" and
+ * no-ops).  This worker runs on the shared task_worker queue, so
+ * the stop happens on a different task and actually takes effect.
+ *
+ * Triggered when Tab5 receives a `device_evicted` error frame —
+ * another device claimed our slot, and auto-reconnect would just
+ * trigger another eviction.  s_disconnecting was already set in
+ * the WS handler so the WEBSOCKET_EVENT_DISCONNECTED branch won't
+ * try to reconnect when the stop completes. */
+static void _voice_stop_ws_worker_fn(void *arg)
+{
+    (void)arg;
+    if (g_voice_ws) {
+        ESP_LOGW(TAG, "device_evicted worker: stopping WS client now");
+        esp_websocket_client_stop(g_voice_ws);
+    }
+}
+
+/* γ3-Tab5 (issue #198): worker for the auth-failed stop path.
+ * Same task-hop pattern as _voice_stop_ws_worker_fn — must run
+ * off the WS task or esp_websocket_client_stop() no-ops.
+ * Separate function (not shared with the eviction worker) so the
+ * ESP_LOG line clearly identifies WHICH path triggered the stop —
+ * makes ops triage on a misconfigured-token device much easier
+ * than a generic "stop_ws" trace. */
+static void _voice_auth_fail_stop_worker_fn(void *arg)
+{
+    (void)arg;
+    if (g_voice_ws) {
+        ESP_LOGW(TAG, "auth_failed worker: stopping WS after %d consecutive 401s",
+                 s_auth_fail_cnt);
+        esp_websocket_client_stop(g_voice_ws);
+    }
+}
+
+static void async_show_toast_cb(void *arg)
+{
+    voice_async_toast_t *t = (voice_async_toast_t *)arg;
+    if (!t) return;
+    if (t->gen == s_session_gen && t->text) {
+       ui_home_show_toast(t->text);
+    } else if (t->text) {
+       ESP_LOGD(TAG, "Stale async toast dropped (gen %lu vs %lu)", (unsigned long)t->gen, (unsigned long)s_session_gen);
+    }
+    free(t->text);
+    free(t);
+}
+
+static void async_refresh_badge_cb(void *arg)
+{
+    voice_async_badge_t *b = (voice_async_badge_t *)arg;
+    if (!b) return;
+    if (b->gen == s_session_gen) {
+       ui_home_refresh_mode_badge();
+    } else {
+       ESP_LOGD(TAG, "Stale async badge refresh dropped (gen %lu vs %lu)", (unsigned long)b->gen,
+                (unsigned long)s_session_gen);
+    }
+    free(b);
+}
+
+void voice_async_toast(char *text)
+{
+    voice_async_toast_t *t = malloc(sizeof(voice_async_toast_t));
+    if (!t) {
+        /* Wave 14 W14-M08: log the silent-drop so ops can see we
+         * squeezed internal SRAM and a user-facing toast never reached
+         * LVGL. */
+        ESP_LOGW(TAG, "voice_async_toast OOM — dropping toast (text=%.40s)",
+                 text ? text : "");
+        free(text);
+        return;
+    }
+    t->gen = s_session_gen;
+    t->text = text;
+    tab5_lv_async_call(async_show_toast_cb, t);
+}
+
+/* TT #328 Wave 3 — async fire of ui_home_show_error_banner from voice WS
+ * task.  Persistent error banner survives across the 2-3 s toast lifetime
+ * so the user can't miss a fatal-state notification (auth lockout, device
+ * eviction, etc).  static-string variant: caller must pass a string literal
+ * or otherwise outlives the call (no malloc/free shuttle). */
+typedef struct {
+   const char *text; /* MUST outlive the async dispatch */
+} voice_banner_async_t;
+
+static void async_show_error_banner_cb(void *arg) {
+   voice_banner_async_t *b = (voice_banner_async_t *)arg;
+   if (!b) return;
+   if (b->text) {
+      ui_home_show_error_banner(b->text, NULL /* non-dismissable */);
+   }
+   free(b);
+}
+
+static void voice_async_error_banner(const char *static_text) {
+   if (!static_text) return;
+   voice_banner_async_t *b = malloc(sizeof(*b));
+   if (!b) {
+      ESP_LOGW(TAG, "voice_async_error_banner OOM — banner dropped");
+      return;
+   }
+   b->text = static_text;
+   tab5_lv_async_call(async_show_error_banner_cb, b);
+}
+
+/* TT #328 Wave 2 — dynamic-string banner variant.  Dragon-side error
+ * messages (config_update.error, transient `error` frames with
+ * non-static strings) need a heap-owned copy so the WS rx task can
+ * safely return before LVGL processes the async call.  Strdups into
+ * a heap-owned struct, the cb shows the banner + frees both.  Pass
+ * `dismissable=true` to allow user-tap dismiss (the standard recovery
+ * path); `false` for system-cleared-only banners. */
+typedef struct {
+   char *text; /* heap, freed in cb after lvgl reads it */
+   bool dismissable;
+} voice_banner_dyn_t;
+
+static void async_dismiss_banner_cb(void) {
+   /* Wave 2: tap-to-dismiss handler.  ui_home_show_error_banner installs
+    * us as the cb when dismissable=true; firing means the user
+    * acknowledged so we just clear. */
+   ui_home_clear_error_banner();
+}
+
+static void async_show_error_banner_dyn_cb(void *arg) {
+   voice_banner_dyn_t *b = (voice_banner_dyn_t *)arg;
+   if (!b) return;
+   if (b->text) {
+      ui_home_show_error_banner(b->text, b->dismissable ? async_dismiss_banner_cb : NULL);
+      free(b->text);
+   }
+   free(b);
+}
+
+static void voice_async_error_banner_dyn(const char *text, bool dismissable) {
+   if (!text || !text[0]) return;
+   voice_banner_dyn_t *b = heap_caps_malloc(sizeof(*b), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!b) {
+      ESP_LOGW(TAG, "voice_async_error_banner_dyn OOM (struct) — banner dropped");
+      return;
+   }
+   size_t len = strlen(text) + 1;
+   b->text = heap_caps_malloc(len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!b->text) {
+      ESP_LOGW(TAG, "voice_async_error_banner_dyn OOM (text) — banner dropped");
+      free(b);
+      return;
+   }
+   memcpy(b->text, text, len);
+   b->dismissable = dismissable;
+   tab5_lv_async_call(async_show_error_banner_dyn_cb, b);
+}
+
+/* TT #328 Wave 2 — recovery-aware banner state.  When config_update.error
+ * fires we mark the fallback banner active; on the next successful
+ * llm_done we auto-clear it (recovery signal).  Volatile because the
+ * flag is written from the WS rx task and read from llm_done handling
+ * on the same task — no contention, but the compiler might reorder
+ * across the lv_async_call boundary otherwise. */
+static volatile bool s_fallback_banner_active = false;
+
+static void async_clear_banner_cb(void *arg) {
+   (void)arg;
+   ui_home_clear_error_banner();
+}
+
+static void voice_async_refresh_badge(void)
+{
+    voice_async_badge_t *b = malloc(sizeof(voice_async_badge_t));
+    if (!b) {
+        ESP_LOGW(TAG, "voice_async_refresh_badge OOM — badge will lag a tick");
+        return;
+    }
+    b->gen = s_session_gen;
+    tab5_lv_async_call(async_refresh_badge_cb, b);
+}
+
+// ---------------------------------------------------------------------------
+// JSON message handling (Dragon -> Tab5)
+// ---------------------------------------------------------------------------
+
+/* TT #328 Wave 2 — debug entry-point exposed via voice.h so the e2e
+ * harness can fire synthetic WS frames into the dispatcher without
+ * needing Dragon to misbehave.  Tiny wrapper, no validation beyond
+ * the len > 0 guard — the JSON parser inside handle_text_message
+ * already rejects malformed input. */
+void voice_debug_inject_text(const char *data, int len) {
+   if (!data || len <= 0) return;
+   voice_ws_proto_handle_text(data, len);
+}
+
+/* TT #331 Wave 23 SRP-A1: was static void handle_text_message — promoted + renamed for the voice_ws_proto layer. */
+void voice_ws_proto_handle_text(const char *data, int len)
+{
+    cJSON *root = cJSON_ParseWithLength(data, len);
+    if (!root) {
+        ESP_LOGW(TAG, "Failed to parse JSON: %.*s", len, data);
+        return;
+    }
+
+    cJSON *type = cJSON_GetObjectItem(root, "type");
+    if (!cJSON_IsString(type)) {
+        ESP_LOGW(TAG, "JSON missing 'type': %.*s", len, data);
+        cJSON_Delete(root);
+        return;
+    }
+
+    const char *type_str = type->valuestring;
+
+    if (strcmp(type_str, "stt_partial") == 0) {
+        cJSON *text = cJSON_GetObjectItem(root, "text");
+        /* U12 (#206): regardless of dictation mode, surface the partial
+         * as a live caption above the chat input pill.  No-op when chat
+         * is closed (s_input is NULL inside ui_chat). */
+        if (cJSON_IsString(text) && text->valuestring) {
+            ui_chat_show_partial(text->valuestring);
+        }
+        if (cJSON_IsString(text) && text->valuestring && voice_get_mode() == VOICE_MODE_DICTATE
+            && s_dictation_text) {
+            /* v4·D audit P1 fix: use bounded copy instead of unchecked
+             * strcat.  Previously the guard compared cur+add+2 against
+             * the buffer size, but under mutex-less concurrent writes
+             * cur_len could change between the check and the strcat.
+             * Take the state mutex and re-bound with snprintf so an
+             * overflow is impossible. */
+            if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+            size_t cur_len = strlen(s_dictation_text);
+            size_t remaining = (cur_len + 1 < DICTATION_TEXT_SIZE)
+                               ? (DICTATION_TEXT_SIZE - cur_len - 1) : 0;
+            if (remaining > 1) {
+                const char *sep = (cur_len > 0) ? " " : "";
+                snprintf(s_dictation_text + cur_len, remaining,
+                         "%s%s", sep, text->valuestring);
+            }
+            if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+            ESP_LOGI(TAG, "STT partial: \"%s\" (total %u chars)",
+                     text->valuestring, (unsigned)strlen(s_dictation_text));
+            voice_set_state(VOICE_STATE_LISTENING, s_dictation_text);
+        }
+    } else if (strcmp(type_str, "stt") == 0) {
+        cJSON *text = cJSON_GetObjectItem(root, "text");
+        /* U12 (#206): final STT result lands as a real chat bubble — clear
+         * the live partial caption so it doesn't linger above the pill. */
+        ui_chat_show_partial(NULL);
+        if (cJSON_IsString(text) && text->valuestring) {
+            if (voice_get_mode() == VOICE_MODE_DICTATE) {
+                if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+                strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
+                s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
+                if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+                ESP_LOGI(TAG, "Dictation complete: %u chars", (unsigned)strlen(text->valuestring));
+                voice_set_state(VOICE_STATE_READY, "dictation_done");
+            } else {
+                if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+                strncpy(s_stt_text, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
+                s_stt_text[MAX_TRANSCRIPT_LEN - 1] = '\0';
+                strncpy(s_transcript, text->valuestring, MAX_TRANSCRIPT_LEN - 1);
+                s_transcript[MAX_TRANSCRIPT_LEN - 1] = '\0';
+                s_llm_text[0] = '\0';
+                if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+                ESP_LOGI(TAG, "STT: \"%s\"", s_stt_text);
+                ui_chat_push_message("user", text->valuestring);
+                voice_set_state(VOICE_STATE_PROCESSING, s_stt_text);
+            }
+        }
+    } else if (strcmp(type_str, "tts_start") == 0) {
+        /* Audit #80 DMA leak hunt (wave 9): log heap state at the 5
+         * interesting boundaries of a chat turn (llm_done, tts_start,
+         * tts_end, media, text_update) so we can diff which stage leaks.
+         * Heap caps are DMA-capable internal SRAM — same pool the WiFi
+         * Rx ring needs to stay alive. */
+        ESP_LOGI(TAG, "TTS start — preparing playback | heap_dma_free=%u largest=%u",
+                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
+                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+        tab5_audio_speaker_enable(true);
+        voice_playback_buf_reset();
+        voice_set_state(VOICE_STATE_SPEAKING, NULL);
+    } else if (strcmp(type_str, "tts_end") == 0) {
+        ESP_LOGI(TAG, "TTS end — drain task will finish playback | heap_dma_free=%u largest=%u",
+                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
+                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+        s_tts_done = true;
+        if (s_play_sem) xSemaphoreGive(s_play_sem);
+    } else if (strcmp(type_str, "llm") == 0) {
+        /* TinkerBox #91 follow-up (#193): ignore late llm tokens that
+         * arrive after a cancel.  Tab5 transitions to READY locally on
+         * cancel-send (see voice_cancel below); Dragon now actually
+         * interrupts the LLM stream within ~1 ms (was ~65 s pre-#91),
+         * but tokens already in TCP flight at cancel-time still arrive
+         * a few hundred ms later.  Without this guard, the unconditional
+         * voice_set_state below pulls the orb back into PROCESSING with
+         * the partial cancelled response text — the cancel APPEARS to
+         * not have worked from the user's perspective.
+         *
+         * Honor llm tokens only when the user is actively waiting for a
+         * turn (PROCESSING or SPEAKING).  All other states (READY after
+         * cancel, IDLE on disconnect, LISTENING when a new mic recording
+         * already started) mean the previous turn is no longer the user's
+         * focus and any late tokens belong to a turn they cancelled.
+         */
+        voice_state_t cur_for_llm = voice_get_state();
+        if (cur_for_llm != VOICE_STATE_PROCESSING && cur_for_llm != VOICE_STATE_SPEAKING) {
+            ESP_LOGD(TAG, "llm token ignored — state=%d (post-cancel late arrival)",
+                     cur_for_llm);
+            cJSON_Delete(root);
+            return;
+        }
+        cJSON *text = cJSON_GetObjectItem(root, "text");
+        if (cJSON_IsString(text) && text->valuestring) {
+            if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+            size_t llm_len = strlen(s_llm_text);
+            size_t add_len = strlen(text->valuestring);
+            if (llm_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
+                strcat(s_llm_text, text->valuestring);
+            }
+            size_t cur_len = strlen(s_transcript);
+            if (cur_len + add_len < MAX_TRANSCRIPT_LEN - 1) {
+                strcat(s_transcript, text->valuestring);
+            }
+            if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+            ESP_LOGD(TAG, "LLM token: \"%s\"", text->valuestring);
+            voice_set_state(VOICE_STATE_PROCESSING, s_llm_text);
+        }
+    } else if (strcmp(type_str, "cancel_ack") == 0) {
+        /* TinkerBox #91: server-side confirmation that cancel landed.
+         * Today we just log it — the state machine already transitioned
+         * to READY when voice_cancel was called, and the llm-token
+         * guard above handles the late-arrival grace window.
+         * If we ever add a "definitely no more late tokens, safe to
+         * resume" semantic, this is where it would slot in. */
+        cJSON *cancelled = cJSON_GetObjectItem(root, "cancelled");
+        int n = cJSON_IsArray(cancelled) ? cJSON_GetArraySize(cancelled) : 0;
+        ESP_LOGI(TAG, "cancel_ack: cancelled=%d slot(s)", n);
+    } else if (strcmp(type_str, "error") == 0) {
+        /* γ2-H8 (issue #196): route Dragon error frames by severity.
+         *
+         * Pre-fix every {"type":"error"} frame landed in the voice-
+         * overlay caption regardless of what went wrong — a recoverable
+         * STT-empty toast and an unrecoverable session-invalid banner
+         * both ended up in the same place.  Dragon's γ1 taxonomy
+         * (TinkerBox PR #102) added structured `severity` ("transient"
+         * vs "fatal") and `scope` fields; this handler honours them:
+         *
+         *   - TRANSIENT → non-blocking ui_home_show_toast(), stay in
+         *     READY.  User can keep talking.
+         *   - FATAL → existing voice-state caption path (more
+         *     permanent surface).  Reset playback + speaker since a
+         *     fatal error means we shouldn't keep half-playing TTS.
+         *
+         * Special case: code="device_evicted" (TinkerBox γ2-M5, PR
+         * #109) means another device claimed our slot.  Auto-reconnect
+         * would just trigger an eviction loop, so we set the
+         * disconnect guard + stop the WS client.  User must
+         * power-cycle or re-launch via the debug endpoint.
+         */
+        cJSON *msg       = cJSON_GetObjectItem(root, "message");
+        cJSON *severity  = cJSON_GetObjectItem(root, "severity");
+        cJSON *code      = cJSON_GetObjectItem(root, "code");
+        const char *err_src  = cJSON_IsString(msg) ? msg->valuestring : "unknown";
+        /* Default to "fatal" for unknown / pre-γ1 frames — safer to
+         * surface in caption (more visible) than to silently toast.
+         * Tab5 is forward-compatible with future severity values too:
+         * anything not "transient" routes to caption. */
+        const char *sev_src  = cJSON_IsString(severity) ? severity->valuestring : "fatal";
+        const char *code_src = cJSON_IsString(code) ? code->valuestring : "";
+        ESP_LOGE(TAG, "Dragon error [%s/%s]: %s", sev_src, code_src, err_src);
+
+        char err_buf[128];
+        strncpy(err_buf, err_src, sizeof(err_buf) - 1);
+        err_buf[sizeof(err_buf) - 1] = '\0';
+
+        bool is_transient = (strcmp(sev_src, "transient") == 0);
+
+        if (is_transient) {
+            /* TRANSIENT → toast via the existing voice_async_toast()
+             * helper.  This handler runs on the WS task, NOT the LVGL
+             * task — voice_async_toast() takes ownership of a strdup'd
+             * buffer, queues it via lv_async_call, and stamps the
+             * session_gen so a stale toast from a prior connection
+             * doesn't surface after a reconnect. */
+            char *toast_copy = strdup(err_buf);
+            if (toast_copy) {
+                voice_async_toast(toast_copy);
+            }
+        } else {
+            /* FATAL → existing caption path. */
+            voice_playback_buf_reset();
+            tab5_audio_speaker_enable(false);
+            bool connected = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
+            voice_set_state(connected ? VOICE_STATE_READY : VOICE_STATE_IDLE, err_buf);
+
+            /* device_evicted: don't loop the eviction.  Stop the WS
+             * client + set the disconnect guard so the
+             * WEBSOCKET_EVENT_DISCONNECTED handler doesn't try to
+             * reconnect.  User regains connectivity via power-cycle
+             * or the /voice/reconnect debug endpoint.
+             *
+             * IMPORTANT: esp_websocket_client_stop() rejects calls
+             * from the WS task itself (logs "Client cannot be
+             * stopped from websocket task" and no-ops).  Hop to the
+             * shared worker queue (task_worker.{c,h}) so the stop
+             * runs on a non-WS task. */
+            if (strcmp(code_src, "device_evicted") == 0 && g_voice_ws) {
+                ESP_LOGW(TAG, "device_evicted: scheduling WS stop to prevent reconnect loop");
+                s_disconnecting = true;
+                tab5_worker_enqueue(_voice_stop_ws_worker_fn, NULL,
+                                    "device_evicted_stop");
+            }
+        }
+    } else if (strcmp(type_str, "session_start") == 0) {
+        cJSON *sid = cJSON_GetObjectItem(root, "session_id");
+        if (cJSON_IsString(sid) && sid->valuestring) {
+            tab5_settings_set_session_id(sid->valuestring);
+            ESP_LOGI(TAG, "Session: %s", sid->valuestring);
+        }
+        cJSON *resumed = cJSON_GetObjectItem(root, "resumed");
+        cJSON *msg_cnt = cJSON_GetObjectItem(root, "message_count");
+        ESP_LOGI(TAG, "session_start: resumed=%s messages=%d",
+                 (cJSON_IsTrue(resumed) ? "yes" : "no"),
+                 cJSON_IsNumber(msg_cnt) ? msg_cnt->valueint : 0);
+
+        if (voice_get_state() == VOICE_STATE_CONNECTING) {
+            voice_set_state(VOICE_STATE_READY, NULL);
+            ESP_LOGI(TAG, "Connected to Dragon voice server");
+
+            uint8_t saved_mode = tab5_settings_get_voice_mode();
+            char saved_model[64] = {0};
+            tab5_settings_get_llm_model(saved_model, sizeof(saved_model));
+            ESP_LOGI(TAG, "Restoring voice_mode=%d model='%s' on reconnect",
+                     saved_mode, saved_model[0] ? saved_model : "(default)");
+            voice_send_config_update((int)saved_mode,
+                                     saved_model[0] ? saved_model : NULL);
+
+            ui_notes_sync_pending();
+        }
+    } else if (strcmp(type_str, "session_messages") == 0) {
+        /* Audit C8/K15 (2026-04-20): Dragon replays the tail of session
+         * messages on a resumed connect.  Rehydrate chat_store so the
+         * user sees their conversation after a reconnect.  Pushed via
+         * ui_chat_push_message which is thread-safe + lv_async_call'd. */
+        cJSON *items = cJSON_GetObjectItem(root, "items");
+        if (cJSON_IsArray(items)) {
+            int n = cJSON_GetArraySize(items);
+            ESP_LOGI(TAG, "session_messages replay: %d items", n);
+            for (int i = 0; i < n; i++) {
+                cJSON *m = cJSON_GetArrayItem(items, i);
+                if (!m) continue;
+                const char *role = cJSON_GetStringValue(
+                    cJSON_GetObjectItem(m, "role"));
+                const char *content = cJSON_GetStringValue(
+                    cJSON_GetObjectItem(m, "content"));
+                if (!role || !content || !content[0]) continue;
+                /* Skip system/tool rows — chat UI only renders
+                 * user/assistant today. */
+                if (strcmp(role, "user") != 0 &&
+                    strcmp(role, "assistant") != 0) continue;
+                ui_chat_push_message(role, content);
+            }
+        }
+    } else if (strcmp(type_str, "dictation_postprocessing") == 0) {
+        /* TinkerBox#94 H4: Dragon spawned the title+summary LLM call after
+         * `stt`.  Pre-fix the user stared at the bare transcript for
+         * 10-20 s with no signal that more was coming.  Show a status
+         * caption so the wait feels intentional. */
+        ESP_LOGI(TAG, "Dictation post-process started");
+        voice_set_state(VOICE_STATE_PROCESSING, "Generating summary...");
+    } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
+        /* TinkerBox#94 H4: LLM failed or wasn't available.  Note already
+         * saved (the transcript landed via the prior `stt` event); user
+         * just doesn't get an auto-generated title/summary.  Clear the
+         * "Generating summary..." caption and toast the friendly
+         * message. */
+        cJSON *msg = cJSON_GetObjectItem(root, "message");
+        const char *m = cJSON_IsString(msg) ? msg->valuestring
+                                            : "Note saved — summary unavailable";
+        ESP_LOGW(TAG, "Dictation post-process error: %s", m);
+        char buf[160];
+        strncpy(buf, m, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        voice_async_toast(strdup(buf));
+        voice_set_state(VOICE_STATE_READY, "dictation_done");
+    } else if (strcmp(type_str, "dictation_postprocessing_cancelled") == 0) {
+       /* TinkerBox#94 H4: a NEW dictation superseded the prior in-flight
+        * post-process.  The new dictation will emit its own
+        * `dictation_postprocessing` event a few ms later — silently log
+        * here so we don't fight the new caption.
+        *
+        * TT #328 Wave 2 (audit error-surfacing) — the original handler
+        * was log-only, but on the cancellation-WITHOUT-followup path
+        * (Dragon shut down, user disconnected mid-dictation, failover
+        * race) the user is left staring at "Generating summary..."
+        * forever because no dictation_postprocessing comes to override
+        * it.  Reset to READY so the caption clears; if a legitimate
+        * follow-up _postprocessing fires it'll re-set the caption a
+        * few ms later anyway, no UI flicker visible. */
+       ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
+       voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
+    } else if (strcmp(type_str, "dictation_summary") == 0) {
+        cJSON *title = cJSON_GetObjectItem(root, "title");
+        cJSON *summary = cJSON_GetObjectItem(root, "summary");
+        if (cJSON_IsString(title)) {
+            strncpy(s_dictation_title, title->valuestring, sizeof(s_dictation_title) - 1);
+            s_dictation_title[sizeof(s_dictation_title) - 1] = '\0';
+        }
+        if (cJSON_IsString(summary)) {
+            strncpy(s_dictation_summary, summary->valuestring, sizeof(s_dictation_summary) - 1);
+            s_dictation_summary[sizeof(s_dictation_summary) - 1] = '\0';
+        }
+        ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
+        voice_set_state(VOICE_STATE_READY, "dictation_summary");
+    } else if (strcmp(type_str, "note_created") == 0) {
+        cJSON *nid = cJSON_GetObjectItem(root, "note_id");
+        cJSON *ntitle = cJSON_GetObjectItem(root, "title");
+        ESP_LOGI(TAG, "Dragon auto-created note: id=%s title=\"%s\"",
+                 cJSON_IsString(nid) ? nid->valuestring : "?",
+                 cJSON_IsString(ntitle) ? ntitle->valuestring : "?");
+    } else if (strcmp(type_str, "llm_done") == 0) {
+        cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
+        ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u",
+                 cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,
+                 (unsigned)heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL),
+                 (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+        /* TT #328 Wave 2 — recovery hook.  The fallback banner that fires
+         * on config_update.error sticks until the user dismisses or until
+         * a successful turn comes back through.  llm_done is the
+         * canonical "things are working again" signal — clear it here so
+         * the user sees the "things are back to normal" state without
+         * having to manually tap the banner. */
+        if (s_fallback_banner_active) {
+           ESP_LOGI(TAG, "Wave 2: clearing fallback banner (recovery via llm_done)");
+           s_fallback_banner_active = false;
+           tab5_lv_async_call(async_clear_banner_cb, NULL);
+        }
+        /* #293: emit obs event for e2e harness. */
+        {
+           char latency_str[24];
+           snprintf(latency_str, sizeof(latency_str), "%.0f", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0);
+           tab5_debug_obs_event("chat.llm_done", latency_str);
+        }
+        /* Prefer the full text field in llm_done (TC bypass uses it)
+         * falling back to the accumulated streamed tokens. */
+        cJSON *full = cJSON_GetObjectItem(root, "text");
+        const char *bubble_text = s_llm_text;
+        if (cJSON_IsString(full) && full->valuestring && full->valuestring[0]) {
+            bubble_text = full->valuestring;
+        }
+        if (bubble_text && bubble_text[0]) {
+            /* #78 + #160: defensive Tab5-side scrub of any <tool>...</tool>
+             * + <args>...</args> markers that survived Dragon's
+             * server-side stripper.  Without this the user sometimes
+             * sees raw "<tool>recall</tool><args>{\"query\":...}</args>"
+             * land as a chat bubble (caught by the audit screenshot in
+             * #160).  The strip handles the bubble destined for chat;
+             * s_llm_text continues to hold the raw text in case other
+             * paths need it. */
+            char clean[MAX_TRANSCRIPT_LEN];
+            md_strip_tool_markers(bubble_text, clean, sizeof(clean));
+            if (clean[0]) {
+                ui_chat_push_message("assistant", clean);
+            }
+        }
+        /* v4·D TC polish: if no TTS is coming (TC bypass never sends
+         * tts_start -- gateway is text-only), transition to READY
+         * directly.  Without this, state sits in PROCESSING forever
+         * after a TC text turn, chat input pill stays on "Thinking...",
+         * voice overlay stays blocked. */
+        if (voice_get_state() == VOICE_STATE_PROCESSING) {
+            voice_set_state(VOICE_STATE_READY, "llm_done");
+        }
+    } else if (strcmp(type_str, "receipt") == 0) {
+       /* SOLID-audit SRP-3 (2026-05-03): receipt accounting + cap-downgrade
+        * policy + chat-bubble stamp deferral all moved to voice_billing.c.
+        * Voice.c parses the JSON fields and hands them in typed; the
+        * billing module owns the rest of the chain. */
+       const char *model = cJSON_GetStringValue(cJSON_GetObjectItem(root, "model"));
+       cJSON *ptok = cJSON_GetObjectItem(root, "prompt_tokens");
+       cJSON *ctok = cJSON_GetObjectItem(root, "completion_tokens");
+       cJSON *mils = cJSON_GetObjectItem(root, "cost_mils");
+       cJSON *retried_j = cJSON_GetObjectItem(root, "retried");
+       voice_billing_record_receipt(model, cJSON_IsNumber(ptok) ? (int)ptok->valuedouble : 0,
+                                    cJSON_IsNumber(ctok) ? (int)ctok->valuedouble : 0,
+                                    cJSON_IsNumber(mils) ? (int)mils->valuedouble : 0, cJSON_IsTrue(retried_j));
+    } else if (strcmp(type_str, "text_update") == 0) {
+        const char *text = cJSON_GetStringValue(cJSON_GetObjectItem(root, "text"));
+        if (text) {
+            ESP_LOGI(TAG, "Text update: replacing last AI message");
+            ui_chat_update_last_message(text);
+        }
+    } else if (strcmp(type_str, "vision_capability") == 0) {
+        /* v4·D Phase 4b: Dragon advertises which model (if any) can see a
+         * camera frame.  Cached for ui_camera to render its violet chip.
+         * Empty/zero on local-only or non-vision models.  Triggered via
+         * Dragon's config_update ACK path so it lands whenever mode
+         * changes. */
+        cJSON *can = cJSON_GetObjectItem(root, "can_see");
+        cJSON *mdl = cJSON_GetObjectItem(root, "model");
+        cJSON *fpm = cJSON_GetObjectItem(root, "per_frame_mils");
+        s_vision_capable = cJSON_IsTrue(can);
+        s_vision_per_frame_mils = cJSON_IsNumber(fpm) ? (int)fpm->valuedouble : 0;
+        const char *m = (cJSON_IsString(mdl) && mdl->valuestring) ? mdl->valuestring : "";
+        snprintf(s_vision_model, sizeof(s_vision_model), "%s", m);
+        ESP_LOGI(TAG, "Vision capability: %s (model=%s, per_frame=%d mils)",
+                 s_vision_capable ? "YES" : "no",
+                 s_vision_model[0] ? s_vision_model : "none",
+                 s_vision_per_frame_mils);
+    } else if (strcmp(type_str, "pong") == 0) {
+        /* Dragon-level JSON pong — logged only. WS-level ping/pong is
+         * handled automatically by esp_websocket_client (pingpong_timeout_sec). */
+        ESP_LOGD(TAG, "App-level pong");
+    } else if (strcmp(type_str, "config_update") == 0) {
+        cJSON *error = cJSON_GetObjectItem(root, "error");
+        if (cJSON_IsString(error) && error->valuestring[0]) {
+            ESP_LOGW(TAG, "Config update error from Dragon: %s", error->valuestring);
+            /* TT #317 Phase 5: don't clobber a Tab5-only ONBOARD pick. */
+            if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
+               tab5_settings_set_voice_mode(0);
+            }
+            voice_async_refresh_badge();
+            {
+                size_t elen = strlen(error->valuestring);
+                if (elen > 80) elen = 80;
+                char *toast_msg = malloc(elen + 1);
+                if (toast_msg) {
+                    memcpy(toast_msg, error->valuestring, elen);
+                    toast_msg[elen] = '\0';
+                    voice_async_toast(toast_msg);
+                }
+            }
+            /* TT #328 Wave 2 (audit error-surfacing) — toast was the
+             * only surface; auto-dismissed in 3 s.  Users glancing
+             * away missed the fact that they got auto-downgraded to
+             * Local + lost cloud STT/TTS quality.  Pair the toast
+             * with a persistent dismissable error banner that sits
+             * until the user acknowledges OR until the next
+             * successful llm_done auto-clears it (recovery signal). */
+            voice_async_error_banner_dyn(error->valuestring, true /* dismissable */);
+            s_fallback_banner_active = true;
+            voice_set_state(VOICE_STATE_READY, error->valuestring);
+        }
+        cJSON *vmode = cJSON_GetObjectItem(root, "voice_mode");
+        if (!cJSON_IsNumber(vmode)) {
+            cJSON *config_obj = cJSON_GetObjectItem(root, "config");
+            if (config_obj) {
+                vmode = cJSON_GetObjectItem(config_obj, "voice_mode");
+            }
+        }
+        if (cJSON_IsNumber(vmode)) {
+            uint8_t mode = (uint8_t)vmode->valueint;
+            /* TT #317 Phase 5: ONBOARD is Tab5-side-only.  Dragon never
+             * knows about it — its ACK always echoes 0/1/2/3.  If user
+             * has set ONBOARD locally, ignore Dragon's echo. */
+            if (tab5_settings_get_voice_mode() != VMODE_LOCAL_ONBOARD) {
+               tab5_settings_set_voice_mode(mode);
+               ESP_LOGI(TAG, "Config update: voice_mode=%d (persisted)", mode);
+            } else {
+               ESP_LOGD(TAG, "Config update: ignoring Dragon vmode=%d (we're in ONBOARD)", mode);
+            }
+            voice_async_refresh_badge();
+        }
+        cJSON *config = cJSON_GetObjectItem(root, "config");
+        bool applied_cloud = false;
+        if (config) {
+            cJSON *cloud = cJSON_GetObjectItem(config, "cloud_mode");
+            if (cJSON_IsBool(cloud)) {
+                bool is_cloud = cJSON_IsTrue(cloud);
+                if (!cJSON_IsNumber(vmode)) {
+                    tab5_settings_set_voice_mode(is_cloud ? 1 : 0);
+                    voice_async_refresh_badge();
+                    applied_cloud = true;
+                }
+            }
+        }
+        /* #262: codec negotiation reply.  Dragon picks one of the
+         * codecs Tab5 advertised in `register` and tells us via
+         * config_update.audio_codec.  Two flavours so it can choose
+         * uplink (mic) and downlink (TTS) independently:
+         *   - audio_codec        : applies to both (legacy / shorthand)
+         *   - audio_uplink_codec : mic only
+         *   - audio_downlink_codec: TTS only
+         * Unrecognized strings fall back to PCM. */
+        cJSON *acu = cJSON_GetObjectItem(root, "audio_uplink_codec");
+        cJSON *acd = cJSON_GetObjectItem(root, "audio_downlink_codec");
+        cJSON *ac  = cJSON_GetObjectItem(root, "audio_codec");
+        if (cJSON_IsString(acu)) {
+            voice_codec_set_uplink(voice_codec_from_name(acu->valuestring));
+        } else if (cJSON_IsString(ac)) {
+            voice_codec_set_uplink(voice_codec_from_name(ac->valuestring));
+        }
+        if (cJSON_IsString(acd)) {
+            voice_codec_set_downlink(voice_codec_from_name(acd->valuestring));
+        } else if (cJSON_IsString(ac)) {
+            voice_codec_set_downlink(voice_codec_from_name(ac->valuestring));
+        }
+        /* Wave 14 W14-L03: if neither voice_mode nor cloud_mode was
+         * present, the handler used to exit silently and Tab5 would
+         * disagree with Dragon about the active mode with no trace.
+         * Log at DEBUG so it's visible via /log without spamming INFO. */
+        if (!cJSON_IsNumber(vmode) && !applied_cloud &&
+            !cJSON_IsString(error)) {
+            ESP_LOGD(TAG, "config_update received with no voice_mode/"
+                         "cloud_mode/error field — no-op");
+        }
+    } else if (strcmp(type_str, "tool_call") == 0) {
+        cJSON *tool = cJSON_GetObjectItem(root, "tool");
+        const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
+        ESP_LOGI(TAG, "Tool call: %s", tool_name);
+
+        const char *status_text = "Thinking...";
+        if (strcmp(tool_name, "web_search") == 0) {
+            status_text = "Searching the web...";
+        } else if (strcmp(tool_name, "remember") == 0 || strcmp(tool_name, "memory_store") == 0) {
+            status_text = "Remembering...";
+        } else if (strcmp(tool_name, "memory_search") == 0 || strcmp(tool_name, "recall") == 0) {
+            status_text = "Recalling...";
+        } else if (strcmp(tool_name, "browser") == 0 || strcmp(tool_name, "browse") == 0) {
+            status_text = "Browsing...";
+        } else if (strcmp(tool_name, "calculator") == 0 || strcmp(tool_name, "math") == 0) {
+            status_text = "Calculating...";
+        } else {
+            status_text = "Using tools...";
+        }
+        voice_set_state(VOICE_STATE_PROCESSING, status_text);
+        /* Tab5 audit D5: also push a system bubble so the user can see
+         * tool activity in chat (not just on the voice overlay label).
+         * CLAUDE.md's "thinking + tool indicator bubbles" claim was wired
+         * only to the overlay-state string previously. */
+        ui_chat_push_system(status_text);
+        /* U7+U8 (#206): record activity so the agents/focus surfaces
+         * can render real history instead of the v5 demo rows. */
+        tool_log_push_call(tool_name, status_text);
+    } else if (strcmp(type_str, "tool_result") == 0) {
+        cJSON *tool = cJSON_GetObjectItem(root, "tool");
+        cJSON *exec_ms = cJSON_GetObjectItem(root, "execution_ms");
+        const char *tool_name = cJSON_IsString(tool) ? tool->valuestring : "unknown";
+        double ms = cJSON_IsNumber(exec_ms) ? exec_ms->valuedouble : 0.0;
+        ESP_LOGI(TAG, "Tool result: %s (%.0fms)", tool_name, ms);
+        voice_set_state(VOICE_STATE_PROCESSING, "Thinking...");
+        /* Tab5 audit D5: close the loop with a completion bubble so the
+         * chat timeline shows what ran + how long it took. */
+        char done_buf[80];
+        snprintf(done_buf, sizeof(done_buf), "%s done (%.0fms)",
+                 tool_name, ms);
+        ui_chat_push_system(done_buf);
+        /* U7+U8 (#206): mark the tool_log entry done so the
+         * agents/focus surfaces can show "DONE  •  234 ms". */
+        tool_log_push_result(tool_name, (uint32_t)ms);
+    } else if (strcmp(type_str, "media") == 0) {
+        const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
+        const char *mtype = cJSON_GetStringValue(cJSON_GetObjectItem(root, "media_type"));
+        cJSON *w_item = cJSON_GetObjectItem(root, "width");
+        cJSON *h_item = cJSON_GetObjectItem(root, "height");
+        int w = cJSON_IsNumber(w_item) ? (int)w_item->valuedouble : 0;
+        int h = cJSON_IsNumber(h_item) ? (int)h_item->valuedouble : 0;
+        const char *alt = cJSON_GetStringValue(cJSON_GetObjectItem(root, "alt"));
+        if (url) {
+            ESP_LOGI(TAG, "Media: %s %dx%d", mtype ? mtype : "image", w, h);
+            ui_chat_push_media(url, mtype, w, h, alt);
+        }
+    } else if (strcmp(type_str, "card") == 0) {
+        const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
+        const char *sub = cJSON_GetStringValue(cJSON_GetObjectItem(root, "subtitle"));
+        const char *img = cJSON_GetStringValue(cJSON_GetObjectItem(root, "image_url"));
+        const char *desc = cJSON_GetStringValue(cJSON_GetObjectItem(root, "description"));
+        if (title) {
+            ESP_LOGI(TAG, "Card: %s", title);
+            ui_chat_push_card(title, sub, img, desc);
+        }
+        /* Wave 23b SOLID-audit SRP-2: nine widget WS verbs (widget_card,
+         * widget_live, widget_live_update, widget_list, widget_chart,
+         * widget_media, widget_prompt, widget_live_dismiss, widget_dismiss)
+         * extracted to voice_widget_ws.{c,h}.  Returns true iff the verb
+         * was recognized + handled; false falls through to the unknown-
+         * verb log below. */
+    } else if (voice_widget_ws_dispatch(type_str, root)) {
+       /* widget verb handled inside voice_widget_ws.c */
+    } else if (strcmp(type_str, "audio_clip") == 0) {
+       const char *url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
+       cJSON *dur_item = cJSON_GetObjectItem(root, "duration_s");
+       float dur = cJSON_IsNumber(dur_item) ? (float)dur_item->valuedouble : 0.0f;
+       const char *label = cJSON_GetStringValue(cJSON_GetObjectItem(root, "label"));
+       if (url) {
+          ESP_LOGI(TAG, "Audio clip: %s (%.1fs)", label ? label : "", dur);
+          ui_chat_push_audio_clip(url, dur, label);
+       }
+    } else {
+       ESP_LOGW(TAG, "Unknown message type: %s (full: %.*s)", type_str, len, data);
+    }
+
+    cJSON_Delete(root);
+}
+
+
+/* Forward decl: handle_binary_message still lives in voice.c until
+ * Task 1.7 moves it.  voice_ws_proto_event_handler dispatches binary
+ * frames through this thunk for now. */
+extern void handle_binary_message(const char *data, int len);
+
+// ---------------------------------------------------------------------------
+// Task 1.6/1.8/1.9: WebSocket event handler + URI helper.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// WebSocket event handler (runs on esp_websocket_client's internal task)
+// ---------------------------------------------------------------------------
+/* TT #331 Wave 23 SRP-A1: was static void voice_ws_event_handler — promoted +
+ * renamed for the voice_ws_proto layer.  Registered with
+ * esp_websocket_register_events from voice_ws_start_client in voice.c. */
+void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
+                                  int32_t event_id, void *event_data)
+{
+    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+
+    switch ((esp_websocket_event_id_t)event_id) {
+    case WEBSOCKET_EVENT_BEFORE_CONNECT:
+        ESP_LOGI(TAG, "WS: BEFORE_CONNECT (host=%s%s)",
+                 s_dragon_host, s_using_ngrok ? " [ngrok]" : "");
+        voice_set_state(VOICE_STATE_CONNECTING, s_dragon_host);
+        break;
+
+    case WEBSOCKET_EVENT_CONNECTED: {
+        ESP_LOGI(TAG, "WS: CONNECTED — sending register frame");
+        /* #293: emit obs event for e2e harness. */
+        tab5_debug_obs_event("ws.connect", "");
+        /* TT #317 Phase 4: stamp WS-alive so the K144 failover gate can
+         * measure how long Dragon's been down before engaging. */
+        s_ws_last_alive_us = esp_timer_get_time();
+        /* TT #317 Phase 5: if a K144 failover engaged during the down
+         * period, surface "Dragon reconnected" so the user knows the
+         * next turn is back on the cloud/LAN brain.  Wave 4b: the flag
+         * lives in voice_onboard now; consume_engagement_flag returns
+         * true once and clears, so the toast fires exactly once per
+         * disconnect cycle. */
+        if (voice_onboard_consume_engagement_flag()) {
+           ESP_LOGI(TAG, "WS reconnected after K144 failover — toast 'Dragon reconnected'");
+           if (tab5_ui_try_lock(100)) {
+              ui_home_show_toast("Dragon reconnected");
+              tab5_ui_unlock();
+           }
+        }
+        /* US-C02: bump session gen on every successful connect. */
+        s_session_gen++;
+        s_handshake_fail_cnt = 0;
+        /* γ3-Tab5 (issue #198): clear the auth-fail counter on a
+         * successful connect so a transient 401 (e.g. a token-rotation
+         * race during Dragon restart) doesn't get sticky after Dragon
+         * recovers.  Only a sustained run of 401s should trip the
+         * stop-retry — recovery must self-heal. */
+        s_auth_fail_cnt = 0;
+        /* T1.1: reset backoff state on every successful connect so a
+         * long-running healthy session doesn't get hit with a 30 s
+         * delay on its first blip. */
+        s_connect_attempt = 0;
+        esp_websocket_client_set_reconnect_timeout(g_voice_ws, WS_CLIENT_BACKOFF_MIN_MS);
+
+        esp_err_t reg_err = voice_ws_send_register();
+        if (reg_err != ESP_OK) {
+            ESP_LOGE(TAG, "WS: register send failed (%s)", esp_err_to_name(reg_err));
+            /* Let auto-reconnect re-attempt. */
+        }
+        /* Don't set READY yet — wait for Dragon's session_start reply so
+         * we know the backend pipeline is fully up. Keep state CONNECTING
+         * until session_start arrives (~6s model load on first boot). */
+        break;
+    }
+
+    case WEBSOCKET_EVENT_DISCONNECTED:
+        ESP_LOGW(TAG, "WS: DISCONNECTED");
+        { tab5_debug_obs_event("ws.disconnect", ""); }
+        /* Flush playback so we don't keep speaking into a dead pipe. */
+        voice_playback_buf_reset();
+        tab5_audio_speaker_enable(false);
+        /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice
+         * state was PROCESSING or SPEAKING), surface a toast so the user
+         * knows why the reply stopped.  Previously a mid-turn Dragon
+         * crash was silent — just a frozen overlay + no answer.  The
+         * home status-bar pill already picks up RECONNECTING via
+         * voice_get_degraded_reason(), so the toast is a short-lived
+         * orient-the-user signal, not the permanent indicator.
+         *
+         * Wave 7 F5 completion (2026-04-21): also pulse the halo orb
+         * rose for ~2.5 s so the visual signal matches the audit spec
+         * ("toast + rose orb pulse"). Toast alone was easy to miss if
+         * the user was looking at the chat area rather than the home
+         * card. ui_home_pulse_orb_alert reverts to the mode-default
+         * orb paint via an LVGL one-shot timer. */
+        {
+            voice_state_t cur = voice_get_state();
+            if ((cur == VOICE_STATE_PROCESSING || cur == VOICE_STATE_SPEAKING) && !s_disconnecting) {
+               tab5_lv_async_call((lv_async_cb_t)ui_home_show_toast, (void *)"Dragon dropped mid-turn - reconnecting");
+               tab5_lv_async_call((lv_async_cb_t)ui_home_pulse_orb_alert, NULL);
+            }
+        }
+        /* T1.1: bump attempt counter + apply exponential-with-full-jitter
+         * backoff to the client's reconnect timer.  Prevents thundering
+         * herd if multiple Tab5s share the same Dragon + avoids 2 s
+         * hammering against a server that's 20 s into its restart. */
+        s_connect_attempt++;
+        {
+            int shift = s_connect_attempt - 1;
+            if (shift < 0) shift = 0;
+            if (shift > 5) shift = 5;
+            uint32_t exp_ms = WS_CLIENT_BACKOFF_MIN_MS << shift;
+            if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
+            uint32_t half = exp_ms / 2;
+            uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
+            uint32_t delay_ms = half + jitter;    /* [exp/2, exp) */
+            ESP_LOGI(TAG, "WS: reconnect attempt=%d backoff=%lums (exp=%lums)",
+                     s_connect_attempt, (unsigned long)delay_ms,
+                     (unsigned long)exp_ms);
+            esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
+        }
+        /* #146: WS-level escalation.  If Wi-Fi probes claim we're fine
+         * (probe task still sees lan=1/ngrok=1) but the voice WS keeps
+         * failing to connect, the Wi-Fi chip's TCP-stack state is bad.
+         * The probe is a one-shot SYN; the WS handshake needs more
+         * buffers + TLS-path + full RX pipeline.  After WS_KICK_THRESHOLD
+         * consecutive failed attempts (~2 min of retry), hard-kick the
+         * stack.  Don't do this on attempt 1-4 — those are normal
+         * transient failures (Dragon restart, brief AP hiccup). */
+        #define WS_KICK_THRESHOLD 5
+        if (s_connect_attempt == WS_KICK_THRESHOLD) {
+            ESP_LOGW(TAG, "WS: %d failed attempts — escalating to hard-kick "
+                          "(stack may be wedged despite probe success)",
+                     s_connect_attempt);
+            esp_err_t kr = tab5_wifi_hard_kick();
+            if (kr != ESP_OK) {
+                /* ESP-Hosted's Wi-Fi slave chip doesn't always recover
+                 * from stop/start without a host-side reboot (observed:
+                 * esp_wifi_start returns ESP_FAIL repeatedly).  Don't
+                 * burn another 5 attempts — reboot now. */
+                ESP_LOGE(TAG, "WS: hard-kick failed (%s) — controlled reboot",
+                         esp_err_to_name(kr));
+                vTaskDelay(pdMS_TO_TICKS(100));
+                esp_restart();
+                /* unreachable */
+            }
+            /* Reset the counter so we give it another 5 tries after the
+             * successful hard kick before escalating again.  If 10
+             * failures in a row, the link-probe zombie path catches it. */
+            s_connect_attempt = 0;
+        }
+        /* T1.2: RECONNECTING while a backoff is queued + WiFi is up.
+         * IDLE only when WiFi is genuinely down or user stopped voice. */
+        {
+            bool wifi_up = tab5_wifi_connected();
+            if (s_initialized && !s_disconnecting && wifi_up) {
+                voice_set_state(VOICE_STATE_RECONNECTING, "backoff");
+            } else {
+                voice_set_state(VOICE_STATE_IDLE, "disconnected");
+            }
+        }
+        /* v4·D audit P0 fix: ngrok fallback was one-way.  Clear the flag
+         * + reset the fail counter so the NEXT successful connection
+         * gets a chance to land on LAN.  The actual URI swap is deferred
+         * to voice_try_lan_probe() which runs off the WS event task. */
+        if (s_using_ngrok && tab5_settings_get_connection_mode() == 0) {
+            s_handshake_fail_cnt = 0;
+            /* Leave s_using_ngrok alone here: we only reset it once the
+             * external LAN probe succeeds (heap_watchdog periodic hook).
+             * Clearing it here without swapping the client URI would be
+             * a lie, and swapping the URI inside the event task has
+             * shown to wedge the client.  Next sprint: add a proper
+             * probe task that pings LAN and schedules the swap via
+             * lv_async_call on success. */
+        }
+        break;
+
+    case WEBSOCKET_EVENT_CLOSED:
+        /* closes #110: was voice_set_state(IDLE, "closed") with NO
+         * reconnect scheduled — if Dragon sends a graceful WS close
+         * frame (restart, idle timeout, etc.) Tab5 parked in IDLE
+         * forever until the user hit /voice/reconnect manually.
+         * DISCONNECTED re-armed the reconnect timer; CLOSED did not.
+         *
+         * Mirror the DISCONNECTED path: bump attempt, apply
+         * exponential-with-full-jitter backoff, transition to
+         * RECONNECTING when Wi-Fi is up so the state bar reflects
+         * that Tab5 is actively trying, not dead.  The managed WS
+         * client's auto-reconnect picks up the new timeout. */
+        ESP_LOGI(TAG, "WS: CLOSED — scheduling reconnect");
+        if (g_voice_ws && !s_disconnecting) {
+            s_connect_attempt++;
+            int shift = s_connect_attempt - 1;
+            if (shift < 0) shift = 0;
+            if (shift > 5) shift = 5;
+            uint32_t exp_ms = WS_CLIENT_BACKOFF_MIN_MS << shift;
+            if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
+            uint32_t half = exp_ms / 2;
+            uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
+            uint32_t delay_ms = half + jitter;
+            ESP_LOGI(TAG, "WS: CLOSED reconnect attempt=%d backoff=%lums",
+                     s_connect_attempt, (unsigned long)delay_ms);
+            esp_websocket_client_set_reconnect_timeout(g_voice_ws, delay_ms);
+            if (tab5_wifi_connected()) {
+                voice_set_state(VOICE_STATE_RECONNECTING, "closed");
+            } else {
+                voice_set_state(VOICE_STATE_IDLE, "closed-nowifi");
+            }
+        } else {
+            voice_set_state(VOICE_STATE_IDLE, "closed");
+        }
+        break;
+
+    case WEBSOCKET_EVENT_DATA:
+        if (!data) break;
+        s_last_activity_us = esp_timer_get_time();
+        if (data->op_code == WS_TRANSPORT_OPCODES_TEXT && data->data_len > 0) {
+            ESP_LOGI(TAG, "WS recv text (%d bytes): %.*s", data->data_len,
+                     data->data_len > 200 ? 200 : data->data_len, data->data_ptr);
+            voice_ws_proto_handle_text(data->data_ptr, data->data_len);
+        } else if (data->op_code == WS_TRANSPORT_OPCODES_BINARY && data->data_len > 0) {
+            /* #268: large binary frames (e.g. Phase 3B video JPEGs >32 KB)
+             * arrive in fragments — esp_websocket_client splits them at
+             * WS_CLIENT_BUFFER_SIZE.  Reassemble using payload_len +
+             * payload_offset before dispatching to handle_binary_message
+             * so the magic-byte sniff sees the whole frame.  Audio
+             * (PCM/OPUS) is single-fragment so the fast path skips
+             * reassembly. */
+            const int frag_total = data->payload_len;
+            const int frag_off   = data->payload_offset;
+            const int frag_len   = data->data_len;
+            if (frag_total <= 0 || frag_total == frag_len) {
+                /* Single-fragment frame — current behavior. */
+                handle_binary_message(data->data_ptr, frag_len);
+            } else {
+                /* Multi-fragment frame.  Lazy-init reassembly buffer
+                 * in PSRAM, sized to the same ceiling voice_video uses. */
+                static uint8_t *s_rx_reasm_buf = NULL;
+                static int      s_rx_reasm_cap = 96 * 1024;
+                if (!s_rx_reasm_buf) {
+                    s_rx_reasm_buf = heap_caps_malloc(
+                        s_rx_reasm_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+                }
+                if (!s_rx_reasm_buf) {
+                    ESP_LOGW(TAG, "rx-reasm OOM (%d B); dropping frag", s_rx_reasm_cap);
+                    break;
+                }
+                if (frag_total > s_rx_reasm_cap) {
+                    ESP_LOGW(TAG, "rx-reasm: payload %d > cap %d; dropping", frag_total, s_rx_reasm_cap);
+                    break;
+                }
+                if (frag_off + frag_len > frag_total) {
+                    ESP_LOGW(TAG, "rx-reasm: bad frag off=%d len=%d total=%d",
+                             frag_off, frag_len, frag_total);
+                    break;
+                }
+                memcpy(s_rx_reasm_buf + frag_off, data->data_ptr, frag_len);
+                if (frag_off + frag_len == frag_total) {
+                    handle_binary_message((const char *)s_rx_reasm_buf, frag_total);
+                }
+            }
+        } else if (data->op_code == WS_TRANSPORT_OPCODES_PING) {
+            ESP_LOGD(TAG, "WS recv PING — client auto-pongs");
+        } else if (data->op_code == WS_TRANSPORT_OPCODES_PONG) {
+            ESP_LOGD(TAG, "WS recv PONG");
+        } else if (data->op_code == WS_TRANSPORT_OPCODES_CLOSE) {
+            ESP_LOGI(TAG, "WS recv CLOSE frame");
+        }
+        break;
+
+    case WEBSOCKET_EVENT_ERROR: {
+        int status = data ? data->error_handle.esp_ws_handshake_status_code : 0;
+        esp_websocket_error_type_t et = data ? data->error_handle.error_type : WEBSOCKET_ERROR_TYPE_NONE;
+        ESP_LOGW(TAG, "WS: ERROR (type=%d, handshake_status=%d, sock_errno=%d)",
+                 (int)et, status,
+                 data ? data->error_handle.esp_transport_sock_errno : 0);
+        /* T1.1: apply the same backoff on error as on disconnect so
+         * a handshake-fail loop doesn't pin at 2 s forever. */
+        {
+            int shift = s_connect_attempt;
+            if (shift < 0) shift = 0;
+            if (shift > 5) shift = 5;
+            uint32_t exp_ms = WS_CLIENT_BACKOFF_MIN_MS << shift;
+            if (exp_ms > WS_CLIENT_BACKOFF_CAP_MS) exp_ms = WS_CLIENT_BACKOFF_CAP_MS;
+            uint32_t half = exp_ms / 2;
+            uint32_t jitter = half > 0 ? (esp_random() % half) : 0;
+            esp_websocket_client_set_reconnect_timeout(g_voice_ws, half + jitter);
+        }
+
+        /* γ3-Tab5 (issue #198): 401 specifically means auth failed —
+         * burning the auth-fail counter every retry will pin the
+         * device against ngrok forever (wrong-token devices used to
+         * loop 401s on both LAN and ngrok endpoints, eating battery
+         * + ngrok bandwidth + log storage).  After WS_AUTH_FAIL_THRESHOLD
+         * consecutive 401s, stop the WS client + show a toast pointing
+         * at Settings.  s_auth_fail_cnt resets on a successful CONNECT
+         * so a transient 401 (token-rotation race during Dragon
+         * restart) doesn't get sticky after recovery.
+         *
+         * Filter on status alone — NOT on
+         * `et == WEBSOCKET_ERROR_TYPE_HANDSHAKE`.  Empirically (live
+         * test on real device against PROD :3502 with rotated token)
+         * a clean 401 from Dragon arrives as `et=1`
+         * (WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT) because the underlying
+         * TCP transport completed successfully — the 401 happens at
+         * the application layer.  Gating on HANDSHAKE here meant the
+         * counter never incremented and the loop ran forever. */
+        if (status == 401) {
+            s_auth_fail_cnt++;
+            ESP_LOGW(TAG, "WS: 401 auth_failed (count=%d/%d)",
+                     s_auth_fail_cnt, WS_AUTH_FAIL_THRESHOLD);
+            if (s_auth_fail_cnt >= WS_AUTH_FAIL_THRESHOLD && !s_disconnecting) {
+                ESP_LOGE(TAG, "WS: %d consecutive 401s — stopping retry loop",
+                         s_auth_fail_cnt);
+                s_disconnecting = true;
+                /* Hop to worker task — esp_websocket_client_stop()
+                 * rejects calls from the WS task itself.  Same pattern
+                 * as the γ2-H8 device_evicted handler. */
+                tab5_worker_enqueue(_voice_auth_fail_stop_worker_fn, NULL,
+                                    "auth_failed_stop");
+                /* TT #328 Wave 3 P0 #15 — pre-Wave-3 this was a 2.2 s toast.
+                 * After 5 silent retries the user got a single transient
+                 * notice they could easily miss.  Upgraded to a persistent
+                 * error banner that stays until they tap it (and presumably
+                 * jump to Settings to fix the token).  Also fires the
+                 * error.auth obs event so /events surfaces the lockout. */
+                tab5_debug_obs_event("error.auth", "ws_401_stop");
+                char *toast = strdup("Invalid Dragon token — check Settings");
+                if (toast) {
+                    voice_async_toast(toast);
+                }
+                voice_async_error_banner(
+                    "Dragon rejected your token (401). Reconnect paused — "
+                    "open Settings → Network to update.");
+                break;
+            }
+        }
+
+        /* Handshake failure → try ngrok fallback (only in conn_mode=auto,
+         * only while still on local URI, after NGROK_FALLBACK_THRESHOLD fails). */
+        if (et == WEBSOCKET_ERROR_TYPE_HANDSHAKE && status != 101) {
+            s_handshake_fail_cnt++;
+            uint8_t conn_mode = tab5_settings_get_connection_mode();
+            if (conn_mode == 0 && !s_using_ngrok
+                && s_handshake_fail_cnt >= NGROK_FALLBACK_THRESHOLD) {
+                char ngrok_uri[128];
+                snprintf(ngrok_uri, sizeof(ngrok_uri),
+                         "wss://%s:%d%s",
+                         TAB5_NGROK_HOST, TAB5_NGROK_PORT, TAB5_VOICE_WS_PATH);
+                ESP_LOGW(TAG, "WS: handshake failed %d× — falling back to %s",
+                         s_handshake_fail_cnt, ngrok_uri);
+                s_using_ngrok = true;
+                s_handshake_fail_cnt = 0;
+                /* set_uri requires a stopped client. The client is
+                 * currently between reconnect attempts; stop+set+start
+                 * to force it onto the new URI immediately. */
+                esp_websocket_client_stop(g_voice_ws);
+                esp_websocket_client_set_uri(g_voice_ws, ngrok_uri);
+                strncpy(s_dragon_host, TAB5_NGROK_HOST, sizeof(s_dragon_host) - 1);
+                s_dragon_host[sizeof(s_dragon_host) - 1] = '\0';
+                s_dragon_port = TAB5_NGROK_PORT;
+                esp_websocket_client_start(g_voice_ws);
+            }
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// URI helpers
+// ---------------------------------------------------------------------------
+/* TT #331 Wave 23 SRP-A1: was static void voice_build_local_uri. */
+void voice_ws_proto_build_local_uri(char *out, size_t out_cap,
+                                    const char *host, uint16_t port)
+{
+    snprintf(out, out_cap, "ws://%s:%u%s", host, (unsigned)port, TAB5_VOICE_WS_PATH);
+}

--- a/main/voice_ws_proto.h
+++ b/main/voice_ws_proto.h
@@ -14,11 +14,12 @@
  */
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "esp_err.h"
 #include "esp_event.h"
 #include "esp_websocket_client.h"
-#include <stddef.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,18 +36,15 @@ void voice_ws_proto_handle_binary(const char *data, int len);
 
 /* esp_websocket_client event callback — register with
  * esp_websocket_register_events from voice_ws_start_client in voice.c. */
-void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
-                                  int32_t event_id, void *event_data);
+void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t event_id, void *event_data);
 
 /* URI helper (LAN target builder).  out_cap must be at least 64. */
-void voice_ws_proto_build_local_uri(char *out, size_t out_cap,
-                                    const char *dragon_host,
-                                    uint16_t dragon_port);
+void voice_ws_proto_build_local_uri(char *out, size_t out_cap, const char *dragon_host, uint16_t dragon_port);
 
 /* UI-async helpers (formerly voice.c statics).  Used by mic_capture_task
  * (in voice.c) and the JSON RX dispatcher to schedule LVGL-thread
  * notifications without taking the LVGL lock from a worker task. */
-void voice_async_toast(char *text);   /* takes ownership of text */
+void voice_async_toast(char *text); /* takes ownership of text */
 
 #ifdef __cplusplus
 }

--- a/main/voice_ws_proto.h
+++ b/main/voice_ws_proto.h
@@ -43,6 +43,11 @@ void voice_ws_proto_build_local_uri(char *out, size_t out_cap,
                                     const char *dragon_host,
                                     uint16_t dragon_port);
 
+/* UI-async helpers (formerly voice.c statics).  Used by mic_capture_task
+ * (in voice.c) and the JSON RX dispatcher to schedule LVGL-thread
+ * notifications without taking the LVGL lock from a worker task. */
+void voice_async_toast(char *text);   /* takes ownership of text */
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/voice_ws_proto.h
+++ b/main/voice_ws_proto.h
@@ -1,0 +1,48 @@
+/**
+ * Voice WebSocket protocol layer (Tab5 ↔ Dragon).
+ *
+ * Owns the on-the-wire dispatch:
+ *   - JSON RX (text frames) → handle_text routes to typed handlers.
+ *   - Binary RX (mag-tagged VID0/AUD0 + untagged PCM) → handle_binary.
+ *   - WS event callback (CONNECTED / DISCONNECTED / DATA / ERROR).
+ *   - TX wrappers around esp_websocket_client_send_{text,bin}.
+ *   - REGISTER frame builder.
+ *
+ * Wave 23 SOLID-audit closure for TT #331 (extract A1).  Pre-extract
+ * this all lived inline in voice.c at L525-1948; voice.c keeps the
+ * state machine + mic capture + listening/dictation/call lifecycles.
+ */
+#pragma once
+
+#include "esp_err.h"
+#include "esp_event.h"
+#include "esp_websocket_client.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* TX wrappers (formerly static helpers in voice.c). */
+esp_err_t voice_ws_send_text(const char *msg);
+esp_err_t voice_ws_send_binary(const void *data, size_t len);
+esp_err_t voice_ws_send_register(void);
+
+/* RX dispatchers — invoked by voice_ws_proto_event_handler. */
+void voice_ws_proto_handle_text(const char *data, int len);
+void voice_ws_proto_handle_binary(const char *data, int len);
+
+/* esp_websocket_client event callback — register with
+ * esp_websocket_register_events from voice_ws_start_client in voice.c. */
+void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
+                                  int32_t event_id, void *event_data);
+
+/* URI helper (LAN target builder).  out_cap must be at least 64. */
+void voice_ws_proto_build_local_uri(char *out, size_t out_cap,
+                                    const char *dragon_host,
+                                    uint16_t dragon_port);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

- Extract WS frame routing out of \`main/voice.c\` into a new sibling module \`main/voice_ws_proto.{c,h}\`.
- voice.c drops from 3,668 → 2,401 LOC (-1,267 LOC).
- voice_ws_proto.c grows from 0 → ~1,580 LOC.
- Same shape as the prior \`voice_billing\` (#351) / \`voice_widget_ws\` (#349) / \`voice_onboard\` (#327) extracts.

## What moved

**TX surface:**
- \`voice_ws_send_text\`, \`voice_ws_send_binary\`, \`voice_ws_send_binary_public\`, \`voice_ws_send_register\`
- \`voice_send_widget_action\` (pure WS-proto: builds widget_action JSON + sends)

**RX surface:**
- \`handle_text_message\` (599 LOC JSON dispatcher) → \`voice_ws_proto_handle_text\`
- \`handle_binary_message\` (VID0/AUD0/untagged-PCM dispatcher) → \`voice_ws_proto_handle_binary\`
- \`upsample_16k_to_48k\` (helper, file-static in new module) → \`voice_ws_proto_upsample_16k_to_48k\`
- \`voice_ws_event_handler\` (esp_websocket_client callback) → \`voice_ws_proto_event_handler\`
- \`voice_debug_inject_text\` (TT #328 Wave 2 e2e injection point — public via voice.h)

**UI-async helpers (only called from the moved RX/event surface):**
- \`voice_async_toast\` (now public — mic_capture_task in voice.c still uses it)
- \`voice_async_error_banner\` / \`voice_async_error_banner_dyn\` / \`voice_async_refresh_badge\`
- \`async_*_cb\` callbacks + their typedef structs
- \`_voice_stop_ws_worker_fn\` / \`_voice_auth_fail_stop_worker_fn\` (eviction + 401 stop workers)
- \`s_fallback_banner_active\` (only used by the moved code → file-static in new module)

**URI helper:**
- \`voice_build_local_uri\` → \`voice_ws_proto_build_local_uri\`

**Tunables (file-static in new module):**
- \`WS_CLIENT_BACKOFF_MIN_MS\` / \`_CAP_MS\`, \`WS_AUTH_FAIL_THRESHOLD\`, \`NGROK_FALLBACK_THRESHOLD\`

## What stays in voice.c

State machine + mic capture task + playback drain task + listening/dictation/call lifecycles + reconnect watchdog + the public API surface.  Final voice.c LOC: 2,401 (target was ~2,470).

## Statics promoted out of voice.c (extern in voice.h, except as noted)

\`s_state_mutex\`, \`s_session_gen\`, \`s_disconnecting\`, \`s_auth_fail_cnt\`, \`s_play_sem\`, \`s_tts_done\`, \`s_transcript\`, \`s_stt_text\`, \`s_llm_text\`, \`s_dictation_text\`, \`s_dictation_title\`, \`s_dictation_summary\`, \`s_vision_capable\`, \`s_vision_per_frame_mils\`, \`s_vision_model\`, \`s_handshake_fail_cnt\`, \`s_connect_attempt\`, \`s_using_ngrok\`, \`s_last_activity_us\`, \`s_ws_last_alive_us\`, \`s_dragon_host\`, \`s_dragon_port\`, \`s_upsample_buf\`, \`g_voice_ws\`.

\`s_initialized\` + the SemaphoreHandle_t pair (\`s_state_mutex\`, \`s_play_sem\`) live as voice_ws_proto.c-local externs (not in voice.h) — \`s_initialized\` collides with ui_voice.c's local static of the same name; the SemaphoreHandle_t pair would force \`<freertos/semphr.h>\` into voice.h's public surface.

\`MAX_TRANSCRIPT_LEN\` + \`DICTATION_TEXT_SIZE\` macros moved to voice.h.

\`playback_buf_reset\` + \`playback_buf_write\` → \`voice_playback_buf_reset\` + \`voice_playback_buf_write\` (public via voice.h).

## Plan adherence

Plan was 6 atomic commits; reality was 5 squash-friendly slices because Tasks 1.6 + 1.8 + 1.9 (handle_text + WS event handler + URI helper) had a tight call-graph cycle that made splitting them into separate intermediate-buildable commits net-negative.  Commit history:
- carve voice_ws_proto.h skeleton
- move TX wrappers + REGISTER + promote g_voice_ws
- move voice_send_widget_action
- move handle_text + WS event handler + UI helpers + URI builder (combined for dep-closure)
- move handle_binary + upsample helper (with TASK_WDT deadlock fix — see commit body)
- clang-format pass

## Verification on physical Tab5 192.168.1.90

- \`idf.py build\` clean
- \`git-clang-format --diff origin/main\` empty
- **story_smoke 14/14** in 129s (baseline 14/14 in 67s)
- **story_full 24/24** in 107s (baseline 23/24 in 99s — beat baseline; the camera record_stop flake from the baseline didn't fire this run)
- AUD0/VID0 binary path verified (TTS playback in story_smoke + 4-mode rotation in story_full both succeed; the moved binary dispatcher is the path TTS audio takes from Dragon back to the speaker)
- Heap floor at fresh boot (~35s uptime, matched baseline timing): **identical to baseline** within rounding noise (psram delta 0.0%, internal_largest delta 0.0%, lvgl delta 0.0%)
- reset_reason after final flash: SW (clean software reset, not panic)

## Notable mid-PR fix

Initial Task 1.7 attempt deadlocked: I swapped a direct \`s_state\` read (under explicit s_state_mutex take/give) for \`voice_get_state()\`, but voice_get_state takes the SAME non-recursive mutex internally → recursive take → TASK_WDT reset → lost 4 smoke steps + auto-reboot.  Fix: drop the explicit take/give since voice_get_state() is itself atomic.  Re-verified green after fix.

Closes #353.
Refs #331.