### PR TITLE
refactor(debug_server): extract /reboot + /sdcard + /widget admin family (refs #332)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"
              "debug_server_call.c" "debug_server_camera.c" "debug_server_obs.c"
-             "debug_server_input.c" "debug_server_nav.c"
+             "debug_server_input.c" "debug_server_nav.c" "debug_server_admin.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -57,6 +57,7 @@
 #include "ui_wifi.h"
 #include "voice.h"
 /* Wave 23b (#332): per-family endpoint extracts + auth shim. */
+#include "debug_server_admin.h"
 #include "debug_server_call.h"
 #include "debug_server_camera.h"
 #include "debug_server_codec.h"
@@ -326,21 +327,7 @@ static esp_err_t info_handler(httpd_req_t *req)
 
 /* touch_handler moved to debug_server_input.c (Wave 23b #332). */
 
-/* ======================================================================== */
-/*  POST /reboot                                                             */
-/* ======================================================================== */
-
-static esp_err_t reboot_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_sendstr(req, "{\"rebooting\":true}");
-    ESP_LOGW(TAG, "Reboot requested via debug server");
-    vTaskDelay(pdMS_TO_TICKS(500));
-    esp_restart();
-    return ESP_OK;  /* unreachable */
-}
+/* /reboot moved to debug_server_admin.c (Wave 23b #332). */
 
 /* ======================================================================== */
 /*  GET /log                                                                 */
@@ -396,70 +383,8 @@ static esp_err_t index_handler(httpd_req_t *req)
 /* heap-trace machinery (start + dump handlers + s_heap_trace_*
  * + TAB5_HEAP_TRACE_NUM_RECORDS) moved to debug_server_obs.c */
 
-/* ── SD card file listing ─────────────────────────────────────────────── */
-
-static void _list_dir_to_json(cJSON *arr, const char *path)
-{
-    DIR *d = opendir(path);
-    if (!d) return;
-
-    struct dirent *entry;
-    while ((entry = readdir(d)) != NULL) {
-        char full[320];
-        snprintf(full, sizeof(full), "%s/%s", path, entry->d_name);
-
-        struct stat st;
-        stat(full, &st);
-
-        cJSON *item = cJSON_CreateObject();
-        cJSON_AddStringToObject(item, "name", entry->d_name);
-        cJSON_AddStringToObject(item, "path", full);
-        cJSON_AddBoolToObject(item, "dir", entry->d_type == DT_DIR);
-        if (entry->d_type != DT_DIR) {
-            cJSON_AddNumberToObject(item, "size", (double)st.st_size);
-        }
-        cJSON_AddItemToArray(arr, item);
-    }
-    closedir(d);
-}
-
-static esp_err_t sdcard_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "mounted", tab5_sdcard_mounted());
-
-    if (tab5_sdcard_mounted()) {
-        cJSON_AddNumberToObject(root, "total_mb", (double)(tab5_sdcard_total_bytes() / (1024*1024)));
-        cJSON_AddNumberToObject(root, "free_mb", (double)(tab5_sdcard_free_bytes() / (1024*1024)));
-
-        /* List /sdcard root */
-        cJSON *files = cJSON_AddArrayToObject(root, "files");
-        _list_dir_to_json(files, "/sdcard");
-
-        /* List /sdcard/rec if it exists */
-        struct stat st;
-        if (stat("/sdcard/rec", &st) == 0) {
-            cJSON *recs = cJSON_AddArrayToObject(root, "recordings");
-            _list_dir_to_json(recs, "/sdcard/rec");
-        }
-    }
-
-    char *json = cJSON_PrintUnformatted(root);
-    cJSON_Delete(root);
-    if (!json) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "JSON alloc");
-        return ESP_FAIL;
-    }
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
-    esp_err_t ret = httpd_resp_sendstr(req, json);
-    free(json);
-    return ret;
-}
+/* _list_dir_to_json + sdcard_handler moved to debug_server_admin.c
+ * (Wave 23b #332). */
 
 /* ── OTA endpoint family extracted to debug_server_ota.c (Wave 23b, #332) ─ */
 
@@ -473,141 +398,8 @@ static esp_err_t sdcard_handler(httpd_req_t *req)
 /* s_nav_target + s_navigating + tab5_debug_set_nav_target +
  * async_navigate moved to debug_server_nav.c (Wave 23b #332). */
 
-/* ── /widget — testing-only hook that injects a widget_live into the store
- *   without requiring Dragon. Body is JSON matching widget_live schema (see
- *   TinkerBox docs/protocol.md §17.2). Used by the Widget Platform test
- *   harness before the Dragon Tab5Surface is wired. */
-#include "widget.h"
-static void async_widget_refresh(void *arg) {
-    (void)arg;
-    extern void ui_home_update_status(void);
-    ui_home_update_status();
-}
-
-static esp_err_t widget_handler(httpd_req_t *req)
-{
-    if (!check_auth(req)) return ESP_OK;
-
-    /* Read body */
-    int len = req->content_len;
-    if (len <= 0 || len > 2048) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "body 1..2048 bytes");
-        return ESP_FAIL;
-    }
-    char *buf = malloc(len + 1);
-    if (!buf) { httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom"); return ESP_FAIL; }
-    int got = 0;
-    while (got < len) {
-        int r = httpd_req_recv(req, buf + got, len - got);
-        if (r <= 0) { free(buf); httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "read"); return ESP_FAIL; }
-        got += r;
-    }
-    buf[len] = '\0';
-
-    cJSON *root = cJSON_Parse(buf);
-    free(buf);
-    if (!root) {
-        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid JSON");
-        return ESP_FAIL;
-    }
-
-    const char *action = cJSON_GetStringValue(cJSON_GetObjectItem(root, "action"));
-    if (action && !strcmp(action, "dismiss")) {
-        const char *cid = cJSON_GetStringValue(cJSON_GetObjectItem(root, "card_id"));
-        if (cid) widget_store_dismiss(cid);
-        cJSON_Delete(root);
-        tab5_lv_async_call(async_widget_refresh, NULL);
-        httpd_resp_sendstr(req, "{\"ok\":true}");
-        return ESP_OK;
-    }
-
-    /* Build widget_t from JSON */
-    widget_t w = {0};
-    const char *sid = cJSON_GetStringValue(cJSON_GetObjectItem(root, "skill_id"));
-    const char *cid = cJSON_GetStringValue(cJSON_GetObjectItem(root, "card_id"));
-    const char *ttl = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
-    const char *bdy = cJSON_GetStringValue(cJSON_GetObjectItem(root, "body"));
-    const char *icn = cJSON_GetStringValue(cJSON_GetObjectItem(root, "icon"));
-    const char *tn  = cJSON_GetStringValue(cJSON_GetObjectItem(root, "tone"));
-    cJSON *prog     = cJSON_GetObjectItem(root, "progress");
-    cJSON *pri      = cJSON_GetObjectItem(root, "priority");
-    cJSON *act      = cJSON_GetObjectItem(root, "action");
-
-    if (!cid) cid = "debug_1";
-    if (!sid) sid = "debug";
-    strncpy(w.card_id,  cid, WIDGET_ID_LEN - 1);
-    strncpy(w.skill_id, sid, WIDGET_SKILL_ID_LEN - 1);
-    if (ttl) strncpy(w.title, ttl, WIDGET_TITLE_LEN - 1);
-    if (bdy) strncpy(w.body,  bdy, WIDGET_BODY_LEN  - 1);
-    if (icn) strncpy(w.icon,  icn, WIDGET_ICON_LEN  - 1);
-    /* v4·D Phase 4c: optional "type" + "items" fields let the debug
-     * endpoint inject widget_list payloads for visual testing. */
-    const char *tstr = cJSON_GetStringValue(cJSON_GetObjectItem(root, "type"));
-    w.type = tstr ? widget_type_from_str(tstr) : WIDGET_TYPE_LIVE;
-    if (w.type == WIDGET_TYPE_NONE) w.type = WIDGET_TYPE_LIVE;
-    w.tone     = widget_tone_from_str(tn);
-    w.progress = cJSON_IsNumber(prog) ? (float)prog->valuedouble : 0.0f;
-    w.priority = cJSON_IsNumber(pri)  ? (uint8_t)pri->valueint   : 50;
-    if (cJSON_IsObject(act)) {
-        const char *al = cJSON_GetStringValue(cJSON_GetObjectItem(act, "label"));
-        const char *ae = cJSON_GetStringValue(cJSON_GetObjectItem(act, "event"));
-        if (al) strncpy(w.action_label, al, WIDGET_ACTION_LBL_LEN - 1);
-        if (ae) strncpy(w.action_event, ae, WIDGET_ACTION_EVT_LEN - 1);
-    }
-    cJSON *items = cJSON_GetObjectItem(root, "items");
-    if (cJSON_IsArray(items)) {
-        int cnt = cJSON_GetArraySize(items);
-        if (cnt > WIDGET_LIST_MAX_ITEMS) cnt = WIDGET_LIST_MAX_ITEMS;
-        for (int i = 0; i < cnt; i++) {
-            cJSON *it = cJSON_GetArrayItem(items, i);
-            if (!cJSON_IsObject(it)) continue;
-            const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(it, "text"));
-            const char *v = cJSON_GetStringValue(cJSON_GetObjectItem(it, "value"));
-            if (t) strncpy(w.items[i].text,  t, WIDGET_LIST_ITEM_TEXT_LEN  - 1);
-            if (v) strncpy(w.items[i].value, v, WIDGET_LIST_ITEM_VALUE_LEN - 1);
-        }
-        w.items_count = (uint8_t)cnt;
-    }
-    /* v4·D Phase 4f: optional "values" + "max" fields for widget_chart. */
-    cJSON *vals = cJSON_GetObjectItem(root, "values");
-    if (cJSON_IsArray(vals)) {
-        int cnt = cJSON_GetArraySize(vals);
-        if (cnt > WIDGET_CHART_MAX_POINTS) cnt = WIDGET_CHART_MAX_POINTS;
-        for (int i = 0; i < cnt; i++) {
-            cJSON *v = cJSON_GetArrayItem(vals, i);
-            w.chart_values[i] = cJSON_IsNumber(v) ? (float)v->valuedouble : 0.0f;
-        }
-        w.chart_count = (uint8_t)cnt;
-    }
-    cJSON *mx = cJSON_GetObjectItem(root, "max");
-    w.chart_max = cJSON_IsNumber(mx) ? (float)mx->valuedouble : 0.0f;
-    /* v4·D Phase 4g: media + prompt fields for /widget debug injection. */
-    const char *media_url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
-    const char *media_alt = cJSON_GetStringValue(cJSON_GetObjectItem(root, "alt"));
-    if (media_url) strncpy(w.media_url, media_url, WIDGET_MEDIA_URL_LEN - 1);
-    if (media_alt) strncpy(w.media_alt, media_alt, WIDGET_MEDIA_ALT_LEN - 1);
-    cJSON *choices = cJSON_GetObjectItem(root, "choices");
-    if (cJSON_IsArray(choices)) {
-        int cnt = cJSON_GetArraySize(choices);
-        if (cnt > WIDGET_PROMPT_MAX_CHOICES) cnt = WIDGET_PROMPT_MAX_CHOICES;
-        for (int i = 0; i < cnt; i++) {
-            cJSON *it = cJSON_GetArrayItem(choices, i);
-            if (!cJSON_IsObject(it)) continue;
-            const char *t  = cJSON_GetStringValue(cJSON_GetObjectItem(it, "text"));
-            const char *ev = cJSON_GetStringValue(cJSON_GetObjectItem(it, "event"));
-            if (t)  strncpy(w.choices[i].text,  t,  WIDGET_PROMPT_CHOICE_LEN - 1);
-            if (ev) strncpy(w.choices[i].event, ev, WIDGET_PROMPT_EVENT_LEN - 1);
-        }
-        w.choices_count = (uint8_t)cnt;
-    }
-    widget_store_upsert(&w);
-    cJSON_Delete(root);
-    tab5_lv_async_call(async_widget_refresh, NULL);
-
-    httpd_resp_set_type(req, "application/json");
-    httpd_resp_sendstr(req, "{\"ok\":true}");
-    return ESP_OK;
-}
+/* widget_handler + async_widget_refresh moved to debug_server_admin.c
+ * (Wave 23b #332). */
 
 /* navigate_handler moved to debug_server_nav.c (Wave 23b #332). */
 
@@ -1741,27 +1533,21 @@ esp_err_t tab5_debug_server_init(void)
         .uri = "/info", .method = HTTP_GET, .handler = info_handler
     };
     /* /touch registered via debug_server_input_register() below. */
-    const httpd_uri_t uri_reboot = {
-        .uri = "/reboot", .method = HTTP_POST, .handler = reboot_handler
-    };
+    /* /reboot registered via debug_server_admin_register() below. */
     /* /log registered via debug_server_obs_register() below. */
 
     /* #148: /open merged into /navigate (single source of truth for
      * screen list).  /navtouch dropped — same underlying dispatcher. */
     /* /coredump /heap_trace_start /heap_trace_dump /crashlog
      * registered via debug_server_obs_register() below. */
-    const httpd_uri_t uri_sdcard = {
-        .uri = "/sdcard", .method = HTTP_GET, .handler = sdcard_handler
-    };
+    /* /sdcard registered via debug_server_admin_register() below. */
     /* #148: /wake removed (feature parked) — /info still reports state. */
     /* Wave 23b (#332): /settings GET+POST + /nvs/erase + /mode all
      * registered en-bloc via the per-family extracted modules
      * (debug_server_settings_register, debug_server_mode_register)
      * below. */
     /* /navigate registered via debug_server_nav_register() below. */
-    const httpd_uri_t uri_widget = {
-        .uri = "/widget", .method = HTTP_POST, .handler = widget_handler
-    };
+    /* /widget registered via debug_server_admin_register() below. */
     /* /camera registered via debug_server_camera_register() below. */
     /* Wave 23b (#332): OTA endpoint family — registered en-bloc via
      * debug_server_ota_register() below. */
@@ -1830,14 +1616,12 @@ esp_err_t tab5_debug_server_init(void)
 
     httpd_register_uri_handler(server, &uri_index);
     httpd_register_uri_handler(server, &uri_info);
-    httpd_register_uri_handler(server, &uri_reboot);
     debug_server_obs_register(server);
-    httpd_register_uri_handler(server, &uri_sdcard);
     /* Wave 23b (#332): /settings (GET+POST) + /nvs/erase registered en-bloc. */
     debug_server_settings_register(server);
     /* Wave 23b (#332): /mode endpoint family registered en-bloc. */
     debug_server_mode_register(server);
-    httpd_register_uri_handler(server, &uri_widget);
+    debug_server_admin_register(server);
     debug_server_camera_register(server);
     /* Wave 23b (#332): OTA endpoint family registered en-bloc. */
     debug_server_ota_register(server);

--- a/main/debug_server_admin.c
+++ b/main/debug_server_admin.c
@@ -1,0 +1,272 @@
+/*
+ * debug_server_admin.c — system-control / storage / widget-injection
+ * debug HTTP family.
+ *
+ * Wave 23b follow-up (#332): fifteenth per-family extract.  Owns:
+ *
+ *   POST /reboot     — esp_restart after a 500 ms grace
+ *   GET  /sdcard     — mount state + total/free MB + root + /sdcard/rec
+ *                      directory listings
+ *   POST /widget     — test-harness hook that injects a widget_live (or
+ *                      dismisses one) directly into the widget store,
+ *                      bypassing Dragon.  Body matches the widget_live
+ *                      schema (TinkerBox docs/protocol.md §17.2).
+ *
+ * Same convention as the prior 14 per-family extracts:
+ *   check_auth(req)  → tab5_debug_check_auth(req)
+ */
+#include "debug_server_admin.h"
+
+#include <dirent.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "cJSON.h"
+#include "debug_server_internal.h"
+#include "esp_err.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "sdcard.h"
+#include "ui_core.h" /* tab5_lv_async_call */
+#include "widget.h"
+
+static const char *TAG = "debug_admin";
+
+#define check_auth(req) tab5_debug_check_auth(req)
+
+/* ── POST /reboot ────────────────────────────────────────────────────── */
+
+static esp_err_t reboot_handler(httpd_req_t *req) {
+   if (!check_auth(req)) return ESP_OK;
+
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_sendstr(req, "{\"rebooting\":true}");
+   ESP_LOGW(TAG, "Reboot requested via debug server");
+   vTaskDelay(pdMS_TO_TICKS(500));
+   esp_restart();
+   return ESP_OK; /* unreachable */
+}
+
+/* ── GET /sdcard ─────────────────────────────────────────────────────── */
+
+static void list_dir_to_json(cJSON *arr, const char *path) {
+   DIR *d = opendir(path);
+   if (!d) return;
+
+   struct dirent *entry;
+   while ((entry = readdir(d)) != NULL) {
+      char full[320];
+      snprintf(full, sizeof(full), "%s/%s", path, entry->d_name);
+
+      struct stat st;
+      stat(full, &st);
+
+      cJSON *item = cJSON_CreateObject();
+      cJSON_AddStringToObject(item, "name", entry->d_name);
+      cJSON_AddStringToObject(item, "path", full);
+      cJSON_AddBoolToObject(item, "dir", entry->d_type == DT_DIR);
+      if (entry->d_type != DT_DIR) {
+         cJSON_AddNumberToObject(item, "size", (double)st.st_size);
+      }
+      cJSON_AddItemToArray(arr, item);
+   }
+   closedir(d);
+}
+
+static esp_err_t sdcard_handler(httpd_req_t *req) {
+   if (!check_auth(req)) return ESP_OK;
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "mounted", tab5_sdcard_mounted());
+
+   if (tab5_sdcard_mounted()) {
+      cJSON_AddNumberToObject(root, "total_mb", (double)(tab5_sdcard_total_bytes() / (1024 * 1024)));
+      cJSON_AddNumberToObject(root, "free_mb", (double)(tab5_sdcard_free_bytes() / (1024 * 1024)));
+
+      /* List /sdcard root */
+      cJSON *files = cJSON_AddArrayToObject(root, "files");
+      list_dir_to_json(files, "/sdcard");
+
+      /* List /sdcard/rec if it exists */
+      struct stat st;
+      if (stat("/sdcard/rec", &st) == 0) {
+         cJSON *recs = cJSON_AddArrayToObject(root, "recordings");
+         list_dir_to_json(recs, "/sdcard/rec");
+      }
+   }
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!json) {
+      httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "JSON alloc");
+      return ESP_FAIL;
+   }
+
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+   httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Authorization");
+   esp_err_t ret = httpd_resp_sendstr(req, json);
+   free(json);
+   return ret;
+}
+
+/* ── POST /widget ────────────────────────────────────────────────────── */
+/* Testing-only hook that injects a widget_live into the store without
+ * requiring Dragon. Body is JSON matching widget_live schema (see
+ * TinkerBox docs/protocol.md §17.2). Used by the Widget Platform test
+ * harness before the Dragon Tab5Surface is wired. */
+
+static void async_widget_refresh(void *arg) {
+   (void)arg;
+   extern void ui_home_update_status(void);
+   ui_home_update_status();
+}
+
+static esp_err_t widget_handler(httpd_req_t *req) {
+   if (!check_auth(req)) return ESP_OK;
+
+   /* Read body */
+   int len = req->content_len;
+   if (len <= 0 || len > 2048) {
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "body 1..2048 bytes");
+      return ESP_FAIL;
+   }
+   char *buf = malloc(len + 1);
+   if (!buf) {
+      httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "oom");
+      return ESP_FAIL;
+   }
+   int got = 0;
+   while (got < len) {
+      int r = httpd_req_recv(req, buf + got, len - got);
+      if (r <= 0) {
+         free(buf);
+         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "read");
+         return ESP_FAIL;
+      }
+      got += r;
+   }
+   buf[len] = '\0';
+
+   cJSON *root = cJSON_Parse(buf);
+   free(buf);
+   if (!root) {
+      httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid JSON");
+      return ESP_FAIL;
+   }
+
+   const char *action = cJSON_GetStringValue(cJSON_GetObjectItem(root, "action"));
+   if (action && !strcmp(action, "dismiss")) {
+      const char *cid = cJSON_GetStringValue(cJSON_GetObjectItem(root, "card_id"));
+      if (cid) widget_store_dismiss(cid);
+      cJSON_Delete(root);
+      tab5_lv_async_call(async_widget_refresh, NULL);
+      httpd_resp_sendstr(req, "{\"ok\":true}");
+      return ESP_OK;
+   }
+
+   /* Build widget_t from JSON */
+   widget_t w = {0};
+   const char *sid = cJSON_GetStringValue(cJSON_GetObjectItem(root, "skill_id"));
+   const char *cid = cJSON_GetStringValue(cJSON_GetObjectItem(root, "card_id"));
+   const char *ttl = cJSON_GetStringValue(cJSON_GetObjectItem(root, "title"));
+   const char *bdy = cJSON_GetStringValue(cJSON_GetObjectItem(root, "body"));
+   const char *icn = cJSON_GetStringValue(cJSON_GetObjectItem(root, "icon"));
+   const char *tn = cJSON_GetStringValue(cJSON_GetObjectItem(root, "tone"));
+   cJSON *prog = cJSON_GetObjectItem(root, "progress");
+   cJSON *pri = cJSON_GetObjectItem(root, "priority");
+   cJSON *act = cJSON_GetObjectItem(root, "action");
+
+   if (!cid) cid = "debug_1";
+   if (!sid) sid = "debug";
+   strncpy(w.card_id, cid, WIDGET_ID_LEN - 1);
+   strncpy(w.skill_id, sid, WIDGET_SKILL_ID_LEN - 1);
+   if (ttl) strncpy(w.title, ttl, WIDGET_TITLE_LEN - 1);
+   if (bdy) strncpy(w.body, bdy, WIDGET_BODY_LEN - 1);
+   if (icn) strncpy(w.icon, icn, WIDGET_ICON_LEN - 1);
+   /* v4·D Phase 4c: optional "type" + "items" fields let the debug
+    * endpoint inject widget_list payloads for visual testing. */
+   const char *tstr = cJSON_GetStringValue(cJSON_GetObjectItem(root, "type"));
+   w.type = tstr ? widget_type_from_str(tstr) : WIDGET_TYPE_LIVE;
+   if (w.type == WIDGET_TYPE_NONE) w.type = WIDGET_TYPE_LIVE;
+   w.tone = widget_tone_from_str(tn);
+   w.progress = cJSON_IsNumber(prog) ? (float)prog->valuedouble : 0.0f;
+   w.priority = cJSON_IsNumber(pri) ? (uint8_t)pri->valueint : 50;
+   if (cJSON_IsObject(act)) {
+      const char *al = cJSON_GetStringValue(cJSON_GetObjectItem(act, "label"));
+      const char *ae = cJSON_GetStringValue(cJSON_GetObjectItem(act, "event"));
+      if (al) strncpy(w.action_label, al, WIDGET_ACTION_LBL_LEN - 1);
+      if (ae) strncpy(w.action_event, ae, WIDGET_ACTION_EVT_LEN - 1);
+   }
+   cJSON *items = cJSON_GetObjectItem(root, "items");
+   if (cJSON_IsArray(items)) {
+      int cnt = cJSON_GetArraySize(items);
+      if (cnt > WIDGET_LIST_MAX_ITEMS) cnt = WIDGET_LIST_MAX_ITEMS;
+      for (int i = 0; i < cnt; i++) {
+         cJSON *it = cJSON_GetArrayItem(items, i);
+         if (!cJSON_IsObject(it)) continue;
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(it, "text"));
+         const char *v = cJSON_GetStringValue(cJSON_GetObjectItem(it, "value"));
+         if (t) strncpy(w.items[i].text, t, WIDGET_LIST_ITEM_TEXT_LEN - 1);
+         if (v) strncpy(w.items[i].value, v, WIDGET_LIST_ITEM_VALUE_LEN - 1);
+      }
+      w.items_count = (uint8_t)cnt;
+   }
+   /* v4·D Phase 4f: optional "values" + "max" fields for widget_chart. */
+   cJSON *vals = cJSON_GetObjectItem(root, "values");
+   if (cJSON_IsArray(vals)) {
+      int cnt = cJSON_GetArraySize(vals);
+      if (cnt > WIDGET_CHART_MAX_POINTS) cnt = WIDGET_CHART_MAX_POINTS;
+      for (int i = 0; i < cnt; i++) {
+         cJSON *v = cJSON_GetArrayItem(vals, i);
+         w.chart_values[i] = cJSON_IsNumber(v) ? (float)v->valuedouble : 0.0f;
+      }
+      w.chart_count = (uint8_t)cnt;
+   }
+   cJSON *mx = cJSON_GetObjectItem(root, "max");
+   w.chart_max = cJSON_IsNumber(mx) ? (float)mx->valuedouble : 0.0f;
+   /* v4·D Phase 4g: media + prompt fields for /widget debug injection. */
+   const char *media_url = cJSON_GetStringValue(cJSON_GetObjectItem(root, "url"));
+   const char *media_alt = cJSON_GetStringValue(cJSON_GetObjectItem(root, "alt"));
+   if (media_url) strncpy(w.media_url, media_url, WIDGET_MEDIA_URL_LEN - 1);
+   if (media_alt) strncpy(w.media_alt, media_alt, WIDGET_MEDIA_ALT_LEN - 1);
+   cJSON *choices = cJSON_GetObjectItem(root, "choices");
+   if (cJSON_IsArray(choices)) {
+      int cnt = cJSON_GetArraySize(choices);
+      if (cnt > WIDGET_PROMPT_MAX_CHOICES) cnt = WIDGET_PROMPT_MAX_CHOICES;
+      for (int i = 0; i < cnt; i++) {
+         cJSON *it = cJSON_GetArrayItem(choices, i);
+         if (!cJSON_IsObject(it)) continue;
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(it, "text"));
+         const char *ev = cJSON_GetStringValue(cJSON_GetObjectItem(it, "event"));
+         if (t) strncpy(w.choices[i].text, t, WIDGET_PROMPT_CHOICE_LEN - 1);
+         if (ev) strncpy(w.choices[i].event, ev, WIDGET_PROMPT_EVENT_LEN - 1);
+      }
+      w.choices_count = (uint8_t)cnt;
+   }
+   widget_store_upsert(&w);
+   cJSON_Delete(root);
+   tab5_lv_async_call(async_widget_refresh, NULL);
+
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_sendstr(req, "{\"ok\":true}");
+   return ESP_OK;
+}
+
+void debug_server_admin_register(httpd_handle_t server) {
+   if (!server) return;
+
+   static const httpd_uri_t uri_reboot = {.uri = "/reboot", .method = HTTP_POST, .handler = reboot_handler};
+   static const httpd_uri_t uri_sdcard = {.uri = "/sdcard", .method = HTTP_GET, .handler = sdcard_handler};
+   static const httpd_uri_t uri_widget = {.uri = "/widget", .method = HTTP_POST, .handler = widget_handler};
+
+   httpd_register_uri_handler(server, &uri_reboot);
+   httpd_register_uri_handler(server, &uri_sdcard);
+   httpd_register_uri_handler(server, &uri_widget);
+}

--- a/main/debug_server_admin.h
+++ b/main/debug_server_admin.h
@@ -1,0 +1,23 @@
+/*
+ * debug_server_admin.h — system-control / storage / widget-injection
+ * debug HTTP family.
+ *
+ * Wave 23b follow-up (#332): fifteenth per-family extract.  Owns
+ * /reboot, /sdcard (storage listing), and /widget (test-harness
+ * widget injection — bypasses Dragon).
+ */
+#pragma once
+
+#include "esp_http_server.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Registers /reboot + /sdcard + /widget against the live HTTPD server.
+ * Called from debug_server.c init after the server is started. */
+void debug_server_admin_register(httpd_handle_t server);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

Wave 23b · 15th per-family extract from debug_server.c (refs #332).  Pulls system-control + storage + widget-injection handlers into a new sibling \`debug_server_admin.{c,h}\`.

## Endpoints moved (all bearer-auth)

| Method + URI | Purpose |
|---|---|
| POST /reboot | esp_restart after a 500 ms grace |
| GET  /sdcard | mount state + total/free MB + root + /sdcard/rec directory listings |
| POST /widget | test-harness hook — inject a widget_live (or dismiss one) into the widget store, bypasses Dragon |

## Helpers moved alongside

- \`list_dir_to_json\` (was file-static \`_list_dir_to_json\`; only sdcard_handler used it)
- \`async_widget_refresh\` (LVGL-thread re-render after upsert/dismiss)

## Verification on physical Tab5 192.168.1.90

- \`idf.py build\` clean, \`git-clang-format --diff\` empty
- **story_smoke 14/14 in 75s**
- \`GET /sdcard\`  → \`{mounted=true, total_mb=121942, free_mb=121730, files=[...], recordings=[...]}\`
- \`POST /widget {\"card_id\":\"test_admin\",...}\` → \`{\"ok\":true}\`
- \`/reboot\` deliberately not exercised (would terminate the test session)

## LOC

| File | Before | After | Δ |
|---|---|---|---|
| \`main/debug_server.c\` | 1,907 | ~1,640 | -267 |
| \`main/debug_server_admin.c\` | 0 | 270 | +270 |

Refs #332.