### PR TITLE
refactor(debug_server): extract /debug/inject_* test-harness family (refs #332)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"
              "debug_server_call.c" "debug_server_camera.c" "debug_server_obs.c"
              "debug_server_input.c" "debug_server_nav.c" "debug_server_admin.c"
-             "debug_server_chat.c"
+             "debug_server_chat.c" "debug_server_inject.c"
              "debug_obs.c" "pool_probe.c" "heap_watchdog.c"
              "service_registry.c" "service_storage.c" "service_display.c"
              "service_audio.c" "service_network.c" "service_dragon.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -63,6 +63,7 @@
 #include "debug_server_chat.h"
 #include "debug_server_codec.h"
 #include "debug_server_dictation.h"
+#include "debug_server_inject.h"
 #include "debug_server_input.h"
 #include "debug_server_internal.h"
 #include "debug_server_m5.h"
@@ -1046,215 +1047,9 @@ static esp_err_t ping_handler(httpd_req_t *req)
 /* ── POST /nvs/erase family extracted to debug_server_settings.c
  *    (Wave 23b, #332) — handler + register live there now. ─────────── */
 
-/* TT #328 Wave 12 — async banner trampoline for /debug/inject_error.
- * Fires on the LVGL thread; takes ownership of the heap-allocated
- * argument struct. */
-typedef struct {
-   char txt[96];
-} debug_inject_banner_arg_t;
-void debug_inject_banner_async(void *arg) {
-   debug_inject_banner_arg_t *p = (debug_inject_banner_arg_t *)arg;
-   if (!p) return;
-   extern void ui_home_show_error_banner(const char *, void (*)(void));
-   ui_home_show_error_banner(p->txt, NULL /* non-dismissable */);
-   free(p);
-}
-
-/* TT #328 Wave 13 — /debug/inject_audio.  Bypass mic + pump caller-
- * supplied PCM through the same WS binary path the mic task uses.
- * Lets the harness validate STT round-trip without canned-mic setup.
- * Wire: raw POST body = 16 kHz mono int16 LE PCM, 1..64 KB. */
-static esp_err_t debug_inject_audio_handler_impl(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   if (req->content_len <= 0 || req->content_len > 65536) {
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "POST body must be 16 kHz mono int16 PCM, 1..64 KB");
-      return send_json_resp(req, r);
-   }
-   uint8_t *pcm = heap_caps_malloc(req->content_len, MALLOC_CAP_SPIRAM);
-   if (!pcm) {
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "PSRAM alloc failed");
-      return send_json_resp(req, r);
-   }
-   int total = 0;
-   while (total < req->content_len) {
-      int n = httpd_req_recv(req, (char *)pcm + total, req->content_len - total);
-      if (n <= 0) break;
-      total += n;
-   }
-   if (total != req->content_len) {
-      heap_caps_free(pcm);
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "short read");
-      return send_json_resp(req, r);
-   }
-   extern esp_err_t voice_start_listening(void);
-   extern esp_err_t voice_stop_listening(void);
-   extern esp_err_t voice_ws_send_binary_public(const void *data, size_t len);
-   esp_err_t e = voice_start_listening();
-   if (e != ESP_OK) {
-      heap_caps_free(pcm);
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "voice_start_listening failed");
-      cJSON_AddStringToObject(r, "esp_err", esp_err_to_name(e));
-      return send_json_resp(req, r);
-   }
-   vTaskDelay(pdMS_TO_TICKS(60));
-   /* 16 kHz × 20 ms = 320 samples × 2 = 640 B/frame, 20 ms cadence. */
-   const size_t frame_bytes = 640;
-   int frames_sent = 0;
-   int bytes_sent = 0;
-   for (int off = 0; off < total; off += frame_bytes) {
-      size_t chunk = total - off;
-      if (chunk > frame_bytes) chunk = frame_bytes;
-      if (voice_ws_send_binary_public(pcm + off, chunk) == ESP_OK) {
-         frames_sent++;
-         bytes_sent += chunk;
-      }
-      vTaskDelay(pdMS_TO_TICKS(20));
-   }
-   vTaskDelay(pdMS_TO_TICKS(80));
-   voice_stop_listening();
-   heap_caps_free(pcm);
-   cJSON *r = cJSON_CreateObject();
-   cJSON_AddBoolToObject(r, "ok", true);
-   cJSON_AddNumberToObject(r, "frames_sent", frames_sent);
-   cJSON_AddNumberToObject(r, "bytes_sent", bytes_sent);
-   tab5_debug_obs_event("debug.inject_audio", "done");
-   return send_json_resp(req, r);
-}
-
-esp_err_t debug_inject_audio_handler(httpd_req_t *req) { return debug_inject_audio_handler_impl(req); }
-
-/* ── Codec endpoint family extracted to debug_server_codec.c (Wave 23b, #332) ─ */
-
-/* TT #328 Wave 12 — synthesize Wave 3 error.* events + their banner/
- * toast UX without needing real fault conditions.  POST body or query
- * params:
- *
- *   {"class": "dragon" | "auth" | "ota" | "sd" | "k144",
- *    "detail": "<obs detail>",
- *    "banner": true|false,
- *    "banner_text": "<optional override>"}
- *
- * Always fires the obs event "error.<class> <detail>".  When
- * banner=true (default), also shows the persistent error banner with
- * banner_text.  Returns {"ok":true,"fired":"error.<class>"}. */
-static esp_err_t debug_inject_error_handler_impl(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-
-   char body[256] = {0};
-   int total = 0;
-   if (req->content_len > 0 && req->content_len < (int)sizeof(body)) {
-      int n = httpd_req_recv(req, body, req->content_len);
-      total = n > 0 ? n : 0;
-   }
-   body[total] = '\0';
-
-   char err_class[16] = {0};
-   char err_detail[40] = {0};
-   char banner_text[96] = {0};
-   bool show_banner = true;
-
-   /* Body JSON parse if present, else fall through to query params. */
-   if (body[0] == '{') {
-      cJSON *root = cJSON_Parse(body);
-      if (root) {
-         cJSON *c = cJSON_GetObjectItem(root, "class");
-         cJSON *d = cJSON_GetObjectItem(root, "detail");
-         cJSON *b = cJSON_GetObjectItem(root, "banner");
-         cJSON *t = cJSON_GetObjectItem(root, "banner_text");
-         if (cJSON_IsString(c)) strncpy(err_class, c->valuestring, sizeof(err_class) - 1);
-         if (cJSON_IsString(d)) strncpy(err_detail, d->valuestring, sizeof(err_detail) - 1);
-         if (cJSON_IsBool(b)) show_banner = cJSON_IsTrue(b);
-         if (cJSON_IsString(t)) strncpy(banner_text, t->valuestring, sizeof(banner_text) - 1);
-         cJSON_Delete(root);
-      }
-   }
-   if (!err_class[0]) {
-      char q[128] = {0};
-      httpd_req_get_url_query_str(req, q, sizeof(q));
-      httpd_query_key_value(q, "class", err_class, sizeof(err_class));
-      httpd_query_key_value(q, "detail", err_detail, sizeof(err_detail));
-   }
-   if (!err_class[0]) {
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "missing class (dragon|auth|ota|sd|k144)");
-      return send_json_resp(req, r);
-   }
-
-   char kind[32];
-   snprintf(kind, sizeof(kind), "error.%s", err_class);
-   tab5_debug_obs_event(kind, err_detail[0] ? err_detail : "synthetic");
-
-   if (show_banner) {
-      const char *txt = banner_text[0] ? banner_text : "Synthetic error injection (debug)";
-      debug_inject_banner_arg_t *arg = malloc(sizeof(*arg));
-      if (arg) {
-         strncpy(arg->txt, txt, sizeof(arg->txt) - 1);
-         arg->txt[sizeof(arg->txt) - 1] = '\0';
-         /* Marshalled to LVGL thread.  Static cb avoids GCC nested-
-          * function trampoline (project avoids those per LEARNINGS). */
-         extern lv_result_t tab5_lv_async_call(lv_async_cb_t cb, void *user_data);
-         tab5_lv_async_call(debug_inject_banner_async, arg);
-      }
-   }
-
-   cJSON *r = cJSON_CreateObject();
-   cJSON_AddBoolToObject(r, "ok", true);
-   cJSON_AddStringToObject(r, "fired", kind);
-   cJSON_AddStringToObject(r, "detail", err_detail);
-   cJSON_AddBoolToObject(r, "banner", show_banner);
-   return send_json_resp(req, r);
-}
-
-esp_err_t debug_inject_error_handler(httpd_req_t *req) { return debug_inject_error_handler_impl(req); }
-
-/* TT #328 Wave 2 — POST /debug/inject_ws.  Body is a JSON string that
- * gets routed through voice.c's WS text dispatcher as if Dragon had
- * sent it.  Lets the e2e harness exercise toast/banner UX paths
- * without needing Dragon to genuinely fail (e.g. fire a fake
- * config_update.error → assert banner → fire a fake llm_done → assert
- * banner cleared).  Body size capped at 2 KB; bigger frames don't
- * fit through the WS path either. */
-static esp_err_t debug_inject_ws_handler_impl(httpd_req_t *req) {
-   if (!check_auth(req)) return ESP_OK;
-   if (req->content_len <= 0 || req->content_len > 2048) {
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "POST body must be JSON, 1..2048 bytes");
-      return send_json_resp(req, r);
-   }
-   char *buf = heap_caps_malloc(req->content_len + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-   if (!buf) {
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "PSRAM alloc failed");
-      return send_json_resp(req, r);
-   }
-   int total = 0;
-   while (total < req->content_len) {
-      int n = httpd_req_recv(req, buf + total, req->content_len - total);
-      if (n <= 0) break;
-      total += n;
-   }
-   buf[total] = '\0';
-   if (total != req->content_len) {
-      heap_caps_free(buf);
-      cJSON *r = cJSON_CreateObject();
-      cJSON_AddStringToObject(r, "error", "short read");
-      return send_json_resp(req, r);
-   }
-   extern void voice_debug_inject_text(const char *data, int len);
-   voice_debug_inject_text(buf, total);
-   heap_caps_free(buf);
-   cJSON *r = cJSON_CreateObject();
-   cJSON_AddBoolToObject(r, "ok", true);
-   cJSON_AddNumberToObject(r, "bytes", total);
-   tab5_debug_obs_event("debug.inject_ws", "done");
-   return send_json_resp(req, r);
-}
-
-esp_err_t debug_inject_ws_handler(httpd_req_t *req) { return debug_inject_ws_handler_impl(req); }
+/* debug_inject_banner_arg_t + banner_async + /debug/inject_audio +
+ * /debug/inject_error + /debug/inject_ws moved to
+ * debug_server_inject.c (Wave 23b #332). */
 
 /* ======================================================================== */
 /*  Server init                                                              */
@@ -1398,21 +1193,14 @@ esp_err_t tab5_debug_server_init(void)
      * harness validate the persistent banner + tone-aware toast paths
      * for error.dragon / error.auth / error.ota / error.sd / error.k144
      * end-to-end. */
-    extern esp_err_t debug_inject_error_handler(httpd_req_t * req);
-    const httpd_uri_t uri_inject_error = {
-        .uri = "/debug/inject_error", .method = HTTP_POST, .handler = debug_inject_error_handler};
-    extern esp_err_t debug_inject_audio_handler(httpd_req_t * req);
-    const httpd_uri_t uri_inject_audio = {
-        .uri = "/debug/inject_audio", .method = HTTP_POST, .handler = debug_inject_audio_handler};
+    /* /debug/inject_error + /debug/inject_audio + /debug/inject_ws
+     * registered via debug_server_inject_register() below. */
     /* Wave 23b (#332): codec endpoint family — registered en-bloc via
      * debug_server_codec_register() below. */
 
     /* TT #328 Wave 2 — synthetic WS-frame injector for error-surfacing
      * user-story tests (config_update.error, dictation_postprocessing_*,
      * generic `error`-type frames). */
-    extern esp_err_t debug_inject_ws_handler(httpd_req_t * req);
-    const httpd_uri_t uri_inject_ws = {
-        .uri = "/debug/inject_ws", .method = HTTP_POST, .handler = debug_inject_ws_handler};
 
     httpd_register_uri_handler(server, &uri_index);
     httpd_register_uri_handler(server, &uri_info);
@@ -1456,11 +1244,9 @@ esp_err_t tab5_debug_server_init(void)
     httpd_register_uri_handler(server, &uri_kb_layout);
     httpd_register_uri_handler(server, &uri_net_ping);
     /* /nvs/erase registered via debug_server_settings_register() above. */
-    httpd_register_uri_handler(server, &uri_inject_error);
-    httpd_register_uri_handler(server, &uri_inject_audio);
+    debug_server_inject_register(server);
     /* Wave 23b (#332): codec endpoint family registered en-bloc. */
     debug_server_codec_register(server);
-    httpd_register_uri_handler(server, &uri_inject_ws);
 
     /* Log the URL */
     char ip[20];

--- a/main/debug_server_inject.c
+++ b/main/debug_server_inject.c
@@ -1,0 +1,249 @@
+/*
+ * debug_server_inject.c — synthetic-injection debug HTTP family.
+ *
+ * Wave 23b follow-up (#332): seventeenth per-family extract.  Owns:
+ *
+ *   POST /debug/inject_audio  — pump caller-supplied PCM through the
+ *                               same WS binary path the mic task uses.
+ *                               Wire: raw POST body = 16 kHz mono int16
+ *                               LE PCM, 1..64 KB.  Bypasses the mic
+ *                               capture loop so the harness can validate
+ *                               STT round-trip without canned audio.
+ *   POST /debug/inject_error  — synthesise a Wave 3 error.* obs event +
+ *                               persistent banner.  Body or query:
+ *                                 class=dragon|auth|ota|sd|k144
+ *                                 detail=<short string>
+ *                                 banner=true|false (default true)
+ *                                 banner_text=<override>
+ *   POST /debug/inject_ws     — route a JSON string through voice.c's
+ *                               WS text dispatcher as if Dragon had sent
+ *                               it.  Lets the harness exercise toast/
+ *                               banner UX paths without making Dragon
+ *                               genuinely fail.
+ *
+ * Same convention as the prior 16 per-family extracts:
+ *   check_auth(req)            → tab5_debug_check_auth(req)
+ *   send_json_resp(req, root)  → tab5_debug_send_json_resp(req, root)
+ */
+#include "debug_server_inject.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "debug_obs.h"
+#include "debug_server_internal.h"
+#include "esp_err.h"
+#include "esp_heap_caps.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "lvgl.h" /* lv_async_cb_t / lv_result_t signature for tab5_lv_async_call */
+
+/* TAG omitted — handlers below use fixed log strings rather than ESP_LOG. */
+
+#define check_auth(req) tab5_debug_check_auth(req)
+#define send_json_resp(req, root) tab5_debug_send_json_resp(req, root)
+
+/* ── Banner async trampoline (LVGL thread) ──────────────────────────── */
+/* TT #328 Wave 12 — async banner trampoline for /debug/inject_error.
+ * Fires on the LVGL thread; takes ownership of the heap-allocated
+ * argument struct. */
+typedef struct {
+   char txt[96];
+} debug_inject_banner_arg_t;
+
+static void debug_inject_banner_async(void *arg) {
+   debug_inject_banner_arg_t *p = (debug_inject_banner_arg_t *)arg;
+   if (!p) return;
+   extern void ui_home_show_error_banner(const char *, void (*)(void));
+   ui_home_show_error_banner(p->txt, NULL /* non-dismissable */);
+   free(p);
+}
+
+/* ── POST /debug/inject_audio ────────────────────────────────────────── */
+
+static esp_err_t debug_inject_audio_handler(httpd_req_t *req) {
+   if (!check_auth(req)) return ESP_OK;
+   if (req->content_len <= 0 || req->content_len > 65536) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "POST body must be 16 kHz mono int16 PCM, 1..64 KB");
+      return send_json_resp(req, r);
+   }
+   uint8_t *pcm = heap_caps_malloc(req->content_len, MALLOC_CAP_SPIRAM);
+   if (!pcm) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "PSRAM alloc failed");
+      return send_json_resp(req, r);
+   }
+   int total = 0;
+   while (total < req->content_len) {
+      int n = httpd_req_recv(req, (char *)pcm + total, req->content_len - total);
+      if (n <= 0) break;
+      total += n;
+   }
+   if (total != req->content_len) {
+      heap_caps_free(pcm);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "short read");
+      return send_json_resp(req, r);
+   }
+   extern esp_err_t voice_start_listening(void);
+   extern esp_err_t voice_stop_listening(void);
+   extern esp_err_t voice_ws_send_binary_public(const void *data, size_t len);
+   esp_err_t e = voice_start_listening();
+   if (e != ESP_OK) {
+      heap_caps_free(pcm);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "voice_start_listening failed");
+      cJSON_AddStringToObject(r, "esp_err", esp_err_to_name(e));
+      return send_json_resp(req, r);
+   }
+   vTaskDelay(pdMS_TO_TICKS(60));
+   /* 16 kHz × 20 ms = 320 samples × 2 = 640 B/frame, 20 ms cadence. */
+   const size_t frame_bytes = 640;
+   int frames_sent = 0;
+   int bytes_sent = 0;
+   for (int off = 0; off < total; off += frame_bytes) {
+      size_t chunk = total - off;
+      if (chunk > frame_bytes) chunk = frame_bytes;
+      if (voice_ws_send_binary_public(pcm + off, chunk) == ESP_OK) {
+         frames_sent++;
+         bytes_sent += chunk;
+      }
+      vTaskDelay(pdMS_TO_TICKS(20));
+   }
+   vTaskDelay(pdMS_TO_TICKS(80));
+   voice_stop_listening();
+   heap_caps_free(pcm);
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddBoolToObject(r, "ok", true);
+   cJSON_AddNumberToObject(r, "frames_sent", frames_sent);
+   cJSON_AddNumberToObject(r, "bytes_sent", bytes_sent);
+   tab5_debug_obs_event("debug.inject_audio", "done");
+   return send_json_resp(req, r);
+}
+
+/* ── POST /debug/inject_error ────────────────────────────────────────── */
+
+static esp_err_t debug_inject_error_handler(httpd_req_t *req) {
+   if (!check_auth(req)) return ESP_OK;
+
+   char body[256] = {0};
+   int total = 0;
+   if (req->content_len > 0 && req->content_len < (int)sizeof(body)) {
+      int n = httpd_req_recv(req, body, req->content_len);
+      total = n > 0 ? n : 0;
+   }
+   body[total] = '\0';
+
+   char err_class[16] = {0};
+   char err_detail[40] = {0};
+   char banner_text[96] = {0};
+   bool show_banner = true;
+
+   /* Body JSON parse if present, else fall through to query params. */
+   if (body[0] == '{') {
+      cJSON *root = cJSON_Parse(body);
+      if (root) {
+         cJSON *c = cJSON_GetObjectItem(root, "class");
+         cJSON *d = cJSON_GetObjectItem(root, "detail");
+         cJSON *b = cJSON_GetObjectItem(root, "banner");
+         cJSON *t = cJSON_GetObjectItem(root, "banner_text");
+         if (cJSON_IsString(c)) strncpy(err_class, c->valuestring, sizeof(err_class) - 1);
+         if (cJSON_IsString(d)) strncpy(err_detail, d->valuestring, sizeof(err_detail) - 1);
+         if (cJSON_IsBool(b)) show_banner = cJSON_IsTrue(b);
+         if (cJSON_IsString(t)) strncpy(banner_text, t->valuestring, sizeof(banner_text) - 1);
+         cJSON_Delete(root);
+      }
+   }
+   if (!err_class[0]) {
+      char q[128] = {0};
+      httpd_req_get_url_query_str(req, q, sizeof(q));
+      httpd_query_key_value(q, "class", err_class, sizeof(err_class));
+      httpd_query_key_value(q, "detail", err_detail, sizeof(err_detail));
+   }
+   if (!err_class[0]) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "missing class (dragon|auth|ota|sd|k144)");
+      return send_json_resp(req, r);
+   }
+
+   char kind[32];
+   snprintf(kind, sizeof(kind), "error.%s", err_class);
+   tab5_debug_obs_event(kind, err_detail[0] ? err_detail : "synthetic");
+
+   if (show_banner) {
+      const char *txt = banner_text[0] ? banner_text : "Synthetic error injection (debug)";
+      debug_inject_banner_arg_t *arg = malloc(sizeof(*arg));
+      if (arg) {
+         strncpy(arg->txt, txt, sizeof(arg->txt) - 1);
+         arg->txt[sizeof(arg->txt) - 1] = '\0';
+         extern lv_result_t tab5_lv_async_call(lv_async_cb_t cb, void *user_data);
+         tab5_lv_async_call(debug_inject_banner_async, arg);
+      }
+   }
+
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddBoolToObject(r, "ok", true);
+   cJSON_AddStringToObject(r, "fired", kind);
+   cJSON_AddStringToObject(r, "detail", err_detail);
+   cJSON_AddBoolToObject(r, "banner", show_banner);
+   return send_json_resp(req, r);
+}
+
+/* ── POST /debug/inject_ws ──────────────────────────────────────────── */
+
+static esp_err_t debug_inject_ws_handler(httpd_req_t *req) {
+   if (!check_auth(req)) return ESP_OK;
+   if (req->content_len <= 0 || req->content_len > 2048) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "POST body must be JSON, 1..2048 bytes");
+      return send_json_resp(req, r);
+   }
+   char *buf = heap_caps_malloc(req->content_len + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!buf) {
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "PSRAM alloc failed");
+      return send_json_resp(req, r);
+   }
+   int total = 0;
+   while (total < req->content_len) {
+      int n = httpd_req_recv(req, buf + total, req->content_len - total);
+      if (n <= 0) break;
+      total += n;
+   }
+   buf[total] = '\0';
+   if (total != req->content_len) {
+      heap_caps_free(buf);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "error", "short read");
+      return send_json_resp(req, r);
+   }
+   extern void voice_debug_inject_text(const char *data, int len);
+   voice_debug_inject_text(buf, total);
+   heap_caps_free(buf);
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddBoolToObject(r, "ok", true);
+   cJSON_AddNumberToObject(r, "bytes", total);
+   tab5_debug_obs_event("debug.inject_ws", "done");
+   return send_json_resp(req, r);
+}
+
+void debug_server_inject_register(httpd_handle_t server) {
+   if (!server) return;
+
+   static const httpd_uri_t uri_inject_audio = {
+       .uri = "/debug/inject_audio", .method = HTTP_POST, .handler = debug_inject_audio_handler};
+   static const httpd_uri_t uri_inject_error = {
+       .uri = "/debug/inject_error", .method = HTTP_POST, .handler = debug_inject_error_handler};
+   static const httpd_uri_t uri_inject_ws = {
+       .uri = "/debug/inject_ws", .method = HTTP_POST, .handler = debug_inject_ws_handler};
+
+   httpd_register_uri_handler(server, &uri_inject_audio);
+   httpd_register_uri_handler(server, &uri_inject_error);
+   httpd_register_uri_handler(server, &uri_inject_ws);
+}

--- a/main/debug_server_inject.h
+++ b/main/debug_server_inject.h
@@ -1,0 +1,25 @@
+/*
+ * debug_server_inject.h — synthetic-injection debug HTTP family.
+ *
+ * Wave 23b follow-up (#332): seventeenth per-family extract.  Owns
+ * the three /debug/inject_* test-harness endpoints that synthesise
+ * faults / audio / WS frames so the e2e suite can exercise UX paths
+ * (banners, toasts, STT round-trip) without needing real fault
+ * conditions.
+ */
+#pragma once
+
+#include "esp_http_server.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Registers /debug/inject_audio + /debug/inject_error +
+ * /debug/inject_ws against the live HTTPD server.  Called from
+ * debug_server.c init after the server is started. */
+void debug_server_inject_register(httpd_handle_t server);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary

Wave 23b · 17th per-family extract from debug_server.c (refs #332).  Pulls all 3 synthetic-injection test-harness handlers + the LVGL-thread banner trampoline into a new sibling \`debug_server_inject.{c,h}\`.

## Endpoints moved (all bearer-auth, test-harness-only)

| Method + URI | Purpose |
|---|---|
| POST /debug/inject_audio | pump caller-supplied PCM through the same WS binary path the mic task uses (16 kHz mono int16 LE, 1..64 KB).  Bypasses the mic capture loop so the harness can validate STT round-trip without canned audio. |
| POST /debug/inject_error | synthesise a Wave 3 error.* obs event + persistent banner.  Body or query: \`class=dragon\|auth\|ota\|sd\|k144\`, \`detail=...\`, \`banner=true\|false\`, \`banner_text=...\` |
| POST /debug/inject_ws | route a JSON string through voice.c's WS text dispatcher as if Dragon had sent it.  Lets the harness exercise toast/banner UX paths without making Dragon genuinely fail. |

## Cleanup

The pre-extract \`_impl\` + thin public-wrapper split (\`debug_inject_X_handler\` forwarding to \`debug_inject_X_handler_impl\`) is collapsed back to single file-static functions — the wrapper existed only because the registration block needed the symbols to be externally visible from outside the impl block, which the family-register pattern handles natively.

## Verification on physical Tab5 192.168.1.90

- \`idf.py build\` clean, \`git-clang-format --diff\` empty
- **story_smoke 14/14 in 76s**
- \`POST /debug/inject_error?class=k144&detail=test\` → \`{ok=true, fired=error.k144, banner=true}\`
- \`POST /debug/inject_ws\` -d \`{\"type\":\"stt_partial\",\"text\":\"hello\"}\` → \`{ok=true, bytes=37}\`

## LOC

| File | Before | After | Δ |
|---|---|---|---|
| \`main/debug_server.c\` | 1,486 | ~1,210 | -276 |
| \`main/debug_server_inject.c\` | 0 | 250 | +250 |

Refs #332.