### PR TITLE
fix(solo): W4-B use-after-free + /solo/inject_audio test endpoint

### DIFF
--- a/main/debug_server_solo.c
+++ b/main/debug_server_solo.c
@@ -22,6 +22,7 @@
 #include "openrouter_client.h"
 #include "openrouter_sse.h"
 #include "solo_rag.h"
+#include "voice_solo.h"
 
 static const char *TAG = "debug_solo";
 
@@ -242,6 +243,39 @@ static esp_err_t rag_test_handler(httpd_req_t *req) {
    return tab5_debug_send_json_resp(req, out);
 }
 
+/* /solo/inject_audio — POST raw 16 kHz mono int16 PCM body → posts an
+ * audio-job to voice_solo_send_audio, which runs STT → LLM → TTS through
+ * OpenRouter just like a real mic-orb session would.  Used by the E2E
+ * harness to drive the W4-B audio chain with deterministic synthetic
+ * input (e.g. espeak-ng-rendered speech) without needing a person to
+ * physically speak.  Body cap 32 s × 16 kHz × 2 B = 1 MB. */
+static esp_err_t inject_audio_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   const size_t cap = 1024 * 1024;
+   if (req->content_len <= 0 || (size_t)req->content_len > cap || (req->content_len % 2) != 0) {
+      return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "POST 16 kHz mono int16 PCM, 1..1MB, even byte count");
+   }
+   int16_t *pcm = heap_caps_malloc((size_t)req->content_len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!pcm) return ESP_ERR_NO_MEM;
+   size_t got = 0;
+   while (got < (size_t)req->content_len) {
+      int n = httpd_req_recv(req, (char *)pcm + got, (size_t)req->content_len - got);
+      if (n <= 0) {
+         heap_caps_free(pcm);
+         return ESP_FAIL;
+      }
+      got += (size_t)n;
+   }
+   size_t samples = got / sizeof(int16_t);
+   esp_err_t e = voice_solo_send_audio(pcm, samples); /* takes ownership */
+   cJSON *out = cJSON_CreateObject();
+   cJSON_AddBoolToObject(out, "ok", e == ESP_OK);
+   cJSON_AddNumberToObject(out, "samples", (double)samples);
+   cJSON_AddNumberToObject(out, "duration_ms", (double)samples * 1000.0 / 16000.0);
+   if (e != ESP_OK) cJSON_AddStringToObject(out, "error", esp_err_to_name(e));
+   return tab5_debug_send_json_resp(req, out);
+}
+
 void debug_server_solo_register(httpd_handle_t server) {
    if (!server) return;
    static const httpd_uri_t uri_sse = {.uri = "/solo/sse_test", .method = HTTP_POST, .handler = sse_test_handler};
@@ -255,6 +289,11 @@ void debug_server_solo_register(httpd_handle_t server) {
    static const httpd_uri_t uri_llm = {.uri = "/solo/llm_test", .method = HTTP_POST, .handler = llm_test_handler};
    httpd_register_uri_handler(server, &uri_llm);
    ESP_LOGI(TAG, "registered /solo/llm_test");
+
+   static const httpd_uri_t uri_audio = {
+       .uri = "/solo/inject_audio", .method = HTTP_POST, .handler = inject_audio_handler};
+   httpd_register_uri_handler(server, &uri_audio);
+   ESP_LOGI(TAG, "registered /solo/inject_audio");
 
    static const httpd_uri_t uri_rag = {.uri = "/solo/rag_test", .method = HTTP_POST, .handler = rag_test_handler};
    httpd_register_uri_handler(server, &uri_rag);

--- a/main/voice.c
+++ b/main/voice.c
@@ -1811,7 +1811,13 @@ esp_err_t voice_stop_listening(void)
 
    /* W4-B (TT #375): SOLO_DIRECT stop path.  Mic is already disabled +
     * drained above; hand the accumulated PCM to voice_solo, which posts
-    * an audio-job to the worker (STT → LLM → TTS through OpenRouter). */
+    * an audio-job to the worker (STT → LLM → TTS through OpenRouter).
+    *
+    * Ownership note: voice_solo_send_audio's worker calls heap_caps_free
+    * on the pcm pointer after STT (voice_solo.c:321).  Our s_solo_pcm
+    * is a persistent buffer reused across mic sessions — passing it
+    * directly would be a use-after-free on the next session.  Copy
+    * into a fresh PSRAM buffer that voice_solo can own + free. */
    if (tab5_settings_get_voice_mode() == VMODE_SOLO_DIRECT) {
       voice_reset_activity_timestamp();
       voice_set_state(VOICE_STATE_PROCESSING, "solo");
@@ -1820,9 +1826,21 @@ esp_err_t voice_stop_listening(void)
          voice_set_state(VOICE_STATE_READY, "solo_empty");
          return ESP_ERR_INVALID_STATE;
       }
-      ESP_LOGI(TAG, "Solo stop: handing %u samples to voice_solo_send_audio", (unsigned)s_solo_samples);
-      esp_err_t e = voice_solo_send_audio(s_solo_pcm, s_solo_samples);
+      size_t n = s_solo_samples;
+      size_t bytes = n * sizeof(int16_t);
+      int16_t *copy = heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (!copy) {
+         ESP_LOGE(TAG, "Solo stop: PSRAM alloc %u bytes failed", (unsigned)bytes);
+         voice_set_state(VOICE_STATE_READY, "solo_oom");
+         return ESP_ERR_NO_MEM;
+      }
+      memcpy(copy, s_solo_pcm, bytes);
+      s_solo_samples = 0; /* reset cursor for next session */
+      ESP_LOGI(TAG, "Solo stop: handing %u samples (%u KB) to voice_solo_send_audio", (unsigned)n,
+               (unsigned)(bytes / 1024));
+      esp_err_t e = voice_solo_send_audio(copy, n); /* takes ownership of copy */
       if (e != ESP_OK) {
+         /* voice_solo_send_audio's error paths already heap_caps_free'd copy */
          ESP_LOGW(TAG, "voice_solo_send_audio failed: %s", esp_err_to_name(e));
          voice_set_state(VOICE_STATE_READY, "solo_dispatch_failed");
       }


### PR DESCRIPTION
## Summary
Two follow-ups to PR #371 shaken out by running e2e + synthetic audio injection on hardware:

1. **W4-B use-after-free** — voice_solo's worker frees the pcm pointer after STT (`voice_solo.c:321`), but W4-B was handing it the persistent static `s_solo_pcm`. Next mic session would crash. Fix: copy into fresh PSRAM in voice_stop_listening, hand the copy off.

2. **`/solo/inject_audio`** — POST raw 16 kHz mono int16 PCM → `voice_solo_send_audio` directly. Lets the E2E harness drive the W4-B audio chain with `espeak-ng`-rendered speech instead of needing a human.

## Live verification
- 4.33 s espeak-ng prompt POSTed, state machine cycles `READY → PROCESSING → READY`
- W4-C `log_health` pre/post fire correctly
- W4-C `log_error_body` captures the OpenRouter 400 (unrelated — OpenRouter doesn't proxy `/audio/transcriptions`, that's a Phase-1 design gap to file separately)

## Test plan
- [x] `idf.py build` clean
- [x] Flash + boot on Tab5 192.168.1.90, no PANIC
- [x] `/solo/llm_test` still works (no regression to typed-text path)
- [x] `/solo/inject_audio` accepts PCM, dispatches to voice_solo_send_audio
- [x] State machine recovers cleanly after STT 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)