### PR TITLE
feat(solo,#379): multimodal /chat/completions audio (closes #379)

### DIFF
--- a/main/openrouter_client.c
+++ b/main/openrouter_client.c
@@ -475,6 +475,242 @@ cleanup:
    return err;
 }
 
+/* ── TT #379: multimodal audio chat ───────────────────────────────────── */
+
+/* Per-stream context for chat_audio's SSE delta dispatcher.  parse_buf is
+ * reused across deltas (mirrors chat_stream's W3-B) and decode_buf grows
+ * on demand for the largest base64-PCM chunk in the stream. */
+typedef struct {
+   openrouter_tts_chunk_cb_t audio_cb;
+   openrouter_chat_delta_cb_t text_cb;
+   void *cb_ctx;
+   char *parse_buf;
+   size_t parse_cap;
+   uint8_t *decode_buf;
+   size_t decode_cap;
+   size_t audio_chunks; /* DEBUG counters surfaced in the final log line. */
+   size_t audio_bytes;
+   size_t text_chunks;
+   size_t text_chars;
+} chat_audio_ctx_t;
+
+/* Grow `parse_buf` (or `decode_buf`) in place to at least `need` bytes,
+ * capped at 256 KB.  Returns ESP_OK on success.  Used by the SSE delta
+ * dispatcher to bound the per-stream PSRAM footprint while avoiding
+ * malloc/free churn on every delta. */
+static esp_err_t grow_psram_buf(uint8_t **buf, size_t *cap, size_t need) {
+   if (*cap >= need) return ESP_OK;
+   size_t newcap = *cap ? *cap : 1024;
+   while (newcap < need && newcap < 256 * 1024) newcap *= 2;
+   if (newcap < need) return ESP_ERR_NO_MEM;
+   uint8_t *grown = heap_caps_realloc(*buf, newcap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!grown) return ESP_ERR_NO_MEM;
+   *buf = grown;
+   *cap = newcap;
+   return ESP_OK;
+}
+
+static void chat_audio_sse_cb(const char *json, size_t len, void *vctx) {
+   chat_audio_ctx_t *c = vctx;
+   /* Stage the SSE event into parse_buf so cJSON_Parse sees a NUL-terminated
+    * buffer; reuse across deltas (same pattern as chat_sse_cb). */
+   if (grow_psram_buf((uint8_t **)&c->parse_buf, &c->parse_cap, len + 1) != ESP_OK) return;
+   memcpy(c->parse_buf, json, len);
+   c->parse_buf[len] = '\0';
+   cJSON *root = cJSON_Parse(c->parse_buf);
+   if (!root) return;
+   cJSON *choices = cJSON_GetObjectItem(root, "choices");
+   if (!cJSON_IsArray(choices) || cJSON_GetArraySize(choices) == 0) {
+      cJSON_Delete(root);
+      return;
+   }
+   cJSON *delta = cJSON_GetObjectItem(cJSON_GetArrayItem(choices, 0), "delta");
+   cJSON *audio = delta ? cJSON_GetObjectItem(delta, "audio") : NULL;
+   if (!audio) {
+      cJSON_Delete(root);
+      return;
+   }
+   /* Transcript text chunk → text_cb (assistant's "voice" rendered as text). */
+   cJSON *transcript = cJSON_GetObjectItem(audio, "transcript");
+   if (cJSON_IsString(transcript) && transcript->valuestring && transcript->valuestring[0]) {
+      size_t tl = strlen(transcript->valuestring);
+      c->text_chunks++;
+      c->text_chars += tl;
+      if (c->text_cb) c->text_cb(transcript->valuestring, tl, c->cb_ctx);
+   }
+   /* Audio chunk: base64-encoded PCM16 → audio_cb after decode. */
+   cJSON *data = cJSON_GetObjectItem(audio, "data");
+   if (cJSON_IsString(data) && data->valuestring) {
+      const char *b64 = data->valuestring;
+      size_t b64_len = strlen(b64);
+      size_t need = (b64_len * 3) / 4 + 2;
+      if (grow_psram_buf(&c->decode_buf, &c->decode_cap, need) == ESP_OK) {
+         size_t out_len = 0;
+         int rc = mbedtls_base64_decode(c->decode_buf, c->decode_cap, &out_len, (const unsigned char *)b64, b64_len);
+         if (rc == 0 && out_len > 0) {
+            c->audio_chunks++;
+            c->audio_bytes += out_len;
+            if (c->audio_cb) c->audio_cb(c->decode_buf, out_len, c->cb_ctx);
+         }
+      }
+   }
+   cJSON_Delete(root);
+}
+
+esp_err_t openrouter_chat_audio(const int16_t *pcm, size_t samples, openrouter_tts_chunk_cb_t audio_cb,
+                                openrouter_chat_delta_cb_t text_cb, void *ctx) {
+   if (!pcm || samples == 0 || (!audio_cb && !text_cb)) return ESP_ERR_INVALID_ARG;
+
+   char model[96] = {0};
+   tab5_settings_get_or_mdl_audio(model, sizeof model);
+   char voice[32] = {0};
+   tab5_settings_get_or_voice(voice, sizeof voice);
+
+   const size_t pcm_bytes = samples * sizeof(int16_t);
+   const size_t wav_bytes = 44 + pcm_bytes;
+
+   /* WAV-wrap the mic PCM in PSRAM, then base64-encode it (the input_audio
+    * field on a content[] block takes the same shape as /audio/transcriptions). */
+   uint8_t *wav = heap_caps_malloc(wav_bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!wav) return ESP_ERR_NO_MEM;
+   wav16_header(wav, pcm_bytes);
+   memcpy(wav + 44, pcm, pcm_bytes);
+
+   const size_t b64_cap = ((wav_bytes + 2) / 3) * 4 + 1;
+   char *b64 = heap_caps_malloc(b64_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!b64) {
+      heap_caps_free(wav);
+      return ESP_ERR_NO_MEM;
+   }
+   size_t b64_olen = 0;
+   int mb = mbedtls_base64_encode((unsigned char *)b64, b64_cap, &b64_olen, wav, wav_bytes);
+   heap_caps_free(wav);
+   if (mb != 0) {
+      heap_caps_free(b64);
+      return ESP_FAIL;
+   }
+   b64[b64_olen] = '\0';
+
+   /* Build the request body:
+    *   { model, modalities, audio:{voice,format},
+    *     stream:true,
+    *     messages:[{role:"user", content:[{type:"input_audio", input_audio:{data,format}}]}] } */
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "model", model);
+   cJSON *modalities = cJSON_CreateArray();
+   cJSON_AddItemToArray(modalities, cJSON_CreateString("text"));
+   cJSON_AddItemToArray(modalities, cJSON_CreateString("audio"));
+   cJSON_AddItemToObject(body, "modalities", modalities);
+   cJSON *audio_cfg = cJSON_CreateObject();
+   cJSON_AddStringToObject(audio_cfg, "voice", voice);
+   cJSON_AddStringToObject(audio_cfg, "format", "pcm16");
+   cJSON_AddItemToObject(body, "audio", audio_cfg);
+   cJSON_AddBoolToObject(body, "stream", true);
+   cJSON *msgs = cJSON_CreateArray();
+   cJSON *user_msg = cJSON_CreateObject();
+   cJSON_AddStringToObject(user_msg, "role", "user");
+   cJSON *content_arr = cJSON_CreateArray();
+   cJSON *audio_block = cJSON_CreateObject();
+   cJSON_AddStringToObject(audio_block, "type", "input_audio");
+   cJSON *input_audio = cJSON_CreateObject();
+   cJSON_AddStringToObject(input_audio, "data", b64);
+   cJSON_AddStringToObject(input_audio, "format", "wav");
+   cJSON_AddItemToObject(audio_block, "input_audio", input_audio);
+   cJSON_AddItemToArray(content_arr, audio_block);
+   cJSON_AddItemToObject(user_msg, "content", content_arr);
+   cJSON_AddItemToArray(msgs, user_msg);
+   cJSON_AddItemToObject(body, "messages", msgs);
+   char *body_str = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+   heap_caps_free(b64);
+   if (!body_str) return ESP_ERR_NO_MEM;
+   const size_t body_len = strlen(body_str);
+
+   log_health("/chat/completions[audio]", "pre");
+
+   int attempt = 0;
+   esp_err_t err = ESP_FAIL;
+   esp_http_client_handle_t c = NULL;
+   openrouter_sse_state_t *sse = NULL;
+   chat_audio_ctx_t actx = {
+       .audio_cb = audio_cb,
+       .text_cb = text_cb,
+       .cb_ctx = ctx,
+       .parse_buf = NULL,
+       .parse_cap = 0,
+       .decode_buf = NULL,
+       .decode_cap = 0,
+   };
+   int64_t t_open = 0;
+retry:
+   attempt++;
+   c = openrouter_open_post("/chat/completions");
+   if (!c) {
+      free(body_str);
+      return ESP_ERR_INVALID_STATE;
+   }
+   esp_http_client_set_header(c, "Content-Type", "application/json");
+   esp_http_client_set_header(c, "Accept", "text/event-stream");
+
+   if (openrouter_sse_init(&sse, chat_audio_sse_cb, &actx) != ESP_OK) {
+      free(body_str);
+      esp_http_client_cleanup(c);
+      inflight_set(NULL);
+      return ESP_ERR_NO_MEM;
+   }
+
+   t_open = esp_timer_get_time();
+   err = esp_http_client_open(c, body_len);
+   if (err != ESP_OK) {
+      ESP_LOGE(TAG, "/chat/completions[audio] open failed: %s (errno=%d) after %lldms (attempt %d)",
+               esp_err_to_name(err), errno, (long long)((esp_timer_get_time() - t_open) / 1000), attempt);
+      if (attempt == 1 && err == ESP_ERR_HTTP_CONNECT) {
+         ESP_LOGW(TAG, "/chat/completions[audio] transient connect failure — retry-once");
+         openrouter_sse_free(sse);
+         sse = NULL;
+         esp_http_client_close(c);
+         esp_http_client_cleanup(c);
+         inflight_set(NULL);
+         vTaskDelay(pdMS_TO_TICKS(500));
+         goto retry;
+      }
+      goto cleanup;
+   }
+   err = write_full(c, body_str, body_len);
+   if (err != ESP_OK) goto cleanup;
+   esp_http_client_fetch_headers(c);
+   int status = esp_http_client_get_status_code(c);
+   if (status != 200) {
+      ESP_LOGE(TAG, "chat_audio status=%d (body_len=%u)", status, (unsigned)body_len);
+      log_error_body(c, "/chat/completions[audio]");
+      err = ESP_FAIL;
+      goto cleanup;
+   }
+   char rbuf[1024];
+   while (1) {
+      int n = esp_http_client_read(c, rbuf, sizeof rbuf);
+      if (n <= 0) break;
+      if (openrouter_sse_feed(sse, rbuf, (size_t)n)) break;
+   }
+
+cleanup:
+   openrouter_sse_free(sse);
+   esp_http_client_close(c);
+   esp_http_client_cleanup(c);
+   inflight_set(NULL);
+   if (actx.parse_buf) heap_caps_free(actx.parse_buf);
+   if (actx.decode_buf) heap_caps_free(actx.decode_buf);
+   free(body_str);
+   ESP_LOGI(TAG,
+            "/chat/completions[audio] done rc=%s in %lldms (attempts=%d) "
+            "audio_chunks=%u audio_bytes=%u text_chunks=%u text_chars=%u",
+            esp_err_to_name(err), (long long)((esp_timer_get_time() - t_open) / 1000), attempt,
+            (unsigned)actx.audio_chunks, (unsigned)actx.audio_bytes, (unsigned)actx.text_chunks,
+            (unsigned)actx.text_chars);
+   log_health("/chat/completions[audio]", "post");
+   return err;
+}
+
 esp_err_t openrouter_tts(const char *text, openrouter_tts_chunk_cb_t cb, void *ctx) {
    if (!text || !*text || !cb) return ESP_ERR_INVALID_ARG;
 

--- a/main/openrouter_client.h
+++ b/main/openrouter_client.h
@@ -48,6 +48,20 @@ esp_err_t openrouter_tts(const char *text, openrouter_tts_chunk_cb_t cb, void *c
  *  frees with heap_caps_free.  *out_dim is set to the dimensionality. */
 esp_err_t openrouter_embed(const char *text, float **out_vec, size_t *out_dim);
 
+/** TT #379 — multimodal audio chat (audio in → audio + text out).
+ *
+ *  Single /chat/completions call against an audio-capable model
+ *  (openai/gpt-4o-audio-preview by default) that replaces the
+ *  STT → LLM → TTS chain.  Streams two interleaved callback types:
+ *    - audio_cb fires with decoded PCM-16LE chunks at 24 kHz mono
+ *      (caller upsamples to its playback rate)
+ *    - text_cb fires with assistant transcript deltas (same shape as
+ *      openrouter_chat_stream — feed into the chat-overlay accumulator)
+ *  Either callback may be NULL.  Returns ESP_OK on [DONE], ESP_FAIL on
+ *  non-200, ESP_ERR_INVALID_STATE if or_key empty. */
+esp_err_t openrouter_chat_audio(const int16_t *pcm, size_t samples, openrouter_tts_chunk_cb_t audio_cb,
+                                openrouter_chat_delta_cb_t text_cb, void *ctx);
+
 /** Abort any in-flight HTTP.  Safe from any task; idempotent. */
 void openrouter_cancel_inflight(void);
 

--- a/main/openrouter_sse.c
+++ b/main/openrouter_sse.c
@@ -17,7 +17,12 @@
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 
-#define LINE_BUF_BYTES 4096
+/* TT #379: bumped 4 KB → 64 KB to fit multimodal audio chunks.  gpt-4o-audio-preview
+ * emits per-delta SSE events with base64-encoded PCM that runs ~24 KB per event;
+ * the 4 KB cap was correct for text-only chat but silently dropped every
+ * audio-bearing event in the multimodal stream.  Allocated in PSRAM so the
+ * internal-SRAM footprint is unchanged. */
+#define LINE_BUF_BYTES (64 * 1024)
 
 struct openrouter_sse_state {
    char *line;

--- a/main/settings.c
+++ b/main/settings.c
@@ -54,6 +54,9 @@ static const char *TAG = "settings";
 #define KEY_OR_MDL_TTS "or_mdl_tts"
 #define KEY_OR_MDL_EMB "or_mdl_emb"
 #define KEY_OR_VOICE "or_voice"
+/* TT #379 — multimodal audio chat model.  One /chat/completions call
+ * with audio in + audio+text out replaces the STT → LLM → TTS chain. */
+#define KEY_OR_MDL_AUD "or_mdl_aud"
 #define KEY_BRIGHTNESS  "brightness"
 #define KEY_VOLUME      "volume"
 #define KEY_DEVICE_ID   "device_id"
@@ -418,6 +421,14 @@ esp_err_t tab5_settings_set_or_mdl_emb(const char *model) { return set_str(KEY_O
 
 esp_err_t tab5_settings_get_or_voice(char *buf, size_t len) { return get_str(KEY_OR_VOICE, buf, len, "alloy"); }
 esp_err_t tab5_settings_set_or_voice(const char *voice) { return set_str(KEY_OR_VOICE, voice ? voice : ""); }
+
+/* TT #379: multimodal audio chat model.  openai/gpt-4o-audio-preview is
+ * the only audio-capable model currently exposed by OpenRouter that
+ * accepts input_audio AND returns audio output via /chat/completions. */
+esp_err_t tab5_settings_get_or_mdl_audio(char *buf, size_t len) {
+   return get_str(KEY_OR_MDL_AUD, buf, len, "openai/gpt-4o-audio-preview");
+}
+esp_err_t tab5_settings_set_or_mdl_audio(const char *model) { return set_str(KEY_OR_MDL_AUD, model ? model : ""); }
 
 /* ── Display ──────────────────────────────────────────────────────────── */
 

--- a/main/settings.h
+++ b/main/settings.h
@@ -79,6 +79,10 @@ esp_err_t tab5_settings_set_or_mdl_emb(const char *model);
 esp_err_t tab5_settings_get_or_voice(char *buf, size_t len);
 esp_err_t tab5_settings_set_or_voice(const char *voice);
 
+/* TT #379 — multimodal audio chat model (audio in → audio+text out via /chat/completions). */
+esp_err_t tab5_settings_get_or_mdl_audio(char *buf, size_t len);
+esp_err_t tab5_settings_set_or_mdl_audio(const char *model);
+
 /* ── v4·D Sovereign Halo mode dials ──────────────────────────────────── */
 /* Three orthogonal dials that replace the 4-mode pill.  Tab5 resolves the
  * triple into the legacy (voice_mode, llm_model) pair Dragon expects.

--- a/main/voice_solo.c
+++ b/main/voice_solo.c
@@ -302,78 +302,64 @@ typedef struct {
    size_t samples;
 } solo_audio_job_t;
 
+/* TT #379: single multimodal /chat/completions call.  Audio in → audio +
+ * transcript out, streamed.  The assistant's transcript is the chat-overlay
+ * text (acc); the audio chunks (PCM-16LE @ 24 kHz mono) flow through
+ * solo_tts_chunk_cb into the playback ring.  Replaces the STT → LLM → TTS
+ * triple-call chain — one round-trip instead of three, no separate
+ * Whisper / TTS hops. */
 static void solo_send_audio_job(void *arg) {
    solo_audio_job_t *job = arg;
    /* W1-D: s_busy already set by busy_take() */
    s_cancel_requested = false; /* W1-C */
 
    voice_set_state(VOICE_STATE_PROCESSING, "solo");
-   tab5_debug_obs_event("solo.stt_start", "");
 
-   /* Step 1 — STT. */
-   char transcript[1024] = {0};
-   int64_t t0 = esp_timer_get_time();
-   esp_err_t err = openrouter_stt(job->pcm, job->samples, transcript, sizeof transcript);
-   int64_t dt = (esp_timer_get_time() - t0) / 1000;
-   char detail[48];
-   snprintf(detail, sizeof detail, "ms=%lld", (long long)dt);
-   tab5_debug_obs_event(err == ESP_OK ? "solo.stt_done" : "solo.error", detail);
-   heap_caps_free(job->pcm);
-   if (s_cancel_requested) {
-      ESP_LOGI(TAG, "solo audio canceled after STT");
-      goto done;
-   }
-   if (err != ESP_OK || transcript[0] == '\0') {
-      ui_home_show_toast("Solo STT failed");
-      goto done;
-   }
-
-   /* Step 2 — LLM streaming with chat-bubble updates. */
-   ui_chat_push_message("user", transcript);
+   /* Chat-overlay placeholder bubbles.  We don't have a separate user
+    * transcript (audio went in, no STT echo) — show "[voice input]"
+    * so the user-side of the turn is visible in the thread. */
+   ui_chat_push_message("user", "[voice input]");
    ui_chat_push_message("assistant", "");
 
    solo_chat_acc_t acc = {0};
    acc.cap = SOLO_ACC_INITIAL_CAP;
    acc.acc = heap_caps_calloc(1, acc.cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-   char *msgs = solo_build_messages_json(transcript);
-   tab5_debug_obs_event("solo.llm_start", "");
-   t0 = esp_timer_get_time();
-   if (msgs && acc.acc) {
-      err = openrouter_chat_stream(msgs, solo_delta_cb, &acc);
+
+   /* Audio chunks start arriving during the same stream — flip state
+    * to SPEAKING the moment we get the first one so the orb pulses. */
+   voice_set_state(VOICE_STATE_SPEAKING, "solo");
+   s_tts_carry_n = 0; /* reset 24→16 downsample carry between turns */
+
+   tab5_debug_obs_event("solo.audio_start", "");
+   int64_t t0 = esp_timer_get_time();
+   esp_err_t err = ESP_FAIL;
+   if (acc.acc) {
+      err = openrouter_chat_audio(job->pcm, job->samples, solo_tts_chunk_cb, solo_delta_cb, &acc);
    } else {
       err = ESP_ERR_NO_MEM;
    }
-   dt = (esp_timer_get_time() - t0) / 1000;
+   int64_t dt = (esp_timer_get_time() - t0) / 1000;
+   char detail[48];
    snprintf(detail, sizeof detail, "ms=%lld", (long long)dt);
+   heap_caps_free(job->pcm);
+
    if (s_cancel_requested) {
       tab5_debug_obs_event("solo.cancel", detail);
-      ESP_LOGI(TAG, "solo audio canceled after LLM — skipping session append");
-      free(msgs);
+      ESP_LOGI(TAG, "solo audio canceled mid-stream — skipping session append");
       heap_caps_free(acc.acc);
       goto done;
    }
-   tab5_debug_obs_event(err == ESP_OK ? "solo.llm_done" : "solo.error", detail);
-   free(msgs);
+   tab5_debug_obs_event(err == ESP_OK ? "solo.audio_done" : "solo.error", detail);
    if (err != ESP_OK) {
-      ui_home_show_toast("Solo LLM failed");
+      ui_home_show_toast("Solo audio chat failed");
       heap_caps_free(acc.acc);
       goto done;
    }
-   /* Persist the user (transcript) + assistant turn now — even if
-    * TTS fails below, the session log is intact. */
-   solo_session_append("user", transcript);
+   /* Persist the turn.  We have no STT transcript for the user side, so
+    * record it as "[voice input]" — the assistant transcript is the
+    * model's spoken reply. */
+   solo_session_append("user", "[voice input]");
    solo_session_append("assistant", acc.acc ? acc.acc : "");
-
-   /* Step 3 — TTS the assistant text into the playback ring. */
-   voice_set_state(VOICE_STATE_SPEAKING, "solo");
-   tab5_debug_obs_event("solo.tts_start", "");
-   t0 = esp_timer_get_time();
-   /* Reset the 24→16 downsample carry between turns. */
-   s_tts_carry_n = 0;
-   err = openrouter_tts(acc.acc, solo_tts_chunk_cb, NULL);
-   dt = (esp_timer_get_time() - t0) / 1000;
-   snprintf(detail, sizeof detail, "ms=%lld", (long long)dt);
-   tab5_debug_obs_event(err == ESP_OK ? "solo.tts_done" : "solo.error", detail);
    heap_caps_free(acc.acc);
 
 done:


### PR DESCRIPTION
## Summary
OpenRouter's `/audio/speech` has no working TTS models, but `/chat/completions` supports multimodal audio I/O via `openai/gpt-4o-audio-preview`.  **One streamed call replaces the entire STT → LLM → TTS chain.**

Request shape (probed live 2026-05-11):
```json
POST /api/v1/chat/completions
{
  "model": "openai/gpt-4o-audio-preview",
  "modalities": ["text", "audio"],
  "audio": {"voice": "alloy", "format": "pcm16"},
  "stream": true,
  "messages": [{
    "role": "user",
    "content": [{"type":"input_audio", "input_audio":{"data":"<b64-wav>", "format":"wav"}}]
  }]
}
```

Response is SSE; each delta has `choices[0].delta.audio` with either `{transcript}` (assistant text) or `{data}` (24 kHz mono int16 PCM chunk in base64).  Interleaved → audio plays back as it arrives.

## What changed
- `openrouter_chat_audio(pcm, samples, audio_cb, text_cb, ctx)` — new function in `openrouter_client.{c,h}`.  Same retry-once + log_health + log_error_body shape as `chat_stream`/`stt`.  Surfaces `audio_chunks/audio_bytes/text_chunks/text_chars` in the final log line.
- `or_mdl_aud` NVS key, default `openai/gpt-4o-audio-preview`.
- `solo_send_audio_job` rewritten — single multimodal call instead of three.
- `openrouter_sse` `LINE_BUF_BYTES` bumped 4 KB → 64 KB (PSRAM) — audio deltas are ~24 KB each, old cap silently dropped them via the W3-C dropping_until_newline path.

## Live verification
Tab5 192.168.1.90, 4.33 s `espeak-ng` "Tell me a fun fact about pineapples" injected via `/solo/inject_audio`:
- `/chat/completions[audio]` rc=ESP_OK in **5945 ms**, attempts=1
- **21 audio chunks, 256.8 KB PCM** (~5.35 s @ 24 kHz)
- **20 text chunks, 88 chars**
- Reply heard on Tab5 speaker: *"Pineapples regenerate! You can grow a new plant by planting the pineapple's leafy crown"*

## Test plan
- [x] `idf.py build` clean
- [x] Flash + boot, no PANIC, `voice_solo_init OK`
- [x] `/solo/llm_test` typed path still works
- [x] `/solo/inject_audio` + espeak-ng → full multimodal chain fires, audio plays, chat shows transcript
- [x] Heap stays healthy (psram_free 14 MB → 15 MB end-of-call)

## Known follow-up
User-side bubble currently shows `"[voice input]"` because audio-in has no transcript echo from the model.  Options: do a parallel `/audio/transcriptions` call to recover the user transcript, or wait for `delta.audio.input_transcript` if OpenRouter ever surfaces one.  Not blocking; speech-in voice-out works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)