### PR TITLE
feat(modes): Tab5 sends real voice_mode (4/5) in config_update — stop clamping

### DIFF
--- a/main/debug_server_mode.c
+++ b/main/debug_server_mode.c
@@ -61,16 +61,16 @@ static esp_err_t mode_set_handler(httpd_req_t *req) {
 
    ESP_LOGI("debug_mode", "Mode switch: voice_mode=%d, llm_model=%s", mode, model[0] ? model : "(unchanged)");
 
-   /* Send config_update to Dragon via voice WS — except for vmode=4
-    * (VMODE_LOCAL_ONBOARD) and vmode=5 (VMODE_SOLO_DIRECT) which are
-    * both Tab5-side-only tiers.  Dragon doesn't understand them and
-    * would ACK with an error that reverts our NVS write back to 0.
-    * When user picks one of those, tell Dragon we're still in
-    * "local" (mode=0) so its STT/TTS stay on local backends; Tab5
-    * then bypasses Dragon for the turn via voice_send_text. */
+   /* Send the real voice_mode to Dragon.  W3-B (cross-stack cohesion
+    * audit 2026-05-11): pre-W3-A Dragon's VoiceMode enum stopped at
+    * ONBOARD=4 and didn't know SOLO=5, so Tab5 used to clamp 4/5 to
+    * 0 here to avoid the "unknown voice_mode=N" downgrade warning.
+    * After W3-A (TinkerBox PR #274) Dragon recognises both 4 and 5
+    * cleanly; select_backends_for_mode applies LOCAL-shaped
+    * placeholders so STT/TTS stay sensible if the user flips back.
+    * Two codebases lying to each other is over. */
    if (voice_is_connected()) {
-      int dragon_mode = (mode >= 4) ? 0 : mode;
-      voice_send_config_update(dragon_mode, model[0] ? model : NULL);
+      voice_send_config_update(mode, model[0] ? model : NULL);
    }
 
    /* Refresh home screen mode badge (runs on LVGL thread) */

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -692,14 +692,12 @@ static void voice_tab_switch(uint8_t new_tab)
              : new_tab == 2 ? "cloud"
              : new_tab == 3 ? "tinkerclaw"
                             : "onboard");
-    /* TT #317 P5b: ONBOARD is Tab5-side-only — Dragon doesn't know about
-     * mode 4 and would error-revert via config_update.  send_voice_config
-     * downgrades to mode 0 in that case via the same path /mode does. */
-    if (new_tab != 4) {
-       send_voice_config();
-    } else if (voice_is_connected()) {
-       voice_send_config_update(0, NULL); /* keep Dragon on local STT/TTS */
-    }
+    /* W3-B (cross-stack cohesion audit 2026-05-11): pre-W3-A this
+     * branched mode 4 (ONBOARD) into a clamp-to-0 path because Dragon
+     * would error-revert on unknown vmode=4.  After W3-A (TinkerBox
+     * PR #274) Dragon recognises ONBOARD + SOLO cleanly via
+     * select_backends_for_mode; the clamp is no longer needed. */
+    send_voice_config();
 }
 
 /* Audit E3 (2026-04-20): tapping TinkerClaw from Settings used to hot-switch


### PR DESCRIPTION
## Summary
**Wave 3-B** of the cross-stack cohesion audit (2026-05-11).  Tab5 firmware was clamping \`voice_mode\` 4 (Onboard) and 5 (Solo) to 0 (Local) when sending \`config_update\` to Dragon, because pre-W3-A Dragon's \`VoiceMode\` enum stopped at 4 and would warn-and-downgrade on unknown values.

After **W3-A** (TinkerBox PR #274, merged + deployed to Dragon 2026-05-11):
- Dragon recognises \`SOLO = 5\` cleanly
- \`select_backends_for_mode\` returns LOCAL-shaped placeholders for SOLO (Dragon's backends idle during SOLO turns)

W3-B removes the Tab5-side clamp so the wire carries the real value.

## Sites changed
- \`main/debug_server_mode.c\` — removed \`dragon_mode = (mode >= 4) ? 0 : mode\` clamp before \`voice_send_config_update\`
- \`main/ui_settings.c\` — collapsed the \`if (new_tab != 4)\` branch in \`voice_tab_switch\`; always calls \`send_voice_config()\` now
- \`main/ui_mode_sheet.c\` — already correct (sent real \`VOICE_MODE_ONBOARD = 4\` via preset chip path)

## E2E verification — live on 192.168.1.90 (built + flashed just now)

**Mode-switch story:**

\`\`\`
Tab5 /mode?m=5 → Dragon log: "voice_mode=5 (SOLO) → stt=moonshine tts=piper llm=ollama"
Tab5 /mode?m=4 → Dragon log: "voice_mode=4 (ONBOARD) → stt=openrouter tts=openrouter llm=ollama"
Tab5 /mode?m=0 → Dragon log: "voice_mode=0 (LOCAL) → stt=moonshine tts=piper llm=ollama"
\`\`\`

Zero \"unknown voice_mode=N — treating as LOCAL\" warnings post-flash.

**Integration sanity (W2a + W3-B):**
SOLO voice turn after the flash: injected espeak-ng \"Tell me a fun fact about pineapples\" → cycled READY in 16 s → real transcript captured (\"Tell me a fun fact about pineapples in under 12 words.\") → assistant reply rendered (\"Pineapples were named by European explorers who thought they looked like pine cones...\").

## Anchor doc
\`docs/AUDIT-state-of-stack-2026-05-11.md\` — Wave 3 section.

## Test plan
- [x] \`git-clang-format --diff origin/main\` clean
- [x] Build succeeds (\`idf.py build\`)
- [x] Flash succeeds + device boots cleanly
- [x] vmode=5 + 4 + 0 all log correctly on Dragon side, no warnings
- [x] SOLO voice turn integration test still passes
- [ ] CI build green

Closes #387 — refs #270 #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)