### PR TITLE
feat(onboard): K144 turns POST to Dragon canonical messages DB (W3-C-c)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -32,7 +32,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "mode_manager.c"
+             "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "voice_messages_sync.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"

--- a/main/voice_messages_sync.c
+++ b/main/voice_messages_sync.c
@@ -1,0 +1,177 @@
+/*
+ * voice_messages_sync.c — see voice_messages_sync.h.
+ *
+ * Wave 3-C-b (cross-stack cohesion audit 2026-05-11).
+ */
+#include "voice_messages_sync.h"
+
+#include <string.h>
+
+#include "cJSON.h"
+#include "esp_heap_caps.h"
+#include "esp_http_client.h"
+#include "esp_log.h"
+#include "config.h" /* TAB5_VOICE_PORT */
+#include "debug_obs.h"
+#include "settings.h"
+#include "task_worker.h"
+
+static const char *TAG = "msg_sync";
+
+/* Job state — fully self-contained.  Worker reads, no NVS touch. */
+typedef struct {
+   char url[160];          /* http://{host}:3502/api/v1/sessions/{session_id}/messages */
+   char auth[160];          /* "Bearer {token}" or "" when no token */
+   char *body;              /* PSRAM, free()d by worker */
+   size_t body_len;
+   /* For obs / log: keep role + a short content prefix.  Avoids
+    * leaking secrets if a malformed caller passes a token as content. */
+   char role[16];
+   char preview[32];
+} msg_sync_job_t;
+
+static void free_job(msg_sync_job_t *job) {
+   if (!job) return;
+   if (job->body) heap_caps_free(job->body);
+   heap_caps_free(job);
+}
+
+static void msg_sync_post_job(void *arg) {
+   msg_sync_job_t *job = (msg_sync_job_t *)arg;
+   if (!job) return;
+
+   esp_http_client_config_t cfg = {
+       .url = job->url,
+       .method = HTTP_METHOD_POST,
+       .timeout_ms = 5000,
+       .buffer_size = 2048,
+       .buffer_size_tx = 1024,
+       .crt_bundle_attach = NULL,
+   };
+   esp_http_client_handle_t client = esp_http_client_init(&cfg);
+   if (!client) {
+      ESP_LOGW(TAG, "http_client_init failed (role=%s)", job->role);
+      tab5_debug_obs_event("msg_sync.error", "init");
+      free_job(job);
+      return;
+   }
+
+   esp_http_client_set_header(client, "Content-Type", "application/json");
+   if (job->auth[0]) {
+      esp_http_client_set_header(client, "Authorization", job->auth);
+   }
+
+   esp_err_t err = esp_http_client_open(client, (int)job->body_len);
+   if (err != ESP_OK) {
+      ESP_LOGW(TAG, "open failed: %s (role=%s)", esp_err_to_name(err), job->role);
+      tab5_debug_obs_event("msg_sync.error", "open");
+      esp_http_client_cleanup(client);
+      free_job(job);
+      return;
+   }
+   int written = esp_http_client_write(client, job->body, (int)job->body_len);
+   if (written < 0 || (size_t)written != job->body_len) {
+      ESP_LOGW(TAG, "write short: %d/%u (role=%s)", written, (unsigned)job->body_len, job->role);
+      tab5_debug_obs_event("msg_sync.error", "write");
+      esp_http_client_close(client);
+      esp_http_client_cleanup(client);
+      free_job(job);
+      return;
+   }
+   int content_len = esp_http_client_fetch_headers(client);
+   (void)content_len;
+   int status = esp_http_client_get_status_code(client);
+   /* Drain body so the connection can be cleanly reused / closed. */
+   char drain[256];
+   while (esp_http_client_read(client, drain, sizeof drain) > 0) {
+      /* discard */
+   }
+   esp_http_client_close(client);
+   esp_http_client_cleanup(client);
+
+   if (status >= 200 && status < 300) {
+      ESP_LOGI(TAG, "POST ok %d role=%s preview=%s", status, job->role, job->preview);
+      char detail[48];
+      snprintf(detail, sizeof detail, "role=%s status=%d", job->role, status);
+      tab5_debug_obs_event("msg_sync.ok", detail);
+   } else {
+      ESP_LOGW(TAG, "POST status=%d role=%s preview=%s", status, job->role, job->preview);
+      char detail[48];
+      snprintf(detail, sizeof detail, "role=%s status=%d", job->role, status);
+      tab5_debug_obs_event("msg_sync.fail", detail);
+   }
+   free_job(job);
+}
+
+esp_err_t voice_messages_sync_post(const char *role,
+                                   const char *content,
+                                   const char *input_mode) {
+   if (!role || !role[0] || !content || !content[0]) {
+      return ESP_ERR_INVALID_ARG;
+   }
+   if (!input_mode || !input_mode[0]) input_mode = "text";
+
+   /* NVS snapshot in caller's thread.  Worker will not touch NVS. */
+   char session_id[64] = {0};
+   char dragon_host[64] = {0};
+   char dragon_tok[96] = {0};
+   tab5_settings_get_session_id(session_id, sizeof session_id);
+   tab5_settings_get_dragon_host(dragon_host, sizeof dragon_host);
+   tab5_settings_get_dragon_api_token(dragon_tok, sizeof dragon_tok);
+
+   if (!session_id[0] || !dragon_host[0]) {
+      ESP_LOGD(TAG, "skip: session_id=%s dragon_host=%s",
+               session_id[0] ? "set" : "empty",
+               dragon_host[0] ? "set" : "empty");
+      return ESP_ERR_INVALID_STATE;
+   }
+
+   /* Build JSON body via cJSON so escaping is correct for arbitrary
+    * UTF-8 content.  Worker takes ownership of the resulting buffer. */
+   cJSON *root = cJSON_CreateObject();
+   if (!root) return ESP_ERR_NO_MEM;
+   cJSON_AddStringToObject(root, "role", role);
+   cJSON_AddStringToObject(root, "content", content);
+   cJSON_AddStringToObject(root, "input_mode", input_mode);
+   char *body = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!body) return ESP_ERR_NO_MEM;
+   size_t body_len = strlen(body);
+
+   /* Re-pack body into PSRAM so cJSON's internal-SRAM allocation can
+    * be freed immediately. */
+   char *psram_body = heap_caps_malloc(body_len + 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!psram_body) {
+      cJSON_free(body);
+      return ESP_ERR_NO_MEM;
+   }
+   memcpy(psram_body, body, body_len + 1);
+   cJSON_free(body);
+
+   msg_sync_job_t *job = heap_caps_calloc(1, sizeof(*job), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!job) {
+      heap_caps_free(psram_body);
+      return ESP_ERR_NO_MEM;
+   }
+   snprintf(job->url, sizeof job->url,
+            "http://%s:%d/api/v1/sessions/%s/messages",
+            dragon_host, TAB5_VOICE_PORT, session_id);
+   if (dragon_tok[0]) {
+      snprintf(job->auth, sizeof job->auth, "Bearer %s", dragon_tok);
+   }
+   job->body = psram_body;
+   job->body_len = body_len;
+   strncpy(job->role, role, sizeof(job->role) - 1);
+   /* Short preview for the obs/log — first ~30 chars, ASCII-only safe. */
+   size_t prev_n = strlen(content);
+   if (prev_n > sizeof(job->preview) - 1) prev_n = sizeof(job->preview) - 1;
+   memcpy(job->preview, content, prev_n);
+
+   esp_err_t r = tab5_worker_enqueue(msg_sync_post_job, job, "msg_sync");
+   if (r != ESP_OK) {
+      ESP_LOGW(TAG, "worker queue full — dropping (role=%s)", role);
+      tab5_debug_obs_event("msg_sync.drop", "queue_full");
+      free_job(job);
+   }
+   return r;
+}

--- a/main/voice_messages_sync.c
+++ b/main/voice_messages_sync.c
@@ -8,11 +8,11 @@
 #include <string.h>
 
 #include "cJSON.h"
+#include "config.h" /* TAB5_VOICE_PORT */
+#include "debug_obs.h"
 #include "esp_heap_caps.h"
 #include "esp_http_client.h"
 #include "esp_log.h"
-#include "config.h" /* TAB5_VOICE_PORT */
-#include "debug_obs.h"
 #include "settings.h"
 #include "task_worker.h"
 
@@ -20,9 +20,9 @@ static const char *TAG = "msg_sync";
 
 /* Job state — fully self-contained.  Worker reads, no NVS touch. */
 typedef struct {
-   char url[160];          /* http://{host}:3502/api/v1/sessions/{session_id}/messages */
-   char auth[160];          /* "Bearer {token}" or "" when no token */
-   char *body;              /* PSRAM, free()d by worker */
+   char url[160];  /* http://{host}:3502/api/v1/sessions/{session_id}/messages */
+   char auth[160]; /* "Bearer {token}" or "" when no token */
+   char *body;     /* PSRAM, free()d by worker */
    size_t body_len;
    /* For obs / log: keep role + a short content prefix.  Avoids
     * leaking secrets if a malformed caller passes a token as content. */
@@ -103,9 +103,7 @@ static void msg_sync_post_job(void *arg) {
    free_job(job);
 }
 
-esp_err_t voice_messages_sync_post(const char *role,
-                                   const char *content,
-                                   const char *input_mode) {
+esp_err_t voice_messages_sync_post(const char *role, const char *content, const char *input_mode) {
    if (!role || !role[0] || !content || !content[0]) {
       return ESP_ERR_INVALID_ARG;
    }
@@ -120,8 +118,7 @@ esp_err_t voice_messages_sync_post(const char *role,
    tab5_settings_get_dragon_api_token(dragon_tok, sizeof dragon_tok);
 
    if (!session_id[0] || !dragon_host[0]) {
-      ESP_LOGD(TAG, "skip: session_id=%s dragon_host=%s",
-               session_id[0] ? "set" : "empty",
+      ESP_LOGD(TAG, "skip: session_id=%s dragon_host=%s", session_id[0] ? "set" : "empty",
                dragon_host[0] ? "set" : "empty");
       return ESP_ERR_INVALID_STATE;
    }
@@ -153,9 +150,8 @@ esp_err_t voice_messages_sync_post(const char *role,
       heap_caps_free(psram_body);
       return ESP_ERR_NO_MEM;
    }
-   snprintf(job->url, sizeof job->url,
-            "http://%s:%d/api/v1/sessions/%s/messages",
-            dragon_host, TAB5_VOICE_PORT, session_id);
+   snprintf(job->url, sizeof job->url, "http://%s:%d/api/v1/sessions/%s/messages", dragon_host, TAB5_VOICE_PORT,
+            session_id);
    if (dragon_tok[0]) {
       snprintf(job->auth, sizeof job->auth, "Bearer %s", dragon_tok);
    }

--- a/main/voice_messages_sync.h
+++ b/main/voice_messages_sync.h
@@ -1,0 +1,58 @@
+/*
+ * voice_messages_sync.h — Wave 3-C-b (cross-stack cohesion audit
+ * 2026-05-11): Tab5 POSTs SOLO and ONBOARD turn pairs to Dragon's
+ * canonical messages DB via `POST /api/v1/sessions/{id}/messages`
+ * (the endpoint added by W3-C-a, TinkerBox PR #276).
+ *
+ * Before this module, SOLO turns lived only in `solo_session_store`
+ * on Tab5 SD (invisible to Dragon) and ONBOARD turns weren't
+ * persisted at all.  After this module, Dragon's messages DB holds
+ * the canonical record across all six voice modes, so the dashboard
+ * Conversations tab sees mode 4/5 activity and cross-session memory
+ * search works uniformly.
+ *
+ * ## API
+ *
+ * `voice_messages_sync_post(role, content, input_mode)` —
+ * fire-and-forget; the actual HTTP POST runs on the shared
+ * task_worker.  Returns ESP_OK if the job was queued, ESP_ERR_NO_MEM
+ * if the worker queue is full (rare; caller logs + continues), or
+ * ESP_ERR_INVALID_STATE if NVS session_id or dragon_host isn't
+ * configured.
+ *
+ * ## Failure mode
+ *
+ * If the HTTP POST fails (Dragon down, 5xx, network error), the
+ * failure is logged at WARN level and the message is dropped.  An
+ * SD-card offline queue + drain-on-WS-reconnect path is deferred to
+ * W3-C-c (#TBD).  Dropping is acceptable for the v1 cohesion
+ * payoff — the canonical store gains the turn whenever the network
+ * is up, and the historical `solo_session_store` on SD still has
+ * the full record locally.
+ *
+ * ## Concurrency
+ *
+ * Caller calls from any context (LVGL or task).  The module
+ * snapshots all NVS reads + JSON construction in the caller's
+ * thread (cheap) and hands a self-contained PSRAM struct to the
+ * worker — the worker never re-reads NVS.
+ */
+#pragma once
+
+#include "esp_err.h"
+#include <stddef.h>
+
+/* Best-effort POST of one turn to Dragon's canonical messages DB.
+ *
+ * @param role        "user" | "assistant" | "system" | "tool"
+ * @param content     non-NULL non-empty UTF-8.  Long values OK — the
+ *                    module PSRAM-allocates a per-call buffer.
+ * @param input_mode  "voice" for SOLO/ONBOARD audio turns,
+ *                    "text" for typed turns, NULL → defaults to "text".
+ * @return ESP_OK on enqueue, ESP_ERR_INVALID_ARG / _STATE / _NO_MEM
+ *         otherwise.  Caller MUST NOT free anything passed in — the
+ *         module copies all inputs.
+ */
+esp_err_t voice_messages_sync_post(const char *role,
+                                   const char *content,
+                                   const char *input_mode);

--- a/main/voice_messages_sync.h
+++ b/main/voice_messages_sync.h
@@ -39,8 +39,9 @@
  */
 #pragma once
 
-#include "esp_err.h"
 #include <stddef.h>
+
+#include "esp_err.h"
 
 /* Best-effort POST of one turn to Dragon's canonical messages DB.
  *
@@ -53,6 +54,4 @@
  *         otherwise.  Caller MUST NOT free anything passed in — the
  *         module copies all inputs.
  */
-esp_err_t voice_messages_sync_post(const char *role,
-                                   const char *content,
-                                   const char *input_mode);
+esp_err_t voice_messages_sync_post(const char *role, const char *content, const char *input_mode);

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -27,6 +27,7 @@
 #include "ui_home.h"      /* ui_home_show_toast */
 #include "voice.h"        /* voice_set_state, VOICE_STATE_* */
 #include "voice_m5_llm.h" /* probe / infer / chain_* */
+#include "voice_messages_sync.h" /* W3-C-c: Dragon canonical message store */
 
 static const char *TAG = "voice_onboard";
 
@@ -288,6 +289,12 @@ static void onboard_failover_text_job(void *arg) {
          tab5_ui_unlock();
       }
       ESP_LOGI(TAG, "K144 reply: '%s'", reply);
+      /* W3-C-c (cross-stack cohesion audit 2026-05-11): POST both
+       * sides of the failover turn to Dragon's canonical messages
+       * DB.  prompt arrived as text (typed in chat); the K144 reply
+       * is text too. */
+      voice_messages_sync_post("user", prompt, "text");
+      voice_messages_sync_post("assistant", reply, "text");
    } else {
       if (tab5_ui_try_lock(150)) {
          ui_home_show_toast("Onboard LLM unavailable");
@@ -482,6 +489,13 @@ static void onboard_text_callback(const char *text, bool from_llm, bool finish, 
 
    if (finish && *len > 0) {
       ESP_LOGI(TAG, "chain %s commit: '%s'", from_llm ? "LLM" : "ASR", buf);
+
+      /* W3-C-c (cross-stack cohesion audit 2026-05-11): POST each
+       * autonomous-chain commit to Dragon's canonical messages DB.
+       * ASR = the user's spoken turn; LLM = K144's reply.  Both
+       * land via the chain's stacked K144 mic + LLM + TTS so they
+       * carry input_mode="voice". */
+      voice_messages_sync_post(from_llm ? "assistant" : "user", buf, "voice");
 
       /* Wave 3a Eigen workaround: chain doesn't include tts.setup any
        * more (K144's SummerTTS crashes mid-stream from LLM).  Instead,

--- a/main/voice_solo.c
+++ b/main/voice_solo.c
@@ -28,6 +28,7 @@
 #include "ui_chat.h"
 #include "ui_home.h"
 #include "voice.h"
+#include "voice_messages_sync.h" /* W3-C-b: Dragon canonical message store */
 
 static const char *TAG = "voice_solo";
 
@@ -202,6 +203,11 @@ static void solo_send_text_job(void *arg) {
        * NUL-terminated by the delta callback. */
       solo_session_append("user", text);
       solo_session_append("assistant", acc.acc ? acc.acc : "");
+      /* W3-C-b (cross-stack cohesion audit 2026-05-11): also POST to
+       * Dragon's canonical messages DB so the dashboard's Conversations
+       * tab and cross-session memory search see the SOLO turn. */
+      voice_messages_sync_post("user", text, "text");
+      voice_messages_sync_post("assistant", acc.acc ? acc.acc : "", "text");
    }
 
    free(msgs_json);
@@ -384,6 +390,11 @@ static void solo_send_audio_job(void *arg) {
     * transcript or the "[voice input]" fallback. */
    solo_session_append("user", user_text);
    solo_session_append("assistant", acc.acc ? acc.acc : "");
+   /* W3-C-b (cross-stack cohesion audit 2026-05-11): also POST to
+    * Dragon's canonical messages DB.  input_mode=voice marks the
+    * audio path so the dashboard can filter by modality. */
+   voice_messages_sync_post("user", user_text, "voice");
+   voice_messages_sync_post("assistant", acc.acc ? acc.acc : "", "voice");
    heap_caps_free(acc.acc);
 
    /* Signal the playback drain task that no more audio is coming for


### PR DESCRIPTION
## Summary
**Wave 3-C-c** of the cross-stack cohesion audit (2026-05-11).  Companion to W3-C-b (PR #390) which hooked SOLO turns.  This PR closes the loop on K144 (vmode=4 Onboard + Local-mode failover) — all six voice modes now contribute to Dragon's canonical messages DB.

**Dependency:** stacks on PR #390; merge that first.

## Hooks

\`main/voice_onboard.c\` — two sites:

- **\`onboard_failover_text_job\`**: Local-mode WS-down failover that routes a text turn through K144 — both \`prompt\` (user) and \`reply\` (assistant) POSTed with \`input_mode=\"text\"\`
- **\`onboard_text_callback\`**: the autonomous chain's per-utterance commit hook — ASR (user) and LLM finish (K144 reply) each POST with \`input_mode=\"voice\"\`

Both feed the same \`voice_messages_sync_post\` introduced in W3-C-b — failure handling, NVS snapshot, and worker scheduling are identical to the SOLO path.

## Scope note: K144 hardware not present in this dev env

\`/m5\` reports \`failover_state=unavailable\` (no K144 module stacked on this Tab5).  Live K144 E2E waits for a Mate-stacked test rig.  The code is mechanically identical to W3-C-b's SOLO hooks; the regression check below proves the SOLO path still works post-flash.

## Regression check — live on 192.168.1.90

\`\`\`
Built + flashed.  SOLO turn (Australia capital prompt):

Tab5 obs events:
  msg_sync.ok            role=user status=201
  msg_sync.ok            role=assistant status=201

Dragon GET /api/v1/sessions/{sid}/messages:
  [user]      input_mode=voice  "What is the capital of Australia..."
  [assistant] input_mode=voice  "The capital of Australia is Canberra..."
\`\`\`

W3-C-b SOLO path unaffected by W3-C-c K144 additions.

## Test plan
- [x] \`git-clang-format --diff origin/main\` clean
- [x] Build (\`idf.py build\`)
- [x] Flash + Tab5 boots cleanly
- [x] SOLO regression: turn cycles + \`msg_sync.ok\` events fire + Dragon roundtrip works
- [ ] K144 live E2E: deferred (hardware not present)
- [ ] CI green

## Non-goals (W3-C-d follow-up)
- SD-card offline queue + drain on WS reconnect
- Delete \`solo_session_store.c\` once W3-C-d proves stable

Closes #391 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)