### PR TITLE
feat(solo): offline queue + drain on WS reconnect (W3-C-d)

### DIFF
--- a/docs/AUDIT-state-of-stack-2026-05-11.md
+++ b/docs/AUDIT-state-of-stack-2026-05-11.md
@@ -1,5 +1,28 @@
 # Cross-stack state-of-the-stack audit — 2026-05-11
 
+## Wave program status — shipped to main (updated as PRs land)
+
+| Wave | Repo | PR | What |
+|---|---|---|---|
+| W1 | TinkerBox | #272 | protocol.md §19 numbering + #N→#124 |
+| W1 | TinkerTab | #382 | tree hygiene + this audit doc landed |
+| W2a | TinkerTab | #384 | SOLO audio playback chain (24→48 kHz upsample, speaker enable, backpressure) + STT prepend for real user transcript |
+| W2b | TinkerTab | #386 | re-enabled `voice.c:1172` zombie-Wi-Fi reboot escalation |
+| W3-A | TinkerBox | #274 | `VoiceMode.SOLO=5` added + `is_solo()` predicate + `config_swap` SOLO branch + 11 new tests |
+| W3-B | TinkerTab | #388 | Tab5 sends real vmode 4/5 in `config_update` (no more clamp-to-0) |
+| W3-C-a | TinkerBox | #276 | `POST /api/v1/sessions/{id}/messages` REST endpoint + 11 handler tests + CI gate |
+| W3-C-b | TinkerTab | #390 | Tab5 SOLO turns POST to Dragon canonical store via new `voice_messages_sync.{c,h}` module |
+| W3-C-c | TinkerTab | #392 | K144 turns (failover + autonomous chain) POST to Dragon canonical store |
+| W3-C-d | TinkerTab | #394 | SD offline queue (`/sdcard/msgsync.txt`, FAT 8.3) + drain on WS reconnect |
+
+**W7 placeholder:** TinkerBox #270 (mode 3 full surface, 7 sub-waves W7-0..G).  Decision logged 2026-05-11: Option C (full surface).
+
+**Remaining roadmap:** W4 turn_id (next) · W5 cost guard · W6 finish Wave 23 · W7 mode 3 sub-program · W8 UX polish · W9 test infra · W10 docs strategy.
+
+**Update this section when shipping new waves so the wave program survives session compaction.**
+
+---
+
 **Product naming (corrected 2026-05-11):**
 - **TinkerClaw** = the umbrella product brand. The Tab5 firmware connects to TinkerClaw running on Dragon hardware.
 - **TinkerTab** = the Tab5 firmware repo (the face).

--- a/main/voice_messages_sync.c
+++ b/main/voice_messages_sync.c
@@ -5,6 +5,7 @@
  */
 #include "voice_messages_sync.h"
 
+#include <stdio.h>
 #include <string.h>
 
 #include "cJSON.h"
@@ -18,11 +19,25 @@
 
 static const char *TAG = "msg_sync";
 
+/* W3-C-d: SD-backed offline queue.  Each line is a JSON envelope:
+ *   {"sid":"<session_id>","body":<the full POST body JSON>}
+ * Body is stored as-is so drain doesn't re-cJSON-build.  Cap is in
+ * lines (not bytes) — 100 entries at ~1 KB each = ~100 KB headroom.
+ * The drop-oldest policy + truncate-on-drain bound the file size. */
+/* FAT 8.3 short filename — Tab5 sdkconfig has CONFIG_FATFS_LFN_NONE=y
+ * so the basename is capped at 8 chars + 3-char extension. */
+#define MSG_SYNC_QUEUE_PATH "/sdcard/msgsync.txt"
+#define MSG_SYNC_QUEUE_CAP 100
+/* Largest single queue line we'll accept on read.  Matches the SOLO
+ * accumulator hard cap (64 KB) + envelope overhead. */
+#define MSG_SYNC_QUEUE_LINE_MAX (72 * 1024)
+
 /* Job state — fully self-contained.  Worker reads, no NVS touch. */
 typedef struct {
-   char url[160];  /* http://{host}:3502/api/v1/sessions/{session_id}/messages */
-   char auth[160]; /* "Bearer {token}" or "" when no token */
-   char *body;     /* PSRAM, free()d by worker */
+   char session_id[64]; /* for offline-queue write on failure */
+   char url[160];       /* http://{host}:3502/api/v1/sessions/{session_id}/messages */
+   char auth[160];      /* "Bearer {token}" or "" when no token */
+   char *body;          /* PSRAM, free()d by worker */
    size_t body_len;
    /* For obs / log: keep role + a short content prefix.  Avoids
     * leaking secrets if a malformed caller passes a token as content. */
@@ -36,12 +51,92 @@ static void free_job(msg_sync_job_t *job) {
    heap_caps_free(job);
 }
 
-static void msg_sync_post_job(void *arg) {
-   msg_sync_job_t *job = (msg_sync_job_t *)arg;
-   if (!job) return;
+/* Append one envelope line to the offline queue.  Drop-oldest if the
+ * file is at MSG_SYNC_QUEUE_CAP entries.  Returns ESP_OK on success.
+ *
+ * Called only from the worker thread (post_job failure path + drain_job
+ * re-queue path) so no mutex needed against itself. */
+static esp_err_t queue_append(const char *session_id, const char *body, size_t body_len) {
+   /* Count current entries — if at cap, evict the oldest line before
+    * appending.  Simple read-tail-only path: read all, drop first
+    * line, write the rest + the new line. */
+   FILE *f = fopen(MSG_SYNC_QUEUE_PATH, "r");
+   size_t lines = 0;
+   if (f) {
+      int c;
+      while ((c = fgetc(f)) != EOF) {
+         if (c == '\n') lines++;
+      }
+      fclose(f);
+   }
 
+   if (lines >= MSG_SYNC_QUEUE_CAP) {
+      /* Roll the oldest off.  Read all, skip first line, rewrite. */
+      char *all = heap_caps_malloc(MSG_SYNC_QUEUE_LINE_MAX * 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (!all) {
+         ESP_LOGW(TAG, "queue rotate alloc failed — appending past cap");
+      } else {
+         f = fopen(MSG_SYNC_QUEUE_PATH, "r");
+         if (f) {
+            /* Skip oldest line. */
+            int c;
+            while ((c = fgetc(f)) != EOF && c != '\n') {
+               /* discard */
+            }
+            size_t off = 0;
+            while ((c = fgetc(f)) != EOF && off < MSG_SYNC_QUEUE_LINE_MAX * 2 - 1) {
+               all[off++] = (char)c;
+            }
+            all[off] = '\0';
+            fclose(f);
+            FILE *out = fopen(MSG_SYNC_QUEUE_PATH, "w");
+            if (out) {
+               fwrite(all, 1, off, out);
+               fclose(out);
+               ESP_LOGI(TAG, "queue rotated: dropped oldest, kept %u bytes", (unsigned)off);
+            }
+         }
+         heap_caps_free(all);
+      }
+   }
+
+   f = fopen(MSG_SYNC_QUEUE_PATH, "a");
+   if (!f) {
+      ESP_LOGW(TAG, "queue append: fopen failed — message lost");
+      tab5_debug_obs_event("msg_sync.queue_err", "fopen");
+      return ESP_FAIL;
+   }
+   /* Build the envelope with cJSON so the embedded body string is
+    * properly escaped.  body itself is JSON; we treat it as an opaque
+    * UTF-8 string in the envelope. */
+   cJSON *env = cJSON_CreateObject();
+   if (!env) {
+      fclose(f);
+      return ESP_ERR_NO_MEM;
+   }
+   cJSON_AddStringToObject(env, "sid", session_id);
+   cJSON_AddRawToObject(env, "body", body); /* body is already valid JSON */
+   char *line = cJSON_PrintUnformatted(env);
+   cJSON_Delete(env);
+   if (!line) {
+      fclose(f);
+      return ESP_ERR_NO_MEM;
+   }
+   fputs(line, f);
+   fputc('\n', f);
+   fclose(f);
+   ESP_LOGI(TAG, "queued offline (%u bytes body)", (unsigned)body_len);
+   tab5_debug_obs_event("msg_sync.queued", "ok");
+   cJSON_free(line);
+   return ESP_OK;
+}
+
+/* Internal POST helper used by both the normal path and the drain
+ * re-post path.  Returns ESP_OK iff HTTP 2xx.  Does NOT log; caller
+ * owns logging + obs events so the two paths can label themselves. */
+static esp_err_t do_http_post(const char *url, const char *auth, const char *body, size_t body_len) {
    esp_http_client_config_t cfg = {
-       .url = job->url,
+       .url = url,
        .method = HTTP_METHOD_POST,
        .timeout_ms = 5000,
        .buffer_size = 2048,
@@ -49,56 +144,49 @@ static void msg_sync_post_job(void *arg) {
        .crt_bundle_attach = NULL,
    };
    esp_http_client_handle_t client = esp_http_client_init(&cfg);
-   if (!client) {
-      ESP_LOGW(TAG, "http_client_init failed (role=%s)", job->role);
-      tab5_debug_obs_event("msg_sync.error", "init");
-      free_job(job);
-      return;
-   }
-
+   if (!client) return ESP_FAIL;
    esp_http_client_set_header(client, "Content-Type", "application/json");
-   if (job->auth[0]) {
-      esp_http_client_set_header(client, "Authorization", job->auth);
+   if (auth && auth[0]) {
+      esp_http_client_set_header(client, "Authorization", auth);
    }
-
-   esp_err_t err = esp_http_client_open(client, (int)job->body_len);
+   esp_err_t err = esp_http_client_open(client, (int)body_len);
    if (err != ESP_OK) {
-      ESP_LOGW(TAG, "open failed: %s (role=%s)", esp_err_to_name(err), job->role);
-      tab5_debug_obs_event("msg_sync.error", "open");
       esp_http_client_cleanup(client);
-      free_job(job);
-      return;
+      return ESP_FAIL;
    }
-   int written = esp_http_client_write(client, job->body, (int)job->body_len);
-   if (written < 0 || (size_t)written != job->body_len) {
-      ESP_LOGW(TAG, "write short: %d/%u (role=%s)", written, (unsigned)job->body_len, job->role);
-      tab5_debug_obs_event("msg_sync.error", "write");
+   int written = esp_http_client_write(client, body, (int)body_len);
+   if (written < 0 || (size_t)written != body_len) {
       esp_http_client_close(client);
       esp_http_client_cleanup(client);
-      free_job(job);
-      return;
+      return ESP_FAIL;
    }
-   int content_len = esp_http_client_fetch_headers(client);
-   (void)content_len;
+   esp_http_client_fetch_headers(client);
    int status = esp_http_client_get_status_code(client);
-   /* Drain body so the connection can be cleanly reused / closed. */
    char drain[256];
    while (esp_http_client_read(client, drain, sizeof drain) > 0) {
       /* discard */
    }
    esp_http_client_close(client);
    esp_http_client_cleanup(client);
+   return (status >= 200 && status < 300) ? ESP_OK : ESP_FAIL;
+}
 
-   if (status >= 200 && status < 300) {
-      ESP_LOGI(TAG, "POST ok %d role=%s preview=%s", status, job->role, job->preview);
+static void msg_sync_post_job(void *arg) {
+   msg_sync_job_t *job = (msg_sync_job_t *)arg;
+   if (!job) return;
+
+   esp_err_t r = do_http_post(job->url, job->auth, job->body, job->body_len);
+   if (r == ESP_OK) {
+      ESP_LOGI(TAG, "POST ok role=%s preview=%s", job->role, job->preview);
       char detail[48];
-      snprintf(detail, sizeof detail, "role=%s status=%d", job->role, status);
+      snprintf(detail, sizeof detail, "role=%s status=ok", job->role);
       tab5_debug_obs_event("msg_sync.ok", detail);
    } else {
-      ESP_LOGW(TAG, "POST status=%d role=%s preview=%s", status, job->role, job->preview);
-      char detail[48];
-      snprintf(detail, sizeof detail, "role=%s status=%d", job->role, status);
-      tab5_debug_obs_event("msg_sync.fail", detail);
+      ESP_LOGW(TAG, "POST failed role=%s preview=%s — queuing offline", job->role, job->preview);
+      tab5_debug_obs_event("msg_sync.fail", job->role);
+      /* W3-C-d: keep the message — append to offline queue so it
+       * survives until WS reconnect triggers a drain. */
+      queue_append(job->session_id, job->body, job->body_len);
    }
    free_job(job);
 }
@@ -150,6 +238,8 @@ esp_err_t voice_messages_sync_post(const char *role, const char *content, const 
       heap_caps_free(psram_body);
       return ESP_ERR_NO_MEM;
    }
+   /* snprintf forces null-termination and silences -Wstringop-truncation. */
+   snprintf(job->session_id, sizeof job->session_id, "%s", session_id);
    snprintf(job->url, sizeof job->url, "http://%s:%d/api/v1/sessions/%s/messages", dragon_host, TAB5_VOICE_PORT,
             session_id);
    if (dragon_tok[0]) {
@@ -157,17 +247,138 @@ esp_err_t voice_messages_sync_post(const char *role, const char *content, const 
    }
    job->body = psram_body;
    job->body_len = body_len;
-   strncpy(job->role, role, sizeof(job->role) - 1);
+   snprintf(job->role, sizeof job->role, "%s", role);
    /* Short preview for the obs/log — first ~30 chars, ASCII-only safe. */
    size_t prev_n = strlen(content);
    if (prev_n > sizeof(job->preview) - 1) prev_n = sizeof(job->preview) - 1;
    memcpy(job->preview, content, prev_n);
+   job->preview[prev_n] = '\0';
 
    esp_err_t r = tab5_worker_enqueue(msg_sync_post_job, job, "msg_sync");
    if (r != ESP_OK) {
       ESP_LOGW(TAG, "worker queue full — dropping (role=%s)", role);
       tab5_debug_obs_event("msg_sync.drop", "queue_full");
       free_job(job);
+   }
+   return r;
+}
+
+/* ── W3-C-d: offline queue drain ─────────────────────────────────── */
+
+/* Process one queue line (post + on failure re-queue).  Returns ESP_OK
+ * iff the entry was successfully POSTed; ESP_FAIL iff it was either
+ * unparseable (dropped) or re-queued for the next drain attempt. */
+static esp_err_t drain_one_line(const char *line, const char *dragon_host, const char *dragon_tok) {
+   cJSON *env = cJSON_Parse(line);
+   if (!env) {
+      ESP_LOGW(TAG, "drain: skip unparseable line");
+      return ESP_FAIL;
+   }
+   const cJSON *sid_j = cJSON_GetObjectItem(env, "sid");
+   const cJSON *body_j = cJSON_GetObjectItem(env, "body");
+   if (!cJSON_IsString(sid_j) || sid_j->valuestring[0] == '\0' || body_j == NULL) {
+      cJSON_Delete(env);
+      ESP_LOGW(TAG, "drain: skip malformed line");
+      return ESP_FAIL;
+   }
+   /* body was written via cJSON_AddRawToObject so it's already a JSON
+    * object node; serialise it back to a string for the POST body. */
+   char *body_str = cJSON_PrintUnformatted(body_j);
+   if (!body_str) {
+      cJSON_Delete(env);
+      return ESP_FAIL;
+   }
+   char url[160];
+   snprintf(url, sizeof url, "http://%s:%d/api/v1/sessions/%s/messages", dragon_host, TAB5_VOICE_PORT,
+            sid_j->valuestring);
+   char auth[160] = {0};
+   if (dragon_tok && dragon_tok[0]) {
+      snprintf(auth, sizeof auth, "Bearer %s", dragon_tok);
+   }
+   esp_err_t r = do_http_post(url, auth, body_str, strlen(body_str));
+   if (r != ESP_OK) {
+      /* Re-queue.  body_str is the inner body JSON (without envelope);
+       * queue_append wraps it in a fresh envelope. */
+      queue_append(sid_j->valuestring, body_str, strlen(body_str));
+   }
+   cJSON_free(body_str);
+   cJSON_Delete(env);
+   return r;
+}
+
+static void msg_sync_drain_job(void *arg) {
+   (void)arg;
+
+   /* Snapshot Dragon host/token once for the whole loop. */
+   char dragon_host[64] = {0};
+   char dragon_tok[96] = {0};
+   tab5_settings_get_dragon_host(dragon_host, sizeof dragon_host);
+   tab5_settings_get_dragon_api_token(dragon_tok, sizeof dragon_tok);
+   if (!dragon_host[0]) {
+      ESP_LOGD(TAG, "drain skip: dragon_host empty");
+      return;
+   }
+
+   /* Rename-to-snapshot pattern: any concurrent queue_append from
+    * the (same) worker thread can't actually race us — the worker
+    * is single-threaded — but on reboot mid-drain we want the
+    * .processing file to still hold the un-replayed entries.  Move
+    * the active queue out of the way so new POST failures during
+    * the drain loop hit a fresh /sdcard/msg_queue.jsonl. */
+   /* FAT 8.3: drain snapshot uses a fresh 8.3 name (msgsync.bak). */
+   const char *processing = "/sdcard/msgsync.bak";
+   if (rename(MSG_SYNC_QUEUE_PATH, processing) != 0) {
+      /* Either no queue file exists yet, or rename failed.  In
+       * either case nothing to drain. */
+      ESP_LOGD(TAG, "drain: no snapshot (nothing to do)");
+      return;
+   }
+
+   FILE *f = fopen(processing, "r");
+   if (!f) {
+      ESP_LOGW(TAG, "drain: failed to open snapshot");
+      remove(processing);
+      return;
+   }
+   char *buf = heap_caps_malloc(MSG_SYNC_QUEUE_LINE_MAX, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!buf) {
+      ESP_LOGE(TAG, "drain: PSRAM line buffer alloc failed");
+      fclose(f);
+      /* Put the snapshot back so the next drain attempt can pick it up. */
+      rename(processing, MSG_SYNC_QUEUE_PATH);
+      return;
+   }
+
+   tab5_debug_obs_event("msg_sync.drain", "start");
+
+   int ok = 0;
+   int fail = 0;
+   while (fgets(buf, MSG_SYNC_QUEUE_LINE_MAX, f) != NULL) {
+      size_t n = strlen(buf);
+      if (n > 0 && buf[n - 1] == '\n') buf[n - 1] = '\0';
+      if (buf[0] == '\0') continue;
+      if (drain_one_line(buf, dragon_host, dragon_tok) == ESP_OK) {
+         ok++;
+      } else {
+         fail++;
+      }
+   }
+   fclose(f);
+   heap_caps_free(buf);
+   /* Snapshot fully processed — re-queued lines (failure path) live
+    * in /sdcard/msg_queue.jsonl now, NOT the snapshot.  Remove it. */
+   remove(processing);
+
+   char detail[48];
+   snprintf(detail, sizeof detail, "ok=%d fail=%d", ok, fail);
+   ESP_LOGI(TAG, "drain complete: %s", detail);
+   tab5_debug_obs_event("msg_sync.drain", detail);
+}
+
+esp_err_t voice_messages_sync_drain(void) {
+   esp_err_t r = tab5_worker_enqueue(msg_sync_drain_job, NULL, "msg_drain");
+   if (r != ESP_OK) {
+      ESP_LOGW(TAG, "drain: worker queue full");
    }
    return r;
 }

--- a/main/voice_messages_sync.h
+++ b/main/voice_messages_sync.h
@@ -22,13 +22,12 @@
  *
  * ## Failure mode
  *
- * If the HTTP POST fails (Dragon down, 5xx, network error), the
- * failure is logged at WARN level and the message is dropped.  An
- * SD-card offline queue + drain-on-WS-reconnect path is deferred to
- * W3-C-c (#TBD).  Dropping is acceptable for the v1 cohesion
- * payoff — the canonical store gains the turn whenever the network
- * is up, and the historical `solo_session_store` on SD still has
- * the full record locally.
+ * If the HTTP POST fails (Dragon down, 5xx, network error), W3-C-d
+ * appends the body to the SD-backed offline queue at
+ * `/sdcard/msg_queue.jsonl`.  When the Tab5 ↔ Dragon WS reconnects,
+ * voice_ws_proto.c calls `voice_messages_sync_drain()` which posts
+ * each queued entry in order.  Per-entry failures get re-queued so
+ * the file is durable across reboots + bounded outages.
  *
  * ## Concurrency
  *
@@ -55,3 +54,18 @@
  *         module copies all inputs.
  */
 esp_err_t voice_messages_sync_post(const char *role, const char *content, const char *input_mode);
+
+/* Drain the SD-backed offline queue.  Reads every entry in
+ * /sdcard/msg_queue.jsonl, attempts to POST each, and re-queues
+ * per-entry failures.  Runs on the shared task_worker.  Idempotent —
+ * back-to-back calls just enqueue duplicate drain jobs which run in
+ * sequence.
+ *
+ * Typical caller: voice_ws_proto.c on WEBSOCKET_EVENT_CONNECTED,
+ * AFTER the register frame so session_id has been confirmed.
+ *
+ * @return ESP_OK if a drain job was queued, ESP_ERR_NO_MEM if the
+ *         worker queue is full.  Empty queue is a cheap no-op, not
+ *         an error.
+ */
+esp_err_t voice_messages_sync_drain(void);

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -34,6 +34,7 @@
 #include "voice.h"           /* g_voice_ws extern + voice_set_state */
 #include "voice_billing.h"   /* receipt + budget */
 #include "voice_codec.h"     /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+#include "voice_messages_sync.h" /* W3-C-d: drain offline queue on reconnect */
 #include "voice_onboard.h"   /* K144 failover hooks */
 #include "voice_video.h"     /* VID0 magic peek + downlink decode */
 #include "voice_widget_ws.h" /* widget_* WS dispatch */
@@ -1233,6 +1234,11 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t even
             ESP_LOGE(TAG, "WS: register send failed (%s)", esp_err_to_name(reg_err));
             /* Let auto-reconnect re-attempt. */
          }
+         /* W3-C-d (cross-stack cohesion audit 2026-05-11): drain any
+          * SOLO/K144 turns that were POSTed while Dragon was
+          * unreachable.  Best-effort — re-queues per-entry failures
+          * for the next reconnect cycle. */
+         voice_messages_sync_drain();
          /* Don't set READY yet — wait for Dragon's session_start reply so
           * we know the backend pipeline is fully up. Keep state CONNECTING
           * until session_start arrives (~6s model load on first boot). */


### PR DESCRIPTION
## Summary

**Wave 3-C-d** closes the WS-down resilience gap that W3-C-b/c left open.  Queued turns now survive Dragon outages and replay automatically on reconnect.

**Stacks on:** PR #390 (W3-C-b SOLO sync) and PR #392 (W3-C-c K144 sync) — both should land first.

## Mechanism

**On POST failure** (any non-2xx, connect/write error), append the body envelope to \`/sdcard/msgsync.txt\` (FAT-8.3-safe name — sdkconfig has \`CONFIG_FATFS_LFN_NONE=y\`).  Envelope = one JSON line per entry: \`{\"sid\":\"<session_id>\",\"body\":<original body JSON>}\`.

**Cap** at 100 entries; drop-oldest policy.

**New API** \`voice_messages_sync_drain()\` — enqueues a drain job on \`task_worker\`.

**Drain uses rename-to-snapshot** (\`msgsync.txt → msgsync.bak\`) so concurrent failure-path appends during the loop go to a fresh queue, not the snapshot being processed.  Per-entry failures re-queue via \`queue_append\` for the next drain cycle.

**Hook**: \`voice_ws_proto.c\` calls \`voice_messages_sync_drain()\` on \`WEBSOCKET_EVENT_CONNECTED\` AFTER \`voice_ws_send_register()\` (so session_id is confirmed before drain replays).

## E2E verification — live on 192.168.1.90

\`\`\`
1. sudo systemctl stop tinkerclaw-voice          (Dragon offline)
2. Tab5 SOLO turn — espeak-ng \"pineapples\" prompt

   Tab5 obs:
     msg_sync.fail        user
     msg_sync.queued      ok          ← appended to SD
     msg_sync.fail        assistant
     msg_sync.queued      ok

3. sudo systemctl start tinkerclaw-voice          (Dragon up)
4. Tab5 WS auto-reconnects in 4 s

   Tab5 obs:
     ws.connect
     msg_sync.drain       start
     msg_sync.drain       ok=2 fail=0  ← both queued msgs replayed

5. Dragon GET /api/v1/sessions/{sid}/messages confirms both turns are now in the canonical store.
\`\`\`

**Zero dropped turns** across the down→up cycle.

## Implementation notes

- stringop-truncation warning fix: \`snprintf(buf, sizeof buf, \"%s\", src)\` instead of \`strncpy(buf, src, sizeof(buf)-1)\` (gcc 14 errors the latter under \`-Werror\`)
- \`msg_sync_post_job\` factored: actual HTTP call lives in \`do_http_post()\` so drain loop re-posts in-thread (the worker is single-threaded and drain runs inside it)
- FAT 8.3: \`msgsync.txt\` (7+3 chars) + \`msgsync.bak\` for snapshot — both fit \`CONFIG_FATFS_LFN_NONE=y\`

## Test plan
- [x] \`git-clang-format --diff origin/main\` clean
- [x] Build (\`idf.py build\`)
- [x] Flash + boot clean
- [x] Dragon-down: SOLO turn queues to SD (msg_sync.queued events fire)
- [x] Dragon-up: drain fires on WS reconnect, all entries POSTed (msg_sync.drain ok=N fail=0)
- [x] Dragon's canonical messages DB confirms the previously-queued turns appear
- [ ] CI green

## Non-goals (next wave)

- Delete \`solo_session_store.c\` entirely (Dragon becomes single source of truth) — defer one more wave so the offline queue has soak time

Closes #393 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)