### PR TITLE
feat(voice): Tab5 handles incoming cap_downgrade from Dragon (W5-C)

### DIFF
--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -874,6 +874,39 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       /* Dragon-level JSON pong — logged only. WS-level ping/pong is
        * handled automatically by esp_websocket_client (pingpong_timeout_sec). */
       ESP_LOGD(TAG, "App-level pong");
+   } else if (strcmp(type_str, "cap_downgrade") == 0) {
+      /* W5-C (cross-stack audit 2026-05-11): Dragon hit its server-side
+       * BUDGET_DAILY_CENTS cap and is telling us to switch to Local.
+       * Frame shape:
+       *   { "type":"cap_downgrade", "reason":"daily_cap_hit",
+       *     "spent_cents":N, "cap_cents":M, "day":"YYYY-MM-DD",
+       *     "turn_id":"..." }
+       * Mirrors the Tab5→Dragon direction already handled in
+       * voice_billing.c — Dragon owns server-side cap enforcement
+       * (W5-A/B), Tab5 owns its own NVS budget.  Either side hitting
+       * its cap drops both back to Local mode + surfaces a toast. */
+      cJSON *spent_j = cJSON_GetObjectItem(root, "spent_cents");
+      cJSON *cap_j = cJSON_GetObjectItem(root, "cap_cents");
+      int spent = cJSON_IsNumber(spent_j) ? spent_j->valueint : -1;
+      int cap = cJSON_IsNumber(cap_j) ? cap_j->valueint : -1;
+      ESP_LOGW(TAG, "Server cap hit: spent=%dc cap=%dc — flipping to Local", spent, cap);
+      char detail[48];
+      snprintf(detail, sizeof detail, "spent=%dc cap=%dc", spent, cap);
+      tab5_debug_obs_event("voice.cap_downgrade_recv", detail);
+      /* Flip NVS vmode to LOCAL only if we're not already on a Tab5-
+       * side-only tier the user explicitly picked (ONBOARD=4 /
+       * SOLO=5).  Those modes don't use Dragon's billable backends
+       * anyway, so the cap is moot for them; user's pick stands. */
+      uint8_t cur = tab5_settings_get_voice_mode();
+      if (cur != VMODE_LOCAL_ONBOARD && cur != VMODE_SOLO_DIRECT && cur != 0) {
+         tab5_settings_set_voice_mode(0);
+         voice_async_refresh_badge();
+         ESP_LOGI(TAG, "Cap downgrade: voice_mode %u → 0 (Local)", cur);
+      }
+      /* User-visible toast.  Pair with persistent banner so a quick
+       * dismiss doesn't hide the fact that they got auto-downgraded. */
+      const char *msg = "Daily budget cap reached — switched to Local mode";
+      voice_async_toast(strdup(msg));
    } else if (strcmp(type_str, "config_update") == 0) {
       cJSON *error = cJSON_GetObjectItem(root, "error");
       if (cJSON_IsString(error) && error->valuestring[0]) {


### PR DESCRIPTION
## Summary

**Wave 5-C** closes the cap-guard loop end-to-end.  W5-A (TinkerBox #283) + W5-B (TinkerBox #285) shipped Dragon-side spend tracking + outbound \`cap_downgrade\` emit; this PR is the Tab5 mirror that handles the incoming frame.

## Mechanism

\`main/voice_ws_proto.c\` adds a new \`type == \"cap_downgrade\"\` dispatch branch:
- Parse \`spent_cents\` + \`cap_cents\` (defensive: -1 if missing)
- Fire obs event \`voice.cap_downgrade_recv\` with \`spent=Nc cap=Mc\`
- ESP_LOGW with values
- If current vmode is 1/2/3 → flip to 0 (LOCAL) via NVS + async badge refresh
- If vmode is 4 (ONBOARD) or 5 (SOLO_DIRECT) → keep user's pick (those tiers don't use Dragon's billable backends; cap is moot)
- Surface toast: \"Daily budget cap reached — switched to Local mode\"

Mirrors the Tab5→Dragon direction already in \`voice_billing.c:106\`.

## E2E verification — live on 192.168.1.90 (built + flashed)

\`\`\`
POST /debug/inject_ws
  {\"type\":\"cap_downgrade\",\"spent_cents\":250,\"cap_cents\":100,\"day\":\"2026-05-12\",\"turn_id\":\"w5c-test\"}

Tab5 obs:
  voice.cap_downgrade_recv   spent=250c cap=100c

Tab5 NVS after:
  voice_mode=0  (was 2 / Cloud)
  llm_model unchanged

Toast: \"Daily budget cap reached — switched to Local mode\" fired
\`\`\`

## Audit finding fully closed

Wave 5 (W5-A + W5-B + W5-C) closes the audit's \"no cost guard\" S2 finding end-to-end:
- Dragon side: spend_tracker (W5-A) + BUDGET_DAILY_CENTS trigger + outbound cap_downgrade emit (W5-B)
- Tab5 side: incoming cap_downgrade handler (this PR, W5-C)

Combined with the existing Tab5→Dragon direction in voice_billing.c, the platform now has bidirectional cap enforcement.

## Test plan
- [x] \`git-clang-format --diff origin/main\` clean
- [x] Build (\`idf.py build\`)
- [x] Flash + boot
- [x] Inject synthetic cap_downgrade → obs event fires, vmode flips
- [ ] CI green

## Non-goals
- SOLO mode receipt POST so Tab5→OpenRouter direct turns count against Dragon's daily total.  Filed under W5-D if needed.

Closes #397 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)