### PR TITLE
feat(ui): mode-switch audio cue — first UI chirp on Tab5 (W8)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -7,6 +7,7 @@ set(UI_SRCS
     "ui_mode_sheet.c"
     "ui_nav_sheet.c"
     "ui_onboarding.c"
+    "ui_audio_cues.c"
     "chat_msg_store.c"
     "chat_header.c"
     "chat_input_bar.c"

--- a/main/main.c
+++ b/main/main.c
@@ -653,6 +653,12 @@ void app_main(void)
     // first enqueue doesn't race the init.
     tab5_worker_init();
 
+    /* W8 (audit 2026-05-11): pre-compute UI audio-cue PCM buffers.
+     * Must come after tab5_worker_init since ui_audio_cue_play
+     * dispatches onto the worker.  Cheap (<100 KB PSRAM total). */
+    extern esp_err_t ui_audio_cues_init(void);
+    (void)ui_audio_cues_init();
+
     /* TT #317 Phase 4: kick off the K144 LLM Module failover warm-up.
      * Posts ONE long-running job to the worker queue; safe to call here
      * because subsequent boot work (UI, voice, watchdog) doesn't depend

--- a/main/ui_audio_cues.c
+++ b/main/ui_audio_cues.c
@@ -1,0 +1,123 @@
+/*
+ * ui_audio_cues.c — see header.
+ *
+ * Wave 8 of the cross-stack cohesion audit (2026-05-11).
+ */
+#include "ui_audio_cues.h"
+
+#include <math.h>
+#include <stdlib.h>
+
+#include "audio.h" /* tab5_audio_speaker_enable, tab5_audio_play_raw */
+#include "debug_obs.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "task_worker.h"
+
+static const char *TAG = "ui_audio_cues";
+
+/* Per-cue PCM + sample count.  48 kHz mono int16. */
+typedef struct {
+   int16_t *pcm;
+   size_t samples;
+   const char *obs_tag;
+} cue_entry_t;
+
+static cue_entry_t s_cues[UI_CUE_COUNT];
+
+#define SAMPLE_RATE 48000
+
+/* Generate a sine wave with linear attack + release envelope.  Volume
+ * capped at `amp_q15` (0..32767).  Buffer must already be allocated
+ * to `samples` int16s. */
+static void gen_sine_envelope(int16_t *buf, size_t samples, float freq_hz, int amp_q15) {
+   const size_t attack = SAMPLE_RATE / 100;  /* 10 ms */
+   const size_t release = SAMPLE_RATE / 100; /* 10 ms */
+   if (samples == 0) return;
+   for (size_t i = 0; i < samples; i++) {
+      float t = (float)i / (float)SAMPLE_RATE;
+      float env = 1.0f;
+      if (i < attack) {
+         env = (float)i / (float)attack;
+      } else if (samples > release && i > samples - release) {
+         env = (float)(samples - i) / (float)release;
+      }
+      float sample = sinf(2.0f * (float)M_PI * freq_hz * t) * env;
+      int v = (int)(sample * (float)amp_q15);
+      if (v > 32767) v = 32767;
+      if (v < -32768) v = -32768;
+      buf[i] = (int16_t)v;
+   }
+}
+
+static esp_err_t init_cue(ui_cue_t id, size_t samples, float freq_hz, int amp_q15, const char *obs_tag) {
+   int16_t *pcm = heap_caps_malloc(samples * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!pcm) {
+      ESP_LOGW(TAG, "PSRAM alloc failed for cue %d", (int)id);
+      return ESP_ERR_NO_MEM;
+   }
+   gen_sine_envelope(pcm, samples, freq_hz, amp_q15);
+   s_cues[id].pcm = pcm;
+   s_cues[id].samples = samples;
+   s_cues[id].obs_tag = obs_tag;
+   ESP_LOGI(TAG, "Cue %d ready: %u samples @ %.0fHz amp=%d", (int)id, (unsigned)samples, (double)freq_hz, amp_q15);
+   return ESP_OK;
+}
+
+esp_err_t ui_audio_cues_init(void) {
+   esp_err_t worst = ESP_OK;
+
+   /* Mode switch: 80 ms 880 Hz (A5) — bright + confirmatory.
+    * Volume ~30% of full-scale int16 so it's not startling. */
+   if (!s_cues[UI_CUE_MODE_SWITCH].pcm) {
+      esp_err_t r = init_cue(UI_CUE_MODE_SWITCH, SAMPLE_RATE / 1000 * 80, 880.0f, 32767 * 30 / 100, "mode_switch");
+      if (r != ESP_OK) worst = r;
+   }
+
+   return worst;
+}
+
+typedef struct {
+   ui_cue_t id;
+} cue_job_t;
+
+static void cue_play_job(void *arg) {
+   cue_job_t *j = (cue_job_t *)arg;
+   if (!j) return;
+   if (j->id >= UI_CUE_COUNT || !s_cues[j->id].pcm) {
+      free(j);
+      return;
+   }
+   const cue_entry_t *c = &s_cues[j->id];
+   tab5_audio_speaker_enable(true);
+   esp_err_t r = tab5_audio_play_raw(c->pcm, c->samples);
+   /* Disable amp after playback to avoid hiss/leakage between cues. */
+   tab5_audio_speaker_enable(false);
+
+   char detail[24];
+   snprintf(detail, sizeof detail, "%s err=%d", c->obs_tag ? c->obs_tag : "?", (int)r);
+   tab5_debug_obs_event("ui.cue", detail);
+   free(j);
+}
+
+void ui_audio_cue_play(ui_cue_t id) {
+   if (id >= UI_CUE_COUNT) {
+      ESP_LOGW(TAG, "Cue id out of range: %d", (int)id);
+      return;
+   }
+   if (!s_cues[id].pcm) {
+      ESP_LOGD(TAG, "Cue %d not initialised — skip", (int)id);
+      return;
+   }
+   cue_job_t *j = malloc(sizeof(*j));
+   if (!j) {
+      ESP_LOGW(TAG, "cue_job_t alloc failed — dropping cue %d", (int)id);
+      return;
+   }
+   j->id = id;
+   esp_err_t r = tab5_worker_enqueue(cue_play_job, j, "cue");
+   if (r != ESP_OK) {
+      ESP_LOGW(TAG, "Worker queue full — dropping cue %d", (int)id);
+      free(j);
+   }
+}

--- a/main/ui_audio_cues.h
+++ b/main/ui_audio_cues.h
@@ -1,0 +1,56 @@
+/*
+ * ui_audio_cues.h — short UI feedback chirps over the Tab5 speaker.
+ *
+ * Wave 8 of the cross-stack cohesion audit (2026-05-11).  Audit found
+ * "device is mute except for LLM speech" and flagged audio cues as
+ * the single largest perceived-quality jump per hour of work
+ * available.  This module owns the small set of pre-computed PCM
+ * tone buffers + a fire-and-forget API to play one.
+ *
+ * ## Architecture
+ *
+ * `ui_audio_cues_init()` is called once at boot from main.c after
+ * the audio + worker subsystems are up.  It pre-computes one PCM
+ * buffer per cue ID in PSRAM, sized for 48 kHz mono int16 with a
+ * short envelope (10 ms attack, 10 ms release) so playback doesn't
+ * click.
+ *
+ * `ui_audio_cue_play(id)` enqueues a job onto the shared
+ * `tab5_worker`.  The worker enables the NS4150B amp, calls
+ * `tab5_audio_play_raw()` (blocks for the cue duration — ~80 ms),
+ * then disables the amp.  The LVGL caller never blocks.
+ *
+ * ## Why not voice_playback_buf_write?
+ *
+ * That path queues into the main TTS playback ring, which means
+ * (a) the cue would play AFTER any currently-playing TTS, and
+ * (b) the drain task's speaker-disable logic depends on the
+ * `s_tts_done` flag from the turn lifecycle, so a cue triggered
+ * outside a turn would leave the amp on indefinitely.  The
+ * bypass-via-worker path keeps cues self-contained.
+ *
+ * ## Failure mode
+ *
+ * If pre-computed buffers are missing (init never ran or alloc
+ * failed), `ui_audio_cue_play()` is a logged no-op — the UI flow
+ * continues uninterrupted.  Cues are sugar; never load-bearing.
+ */
+#pragma once
+
+#include "esp_err.h"
+
+typedef enum {
+   UI_CUE_MODE_SWITCH = 0,
+   UI_CUE_COUNT,
+} ui_cue_t;
+
+/* Pre-compute all cue PCM buffers in PSRAM.  Idempotent — safe to
+ * call more than once at boot.  Returns ESP_OK on success or an
+ * ESP error if any allocation failed (any successful pre-allocations
+ * are kept; only the failed cue is dropped). */
+esp_err_t ui_audio_cues_init(void);
+
+/* Fire-and-forget cue playback.  Returns immediately; actual audio
+ * runs on the shared task_worker.  No-op if `id` is out of range
+ * or the cue's pre-computed buffer is missing. */
+void ui_audio_cue_play(ui_cue_t id);

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -12,8 +12,9 @@
 #include "esp_log.h"
 #include "lvgl.h"
 #include "settings.h"
-#include "ui_core.h" /* W8: tab5_ui_try_lock / tab5_ui_unlock for or_key gate toast */
-#include "ui_home.h" /* W8: ui_home_show_toast */
+#include "ui_audio_cues.h" /* W8: mode-switch chirp on preset / dial commit */
+#include "ui_core.h"       /* W8: tab5_ui_try_lock / tab5_ui_unlock for or_key gate toast */
+#include "ui_home.h"       /* W8: ui_home_show_toast */
 #include "ui_theme.h"
 #include "voice.h"
 
@@ -486,6 +487,13 @@ static void refresh_composite(void)
 
 static void persist_and_notify_dragon(void)
 {
+    /* W8: confirmatory chirp.  Fired from EVERY user-driven mode-sheet
+     * commit (dial segment tap → persist_and_notify_dragon, plus every
+     * preset chip case 0..3 below).  Audit found the device mute on
+     * UI interactions; the cue closes that gap.  Worker-dispatched so
+     * the LVGL caller doesn't block. */
+    ui_audio_cue_play(UI_CUE_MODE_SWITCH);
+
     /* Persist the three tiers + the derived voice_mode + (optional) llm_model. */
     tab5_settings_set_int_tier(s_int_tier);
     tab5_settings_set_voi_tier(s_voi_tier);
@@ -539,6 +547,7 @@ void preset_click_cb(lv_event_t *e)
                       * stays at whatever the user last picked.  Closes the
                       * "K144 unreachable from sheet" half of audit P0 #10. */
            tab5_settings_set_voice_mode(VOICE_MODE_ONBOARD);
+           ui_audio_cue_play(UI_CUE_MODE_SWITCH); /* W8: chirp on Onboard preset */
            char model[64] = {0};
            tab5_settings_get_llm_model(model, sizeof(model));
            voice_send_config_update(VOICE_MODE_ONBOARD, model);

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -487,25 +487,24 @@ static void refresh_composite(void)
 
 static void persist_and_notify_dragon(void)
 {
-    /* W8: confirmatory chirp.  Fired from EVERY user-driven mode-sheet
-     * commit (dial segment tap → persist_and_notify_dragon, plus every
-     * preset chip case 0..3 below).  Audit found the device mute on
-     * UI interactions; the cue closes that gap.  Worker-dispatched so
-     * the LVGL caller doesn't block. */
-    ui_audio_cue_play(UI_CUE_MODE_SWITCH);
+   /* W8: confirmatory chirp.  Fired from EVERY user-driven mode-sheet
+    * commit (dial segment tap → persist_and_notify_dragon, plus every
+    * preset chip case 0..3 below).  Audit found the device mute on
+    * UI interactions; the cue closes that gap.  Worker-dispatched so
+    * the LVGL caller doesn't block. */
+   ui_audio_cue_play(UI_CUE_MODE_SWITCH);
 
-    /* Persist the three tiers + the derived voice_mode + (optional) llm_model. */
-    tab5_settings_set_int_tier(s_int_tier);
-    tab5_settings_set_voi_tier(s_voi_tier);
-    tab5_settings_set_aut_tier(s_aut_tier);
+   /* Persist the three tiers + the derived voice_mode + (optional) llm_model. */
+   tab5_settings_set_int_tier(s_int_tier);
+   tab5_settings_set_voi_tier(s_voi_tier);
+   tab5_settings_set_aut_tier(s_aut_tier);
 
-    char model_out[64] = {0};
-    uint8_t new_mode = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier,
-                                          model_out, sizeof(model_out));
-    tab5_settings_set_voice_mode(new_mode);
-    if (model_out[0]) {
-        tab5_settings_set_llm_model(model_out);
-    }
+   char model_out[64] = {0};
+   uint8_t new_mode = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier, model_out, sizeof(model_out));
+   tab5_settings_set_voice_mode(new_mode);
+   if (model_out[0]) {
+      tab5_settings_set_llm_model(model_out);
+   }
 
     /* Fire config_update to Dragon so it swaps backends on the next turn.
      * Re-read llm_model from NVS to send what's actually stored (either


### PR DESCRIPTION
## Summary
**Wave 8 UX polish** — closes the audit's \"device is mute except for LLM speech\" finding for mode-switch user actions.  Audit flagged this as \"single largest perceived-quality jump per hour\" available.

## New module

\`main/ui_audio_cues.{c,h}\`:
- \`ui_audio_cues_init()\` pre-computes PCM buffers in PSRAM (sine + 10ms ADSR envelope to avoid click)
- \`ui_audio_cue_play(id)\` fire-and-forget; worker enables amp → \`tab5_audio_play_raw\` → disables amp.  LVGL caller never blocks.

## First cue

\`UI_CUE_MODE_SWITCH\`: 80 ms, 880 Hz (A5), ~30% amplitude.  Bright + confirmatory.

## Hooks
- \`main.c\` — init called after \`tab5_worker_init()\`
- \`ui_mode_sheet.c persist_and_notify_dragon\` — fires on every dial commit + presets 0-3
- \`ui_mode_sheet.c preset_click_cb\` case 4 (Onboard) — explicit wire since direct-write bypasses persist_and_notify_dragon

## Why not the main playback ring?

\`voice_playback_buf_write\` would (a) queue behind any in-progress TTS and (b) the drain task's speaker-off logic depends on \`s_tts_done\` from the turn lifecycle, leaving the amp on indefinitely after an out-of-turn cue.  Worker-bypass keeps cues self-contained.

## Live verification

Built + flashed.  Opened mode sheet (long-press orb) + tapped Local preset chip:

\`\`\`
Tab5 obs:
  screen.navigate    home
  ui.cue             mode_switch err=0
\`\`\`

\`err=0\` = \`tab5_audio_play_raw\` returned ESP_OK → amp enabled → 3840 samples streamed via I2S → amp disabled.  Audibility verification needs eye-on-device.

## Test plan
- [x] git-clang-format clean
- [x] idf.py build passes
- [x] Tab5 flashes + boots cleanly
- [x] Mode-sheet preset tap fires \`ui.cue\` obs event with \`err=0\`
- [ ] CI green
- [ ] Eye-on-device: hear an 880 Hz chirp when committing a mode

## Non-goals (deferred)
- UI_CUE_CANCEL (60ms 220Hz low)
- UI_CUE_ERROR (100ms 220Hz × 2)
- Boot chirp
- Reduced-motion / silent-mode NVS toggle

Closes #403 — refs #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)