### PR TITLE
feat(ui): cancel + error audio cues (W8, closes #405, refs #270)

### DIFF
--- a/main/ui_audio_cues.c
+++ b/main/ui_audio_cues.c
@@ -74,6 +74,21 @@ esp_err_t ui_audio_cues_init(void) {
       if (r != ESP_OK) worst = r;
    }
 
+   /* Cancel: 60 ms 220 Hz (A3) — sub-octave of mode_switch, low +
+    * dismissive.  40% amplitude since low frequencies sound quieter
+    * at the same digital level. */
+   if (!s_cues[UI_CUE_CANCEL].pcm) {
+      esp_err_t r = init_cue(UI_CUE_CANCEL, SAMPLE_RATE / 1000 * 60, 220.0f, 32767 * 40 / 100, "cancel");
+      if (r != ESP_OK) worst = r;
+   }
+
+   /* Error: 120 ms 200 Hz — longer + lower than cancel so they
+    * don't get confused.  Same 40% amplitude. */
+   if (!s_cues[UI_CUE_ERROR].pcm) {
+      esp_err_t r = init_cue(UI_CUE_ERROR, SAMPLE_RATE / 1000 * 120, 200.0f, 32767 * 40 / 100, "error");
+      if (r != ESP_OK) worst = r;
+   }
+
    return worst;
 }
 

--- a/main/ui_audio_cues.h
+++ b/main/ui_audio_cues.h
@@ -40,7 +40,9 @@
 #include "esp_err.h"
 
 typedef enum {
-   UI_CUE_MODE_SWITCH = 0,
+   UI_CUE_MODE_SWITCH = 0, /* 80 ms 880 Hz — bright, confirmatory */
+   UI_CUE_CANCEL = 1,      /* 60 ms 220 Hz — low, dismissive */
+   UI_CUE_ERROR = 2,       /* 120 ms 200 Hz — longer, somber */
    UI_CUE_COUNT,
 } ui_cue_t;
 

--- a/main/voice.c
+++ b/main/voice.c
@@ -50,6 +50,7 @@
 #include "settings.h"
 #include "task_worker.h" /* #133: defer queue-drain to avoid stack blow */
 #include "tool_log.h"    /* U7+U8 (#206): record tool activity for ui_agents/ui_focus */
+#include "ui_audio_cues.h" /* W8: UI_CUE_CANCEL on voice_cancel */
 #include "ui_chat.h"
 #include "ui_core.h"
 #include "ui_home.h" /* TT #317 Phase 4: ui_home_show_toast for failover UX */
@@ -1907,6 +1908,10 @@ esp_err_t voice_cancel(void)
         return ESP_OK;
     }
     ESP_LOGI(TAG, "Cancelling voice session");
+
+    /* W8 (audit 2026-05-11): confirmatory cancel chirp.  Audit found the
+     * device was mute on UI interactions; this closes the cancel branch. */
+    ui_audio_cue_play(UI_CUE_CANCEL);
 
     /* W1-C (TT #372): in vmode=5 SOLO_DIRECT the in-flight HTTP turn
      * lives in voice_solo, not the Dragon WS path.  Set the cancel flag

--- a/main/voice_solo.c
+++ b/main/voice_solo.c
@@ -25,6 +25,7 @@
 #include "solo_rag.h"
 #include "solo_session_store.h"
 #include "task_worker.h"
+#include "ui_audio_cues.h"
 #include "ui_chat.h"
 #include "ui_home.h"
 #include "voice.h"
@@ -197,6 +198,7 @@ static void solo_send_text_job(void *arg) {
       tab5_debug_obs_event("solo.error", detail);
       ESP_LOGE(TAG, "solo LLM failed: %s", esp_err_to_name(err));
       ui_home_show_toast("Solo LLM failed");
+      ui_audio_cue_play(UI_CUE_ERROR);
    } else {
       tab5_debug_obs_event("solo.llm_done", detail);
       /* Persist both turns to the SD-backed session.  acc.acc is
@@ -382,6 +384,7 @@ static void solo_send_audio_job(void *arg) {
    tab5_debug_obs_event(err == ESP_OK ? "solo.audio_done" : "solo.error", detail);
    if (err != ESP_OK) {
       ui_home_show_toast("Solo audio chat failed");
+      ui_audio_cue_play(UI_CUE_ERROR);
       heap_caps_free(acc.acc);
       tab5_audio_speaker_enable(false); /* abort path — speaker off */
       goto done_free_pcm;


### PR DESCRIPTION
## Summary
- Adds `UI_CUE_CANCEL` (60 ms 220 Hz @ 40 % amp) + `UI_CUE_ERROR` (120 ms 200 Hz @ 40 % amp) to the `ui_audio_cues` module
- Hooks the cancel cue inside `voice_cancel()` and the error cue after both `ui_home_show_toast` calls in `voice_solo` (Solo LLM failed / Solo audio chat failed)
- Closes the W8 audio-cue gap left by PR #404 (which only wired mode_switch)

## Test plan
- [x] `idf.py build` clean (cues compile in voice.c + voice_solo.c)
- [x] Flash + boot Tab5 — all 3 cues report ready in PSRAM:
  - `Cue 0 ready: 3840 samples @ 880Hz amp=9830`
  - `Cue 1 ready: 2880 samples @ 220Hz amp=13106`
  - `Cue 2 ready: 5760 samples @ 200Hz amp=13106`
- [x] `POST /voice/cancel` → obs ring entry: `ui.cue cancel err=0`
- [x] Error cue wired next to existing toast (no behavior change beyond the chirp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)