### PR TITLE
test: nightly stress soak + Tab5 host discovery (closes #414, refs W9-B)

### DIFF
--- a/docs/AUDIT-state-of-stack-2026-05-11.md
+++ b/docs/AUDIT-state-of-stack-2026-05-11.md
@@ -21,10 +21,11 @@
 | W9-A (1/N) | TinkerTab | #409 | host-targeted unit test infra (`tests/host/CMakeLists.txt`) + `test_md_strip.c` (10 assertions / 3 public functions) + `host-tests` CI workflow (7 s gate).  Plain `<assert.h>` driver, no cmocka dep.  **Closes #408** |
 | W9-A (2/N) | TinkerTab | #411 | `tests/host/shim/` ESP-IDF shims (heap_caps, esp_log, esp_err) + `test_openrouter_sse.c` (9 tests / 18 assertions: overflow drop+resume, 50 KB intact, [DONE] sentinel, CRLF, comment-line drop, multi-event single feed, split-feeds, optional space).  Pins both recent SSE regressions (W3-C overflow restart, TT #379 64 KB bump).  **Closes #410** |
 | W9-A (3/N) | TinkerTab | #413 | `test_spring_anim.c` (9 tests / 18 assertions) — damped harmonic oscillator math.  Pins each of the 3 regime branches (under/critical/over), the SPRING_MAX_ELAPSED_S pathological-config bail-out, the zero-mass clamp, and SNAPPY/BOUNCY/SMOOTH preset envelopes.  **Closes #412** |
+| W9-B | TinkerTab | #415 | `tests/e2e/discover.py` — Tab5 host discovery chain (arg → env → mDNS espressif.local → cache → fail).  Replaces hardcoded `192.168.1.90` in `runner.py`.  New `tests/e2e/nightly.sh` cron-deployable wrapper for `story_stress --reboot`.  Live-verified: 14/14 PASS through new discovery wiring.  **Closes #414** |
 
 **W7 placeholder:** TinkerBox #270 (mode 3 full surface, 7 sub-waves W7-0..G).  Decision logged 2026-05-11: Option C (full surface).
 
-**Remaining roadmap:** W9-A more slices (heavier modules need cJSON / NVS / SD shims) · W9-B nightly cron + driver IP fix · W9-C protocol contract test · W9-D Dragon-restart resilience · W10 docs strategy.
+**Remaining roadmap:** W9-A more slices (heavier modules need cJSON / NVS / SD shims) · W9-C protocol contract test · W9-D Dragon-restart resilience · W10 docs strategy.
 
 **Update this section when shipping new waves so the wave program survives session compaction.**
 

--- a/tests/e2e/discover.py
+++ b/tests/e2e/discover.py
@@ -1,0 +1,131 @@
+"""Tab5 host discovery — mDNS first, then env/arg, then bail.
+
+The DGX dev host's LAN has flipped between 192.168.1.x and 192.168.70.x
+multiple times and the Tab5 itself is DHCP-leased, so any hardcoded IP
+rots within a week.  This module gives the runner + nightly cron a
+single source-of-truth for "where is the Tab5 right now?".
+
+Resolution order:
+
+    1. Explicit URL passed to `find_tab5(prefer_url=...)`
+    2. TAB5_URL environment variable
+    3. mDNS lookup of `espressif.local` (Tab5 advertises this name by
+       default via the IDF mDNS service — verified live 2026-05-04)
+    4. Cached IP from previous successful run at ~/.tinker_tab5_url
+    5. `None` — caller decides whether to error or scan
+
+The function returns the full `http://host:8080` URL (port can be
+overridden), not a bare IP, so the runner can drop it straight into
+`Tab5Driver(base_url=...)`.  Last-known IPs are cached so a flaky
+mDNS hop doesn't break a run.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+CACHE_PATH = Path.home() / ".tinker_tab5_url"
+DEFAULT_HOSTNAME = "espressif.local"
+DEFAULT_PORT = 8080
+
+
+def _probe(url: str, timeout: float = 1.5) -> bool:
+    """Return True iff GET ``{url}/info`` returns a JSON body with the
+    Tab5 ``auth_required`` field.  Anything else (timeout, wrong
+    server, non-Tab5 host) → False."""
+    try:
+        import urllib.request
+        import json
+        with urllib.request.urlopen(f"{url}/info", timeout=timeout) as r:
+            body = json.loads(r.read().decode("utf-8", errors="replace"))
+        return bool(body.get("auth_required"))
+    except Exception:
+        return False
+
+
+def _resolve_mdns(name: str = DEFAULT_HOSTNAME, timeout: float = 2.0) -> Optional[str]:
+    """Resolve an mDNS hostname to an IP.  Uses avahi-resolve-host-name
+    if present (Linux), else stdlib socket.gethostbyname.  Returns the
+    IP string or None."""
+    try:
+        out = subprocess.run(
+            ["avahi-resolve-host-name", "-4", name],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            parts = out.stdout.strip().split()
+            if len(parts) >= 2:
+                return parts[-1]
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    try:
+        return socket.gethostbyname(name)
+    except OSError:
+        return None
+
+
+def _read_cache() -> Optional[str]:
+    try:
+        url = CACHE_PATH.read_text().strip()
+        return url or None
+    except (OSError, ValueError):
+        return None
+
+
+def _write_cache(url: str) -> None:
+    try:
+        CACHE_PATH.write_text(url)
+    except OSError:
+        pass  # cache is best-effort; never block a run on cache I/O
+
+
+def find_tab5(
+    prefer_url: Optional[str] = None,
+    *,
+    port: int = DEFAULT_PORT,
+    hostname: str = DEFAULT_HOSTNAME,
+) -> Optional[str]:
+    """Return a verified Tab5 base URL, or None.
+
+    `prefer_url` wins over every other source — used by `--base-url`
+    callers who explicitly want to target one device.  A successfully
+    resolved URL is written to the cache so the next run starts with a
+    warm hint."""
+    candidates = []
+    if prefer_url:
+        candidates.append(prefer_url)
+    env_url = os.environ.get("TAB5_URL")
+    if env_url and env_url not in candidates:
+        candidates.append(env_url)
+    mdns_ip = _resolve_mdns(hostname)
+    if mdns_ip:
+        candidates.append(f"http://{mdns_ip}:{port}")
+    cached = _read_cache()
+    if cached and cached not in candidates:
+        candidates.append(cached)
+
+    for url in candidates:
+        if _probe(url):
+            _write_cache(url)
+            return url
+    return None
+
+
+def main() -> int:
+    """CLI: print the discovered URL or exit non-zero."""
+    url = find_tab5()
+    if not url:
+        print("Tab5 not found via env/mDNS/cache.  Try:")
+        print("  TAB5_URL=http://<ip>:8080 python3 discover.py")
+        return 1
+    print(url)
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/tests/e2e/nightly.sh
+++ b/tests/e2e/nightly.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# W9-B (audit 2026-05-11): nightly Tab5 soak via the e2e harness.
+#
+# Cron-deployable wrapper around `runner.py story_stress --reboot`.
+# Resolves the Tab5 URL through tests/e2e/discover.py first so a DHCP
+# rotation doesn't break overnight runs.  Output goes to a dated dir
+# under tests/e2e/runs/nightly/; the latest report path is written to
+# runs/nightly/LATEST for downstream tooling to pick up.
+#
+# Install as a user cron (no sudo needed):
+#
+#   crontab -e
+#   # Run at 03:00 nightly, log to journald via systemd-cat
+#   0 3 * * * /home/rebelforce/projects/TinkerTab/tests/e2e/nightly.sh \
+#             2>&1 | systemd-cat -t tab5-nightly
+#
+# Exits non-zero on harness failure so cron's MAILTO will surface it.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+E2E_DIR="$REPO_DIR/tests/e2e"
+RUNS_DIR="$E2E_DIR/runs/nightly"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$RUNS_DIR/$TS"
+mkdir -p "$RUN_DIR"
+
+cd "$E2E_DIR"
+
+# Resolve Tab5 URL first so we fail fast with a clear message instead of
+# hanging the soak waiting on a dead IP.
+if ! URL=$(python3 discover.py 2>&1); then
+   echo "[nightly $TS] FATAL: Tab5 not found"
+   echo "$URL"
+   exit 2
+fi
+echo "[nightly $TS] Tab5 located at $URL"
+echo "$URL" > "$RUN_DIR/tab5_url"
+
+# story_stress = the 10-min mixed nav+screenshot+chat cycle (~6 cycles,
+# 76 steps).  --reboot starts from clean state so a fragmentation-
+# accumulation regression has a stable baseline.
+TAB5_URL="$URL" python3 runner.py story_stress --reboot 2>&1 \
+   | tee "$RUN_DIR/run.log"
+RC=${PIPESTATUS[0]}
+
+# The runner already writes its own per-run dir under runs/.  Surface
+# its location for downstream tooling + keep a stable LATEST pointer
+# at this script's run dir.
+ln -sfn "$RUN_DIR" "$RUNS_DIR/LATEST"
+
+if [[ $RC -ne 0 ]]; then
+   echo "[nightly $TS] FAIL rc=$RC"
+   exit $RC
+fi
+echo "[nightly $TS] PASS"

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -2803,8 +2803,10 @@ SCENARIOS: dict[str, Callable[[Runner], None]] = {
 def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("scenario", choices=list(SCENARIOS.keys()) + ["all"])
-    p.add_argument("--base-url", default=os.environ.get(
-        "TAB5_URL", "http://192.168.1.90:8080"))
+    p.add_argument("--base-url", default=None,
+                   help="Override Tab5 URL.  Falls back to TAB5_URL env, "
+                        "then mDNS (espressif.local), then ~/.tinker_tab5_url "
+                        "cache.  See tests/e2e/discover.py.")
     p.add_argument("--token",
                    default=os.environ.get("TAB5_TOKEN",
                                           "05eed3b13bf62d92cfd8ac424438b9f2"))
@@ -2812,7 +2814,17 @@ def main() -> int:
                    help="Reboot Tab5 before running (clean state)")
     args = p.parse_args()
 
-    tab5 = Tab5Driver(base_url=args.base_url, token=args.token)
+    # W9-B: resolve the Tab5 URL through the discovery chain instead of
+    # using a hardcoded LAN IP that rots when DHCP rotates.
+    from discover import find_tab5  # noqa: E402
+    base_url = find_tab5(prefer_url=args.base_url)
+    if not base_url:
+        print("ERROR: cannot locate Tab5.  Try one of:")
+        print("  export TAB5_URL=http://<ip>:8080")
+        print("  enable mDNS + verify `avahi-resolve-host-name -4 espressif.local`")
+        return 2
+
+    tab5 = Tab5Driver(base_url=base_url, token=args.token)
     if args.reboot:
         print("Rebooting Tab5…")
         tab5.reboot()


### PR DESCRIPTION
## Summary
- `tests/e2e/discover.py` — Tab5 host discovery chain (arg → env → mDNS `espressif.local` → cache → fail). Each candidate is probed via `GET /info` before being trusted, so a stale cache falls through cleanly to the next source. Successful URLs cache to `~/.tinker_tab5_url`.
- `tests/e2e/runner.py main()` switches from hardcoded `http://192.168.1.90:8080` to `find_tab5(prefer_url=args.base_url)`.
- New `tests/e2e/nightly.sh` — cron-deployable wrapper around `story_stress --reboot`. Logs to `tests/e2e/runs/nightly/<UTC-TS>/` with a stable `LATEST` symlink.
- Audit doc updated.

## Test plan
- [x] `python3 discover.py` resolves via TAB5_URL env fallback (mDNS not currently advertised by the Tab5 — discovery chain handles that gracefully)
- [x] `TAB5_URL=http://192.168.1.90:8080 python3 runner.py story_smoke` → 14/14 PASS in 116 s through the new discovery wiring (live hardware)
- [x] `bash -n nightly.sh` syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)