### PR TITLE
docs: ADR scaffold + first ADR (closes #422, refs W10-C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,8 @@ When the issue tracker accumulates >10 open items, work in **waves**: one wave a
 
 For multi-week features (Grove, K144, widget platform), **write a plan doc first** (`docs/PLAN-*.md`) with: hardware reality, code architecture, phased breakdown with file:line refs, honest unknowns, code anchors.  File a tracking issue that links to the doc as source-of-truth.  Branches die; docs + issues persist.
 
+For **non-obvious cross-stack architectural decisions** (host-test pattern, lv_async_call discipline, codec gating policy, etc.), write an ADR — see [`docs/adr/README.md`](docs/adr/README.md) for the criteria + template.  ADRs are short, immutable once accepted, and live forever so future contributors don't re-litigate decisions that already took real thinking to settle.  Not every PR needs one; one a quarter is healthy.
+
 ### Issue Format
 ```
 ## Bug / Problem

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,30 @@
+# NNNN — Decision title in active voice
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Deciders:** GitHub handles
+- **Tags:** (optional) tab5 / dragon / cross-stack / testing / build
+
+## Context
+
+What's the situation that forces a decision?  One paragraph.  Include
+the constraint that makes the obvious answer wrong — that's the
+information future readers actually need.
+
+## Decision
+
+What we're doing.  Active voice, present tense.  Two or three
+sentences.
+
+## Consequences
+
+- What gets easier (the win we paid for)
+- What gets harder (the cost we accepted)
+- What's now off the table (alternatives we ruled out and won't
+  revisit without a new ADR)
+
+## Alternatives considered
+
+Brief.  For each alternative, one sentence on why we didn't pick it.
+The point is to spare a future contributor the same "what about X?"
+loop we already ran.

--- a/docs/adr/0001-host-test-infra-pattern.md
+++ b/docs/adr/0001-host-test-infra-pattern.md
@@ -1,0 +1,69 @@
+# 0001 — Host-test infra uses plain `<assert.h>` + tiny ESP-IDF shims
+
+- **Status:** Accepted
+- **Date:** 2026-05-12
+- **Deciders:** lorcan35
+- **Tags:** testing / build / tab5
+
+## Context
+
+W9-A from the 2026-05-11 cross-stack audit asked for a "CMocka host
+CMake target" so the pure-logic Tab5 modules (`md_strip`,
+`openrouter_sse`, `spring_anim`, etc.) could be unit-tested off-device.
+CMocka was the audit's first guess because it's the canonical
+ESP-IDF unit-test framework — but ESP-IDF only ships it for on-target
+runs, not for host builds.  Bringing CMocka onto the host means either
+an apt dependency (`libcmocka-dev`) or vendoring it into the tree.
+
+Several modules (everything except `md_strip`) include ESP-IDF
+headers (`esp_heap_caps.h`, `esp_log.h`, `esp_err.h`) for tiny
+surfaces — `heap_caps_malloc` aliasing into `malloc`, `ESP_LOGW`
+formatting to stderr, the `esp_err_t` enum.  A full ESP-IDF host
+build is wildly out of scope; a minimal stand-in is plenty.
+
+## Decision
+
+Host tests use:
+
+1. **Plain `<assert.h>` + a hand-rolled per-file driver** — no CMocka
+   dependency at all.  Each `tests/host/test_*.c` is its own
+   executable that returns non-zero on first failed assertion and
+   prints `file:line` of the failure.
+2. **Tiny shim headers in `tests/host/shim/`** — `esp_heap_caps.h`,
+   `esp_log.h`, `esp_err.h` reduced to the surface the tested modules
+   actually touch.  Shim directory is added first on the include path
+   so the compiler picks these up before any real ESP-IDF headers
+   (which aren't on the host path anyway, but belt-and-suspenders).
+3. **One CMake target per module** in `tests/host/CMakeLists.txt`,
+   wired into `ctest` via `add_test`.
+4. **CI runs via a new `host-tests` workflow** that does
+   `cmake -S tests/host && cmake --build && ctest` — sub-7 s gate.
+
+## Consequences
+
+- **Easier:** CI image stays minimal (no apt-install), test driver
+  is portable to any C compiler, adding a new module to the suite is
+  one CMake entry + one test file.  Sub-second test runtime.
+- **Harder:** No mocking framework.  When a module needs mock state
+  (Dragon HTTP responses, NVS reads), we hand-roll capture-by-context
+  patterns in the test driver.  Acceptable for the modules in scope;
+  if a future module needs real mocking we re-open the CMocka
+  question.
+- **Off the table without a new ADR:** dragging Google Test, Unity,
+  or CMocka into the build.  Adding a host-test for a module that
+  needs more than 3–4 ESP-IDF surface shims (those should grow the
+  shim directory; if the surface keeps expanding the module is too
+  ESP-IDF-coupled to host-test).
+
+## Alternatives considered
+
+- **CMocka via apt** — works but adds a CI dependency for a
+  rebuilt-from-scratch image; CMocka's `_test_setup`/`expect_value`
+  features aren't actually needed by any module in scope.
+- **Google Test (C++)** — would force a C++ link step and a heavier
+  shim layer.  Tab5 firmware is pure C; the test infra should
+  match.
+- **Unity** — closer to the right shape but still a vendor decision
+  for ~30 assertions per module.  Plain `<assert.h>` is enough.
+- **Run tests on the ESP-IDF host target** — too much setup for a
+  feature we want every PR to gate on.  Sub-second matters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records
+
+W10-C from the 2026-05-11 cross-stack audit.  ADRs capture
+**non-obvious cross-stack architectural decisions** that took
+real thinking to settle and that future contributors (or future
+sessions of the same contributor) should not have to re-litigate.
+
+## When to write one
+
+Write an ADR when a decision satisfies **all three**:
+
+1. **Cross-cutting** — touches Tab5 firmware *and* Dragon server,
+   or touches >2 modules in either repo
+2. **Non-reversible at low cost** — choosing it commits other code
+   to its assumptions; reverting requires touching many sites
+3. **Non-obvious justification** — a reader scanning the code
+   without context would ask "why on earth did they do it that
+   way?" and not get an answer from grep
+
+## What NOT to ADR
+
+- Pure refactors (no behavior change)
+- Single-module patches
+- Library version bumps
+- One-line bug fixes
+- Anything captured well in a commit message + `LEARNINGS.md` entry
+
+## File naming
+
+`NNNN-kebab-slug.md` — zero-padded sequential 4-digit number,
+then a slug describing the decision.  Numbers never change once
+assigned; ADRs are immutable once **Accepted** (status notes
+below).  Superseded ADRs are kept in place with a status update
++ link to the replacement.
+
+## Template
+
+Use [`0000-template.md`](0000-template.md) — copy, rename, fill in.
+Sections are deliberately short.
+
+## Status values
+
+- **Proposed** — under discussion; not yet implemented
+- **Accepted** — in force; implementation lives in the repo
+- **Superseded** — replaced by ADR-NNNN (links forward)
+- **Deprecated** — no longer used, kept for historical context
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-host-test-infra-pattern.md) | Host-test infra: plain assert + ESP-IDF shims | Accepted |


### PR DESCRIPTION
## Summary
- New \`docs/adr/\` directory with README (criteria + template + index) and \`0000-template.md\`
- First ADR: \`0001-host-test-infra-pattern.md\` — captures the W9-A decision to ship plain \`<assert.h>\` + tiny ESP-IDF shims instead of CMocka / Unity / Google Test
- CLAUDE.md "Wave-style closures + plan docs" section gains a pointer to the ADR criteria

## Test plan
- [x] ADR README index links to 0001
- [x] 0001 follows template (Context / Decision / Consequences / Alternatives)
- [x] CLAUDE.md cross-links the ADR system from Workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)