### PR TITLE
feat(ui): W7-E.1 ui_notification toast path for channel_message

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -8,6 +8,7 @@ set(UI_SRCS
     "ui_nav_sheet.c"
     "ui_onboarding.c"
     "ui_audio_cues.c"
+    "ui_notification.c"
     "chat_msg_store.c"
     "chat_header.c"
     "chat_input_bar.c"

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1927,6 +1927,8 @@ static void screen_gesture_cb(lv_event_t *e)
 #define TOAST_LIFETIME_INFO_MS 2200
 #define TOAST_LIFETIME_WARN_MS 3500
 #define TOAST_LIFETIME_ERROR_MS 5000
+#define TOAST_LIFETIME_INCOMING_MS 3000 /* W7-E.1 — slightly longer than INFO so sender + preview both register */
+#define TOAST_BORDER_INCOMING 0x6B5BFF  /* W7-E.1 — blue-violet per PLAN §4.1 */
 #define TOAST_LIFETIME_PER_CHAR_MS 60
 #define TOAST_LIFETIME_CAP_MS 8000
 #define TOAST_FRAME_MS 16 /* ~60 fps */
@@ -1942,6 +1944,7 @@ static uint32_t toast_lifetime_for(ui_toast_tone_t tone, const char *text) {
    uint32_t base = TOAST_LIFETIME_INFO_MS;
    if (tone == UI_TOAST_WARN) base = TOAST_LIFETIME_WARN_MS;
    if (tone == UI_TOAST_ERROR) base = TOAST_LIFETIME_ERROR_MS;
+   if (tone == UI_TOAST_INCOMING) base = TOAST_LIFETIME_INCOMING_MS;
    uint32_t scale = text ? (uint32_t)strlen(text) * TOAST_LIFETIME_PER_CHAR_MS : 0;
    uint32_t total = base + scale;
    if (total > TOAST_LIFETIME_CAP_MS) total = TOAST_LIFETIME_CAP_MS;
@@ -1949,9 +1952,10 @@ static uint32_t toast_lifetime_for(ui_toast_tone_t tone, const char *text) {
 }
 
 static uint32_t toast_border_for(ui_toast_tone_t tone) {
-   if (tone == UI_TOAST_WARN) return TH_MODE_HYBRID; /* yellow */
-   if (tone == UI_TOAST_ERROR) return TH_STATUS_RED; /* rose-red */
-   return TH_CARD_BORDER;                            /* legacy subtle */
+   if (tone == UI_TOAST_WARN) return TH_MODE_HYBRID;            /* yellow */
+   if (tone == UI_TOAST_ERROR) return TH_STATUS_RED;            /* rose-red */
+   if (tone == UI_TOAST_INCOMING) return TOAST_BORDER_INCOMING; /* W7-E.1 blue-violet */
+   return TH_CARD_BORDER;                                       /* legacy subtle */
 }
 
 /* Track the currently-displayed toast so a back-to-back show_toast can
@@ -2043,6 +2047,7 @@ static void show_toast_internal_tone(const char *text, ui_toast_tone_t tone) {
     * 2 px border in the matching mode-tone hue so they stand out without
     * the full toast bg getting tinted (keeps text contrast unchanged). */
    uint32_t border = toast_border_for(tone);
+   /* W7-E.1 — INCOMING falls into the "not INFO" branch, gets the 2 px border. */
    int bw = (tone == UI_TOAST_INFO) ? 1 : 2;
    lv_obj_set_style_border_width(t, bw, 0);
    lv_obj_set_style_border_color(t, lv_color_hex(border), 0);

--- a/main/ui_home.h
+++ b/main/ui_home.h
@@ -36,9 +36,10 @@ void ui_home_show_toast(const char *text);
  *  baseline lifetime so the user has time to read.  Lifetimes are also
  *  scaled by message length (60 ms/char on top of the baseline). */
 typedef enum {
-   UI_TOAST_INFO = 0,  /* amber  — legacy default */
-   UI_TOAST_WARN = 1,  /* yellow — non-fatal degradation */
-   UI_TOAST_ERROR = 2, /* rose   — failure user must notice */
+   UI_TOAST_INFO = 0,     /* amber  — legacy default */
+   UI_TOAST_WARN = 1,     /* yellow — non-fatal degradation */
+   UI_TOAST_ERROR = 2,    /* rose   — failure user must notice */
+   UI_TOAST_INCOMING = 3, /* blue-violet — W7-E.1 channel_message arrival */
 } ui_toast_tone_t;
 
 /** Show a toast with a severity tone + auto-scaled lifetime.

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -1,0 +1,90 @@
+/*
+ * ui_notification.c — see header.
+ *
+ * Wave 7-E.1 (toast-path slice).
+ */
+#include "ui_notification.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "debug_obs.h"
+#include "esp_log.h"
+#include "lvgl.h"
+#include "settings.h"
+#include "ui_audio_cues.h"
+#include "ui_core.h" /* tab5_lv_async_call */
+#include "ui_home.h"
+
+static const char *TAG = "ui_notification";
+
+/* True if quiet-hours is currently active per NVS + local clock.  Mirrors
+ * `tab5_settings_quiet_active(hour_local)` which expects an [0..23] hour. */
+static bool quiet_now(void) {
+   if (!tab5_settings_get_quiet_on()) return false;
+   time_t now = time(NULL);
+   if (now <= 0) return false; /* clock not yet synced — be permissive */
+   struct tm lt;
+   localtime_r(&now, &lt);
+   return tab5_settings_quiet_active(lt.tm_hour);
+}
+
+/* Owned copy queued for the LVGL thread.  Freed in the async callback. */
+static void notif_show_async_cb(void *arg) {
+   channel_message_t *msg = (channel_message_t *)arg;
+   if (!msg) return;
+
+   /* Compose toast text: "[ch] sender · preview".  Bounded with %.Ns
+    * specifiers so compiler can prove no truncation can OOB the 200 B
+    * buffer.  Visually we want the line short anyway — long previews
+    * read better in the now-card surface (W7-E.2). */
+   char text[200];
+   const char *ch = msg->channel[0] ? msg->channel : "?";
+   const char *sender = msg->sender[0] ? msg->sender : "Someone";
+   const char *preview = msg->preview[0] ? msg->preview : "(no preview)";
+   snprintf(text, sizeof(text), "[%.15s] %.40s · %.120s", ch, sender, preview);
+
+   ui_home_show_toast_ex(text, UI_TOAST_INCOMING);
+
+   /* Audio cue: low ping for the toast surface.  Respect quiet hours
+    * per spec §4.3 — visible toast still fires, audio is suppressed. */
+   if (!quiet_now()) {
+      ui_audio_cue_play(UI_CUE_INCOMING_LOW);
+   }
+
+   char detail[48];
+   snprintf(detail, sizeof(detail), "%.8s/%.20s pri=%.6s", ch, sender, msg->priority[0] ? msg->priority : "?");
+   tab5_debug_obs_event("ui.notif", detail);
+
+   free(msg);
+}
+
+void ui_notification_show(const channel_message_t *msg) {
+   if (!msg) return;
+
+   /* Allocate an owned copy for the async hop.  malloc (not heap_caps)
+    * because the payload is small (~400 B) and the LVGL thread reads it
+    * during the same tick. */
+   channel_message_t *owned = (channel_message_t *)malloc(sizeof(*owned));
+   if (!owned) {
+      ESP_LOGW(TAG, "OOM — dropping channel_message from %s/%s", msg->channel, msg->sender);
+      return;
+   }
+   memcpy(owned, msg, sizeof(*owned));
+
+   /* Defensive null-termination — every field is char[N] but the caller
+    * might have set them via memcpy without the trailing NUL. */
+   owned->channel[CHANNEL_NAME_MAX - 1] = '\0';
+   owned->message_id[CHANNEL_MSG_ID_MAX - 1] = '\0';
+   owned->thread_id[CHANNEL_THREAD_ID_MAX - 1] = '\0';
+   owned->sender[CHANNEL_SENDER_MAX - 1] = '\0';
+   owned->preview[CHANNEL_PREVIEW_MAX - 1] = '\0';
+   owned->priority[CHANNEL_PRIORITY_MAX - 1] = '\0';
+
+   lv_result_t r = tab5_lv_async_call(notif_show_async_cb, owned);
+   if (r != LV_RESULT_OK) {
+      ESP_LOGW(TAG, "lv_async_call failed — dropping channel_message");
+      free(owned);
+   }
+}

--- a/main/ui_notification.h
+++ b/main/ui_notification.h
@@ -1,0 +1,54 @@
+/*
+ * ui_notification.h — Tab5-side surface for `channel_message` frames.
+ *
+ * Wave 7-E (mode-3 / TinkerClaw gateway integration).  Design spec:
+ *   docs/PLAN-agent-mode-notification-surface.md
+ *
+ * v0 (W7-E.1, this slice) ships the toast path only:
+ *   - parses `channel_message` WS frames into channel_message_t
+ *   - routes everything to ui_home_show_toast_ex(text, UI_TOAST_INCOMING)
+ *   - fires UI_CUE_INCOMING_LOW unless quiet-hours active
+ *
+ * Future slices:
+ *   - W7-E.2: now-card claim for high-priority / reply-shaped messages
+ *   - W7-E.3: dedupe + snooze rings
+ *   - W7-E.4: voice reply flow (Tab5 → Dragon `channel_reply`)
+ *   - W7-E.5: Settings → Channels per-channel toggles
+ *   - W7-E.6: quiet-hours polish + final integration
+ */
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Short canonical channel names (matches NVS `ch_*_on` suffix).  Free-form
+ * string so future gateway-added channels don't need a Tab5 firmware bump. */
+#define CHANNEL_NAME_MAX 16
+#define CHANNEL_SENDER_MAX 64
+#define CHANNEL_PREVIEW_MAX 160
+#define CHANNEL_MSG_ID_MAX 64
+#define CHANNEL_THREAD_ID_MAX 64
+#define CHANNEL_PRIORITY_MAX 16
+
+typedef struct {
+   char channel[CHANNEL_NAME_MAX];        /* "tg", "wa", "dc", ... */
+   char message_id[CHANNEL_MSG_ID_MAX];   /* dedupe key; reserved W7-E.3 */
+   char thread_id[CHANNEL_THREAD_ID_MAX]; /* reply target; reserved W7-E.4 */
+   char sender[CHANNEL_SENDER_MAX];       /* sender display name */
+   char preview[CHANNEL_PREVIEW_MAX];     /* short text for toast */
+   char priority[CHANNEL_PRIORITY_MAX];   /* "low" / "normal" / "high" */
+   bool sender_starred;
+   bool needs_reply;
+} channel_message_t;
+
+/* Thread-safe.  Internally hops to the LVGL thread via tab5_lv_async_call
+ * before rendering.  `msg` is copied — caller retains ownership of the
+ * source struct. */
+void ui_notification_show(const channel_message_t *msg);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -31,15 +31,16 @@
 #include "ui_core.h" /* tab5_lv_async_call */
 #include "ui_home.h"
 #include "ui_notes.h"
-#include "voice.h"           /* g_voice_ws extern + voice_set_state */
-#include "voice_billing.h"   /* receipt + budget */
-#include "voice_codec.h"     /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+#include "ui_notification.h"
+#include "voice.h"               /* g_voice_ws extern + voice_set_state */
+#include "voice_billing.h"       /* receipt + budget */
+#include "voice_codec.h"         /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
 #include "voice_messages_sync.h" /* W3-C-d: drain offline queue on reconnect */
-#include "voice_onboard.h"   /* K144 failover hooks */
-#include "voice_video.h"     /* VID0 magic peek + downlink decode */
-#include "voice_widget_ws.h" /* widget_* WS dispatch */
-#include "widget.h"          /* widget_live_update / widget_live_dismiss */
-#include "wifi.h"            /* tab5_wifi_hard_kick / tab5_wifi_connected */
+#include "voice_onboard.h"       /* K144 failover hooks */
+#include "voice_video.h"         /* VID0 magic peek + downlink decode */
+#include "voice_widget_ws.h"     /* widget_* WS dispatch */
+#include "widget.h"              /* widget_live_update / widget_live_dismiss */
+#include "wifi.h"                /* tab5_wifi_hard_kick / tab5_wifi_connected */
 
 static const char *TAG = "tab5_voice_ws";
 
@@ -907,6 +908,59 @@ void voice_ws_proto_handle_text(const char *data, int len) {
        * dismiss doesn't hide the fact that they got auto-downgraded. */
       const char *msg = "Daily budget cap reached — switched to Local mode";
       voice_async_toast(strdup(msg));
+   } else if (strcmp(type_str, "channel_message") == 0) {
+      /* W7-E.1: route gateway-watched channel messages (Telegram,
+       * WhatsApp, Discord, ...) into the notification surface.  v0
+       * implements the toast path only; high-priority / now-card
+       * routing lands in W7-E.2. */
+      channel_message_t msg;
+      memset(&msg, 0, sizeof(msg));
+
+      cJSON *ch = cJSON_GetObjectItem(root, "channel");
+      if (cJSON_IsString(ch) && ch->valuestring) {
+         strncpy(msg.channel, ch->valuestring, sizeof(msg.channel) - 1);
+      }
+      cJSON *mid = cJSON_GetObjectItem(root, "message_id");
+      if (cJSON_IsString(mid) && mid->valuestring) {
+         strncpy(msg.message_id, mid->valuestring, sizeof(msg.message_id) - 1);
+      }
+      cJSON *tid = cJSON_GetObjectItem(root, "thread_id");
+      if (cJSON_IsString(tid) && tid->valuestring) {
+         strncpy(msg.thread_id, tid->valuestring, sizeof(msg.thread_id) - 1);
+      }
+      cJSON *sender = cJSON_GetObjectItem(root, "sender");
+      if (cJSON_IsObject(sender)) {
+         cJSON *dn = cJSON_GetObjectItem(sender, "display_name");
+         if (cJSON_IsString(dn) && dn->valuestring) {
+            strncpy(msg.sender, dn->valuestring, sizeof(msg.sender) - 1);
+         }
+         cJSON *starred = cJSON_GetObjectItem(sender, "starred");
+         msg.sender_starred = cJSON_IsTrue(starred);
+      }
+      /* Prefer `preview` (short) over `text` (full).  Fall back to
+       * text when preview is missing so a minimal injection still
+       * renders a useful toast. */
+      cJSON *preview = cJSON_GetObjectItem(root, "preview");
+      cJSON *text_full = cJSON_GetObjectItem(root, "text");
+      const char *preview_src = NULL;
+      if (cJSON_IsString(preview) && preview->valuestring && preview->valuestring[0]) {
+         preview_src = preview->valuestring;
+      } else if (cJSON_IsString(text_full) && text_full->valuestring) {
+         preview_src = text_full->valuestring;
+      }
+      if (preview_src) {
+         strncpy(msg.preview, preview_src, sizeof(msg.preview) - 1);
+      }
+      cJSON *pri = cJSON_GetObjectItem(root, "priority");
+      if (cJSON_IsString(pri) && pri->valuestring) {
+         strncpy(msg.priority, pri->valuestring, sizeof(msg.priority) - 1);
+      }
+      cJSON *needs = cJSON_GetObjectItem(root, "needs_reply");
+      msg.needs_reply = cJSON_IsTrue(needs);
+
+      ESP_LOGI(TAG, "channel_message: ch=%s sender=%s pri=%s preview=\"%.40s\"", msg.channel, msg.sender, msg.priority,
+               msg.preview);
+      ui_notification_show(&msg);
    } else if (strcmp(type_str, "config_update") == 0) {
       cJSON *error = cJSON_GetObjectItem(root, "error");
       if (cJSON_IsString(error) && error->valuestring[0]) {


### PR DESCRIPTION
## Summary
First implementation slice of the W7-E agent-mode notification surface per [`docs/PLAN-agent-mode-notification-surface.md`](docs/PLAN-agent-mode-notification-surface.md) §10. Closes #446.

- **New** `main/ui_notification.{c,h}`
  - `channel_message_t` struct (channel / sender / preview / priority + reserved message_id / thread_id slots)
  - `ui_notification_show(msg)` — thread-safe (copies + hops to LVGL via `tab5_lv_async_call`)
  - v0 always routes to toast; now-card claim path lands in W7-E.2
- **Extended** `main/ui_home.{c,h}` — `UI_TOAST_INCOMING` tone, blue-violet border `0x6B5BFF` (PLAN §4.1), 3 s baseline lifetime
- **Wired** `main/voice_ws_proto.c` — parses `channel_message` JSON frames into `channel_message_t`, prefers `preview` over full `text` for the toast surface
- **Audio** fires `UI_CUE_INCOMING_LOW` (shipped W7-E.0 #444), suppressed when quiet hours active (NVS `quiet_on` + start/end window check)

## Verified on Tab5 192.168.1.90
- ✅ `idf.py build` clean
- ✅ `git-clang-format --diff origin/main` empty
- ✅ POST `/debug/inject_ws` with synthetic Telegram frame → toast renders with `[tg] Jamie Park · Are you still on for lunch Thursday?` + blue-violet border + spring slide-in
- ✅ obs ring fires three events in order: `debug.inject_ws done` → `ui.notif tg/Jamie Park pri=low` → `ui.cue incoming_low err=0`
- ✅ Heap stable, no LVGL panics

## Scope / Out of scope
- ✅ Toast path
- ✅ Quiet-hours audio suppression
- ⏭️ Now-card claim path → **W7-E.2**
- ⏭️ Dedupe + snooze rings → **W7-E.3**
- ⏭️ Voice reply flow → **W7-E.4**
- ⏭️ Settings UI per-channel toggles → **W7-E.5**
- ⏭️ Quiet-hours visual half-opacity fade → **W7-E.6**

## Test plan
- [x] `idf.py build` — clean
- [x] git-clang-format — clean
- [x] Flash + boot Tab5 — boot serial shows all 5 cues pre-allocated
- [x] Inject synthetic `channel_message` via `/debug/inject_ws`
- [x] Toast visible with correct sender + preview text
- [x] Blue-violet border distinguishable from INFO/WARN/ERROR
- [x] Audio chirp fires
- [x] obs ring shows the three expected events
- [x] Heap stable across multiple injections

## Anchors
- Plan: [`docs/PLAN-agent-mode-notification-surface.md`](docs/PLAN-agent-mode-notification-surface.md)
- Audit: [`docs/AUDIT-state-of-stack-2026-05-11.md`](docs/AUDIT-state-of-stack-2026-05-11.md)
- W7-E.0 predecessor: #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)