### PR TITLE
feat(ui): W7-E.3 dedupe ring + snooze ring for channel notifications

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -659,6 +659,12 @@ void app_main(void)
     extern esp_err_t ui_audio_cues_init(void);
     (void)ui_audio_cues_init();
 
+    /* W7-E.3: arm the snooze-walk timer so deferred channel messages
+     * refire on schedule.  Runs on the LVGL thread (lv_timer) so safe
+     * to call here — LVGL is already up by this point in boot. */
+    extern void ui_notification_init(void);
+    ui_notification_init();
+
     /* TT #317 Phase 4: kick off the K144 LLM Module failover warm-up.
      * Posts ONE long-running job to the worker queue; safe to call here
      * because subsequent boot work (UI, voice, watchdog) doesn't depend

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -2378,9 +2378,13 @@ static void channel_card_reply_cb(lv_event_t *e) {
 
 static void channel_card_snooze_cb(lv_event_t *e) {
    (void)e;
-   tab5_debug_obs_event("ui.notif.now", "snooze_stub");
+   tab5_debug_obs_event("ui.notif.now", "snooze");
    channel_card_destroy();
-   show_toast_internal_tone("Snooze coming in W7-E.3", UI_TOAST_INFO);
+   /* W7-E.3: real snooze ring — entry stays in PSRAM for 15 min, then
+    * re-fires through the standard routing path.  Forward-declared
+    * extern so ui_home doesn't pull the full ui_notification.h. */
+   extern void ui_notification_snooze_current(void);
+   ui_notification_snooze_current();
 }
 
 /* Build one of the three action pills on the card.  Returns the pill obj. */

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -1,16 +1,18 @@
 /*
  * ui_notification.c — see header.
  *
- * Wave 7-E.1 (toast-path slice).
+ * Wave 7-E.1 toast path + W7-E.2 now-card router + W7-E.3 dedupe + snooze rings.
  */
 #include "ui_notification.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
 #include "debug_obs.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "lvgl.h"
 #include "settings.h"
 #include "ui_audio_cues.h"
@@ -18,6 +20,48 @@
 #include "ui_home.h"
 
 static const char *TAG = "ui_notification";
+
+/* ── W7-E.3: dedupe ring ───────────────────────────────────────────── */
+
+/* 32 entries keyed on message_id.  PSRAM-cheap (32 × 64 B = 2 KB in BSS).
+ * Older entries get overwritten as new arrivals push past the head. */
+#define DEDUPE_RING_SIZE 32
+static char s_dedupe_ring[DEDUPE_RING_SIZE][CHANNEL_MSG_ID_MAX];
+static int s_dedupe_head = 0;
+
+/* Returns true if `id` is new (was not in the ring; added).  Returns
+ * false if it was already present (caller should skip).  Empty id always
+ * passes through (no dedupe — older Dragon builds may omit message_id). */
+static bool dedupe_check_and_add(const char *id) {
+   if (!id || !id[0]) return true; /* no id → always allow */
+   for (int i = 0; i < DEDUPE_RING_SIZE; i++) {
+      if (s_dedupe_ring[i][0] && strncmp(s_dedupe_ring[i], id, CHANNEL_MSG_ID_MAX) == 0) {
+         return false;
+      }
+   }
+   /* snprintf is bounds-safe and dodges the GCC strncpy-truncation warning
+    * since we explicitly cap output length including NUL. */
+   snprintf(s_dedupe_ring[s_dedupe_head], CHANNEL_MSG_ID_MAX, "%s", id);
+   s_dedupe_head = (s_dedupe_head + 1) % DEDUPE_RING_SIZE;
+   return true;
+}
+
+/* ── W7-E.3: snooze ring ───────────────────────────────────────────── */
+
+#define SNOOZE_RING_SIZE 8
+#define SNOOZE_DELAY_MS (15 * 60 * 1000) /* 15 minutes per PLAN §3.2 */
+#define SNOOZE_TICK_MS (60 * 1000)       /* walker fires every 60 s */
+
+static channel_message_t s_snooze_ring[SNOOZE_RING_SIZE];
+static uint64_t s_snooze_fire_at[SNOOZE_RING_SIZE]; /* esp_timer_get_time() µs */
+static int s_snooze_count = 0;
+static lv_timer_t *s_snooze_timer = NULL;
+
+/* W7-E.2 → W7-E.3 handoff: remember the most recent now-card message so
+ * the SNOOZE button can recover it without ui_home needing to carry the
+ * full channel_message_t through its public API. */
+static channel_message_t s_last_now_msg;
+static bool s_last_now_msg_valid = false;
 
 /* True if quiet-hours is currently active per NVS + local clock.  Mirrors
  * `tab5_settings_quiet_active(hour_local)` which expects an [0..23] hour. */
@@ -45,6 +89,16 @@ static void notif_show_async_cb(void *arg) {
    channel_message_t *msg = (channel_message_t *)arg;
    if (!msg) return;
 
+   /* W7-E.3: dedupe before any surface side-effect.  Same message_id
+    * arriving twice = silent drop with obs trail. */
+   if (!dedupe_check_and_add(msg->message_id)) {
+      char detail[48];
+      snprintf(detail, sizeof(detail), "drop %.32s", msg->message_id);
+      tab5_debug_obs_event("ui.notif.dedupe", detail);
+      free(msg);
+      return;
+   }
+
    const char *ch = msg->channel[0] ? msg->channel : "?";
    const char *sender = msg->sender[0] ? msg->sender : "Someone";
    const char *preview = msg->preview[0] ? msg->preview : "(no preview)";
@@ -53,6 +107,9 @@ static void notif_show_async_cb(void *arg) {
    if (to_now_card) {
       /* Richer surface: kicker + multi-line preview + 3-button row. */
       ui_home_show_channel_now(ch, sender, preview);
+      /* Cache for the SNOOZE button — see ui_notification_snooze_current. */
+      memcpy(&s_last_now_msg, msg, sizeof(s_last_now_msg));
+      s_last_now_msg_valid = true;
    } else {
       /* Toast: compose "[ch] sender · preview".  Bounded with %.Ns
        * specifiers so compiler can prove no truncation. */
@@ -102,4 +159,76 @@ void ui_notification_show(const channel_message_t *msg) {
       ESP_LOGW(TAG, "lv_async_call failed — dropping channel_message");
       free(owned);
    }
+}
+
+/* ── W7-E.3: snooze walker + public API ────────────────────────────── */
+
+static uint64_t snooze_now_us(void) { return (uint64_t)esp_timer_get_time(); }
+
+/* LVGL-thread periodic timer.  Walks the ring; any entry whose fire_at
+ * has passed gets removed + re-shown via the normal routing path. */
+static void snooze_walk_cb(lv_timer_t *t) {
+   (void)t;
+   uint64_t now_us = snooze_now_us();
+   /* Walk in reverse so we can remove without re-indexing. */
+   for (int i = s_snooze_count - 1; i >= 0; i--) {
+      if (s_snooze_fire_at[i] > now_us) continue;
+
+      /* Snapshot the message so we can fire it after we shrink the ring
+       * — ui_notification_show could recursively populate s_snooze_ring
+       * if the re-fire ends up snoozed again. */
+      channel_message_t fire = s_snooze_ring[i];
+      if (i < s_snooze_count - 1) {
+         memmove(&s_snooze_ring[i], &s_snooze_ring[i + 1], sizeof(s_snooze_ring[0]) * (s_snooze_count - i - 1));
+         memmove(&s_snooze_fire_at[i], &s_snooze_fire_at[i + 1], sizeof(uint64_t) * (s_snooze_count - i - 1));
+      }
+      s_snooze_count--;
+
+      /* Clear the dedupe slot for this id so the refire isn't silently
+       * dropped.  Simpler than tracking a "snooze bypass" flag through
+       * the async hop. */
+      if (fire.message_id[0]) {
+         for (int k = 0; k < DEDUPE_RING_SIZE; k++) {
+            if (strncmp(s_dedupe_ring[k], fire.message_id, CHANNEL_MSG_ID_MAX) == 0) {
+               s_dedupe_ring[k][0] = '\0';
+               break;
+            }
+         }
+      }
+
+      tab5_debug_obs_event("ui.notif.snooze", "refire");
+      ui_notification_show(&fire);
+   }
+}
+
+void ui_notification_init(void) {
+   if (s_snooze_timer) return;
+   s_snooze_timer = lv_timer_create(snooze_walk_cb, SNOOZE_TICK_MS, NULL);
+   ESP_LOGI(TAG, "snooze walker armed (tick=%u ms, delay=%u ms)", (unsigned)SNOOZE_TICK_MS, (unsigned)SNOOZE_DELAY_MS);
+}
+
+void ui_notification_snooze_current(void) {
+   if (!s_last_now_msg_valid) {
+      ESP_LOGW(TAG, "snooze requested but no now-card message in cache");
+      return;
+   }
+
+   /* Overflow: drop oldest. */
+   if (s_snooze_count >= SNOOZE_RING_SIZE) {
+      memmove(&s_snooze_ring[0], &s_snooze_ring[1], sizeof(s_snooze_ring[0]) * (SNOOZE_RING_SIZE - 1));
+      memmove(&s_snooze_fire_at[0], &s_snooze_fire_at[1], sizeof(uint64_t) * (SNOOZE_RING_SIZE - 1));
+      s_snooze_count = SNOOZE_RING_SIZE - 1;
+      tab5_debug_obs_event("ui.notif.snooze", "overflow");
+   }
+
+   s_snooze_ring[s_snooze_count] = s_last_now_msg;
+   s_snooze_fire_at[s_snooze_count] = snooze_now_us() + (uint64_t)SNOOZE_DELAY_MS * 1000ULL;
+   s_snooze_count++;
+
+   char detail[48];
+   snprintf(detail, sizeof(detail), "added %.8s/%.20s in=%us", s_last_now_msg.channel, s_last_now_msg.sender,
+            (unsigned)(SNOOZE_DELAY_MS / 1000));
+   tab5_debug_obs_event("ui.notif.snooze", detail);
+
+   ui_home_show_toast_ex("Snoozed for 15 minutes", UI_TOAST_INFO);
 }

--- a/main/ui_notification.h
+++ b/main/ui_notification.h
@@ -49,6 +49,18 @@ typedef struct {
  * source struct. */
 void ui_notification_show(const channel_message_t *msg);
 
+/* W7-E.3: boot-time init.  Kicks the 60 s snooze-walk timer so deferred
+ * messages refire on schedule.  Idempotent; safe to call more than once.
+ * Must run on the LVGL thread (typically from main.c after ui_core_init).
+ */
+void ui_notification_init(void);
+
+/* W7-E.3: enqueue the most recently shown now-card message into the
+ * snooze ring with `fire_at = now + 15 min`.  Overflow (>8) drops the
+ * oldest entry.  Wired to the SNOOZE button in ui_home.  No-op if no
+ * now-card message has been shown yet this boot. */
+void ui_notification_snooze_current(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
Third W7-E slice — implements the dedupe + snooze rings per [\`docs/PLAN-agent-mode-notification-surface.md\`](docs/PLAN-agent-mode-notification-surface.md) §3.2 + §8. Closes #452.

### What's new
1. **Dedupe ring** — 32-entry BSS-resident ring keyed on \`message_id\`. Same message twice → silent drop with \`ui.notif.dedupe drop {id}\` obs trail. Empty id always passes (older Dragon emitters).
2. **Snooze ring** — 8-entry ring of \`channel_message_t\` + \`fire_at_us\`. \`ui_notification_snooze_current()\` recovers the most-recent now-card message + queues with \`fire_at = now + 15 min\`. Overflow drops oldest. 60 s lv_timer walks + re-fires expired entries through the standard routing.
3. **Init wiring** — new \`ui_notification_init()\` called from \`main.c\` at boot, arms the walker timer.
4. **SNOOZE button** — no longer fires the stub toast; calls the real ring API.

### Out of scope
- Widget backstack restoration — W7-E.2 overlay sits on \`lv_layer_top\` and doesn't displace the live-line widget. Nothing structurally to restore.
- Real REPLY flow → **W7-E.4**
- Settings UI → **W7-E.5**
- Quiet-hours visual fade → **W7-E.6**
- Persistence across reboot — PSRAM only per PLAN §9; v2

### Verification on Tab5 192.168.1.90
| Test | Obs trail |
|---|---|
| Inject id=\`dedupe-test-1\` (low pri) | \`ui.notif tg/Alice pri=low surf=toast\` |
| Inject id=\`dedupe-test-1\` again | \`ui.notif.dedupe drop dedupe-test-1\` ✅ silent |
| Inject id=\`dedupe-test-2\` (low pri) | \`ui.notif wa/Bob pri=low surf=toast\` ✅ new id works |
| Inject id=\`snooze-test-1\` (high pri) | \`ui.notif tg/Carol pri=high surf=now\` + \`ui.cue incoming_high\` |
| Tap SNOOZE button | \`ui.notif.now snooze\` + \`ui.notif.snooze added tg/Carol in=900s\` ✅ |

### Test plan
- [x] \`idf.py build\` clean
- [x] \`git-clang-format --diff\` empty
- [x] Dedupe: 3 injects, 2nd silently dropped via obs
- [x] Snooze: now-card → SNOOZE → ring populated; now-card hidden
- [x] Boot serial shows \`snooze walker armed\`
- [x] Heap stable

## Anchors
- Plan: [\`docs/PLAN-agent-mode-notification-surface.md\`](docs/PLAN-agent-mode-notification-surface.md)
- Audit: [\`docs/AUDIT-state-of-stack-2026-05-11.md\`](docs/AUDIT-state-of-stack-2026-05-11.md)
- Predecessors: #444 (cues), #447 (toast), #450 (now-card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)