### PR TITLE
feat: W7-E.4 channel_reply WS plumbing + REPLY button wiring

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -2371,9 +2371,13 @@ static void channel_card_dismiss_cb(lv_event_t *e) {
 
 static void channel_card_reply_cb(lv_event_t *e) {
    (void)e;
-   tab5_debug_obs_event("ui.notif.now", "reply_stub");
+   tab5_debug_obs_event("ui.notif.now", "reply");
    channel_card_destroy();
-   show_toast_internal_tone("Reply flow coming in W7-E.4", UI_TOAST_INFO);
+   /* W7-E.4: real reply path — uses the v0 quick-ack placeholder
+    * ("👍").  Real user-typed/dictated text lands in W7-E.4b.
+    * Forward-declared extern so ui_home doesn't pull ui_notification.h. */
+   extern void ui_notification_reply_current(const char *text);
+   ui_notification_reply_current(NULL);
 }
 
 static void channel_card_snooze_cb(lv_event_t *e) {

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -18,6 +18,7 @@
 #include "ui_audio_cues.h"
 #include "ui_core.h" /* tab5_lv_async_call */
 #include "ui_home.h"
+#include "voice.h" /* W7-E.4: voice_send_channel_reply */
 
 static const char *TAG = "ui_notification";
 
@@ -205,6 +206,33 @@ void ui_notification_init(void) {
    if (s_snooze_timer) return;
    s_snooze_timer = lv_timer_create(snooze_walk_cb, SNOOZE_TICK_MS, NULL);
    ESP_LOGI(TAG, "snooze walker armed (tick=%u ms, delay=%u ms)", (unsigned)SNOOZE_TICK_MS, (unsigned)SNOOZE_DELAY_MS);
+}
+
+void ui_notification_reply_current(const char *text) {
+   if (!s_last_now_msg_valid) {
+      ESP_LOGW(TAG, "reply requested but no now-card message in cache");
+      tab5_debug_obs_event("ui.notif.reply", "no_cache");
+      return;
+   }
+   /* "👍" UTF-8 is 4 bytes (F0 9F 91 8D); use as quick-ack placeholder
+    * when caller didn't supply real dictated text (W7-E.4b will). */
+   const char *reply_text = (text && text[0]) ? text : "\xF0\x9F\x91\x8D";
+
+   esp_err_t r = voice_send_channel_reply(s_last_now_msg.channel, s_last_now_msg.thread_id, reply_text);
+
+   char detail[64];
+   if (r == ESP_OK) {
+      snprintf(detail, sizeof(detail), "sent ch=%.10s thread=%.20s", s_last_now_msg.channel, s_last_now_msg.thread_id);
+      tab5_debug_obs_event("ui.notif.reply", detail);
+
+      char toast[96];
+      snprintf(toast, sizeof(toast), "Reply queued to %.40s", s_last_now_msg.sender);
+      ui_home_show_toast_ex(toast, UI_TOAST_INFO);
+   } else {
+      snprintf(detail, sizeof(detail), "send_fail err=%d", (int)r);
+      tab5_debug_obs_event("ui.notif.reply", detail);
+      ui_home_show_toast_ex("Reply not sent — Dragon offline", UI_TOAST_WARN);
+   }
 }
 
 void ui_notification_snooze_current(void) {

--- a/main/ui_notification.h
+++ b/main/ui_notification.h
@@ -61,6 +61,15 @@ void ui_notification_init(void);
  * now-card message has been shown yet this boot. */
 void ui_notification_snooze_current(void);
 
+/* W7-E.4: send a channel_reply for the most recently shown now-card
+ * message.  If `text` is NULL/empty, the quick-ack placeholder
+ * "👍" is used so the v0 button is meaningfully wired without the
+ * full voice-dictation overlay (deferred to W7-E.4b).  Toasts
+ * "Reply queued to {sender}" on send; Dragon's async ACK lands as
+ * "Replied via {channel}" through the channel_reply_ack handler.
+ * No-op if no now-card message has been shown yet this boot. */
+void ui_notification_reply_current(const char *text);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/voice.c
+++ b/main/voice.c
@@ -2202,6 +2202,35 @@ esp_err_t voice_send_text(const char *text)
     return ret;
 }
 
+/* W7-E.4: channel_reply WS sender.  Routes a Tab5-side reply to a
+ * gateway-watched channel back through Dragon (which forwards to the
+ * gateway via chat.reply RPC).  No state-machine side-effects — this is
+ * a one-shot fire-and-forget; Dragon ACKs asynchronously via the
+ * channel_reply_ack frame handled in voice_ws_proto.c. */
+esp_err_t voice_send_channel_reply(const char *channel, const char *thread_id, const char *text) {
+   if (!channel || !channel[0]) return ESP_ERR_INVALID_ARG;
+   if (!thread_id || !thread_id[0]) return ESP_ERR_INVALID_ARG;
+   if (!text || !text[0]) return ESP_ERR_INVALID_ARG;
+   if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) {
+      return ESP_ERR_INVALID_STATE;
+   }
+
+   cJSON *msg = cJSON_CreateObject();
+   if (!msg) return ESP_ERR_NO_MEM;
+   cJSON_AddStringToObject(msg, "type", "channel_reply");
+   cJSON_AddStringToObject(msg, "channel", channel);
+   cJSON_AddStringToObject(msg, "thread_id", thread_id);
+   cJSON_AddStringToObject(msg, "text", text);
+   char *json = cJSON_PrintUnformatted(msg);
+   cJSON_Delete(msg);
+   if (!json) return ESP_ERR_NO_MEM;
+
+   ESP_LOGI(TAG, "Sending channel_reply ch=%s thread=%s text=%.40s", channel, thread_id, text);
+   esp_err_t ret = voice_ws_send_text(json);
+   cJSON_free(json);
+   return ret;
+}
+
 /* voice_send_widget_action moved to voice_ws_proto.c (TT #331 Wave 23
  * SRP-A1) — pure WS-proto concern: builds a JSON frame + calls
  * voice_ws_send_text. */

--- a/main/voice.h
+++ b/main/voice.h
@@ -184,6 +184,14 @@ esp_err_t voice_clear_history(void);
 /** Send a text message to Dragon, bypassing STT (goes straight to LLM). */
 esp_err_t voice_send_text(const char *text);
 
+/** W7-E.4: send a channel_reply WS frame to Dragon.  Builds
+ *  {"type":"channel_reply","channel":...,"thread_id":...,"text":...}
+ *  and queues it on the voice WS.  Returns ESP_ERR_INVALID_STATE if the
+ *  WS isn't connected, ESP_ERR_INVALID_ARG on NULL args.  Reply ack
+ *  arrives asynchronously as a channel_reply_ack frame handled in
+ *  voice_ws_proto.c. */
+esp_err_t voice_send_channel_reply(const char *channel, const char *thread_id, const char *text);
+
 /** W4-A: return the current turn_id (12-hex-char string + null).  Set by
  *  voice_start_listening / voice_start_dictation / voice_send_text on every
  *  fresh turn.  Returns "-" before the first turn (never NULL).  Use to

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -908,6 +908,36 @@ void voice_ws_proto_handle_text(const char *data, int len) {
        * dismiss doesn't hide the fact that they got auto-downgraded. */
       const char *msg = "Daily budget cap reached — switched to Local mode";
       voice_async_toast(strdup(msg));
+   } else if (strcmp(type_str, "channel_reply_ack") == 0) {
+      /* W7-E.4: Dragon's confirmation that a channel_reply landed.
+       * Schema: {"type":"channel_reply_ack","thread_id":"...","ok":bool,
+       *          "platform_message_id":"...","channel":"...",
+       *          ["error":"..."]}.  Toast on either side so the user
+       *          sees the outcome. */
+      cJSON *ok_node = cJSON_GetObjectItem(root, "ok");
+      cJSON *ch_node = cJSON_GetObjectItem(root, "channel");
+      cJSON *err_node = cJSON_GetObjectItem(root, "error");
+      bool ok = cJSON_IsTrue(ok_node);
+      const char *ch = (cJSON_IsString(ch_node) && ch_node->valuestring) ? ch_node->valuestring : "channel";
+      if (ok) {
+         char *toast = malloc(64);
+         if (toast) {
+            snprintf(toast, 64, "Replied via %.40s", ch);
+            voice_async_toast(toast);
+         }
+         tab5_debug_obs_event("ui.notif.reply", "ack_ok");
+      } else {
+         const char *errmsg =
+             (cJSON_IsString(err_node) && err_node->valuestring) ? err_node->valuestring : "send failed";
+         char *toast = malloc(128);
+         if (toast) {
+            snprintf(toast, 128, "Reply failed: %.80s", errmsg);
+            voice_async_toast(toast);
+         }
+         char detail[48];
+         snprintf(detail, sizeof(detail), "ack_fail %.30s", errmsg);
+         tab5_debug_obs_event("ui.notif.reply", detail);
+      }
    } else if (strcmp(type_str, "channel_message") == 0) {
       /* W7-E.1: route gateway-watched channel messages (Telegram,
        * WhatsApp, Discord, ...) into the notification surface.  v0


### PR DESCRIPTION
## Summary
Fourth W7-E slice — wires the REPLY button to a real `channel_reply` WS frame send + handles Dragon's async ACK. Closes #455. Per [`docs/PLAN-agent-mode-notification-surface.md`](docs/PLAN-agent-mode-notification-surface.md) §3.3.

### What's new
- **`main/voice.{c,h}`** — `voice_send_channel_reply(channel, thread_id, text)` builds `{"type":"channel_reply", ...}` + sends over voice WS
- **`main/voice_ws_proto.c`** — handles `channel_reply_ack`; `ok=true` → "Replied via {channel}" toast + `ui.notif.reply ack_ok`; `ok=false` → error toast + `ack_fail`
- **`main/ui_notification.{c,h}`** — `ui_notification_reply_current(text)` recovers cached now-card message; if `text==NULL` uses 👍 quick-ack
- **`main/ui_home.c`** REPLY button — was stub toast, now calls `ui_notification_reply_current(NULL)`

### Why "quick-ack" + 👍 placeholder for v0
The spec calls for full voice-overlay reply mode with header chip + dictation. That's a substantively larger surface (refactor of voice overlay state machine to support "reply mode" sticky-context). Splitting it lets this slice ship the **WS plumbing end-to-end** today; W7-E.4b can add real dictation/typing on top of the now-proven wire shape.

### Out of scope
- Real user-dictation reply text → **W7-E.4b**
- Dragon-side `channel_reply` receiver → **TinkerBox W7-F** (Tab5 sends regardless; Dragon may ignore until W7-F lands)
- SD offline-queue for failed replies → W7-E.4b (pattern already in `voice_messages_sync`)
- Settings UI → W7-E.5
- Quiet-hours visual fade → W7-E.6

### Live verification on Tab5 192.168.1.90
| Step | Obs |
|---|---|
| Inject high-pri `channel_message` | `ui.notif tg/Jamie pri=high surf=now` + `ui.cue incoming_high err=0` |
| Tap REPLY button | `ui.notif.now reply` + `ui.notif.reply sent ch=tg thread=tg:8675309` |
| Simulated Dragon ACK | `ui.notif.reply ack_ok` + "Replied via telegram" toast |
| Heap stable | ✅ |

### Test plan
- [x] `idf.py build` clean
- [x] `git-clang-format --diff` empty
- [x] Reply send path fires WS frame + logs obs
- [x] ACK path fires confirmation toast + logs obs
- [x] No now-card cached → `no_cache` obs (verified by code path inspection)

## Anchors
- Plan §3.3
- Predecessors: #444 (cues), #447 (toast), #450 (now-card), #453 (dedupe+snooze)

🤖 Generated with [Claude Code](https://claude.com/claude-code)