### PR TITLE
feat: W7-E.5 Settings → CHANNELS section + 8 ch_*_on NVS keys

### DIFF
--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -131,6 +131,16 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
    cJSON_AddNumberToObject(root, "quiet_start", tab5_settings_get_quiet_start());
    cJSON_AddNumberToObject(root, "quiet_end", tab5_settings_get_quiet_end());
 
+   /* W7-E.5: per-channel notification toggles. */
+   cJSON_AddNumberToObject(root, "ch_tg_on", tab5_settings_get_ch_tg_on());
+   cJSON_AddNumberToObject(root, "ch_wa_on", tab5_settings_get_ch_wa_on());
+   cJSON_AddNumberToObject(root, "ch_dc_on", tab5_settings_get_ch_dc_on());
+   cJSON_AddNumberToObject(root, "ch_sl_on", tab5_settings_get_ch_sl_on());
+   cJSON_AddNumberToObject(root, "ch_sg_on", tab5_settings_get_ch_sg_on());
+   cJSON_AddNumberToObject(root, "ch_im_on", tab5_settings_get_ch_im_on());
+   cJSON_AddNumberToObject(root, "ch_ma_on", tab5_settings_get_ch_ma_on());
+   cJSON_AddNumberToObject(root, "ch_em_on", tab5_settings_get_ch_em_on());
+
    /* Audit U2 (#206): auto-rotate persisted preference. */
    cJSON_AddNumberToObject(root, "auto_rot", tab5_settings_get_auto_rotate());
    /* #260: camera rotation persisted preference. */
@@ -339,6 +349,27 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("quiet_end"));
       }
    }
+
+   /* W7-E.5: per-channel toggles. */
+#define CHANNEL_SET_FROM_JSON(key, setter)                                         \
+   do {                                                                            \
+      cJSON *node = cJSON_GetObjectItem(req_json, key);                            \
+      if (cJSON_IsNumber(node) || cJSON_IsBool(node)) {                            \
+         int v = cJSON_IsBool(node) ? cJSON_IsTrue(node) : (int)node->valuedouble; \
+         if (setter(v ? 1 : 0) == ESP_OK) {                                        \
+            cJSON_AddItemToArray(updated, cJSON_CreateString(key));                \
+         }                                                                         \
+      }                                                                            \
+   } while (0)
+   CHANNEL_SET_FROM_JSON("ch_tg_on", tab5_settings_set_ch_tg_on);
+   CHANNEL_SET_FROM_JSON("ch_wa_on", tab5_settings_set_ch_wa_on);
+   CHANNEL_SET_FROM_JSON("ch_dc_on", tab5_settings_set_ch_dc_on);
+   CHANNEL_SET_FROM_JSON("ch_sl_on", tab5_settings_set_ch_sl_on);
+   CHANNEL_SET_FROM_JSON("ch_sg_on", tab5_settings_set_ch_sg_on);
+   CHANNEL_SET_FROM_JSON("ch_im_on", tab5_settings_set_ch_im_on);
+   CHANNEL_SET_FROM_JSON("ch_ma_on", tab5_settings_set_ch_ma_on);
+   CHANNEL_SET_FROM_JSON("ch_em_on", tab5_settings_set_ch_em_on);
+#undef CHANNEL_SET_FROM_JSON
 
    /* Audit U2 (#206): auto-rotate POST setter for testability — also
     * triggers ui_core_apply_auto_rotation so the new value takes

--- a/main/settings.c
+++ b/main/settings.c
@@ -546,6 +546,41 @@ bool tab5_settings_quiet_active(int hour_local)
     return (hour_local >= s || hour_local < e);
 }
 
+/* ── W7-E.5: per-channel notification opt-in ─────────────────────────── */
+
+uint8_t tab5_settings_get_ch_tg_on(void) { return get_u8("ch_tg_on", 0); }
+esp_err_t tab5_settings_set_ch_tg_on(uint8_t on) { return set_u8("ch_tg_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_wa_on(void) { return get_u8("ch_wa_on", 0); }
+esp_err_t tab5_settings_set_ch_wa_on(uint8_t on) { return set_u8("ch_wa_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_dc_on(void) { return get_u8("ch_dc_on", 0); }
+esp_err_t tab5_settings_set_ch_dc_on(uint8_t on) { return set_u8("ch_dc_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_sl_on(void) { return get_u8("ch_sl_on", 0); }
+esp_err_t tab5_settings_set_ch_sl_on(uint8_t on) { return set_u8("ch_sl_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_sg_on(void) { return get_u8("ch_sg_on", 0); }
+esp_err_t tab5_settings_set_ch_sg_on(uint8_t on) { return set_u8("ch_sg_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_im_on(void) { return get_u8("ch_im_on", 0); }
+esp_err_t tab5_settings_set_ch_im_on(uint8_t on) { return set_u8("ch_im_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_ma_on(void) { return get_u8("ch_ma_on", 0); }
+esp_err_t tab5_settings_set_ch_ma_on(uint8_t on) { return set_u8("ch_ma_on", on ? 1 : 0); }
+uint8_t tab5_settings_get_ch_em_on(void) { return get_u8("ch_em_on", 0); }
+esp_err_t tab5_settings_set_ch_em_on(uint8_t on) { return set_u8("ch_em_on", on ? 1 : 0); }
+
+bool tab5_settings_get_channel_enabled(const char *channel_short) {
+   if (!channel_short || !channel_short[0]) return true; /* no channel → fail-open */
+   if (strcmp(channel_short, "tg") == 0) return tab5_settings_get_ch_tg_on() != 0;
+   if (strcmp(channel_short, "wa") == 0) return tab5_settings_get_ch_wa_on() != 0;
+   if (strcmp(channel_short, "dc") == 0) return tab5_settings_get_ch_dc_on() != 0;
+   if (strcmp(channel_short, "sl") == 0) return tab5_settings_get_ch_sl_on() != 0;
+   if (strcmp(channel_short, "sg") == 0) return tab5_settings_get_ch_sg_on() != 0;
+   if (strcmp(channel_short, "im") == 0) return tab5_settings_get_ch_im_on() != 0;
+   if (strcmp(channel_short, "ma") == 0) return tab5_settings_get_ch_ma_on() != 0;
+   if (strcmp(channel_short, "em") == 0) return tab5_settings_get_ch_em_on() != 0;
+   /* Unknown channel — fail-open so future Dragon additions still surface
+    * (user can react + ship a Settings entry).  Common known prefixes
+    * ("telegram" etc.) also match 2-char shorthand if Dragon emits them. */
+   return true;
+}
+
 /* ── Connection mode ────────────────────────────────────────────────── */
 
 uint8_t tab5_settings_get_connection_mode(void)

--- a/main/settings.h
+++ b/main/settings.h
@@ -214,6 +214,36 @@ esp_err_t tab5_settings_set_quiet_end(uint8_t hour);
  *  Convenience — does the wrap-past-midnight math for you. */
 bool      tab5_settings_quiet_active(int hour_local);
 
+/* ── W7-E.5: per-channel notification opt-in ─────────────────────────── */
+
+/** 8 channels Tab5 understands.  Tab5 silently drops `channel_message`
+ *  frames whose channel name resolves to "off"; Dragon may still emit
+ *  (the source-side suppression lives in W7-F).  All default 0 — user
+ *  opts in per platform via Settings → CHANNELS. */
+uint8_t tab5_settings_get_ch_tg_on(void);
+esp_err_t tab5_settings_set_ch_tg_on(uint8_t on);
+uint8_t tab5_settings_get_ch_wa_on(void);
+esp_err_t tab5_settings_set_ch_wa_on(uint8_t on);
+uint8_t tab5_settings_get_ch_dc_on(void);
+esp_err_t tab5_settings_set_ch_dc_on(uint8_t on);
+uint8_t tab5_settings_get_ch_sl_on(void);
+esp_err_t tab5_settings_set_ch_sl_on(uint8_t on);
+uint8_t tab5_settings_get_ch_sg_on(void);
+esp_err_t tab5_settings_set_ch_sg_on(uint8_t on);
+uint8_t tab5_settings_get_ch_im_on(void);
+esp_err_t tab5_settings_set_ch_im_on(uint8_t on);
+uint8_t tab5_settings_get_ch_ma_on(void);
+esp_err_t tab5_settings_set_ch_ma_on(uint8_t on);
+uint8_t tab5_settings_get_ch_em_on(void);
+esp_err_t tab5_settings_set_ch_em_on(uint8_t on);
+
+/** Convenience: map a 2-char canonical channel name ("tg"/"wa"/"dc"/...)
+ *  → bool enabled.  Returns true for unknown names so a future Dragon
+ *  emitting a channel Tab5 doesn't know about still surfaces (fail-open
+ *  on the unknown-channel axis; user must explicitly opt out via a
+ *  future Settings UI for it). */
+bool tab5_settings_get_channel_enabled(const char *channel_short);
+
 /* ── Auto-rotate (audit U2 / TinkerTab #206) ─────────────────────────── */
 
 /** Auto-rotate the display 180° when held upside-down (USB up).  IMU

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -90,6 +90,17 @@ static void notif_show_async_cb(void *arg) {
    channel_message_t *msg = (channel_message_t *)arg;
    if (!msg) return;
 
+   /* W7-E.5: per-channel opt-in gate.  Settings → CHANNELS controls
+    * which platforms surface on this device.  Fail-open on unknown
+    * channel names so future Dragon additions still get through. */
+   if (msg->channel[0] && !tab5_settings_get_channel_enabled(msg->channel)) {
+      char detail[32];
+      snprintf(detail, sizeof(detail), "%.16s", msg->channel);
+      tab5_debug_obs_event("ui.notif.channel_off", detail);
+      free(msg);
+      return;
+   }
+
    /* W7-E.3: dedupe before any surface side-effect.  Same message_id
     * arriving twice = silent drop with obs trail. */
    if (!dedupe_check_and_add(msg->message_id)) {

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -816,6 +816,27 @@ static void cb_quiet_on(lv_event_t *e)
     ui_home_refresh_sys_label();
 }
 
+/* W7-E.5: per-channel notification toggles.  Each callback persists to
+ * NVS via the matching tab5_settings_set_ch_*_on; the notification
+ * router (ui_notification.c) reads the value at incoming-message time,
+ * so toggling takes effect instantly without re-render. */
+#define CHANNEL_TOGGLE_CB(short_name, fn_name)          \
+   static void cb_ch_##fn_name##_on(lv_event_t *e) {    \
+      lv_obj_t *sw = lv_event_get_target(e);            \
+      bool on = lv_obj_has_state(sw, LV_STATE_CHECKED); \
+      tab5_settings_set_ch_##fn_name##_on(on ? 1 : 0);  \
+      ESP_LOGI(TAG, "Channel " short_name ": %d", on);  \
+   }
+
+CHANNEL_TOGGLE_CB("tg", tg)
+CHANNEL_TOGGLE_CB("wa", wa)
+CHANNEL_TOGGLE_CB("dc", dc)
+CHANNEL_TOGGLE_CB("sl", sl)
+CHANNEL_TOGGLE_CB("sg", sg)
+CHANNEL_TOGGLE_CB("im", im)
+CHANNEL_TOGGLE_CB("ma", ma)
+CHANNEL_TOGGLE_CB("em", em)
+
 /* Audit U3 (#206): start/end-hour sliders.  Both fire on
  * LV_EVENT_VALUE_CHANGED while dragging, so we update the label live
  * AND persist to NVS on every step.  ui_home re-reads on next sys-label
@@ -1839,6 +1860,32 @@ lv_obj_t *ui_settings_create(void)
         }
     }
     y += ROW_H + 20;
+
+    /* ════════════════════════════════════════════════════════════════
+     *  SECTION: CHANNELS (W7-E.5 — per-platform notification opt-in)
+     * ════════════════════════════════════════════════════════════════ */
+    feed_wdt();
+    ESP_LOGI(TAG, "Phase 1 — Section: Channels");
+    lv_color_t acc_channels = lv_color_hex(ACC_VOICE); /* shares amber w/ Voice */
+
+    y = mk_section(s_scroll, "CHANNELS", acc_channels, y);
+
+    struct {
+       const char *label;
+       uint8_t (*getter)(void);
+       lv_event_cb_t cb;
+    } ch_rows[] = {
+        {"Telegram", tab5_settings_get_ch_tg_on, cb_ch_tg_on}, {"WhatsApp", tab5_settings_get_ch_wa_on, cb_ch_wa_on},
+        {"Discord", tab5_settings_get_ch_dc_on, cb_ch_dc_on},  {"Slack", tab5_settings_get_ch_sl_on, cb_ch_sl_on},
+        {"Signal", tab5_settings_get_ch_sg_on, cb_ch_sg_on},   {"iMessage", tab5_settings_get_ch_im_on, cb_ch_im_on},
+        {"Matrix", tab5_settings_get_ch_ma_on, cb_ch_ma_on},   {"Email", tab5_settings_get_ch_em_on, cb_ch_em_on},
+    };
+    for (size_t i = 0; i < sizeof(ch_rows) / sizeof(ch_rows[0]); i++) {
+       mk_row_label(s_scroll, ch_rows[i].label, y);
+       mk_switch(s_scroll, acc_channels, 660, y, ch_rows[i].getter() != 0, ch_rows[i].cb, NULL);
+       y += ROW_H + 8;
+    }
+    y += 20;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: DISPLAY (amber #F5A623)


### PR DESCRIPTION
## Summary
Fifth W7-E slice — per-channel notification opt-in. Closes #458. Per [`docs/PLAN-agent-mode-notification-surface.md`](docs/PLAN-agent-mode-notification-surface.md) §5.

### What's new
1. **`main/settings.{c,h}`** — 8 `ch_*_on` NVS keys (tg / wa / dc / sl / sg / im / ma / em) all default 0 + `tab5_settings_get_channel_enabled(short)` helper (fail-open on unknown channel names)
2. **`main/ui_settings.c`** — new CHANNELS section between VOICE MODE and DISPLAY with 8 toggle rows
3. **`main/ui_notification.c`** — router gate: if `channel` is non-empty AND disabled, silent drop with `ui.notif.channel_off` obs
4. **`main/debug_server_settings.c`** — `/settings` GET surfaces ch_*_on; POST accepts ch_*_on writes

### Verification on Tab5 192.168.1.90
| Test | Result |
|---|---|
| Fresh boot GET /settings | All 8 ch_*_on default to 0 |
| Settings UI scroll → CHANNELS section | ✅ All 8 toggles render (Telegram → Email) |
| Inject channel=tg with ch_tg_on=0 | `ui.notif.channel_off tg` (suppressed) |
| POST /settings {ch_tg_on:1} | `{"updated":["ch_tg_on"]}` |
| Re-inject channel=tg | `ui.notif tg/Bob pri=low surf=toast` (surfaces) |
| Inject channel=wa (still off) | `ui.notif.channel_off wa` (orthogonality) |
| NVS persistence | Telegram toggle still ON after reflash + reboot |

### Out of scope
- Dragon-side `config_update.channels` source suppression → **W7-F**
- Real Reply dictation → **W7-E.4b**
- Quiet-hours visual half-opacity fade → **W7-E.6**

### Test plan
- [x] `idf.py build` clean
- [x] `git-clang-format --diff` empty
- [x] GET /settings includes all 8 ch_*_on keys
- [x] POST /settings ch_tg_on round-trips
- [x] Router gate suppresses disabled channels via obs trail
- [x] Settings UI renders the section + all 8 toggles
- [x] NVS persistence survives reflash

## Anchors
- Plan §5 + NVS table
- Predecessors: #444 (cues), #447 (toast), #450 (now-card), #453 (dedupe+snooze), #456 (reply)

🤖 Generated with [Claude Code](https://claude.com/claude-code)