### PR TITLE
feat(ui): W7-E.6 quiet-hours visual fade + snooze re-fire defer

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1931,7 +1931,9 @@ static void screen_gesture_cb(lv_event_t *e)
 #define TOAST_LIFETIME_WARN_MS 3500
 #define TOAST_LIFETIME_ERROR_MS 5000
 #define TOAST_LIFETIME_INCOMING_MS 3000 /* W7-E.1 — slightly longer than INFO so sender + preview both register */
-#define TOAST_BORDER_INCOMING 0x6B5BFF  /* W7-E.1 — blue-violet per PLAN §4.1 */
+#define TOAST_LIFETIME_INCOMING_QUIET_MS 1500 /* W7-E.6 — dim + quick fade per PLAN §4.3 */
+#define TOAST_BORDER_INCOMING 0x6B5BFF        /* W7-E.1 — blue-violet per PLAN §4.1 */
+#define TOAST_OPA_QUIET 120                   /* W7-E.6 — half the default 240 bg opacity */
 #define TOAST_LIFETIME_PER_CHAR_MS 60
 #define TOAST_LIFETIME_CAP_MS 8000
 #define TOAST_FRAME_MS 16 /* ~60 fps */
@@ -1948,6 +1950,9 @@ static uint32_t toast_lifetime_for(ui_toast_tone_t tone, const char *text) {
    if (tone == UI_TOAST_WARN) base = TOAST_LIFETIME_WARN_MS;
    if (tone == UI_TOAST_ERROR) base = TOAST_LIFETIME_ERROR_MS;
    if (tone == UI_TOAST_INCOMING) base = TOAST_LIFETIME_INCOMING_MS;
+   /* W7-E.6: quiet variant — short fixed lifetime, don't scale with text len.
+    * Quiet hours = don't grab attention. */
+   if (tone == UI_TOAST_INCOMING_QUIET) return TOAST_LIFETIME_INCOMING_QUIET_MS;
    uint32_t scale = text ? (uint32_t)strlen(text) * TOAST_LIFETIME_PER_CHAR_MS : 0;
    uint32_t total = base + scale;
    if (total > TOAST_LIFETIME_CAP_MS) total = TOAST_LIFETIME_CAP_MS;
@@ -1955,10 +1960,11 @@ static uint32_t toast_lifetime_for(ui_toast_tone_t tone, const char *text) {
 }
 
 static uint32_t toast_border_for(ui_toast_tone_t tone) {
-   if (tone == UI_TOAST_WARN) return TH_MODE_HYBRID;            /* yellow */
-   if (tone == UI_TOAST_ERROR) return TH_STATUS_RED;            /* rose-red */
-   if (tone == UI_TOAST_INCOMING) return TOAST_BORDER_INCOMING; /* W7-E.1 blue-violet */
-   return TH_CARD_BORDER;                                       /* legacy subtle */
+   if (tone == UI_TOAST_WARN) return TH_MODE_HYBRID;                  /* yellow */
+   if (tone == UI_TOAST_ERROR) return TH_STATUS_RED;                  /* rose-red */
+   if (tone == UI_TOAST_INCOMING) return TOAST_BORDER_INCOMING;       /* W7-E.1 blue-violet */
+   if (tone == UI_TOAST_INCOMING_QUIET) return TOAST_BORDER_INCOMING; /* W7-E.6 same hue, dim via bg opa */
+   return TH_CARD_BORDER;                                             /* legacy subtle */
 }
 
 /* Track the currently-displayed toast so a back-to-back show_toast can
@@ -2042,7 +2048,11 @@ static void show_toast_internal_tone(const char *text, ui_toast_tone_t tone) {
    lv_obj_remove_style_all(t);
    lv_obj_set_size(t, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
    lv_obj_set_style_bg_color(t, lv_color_hex(TH_CARD_ELEVATED), 0);
-   lv_obj_set_style_bg_opa(t, 240, 0);
+   /* W7-E.6: quiet variant uses half-opacity background so the user
+    * sees the message arrived but it doesn't visually compete with
+    * whatever they're doing during sleep hours. */
+   int bg_opa = (tone == UI_TOAST_INCOMING_QUIET) ? TOAST_OPA_QUIET : 240;
+   lv_obj_set_style_bg_opa(t, bg_opa, 0);
    lv_obj_set_style_radius(t, 18, 0);
    lv_obj_set_style_pad_hor(t, 22, 0);
    lv_obj_set_style_pad_ver(t, 14, 0);

--- a/main/ui_home.h
+++ b/main/ui_home.h
@@ -36,10 +36,11 @@ void ui_home_show_toast(const char *text);
  *  baseline lifetime so the user has time to read.  Lifetimes are also
  *  scaled by message length (60 ms/char on top of the baseline). */
 typedef enum {
-   UI_TOAST_INFO = 0,     /* amber  — legacy default */
-   UI_TOAST_WARN = 1,     /* yellow — non-fatal degradation */
-   UI_TOAST_ERROR = 2,    /* rose   — failure user must notice */
-   UI_TOAST_INCOMING = 3, /* blue-violet — W7-E.1 channel_message arrival */
+   UI_TOAST_INFO = 0,           /* amber  — legacy default */
+   UI_TOAST_WARN = 1,           /* yellow — non-fatal degradation */
+   UI_TOAST_ERROR = 2,          /* rose   — failure user must notice */
+   UI_TOAST_INCOMING = 3,       /* blue-violet — W7-E.1 channel_message arrival */
+   UI_TOAST_INCOMING_QUIET = 4, /* dim variant — W7-E.6 channel_message during quiet hours */
 } ui_toast_tone_t;
 
 /** Show a toast with a severity tone + auto-scaled lifetime.

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -116,8 +116,12 @@ static void notif_show_async_cb(void *arg) {
    const char *preview = msg->preview[0] ? msg->preview : "(no preview)";
    bool to_now_card = route_to_now_card(msg);
 
+   bool quiet = quiet_now();
+
    if (to_now_card) {
-      /* Richer surface: kicker + multi-line preview + 3-button row. */
+      /* Richer surface: kicker + multi-line preview + 3-button row.
+       * High-priority gets through visually even in quiet hours per
+       * PLAN §4.3 — user opted into the priority signal. */
       ui_home_show_channel_now(ch, sender, preview);
       /* Cache for the SNOOZE button — see ui_notification_snooze_current. */
       memcpy(&s_last_now_msg, msg, sizeof(s_last_now_msg));
@@ -127,18 +131,20 @@ static void notif_show_async_cb(void *arg) {
        * specifiers so compiler can prove no truncation. */
       char text[200];
       snprintf(text, sizeof(text), "[%.15s] %.40s · %.120s", ch, sender, preview);
-      ui_home_show_toast_ex(text, UI_TOAST_INCOMING);
+      /* W7-E.6: dim variant during quiet hours — visible but not
+       * attention-grabbing per PLAN §4.3. */
+      ui_home_show_toast_ex(text, quiet ? UI_TOAST_INCOMING_QUIET : UI_TOAST_INCOMING);
    }
 
    /* Audio cue: HIGH for now-card, LOW for toast.  Respect quiet hours
     * per spec §4.3 — visible surface still fires, audio is suppressed. */
-   if (!quiet_now()) {
+   if (!quiet) {
       ui_audio_cue_play(to_now_card ? UI_CUE_INCOMING_HIGH : UI_CUE_INCOMING_LOW);
    }
 
-   char detail[48];
-   snprintf(detail, sizeof(detail), "%.6s/%.16s pri=%.6s surf=%s", ch, sender, msg->priority[0] ? msg->priority : "?",
-            to_now_card ? "now" : "toast");
+   char detail[64];
+   snprintf(detail, sizeof(detail), "%.6s/%.16s pri=%.6s surf=%s%s", ch, sender, msg->priority[0] ? msg->priority : "?",
+            to_now_card ? "now" : "toast", quiet ? " quiet" : "");
    tab5_debug_obs_event("ui.notif", detail);
 
    free(msg);
@@ -181,6 +187,16 @@ static uint64_t snooze_now_us(void) { return (uint64_t)esp_timer_get_time(); }
  * has passed gets removed + re-shown via the normal routing path. */
 static void snooze_walk_cb(lv_timer_t *t) {
    (void)t;
+   /* W7-E.6: during quiet hours, leave the ring untouched so re-fires
+    * don't wake the user.  Next 60 s tick after quiet ends will process
+    * the accumulated backlog naturally — entries with `fire_at` already
+    * in the past stay flagged ready. */
+   if (quiet_now()) {
+      if (s_snooze_count > 0) {
+         tab5_debug_obs_event("ui.notif.snooze", "defer_quiet");
+      }
+      return;
+   }
    uint64_t now_us = snooze_now_us();
    /* Walk in reverse so we can remove without re-indexing. */
    for (int i = s_snooze_count - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary
Sixth (and final) W7-E slice — closes the notification surface spec end-to-end. Closes #461. Per [`docs/PLAN-agent-mode-notification-surface.md`](docs/PLAN-agent-mode-notification-surface.md) §4.3 + §3.2.

### What's new
- **`main/ui_home.{c,h}`** — new `UI_TOAST_INCOMING_QUIET` tone (= 4); half-opacity background (120 vs 240), same blue-violet border, fixed 1.5 s lifetime
- **`main/ui_notification.c`** — when `quiet_now()`, toast path uses the dim variant; now-card still surfaces at full opacity (high-priority bypass per spec); audio cue still suppressed; `ui.notif` obs gains a " quiet" suffix
- **Snooze walker** gated on `quiet_now()` — ring left untouched during quiet hours; next 60 s tick after quiet ends processes the backlog naturally. Logs `ui.notif.snooze defer_quiet` for visibility

### Live verification on Tab5 192.168.1.90
| Test | Result |
|---|---|
| Quiet OFF + low-pri tg | Bright toast + LOW cue. obs `tg/Alice pri=low surf=toast` |
| Quiet ON (23→1 wrap) + low-pri tg | Dim half-opacity toast + audio suppressed. obs `tg/Dave pri=low surf=toast quiet` |
| Quiet ON + high-pri tg | Full-opacity now-card (visual bypass) + audio suppressed. obs `tg/Eve pri=high surf=now quiet` |
| Screenshots | Comparison confirms bright vs dim visual difference |

### Out of scope
- Dragon-side suppression (W7-F)
- Real voice dictation reply (W7-E.4b)

### Test plan
- [x] `idf.py build` clean
- [x] `git-clang-format --diff` empty
- [x] Quiet OFF inject → bright toast + audio
- [x] Quiet ON low-pri → dim toast, no audio, obs marker present
- [x] Quiet ON high-pri → full now-card, no audio, obs marker present
- [x] Screenshots show dim vs bright visual difference
- [x] obs trail has `surf=toast quiet` / `surf=now quiet` suffixes

## Anchors
- Plan §4.3 + §3.2
- Predecessors: #444, #447, #450, #453, #456, #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)