### PR TITLE
fix(ui): auto-dismiss channel-now overlay on screen navigation

### DIFF
--- a/main/debug_server_nav.c
+++ b/main/debug_server_nav.c
@@ -91,6 +91,14 @@ static void async_navigate(void *arg) {
    ui_focus_hide();
    ui_sessions_hide();
    ui_keyboard_hide();
+   /* W7-E follow-up (TT #464): channel-now overlay lives on lv_layer_top
+    * so it survives screen loads unless explicitly dismissed.  Any user-
+    * initiated navigation is a clear "I'm not dealing with this right
+    * now" gesture — drop the overlay so it doesn't shadow the destination
+    * screen.  Snoozed messages still re-fire on the walker timer; the
+    * underlying notification state isn't lost. */
+   extern void ui_home_hide_channel_now(void);
+   ui_home_hide_channel_now();
    /* Wave 4 UX fix: if the voice overlay is up but voice is idle, a
     * nav request means the user has moved on.  Dismiss so the user
     * sees the screen they just navigated to instead of a stale


### PR DESCRIPTION
## Summary
Closes #464. W7-E follow-up polish caught during the end-to-end UX validation that shipped with #463.

The W7-E.2 channel-now overlay lives on `lv_layer_top` so it survives screen loads. But that meant it visually shadowed the destination when the user navigated to Settings/Camera/Files/etc.

### Fix
`main/debug_server_nav.c` — add `ui_home_hide_channel_now()` to the existing chorus of `*_hide()` calls in `async_navigate`.

### Verification on Tab5 192.168.1.90
| Step | Screenshot |
|---|---|
| Inject high-pri → now-card visible on home | nav01 — rose overlay with 3 buttons |
| Navigate to Settings | nav02 — Settings renders cleanly, no overlay shadow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)