### PR TITLE
feat(ui): W7-B Tab5 follow-up — live refresh of agent_skills on mode change

### DIFF
--- a/main/debug_server_mode.c
+++ b/main/debug_server_mode.c
@@ -26,6 +26,10 @@ static void async_refresh_mode_badge(void *arg) {
    (void)arg;
    extern void ui_home_refresh_mode_badge(void);
    ui_home_refresh_mode_badge();
+   /* W7-B follow-up (TT #467): if the Agents overlay is currently visible,
+    * re-fetch the agent-skill catalog so its vmode=3 gate updates live. */
+   extern void ui_agents_on_mode_change(void);
+   ui_agents_on_mode_change();
 }
 
 /* POST /mode?m=0|1|2|3|4&model=... — switch voice mode.

--- a/main/ui_agents.c
+++ b/main/ui_agents.c
@@ -1402,3 +1402,13 @@ bool ui_agents_is_visible(void)
 {
     return s_visible;
 }
+
+/* W7-B follow-up (TT #467): re-fire the skill-catalog fetch on voice-mode
+ * change so the vmode=3 gate inside `fetch_agent_skills_job` updates live.
+ * No-op when the overlay is hidden — the next ui_agents_show() will fetch
+ * from scratch anyway. */
+void ui_agents_on_mode_change(void) {
+   if (!s_visible) return;
+   ESP_LOGI(TAG, "mode change → re-fetching agent_skills catalog");
+   kick_off_agent_skills_fetch();
+}

--- a/main/ui_agents.h
+++ b/main/ui_agents.h
@@ -22,3 +22,10 @@ void ui_agents_hide(void);
 
 /** True if the overlay is currently visible. */
 bool ui_agents_is_visible(void);
+
+/** W7-B follow-up (TT #467): notify the overlay that the user's voice
+ *  mode changed.  When the overlay is currently visible, re-kicks the
+ *  agent-skill catalog fetch so the vmode=3 gate (W7-B.4) updates live
+ *  — switching into mode 3 reveals the skill section; switching out
+ *  hides it.  Safe to call when the overlay is hidden (no-op). */
+void ui_agents_on_mode_change(void);

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -515,6 +515,11 @@ static void persist_and_notify_dragon(void)
 
     ESP_LOGI(TAG, "Tier change resolved -> voice_mode=%d model=%s",
              new_mode, model_to_send);
+    /* W7-B follow-up (TT #467): refresh agent_skills catalog if Agents
+     * overlay is visible — its vmode=3 gate needs to update live when
+     * the user dials in/out of TinkerClaw. */
+    extern void ui_agents_on_mode_change(void);
+    ui_agents_on_mode_change();
 }
 
 /* Wave 10 H5 Presets: one-tap recipes that set all three dials to the
@@ -551,6 +556,10 @@ void preset_click_cb(lv_event_t *e)
            tab5_settings_get_llm_model(model, sizeof(model));
            voice_send_config_update(VOICE_MODE_ONBOARD, model);
            ESP_LOGI(TAG, "Onboard preset -> voice_mode=%d (K144)", VOICE_MODE_ONBOARD);
+           {
+              extern void ui_agents_on_mode_change(void);
+              ui_agents_on_mode_change();
+           }
            ui_mode_sheet_hide();
            return;
         case 5: /* Solo — W8 (cross-stack audit 2026-05-11): closes the
@@ -576,6 +585,10 @@ void preset_click_cb(lv_event_t *e)
            tab5_settings_get_llm_model(model2, sizeof(model2));
            voice_send_config_update(VOICE_MODE_SOLO, model2);
            ESP_LOGI(TAG, "Solo preset -> voice_mode=%d (OpenRouter direct)", VOICE_MODE_SOLO);
+           {
+              extern void ui_agents_on_mode_change(void);
+              ui_agents_on_mode_change();
+           }
         }
            ui_mode_sheet_hide();
            return;


### PR DESCRIPTION
## Summary
Pure-Tab5 polish that closes a W7-B follow-up tracked in the audit memory. Closes #467.

Pre-fix: the agent-skill catalog only fetched on overlay open, so switching voice modes while the overlay was visible left the section stale.

### What's new
- **`main/ui_agents.{c,h}`** — new `ui_agents_on_mode_change()` re-kicks the catalog fetch when overlay is visible (no-op when hidden)
- **`main/debug_server_mode.c`** — `/mode` POST handler now propagates the hook
- **`main/ui_mode_sheet.c`** — 3 mode-set sites (dial commit + Onboard preset + Solo preset) call the hook

### Live verification on Tab5 192.168.1.90
| Test | Result |
|---|---|
| Open Agents in vmode=0 | No skill section (W7-B.4 gate) |
| POST `/mode?m=3` while overlay open | obs `agent_skills count=9 observed=1` + section renders with 9 chips |
| POST `/mode?m=0` | obs `agent_skills skip vmode=0` + section gone |
| Heap stable across multiple toggles | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)