### PR TITLE
fix(ui): paint W7-E.4c reply chip even if voice overlay already shown

### DIFF
--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -268,6 +268,14 @@ void ui_notification_reply_current(const char *text) {
    /* W7-E.4b: voice-dictated reply path.  Arm + prompt. */
    voice_arm_channel_reply(s_last_now_msg.channel, s_last_now_msg.thread_id, s_last_now_msg.sender);
 
+   /* TT #481 (W7-E.4c follow-up): if the voice overlay is already up
+    * (e.g. user was mid-conversation when a now-card arrived), the
+    * chip-paint inside ui_voice_show won't re-run on next listening
+    * start because s_visible is already true.  Repaint explicitly so
+    * the chip appears on either path: overlay-already-up OR fresh-open. */
+   extern void ui_voice_refresh_reply_chip(void);
+   ui_voice_refresh_reply_chip();
+
    char detail[64];
    snprintf(detail, sizeof(detail), "armed ch=%.8s sender=%.20s", s_last_now_msg.channel, s_last_now_msg.sender);
    tab5_debug_obs_event("ui.notif.reply", detail);

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -669,20 +669,11 @@ void ui_voice_show(void)
     lv_obj_set_style_opa(s_overlay, VO_BG_OPA, 0);
 
     /* W7-E.4c: reveal the reply-context chip if the user just tapped
-     * REPLY on a now-card.  voice_peek_channel_reply reads the armed
-     * state without clearing (the STT-complete branch in
-     * voice_ws_proto.c consumes via voice_consume_channel_reply). */
-    if (s_lbl_reply_chip) {
-       char ch[16] = {0}, thread[64] = {0}, sender[64] = {0};
-       if (voice_peek_channel_reply(ch, thread, sender)) {
-          char text[160];
-          snprintf(text, sizeof(text), "Replying to %.40s (%.8s)", sender[0] ? sender : "?", ch[0] ? ch : "?");
-          lv_label_set_text(s_lbl_reply_chip, text);
-          lv_obj_clear_flag(s_lbl_reply_chip, LV_OBJ_FLAG_HIDDEN);
-       } else {
-          lv_obj_add_flag(s_lbl_reply_chip, LV_OBJ_FLAG_HIDDEN);
-       }
-    }
+     * REPLY on a now-card.  Body extracted to
+     * ui_voice_refresh_reply_chip so callers that arm context AFTER
+     * the overlay is already shown (TT #481 — `ui_voice_show`
+     * short-circuits at top) can trigger the repaint manually. */
+    ui_voice_refresh_reply_chip();
 
     /* Child-opacity ramp is driven by fade_overlay_cb from start→end
      * in the old animation; skipping it means child content snaps on
@@ -690,6 +681,25 @@ void ui_voice_show(void)
      * text labels' opacity instead of the container. */
 
     ESP_LOGI(TAG, "Voice overlay shown (instant, W15-C07)");
+}
+
+/* TT #481 (W7-E.4c follow-up): chip-repaint helper.  Was inlined inside
+ * ui_voice_show; extracted so callers that arm context after the overlay
+ * is already up (e.g. ui_notification_reply_current when chat → voice
+ * overlay was already visible) can still trigger the visual repaint.
+ * Idempotent — safe to call multiple times; bails when the chip widget
+ * hasn't been built yet (overlay not constructed). */
+void ui_voice_refresh_reply_chip(void) {
+   if (!s_lbl_reply_chip) return;
+   char ch[16] = {0}, thread[64] = {0}, sender[64] = {0};
+   if (voice_peek_channel_reply(ch, thread, sender)) {
+      char text[160];
+      snprintf(text, sizeof(text), "Replying to %.40s (%.8s)", sender[0] ? sender : "?", ch[0] ? ch : "?");
+      lv_label_set_text(s_lbl_reply_chip, text);
+      lv_obj_clear_flag(s_lbl_reply_chip, LV_OBJ_FLAG_HIDDEN);
+   } else {
+      lv_obj_add_flag(s_lbl_reply_chip, LV_OBJ_FLAG_HIDDEN);
+   }
 }
 
 void ui_voice_hide(void)

--- a/main/ui_voice.h
+++ b/main/ui_voice.h
@@ -26,6 +26,16 @@ void ui_voice_show(void);
 void ui_voice_hide(void);
 bool ui_voice_is_visible(void);
 
+/** TT #481 (W7-E.4c follow-up): repaint the reply-context chip from
+ *  the currently-armed channel_reply state.  Idempotent — when context
+ *  is armed, shows the chip; when not, hides it.  Call right after
+ *  `voice_arm_channel_reply` from any path where the voice overlay may
+ *  already be up — `ui_voice_show` short-circuits when `s_visible` is
+ *  already true so the chip-paint inside it doesn't re-run.  Safe to
+ *  call before the overlay is built (bails when widget is NULL).
+ *  LVGL thread only. */
+void ui_voice_refresh_reply_chip(void);
+
 /**
  * Dismiss the overlay only if voice is in a non-active state
  * (IDLE/READY/RECONNECTING/CONNECTING).  During LISTENING / PROCESSING /


### PR DESCRIPTION
## Summary
Closes #481. Polish bug caught during the W7-E full UX validation pass.

When the user was mid-conversation (voice overlay up) and a high-priority `channel_message` arrived → tap REPLY → arm context, the reply chip didn't render because `ui_voice_show` short-circuits when `s_visible` is already true, so the chip-paint block inside it never re-ran.

### Fix
- **`main/ui_voice.{c,h}`** — extracted the chip-repaint block into a new public `ui_voice_refresh_reply_chip(void)`. Idempotent.
- **`ui_voice_show`** now calls the helper instead of inlining (first-open behavior unchanged).
- **`ui_notification.c::ui_notification_reply_current`** — after `voice_arm_channel_reply`, also calls `ui_voice_refresh_reply_chip` so the chip paints on either path: overlay-already-up OR fresh-open.

### Verified on Tab5 192.168.1.90
Bug scenario: voice overlay up → high-pri inject → tap REPLY → reopen voice overlay → chip "Replying to Mom (tg)" now visible at top with rose `TH_MODE_CLAW` border (screenshot attached to issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)