### PR TITLE
W4-D: debug.coredump_pull obs event in /coredump handler

### DIFF
--- a/main/debug_server_obs.c
+++ b/main/debug_server_obs.c
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 
 #include "cJSON.h"
+#include "debug_obs.h"
 #include "debug_server_internal.h"
 #include "esp_core_dump.h"
 #include "esp_err.h"
@@ -225,6 +226,13 @@ static esp_err_t coredump_handler(httpd_req_t *req) {
    /* Terminate chunked stream. */
    httpd_resp_send_chunk(req, NULL, 0);
    ESP_LOGI(TAG, "/coredump: sent %zu/%zu bytes", sent, size);
+   /* W4-D (audit 2026-05-11): fire an obs event so the Dragon-side
+    * coredump scraper's pull leaves a fingerprint on the Tab5 obs
+    * ring — operators can correlate "Dragon archived dump at T" with
+    * "Tab5 served the bytes at T" without reading httpd logs. */
+   char obs_buf[48];
+   snprintf(obs_buf, sizeof(obs_buf), "bytes=%zu", sent);
+   tab5_debug_obs_event("debug.coredump_pull", obs_buf);
    return ESP_OK;
 }
 


### PR DESCRIPTION
Companion to TinkerBox #322/#323 — Dragon-side coredump scraper.

Adds `tab5_debug_obs_event("debug.coredump_pull", "bytes=<n>")` at the end of the `/coredump` handler in `main/debug_server_obs.c` so the Tab5 obs ring has on-device fingerprint of every scrape. Operators can correlate "Dragon archived dump at T" with "Tab5 served the bytes at T" without reading httpd logs.

## Live-verified on Tab5 192.168.1.90
After Dragon's scraper iterated through the test window, Tab5's `/events` ring showed 4× `debug.coredump_pull bytes=37540` entries matching the dump SHA archived to Dragon disk (`26bf6b03b63c35d60b5d5137b77b11de601009ef6172b08ca36e01229ca24d69`).

Full user-story test green (21/21): nav, voice-mode cycle 0→5, channel toggle, camera frame fetch, cross-stack chat, scraper iteration, obs event, final health + heap stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)