### PR TITLE
feat(dictation): pipeline state machine + VAD + instrumentation (PR 1 of 4)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-dictation-pipeline-pr1.md
+++ b/docs/superpowers/plans/2026-05-14-dictation-pipeline-pr1.md
@@ -1,0 +1,1567 @@
+# Dictation pipeline PR 1 — state machine + VAD + instrumentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the canonical `dict_pipeline_t` state machine in a new `main/voice_dictation.{c,h}` module, wire all existing dictation entry points (voice.c WS path + ui_notes.c REST polling path) to drive transitions, and add a `/dictation_pipeline` debug endpoint so PR 2/3 can verify the state without UI surfaces yet.
+
+**Architecture:** New pure-C module owns the state, transitions, and a fan-out subscriber list. Existing dictation code paths call `voice_dictation_set_state(...)` at well-defined points. UI subscribers come in PR 2 + PR 3. The module is host-testable — caller passes monotonic timestamps so the module has zero ESP-IDF deps.
+
+**Tech Stack:** ESP-IDF 5.5.2 component (`main/`), plain C state machine, host-test via `tests/host/` (assert.h + ctest pattern matching `test_md_strip.c`). Spec at [`docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md`](../specs/2026-05-14-dictation-pipeline-notes-redesign-design.md).
+
+---
+
+## File map
+
+**Create:**
+- `main/voice_dictation.h` — public state-machine API (types, subscribe, set_state, get)
+- `main/voice_dictation.c` — implementation (subscriber list, transition validation, thread-safe state)
+- `tests/host/test_voice_dictation.c` — host-targeted unit tests
+
+**Modify:**
+- `main/CMakeLists.txt` — add `voice_dictation.c` to component sources
+- `tests/host/CMakeLists.txt` — add `test_voice_dictation` target
+- `main/main.c` — call `voice_dictation_init()` at boot
+- `main/voice.c` — instrument `voice_start_dictation` + `voice_stop_listening` + VAD auto-stop + 5-min hard cap
+- `main/voice_ws_proto.c` — instrument `dictation_summary` JSON handler + WS disconnect failure path
+- `main/ui_notes.c` — instrument `transcription_queue_task` transitions (overlap with PR #517's reason-marking)
+- `main/debug_server_dictation.c` — add `GET /dictation_pipeline` reporting current state name + reason name + age
+
+**Boundary rule:** `voice_dictation.c` MUST stay free of ESP-IDF deps for clean host testing. Anything platform-y (timers, mutexes) is shimmed in `tests/host/shim/` or stays in the instrumentation callers.
+
+**Known deviations from spec:**
+
+- The spec's locked-decisions table says "4 s VAD silence".  The existing
+  `DICTATION_AUTO_STOP_FRAMES = 250` in `main/voice.c` is 5 s (250 frames
+  × 20 ms).  PR 1 keeps this at 5 s to preserve current behaviour —
+  changing it is a tuning knob best done in PR 2 once the orb's
+  RECORDING state is visible and we can see whether 4 s feels snappier.
+  Filed as a follow-up under the spec's "Risks + open questions" §2.
+
+---
+
+## Tasks
+
+### Task 1 — Public types + API surface (`voice_dictation.h`)
+
+**Files:**
+- Create: `main/voice_dictation.h`
+
+- [ ] **Step 1: Write the header**
+
+```c
+/* main/voice_dictation.h — Canonical state machine for a dictation
+ * pipeline (RECORDING → UPLOADING → TRANSCRIBING → SAVED, with FAILED
+ * as a terminal branch).  Multiple UI surfaces subscribe and render
+ * the same state.
+ *
+ * Designed for host-testability: zero ESP-IDF deps in voice_dictation.c.
+ * Callers pass monotonic timestamps in ms.  See spec at
+ * docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+   DICT_IDLE = 0,
+   DICT_RECORDING,
+   DICT_UPLOADING,
+   DICT_TRANSCRIBING,
+   DICT_SAVED,
+   DICT_FAILED,
+} dict_state_t;
+
+typedef enum {
+   DICT_FAIL_NONE = 0,
+   DICT_FAIL_AUTH,        /* Dragon returned 401 / 403 */
+   DICT_FAIL_NETWORK,     /* Other HTTP error / WS disconnect / open failed */
+   DICT_FAIL_EMPTY,       /* Dragon returned 200 with empty STT text */
+   DICT_FAIL_NO_AUDIO,    /* WAV missing or unreadable / Dragon got no PCM */
+   DICT_FAIL_TOO_LONG,    /* hit 5-min hard cap during recording */
+   DICT_FAIL_CANCELLED,   /* user tapped cancel */
+} dict_fail_t;
+
+typedef struct {
+   dict_state_t state;
+   dict_fail_t  fail_reason;     /* meaningful only when state == DICT_FAILED */
+   uint32_t     started_ms;      /* time of last IDLE→RECORDING (0 if never recorded) */
+   uint32_t     stopped_ms;      /* time of RECORDING→next (0 while still recording) */
+   uint32_t     last_change_ms;  /* time of most recent transition */
+   int          note_slot;       /* -1 until SD WAV slot allocated; >=0 after */
+} dict_event_t;
+
+typedef void (*dict_subscriber_t)(const dict_event_t *event, void *user_data);
+
+/* Boot-time init.  Idempotent.  Safe to call before FreeRTOS scheduler.
+ * Initialises state to DICT_IDLE, clears subscriber list. */
+void voice_dictation_init(void);
+
+/* Register a subscriber.  Returns >=0 handle on success, -1 if the
+ * subscriber table is full (compile-time constant DICT_MAX_SUBSCRIBERS). */
+int voice_dictation_subscribe(dict_subscriber_t cb, void *user_data);
+
+/* Remove a subscriber by handle.  No-op if handle is invalid. */
+void voice_dictation_unsubscribe(int handle);
+
+/* Drive a state transition.  Caller supplies monotonic time in ms.
+ * Invalid transitions (e.g. SAVED → RECORDING directly) log a warning
+ * and are NO-OPs — the state machine never moves backward except via
+ * the explicit SAVED→IDLE / FAILED→IDLE retry paths.
+ *
+ * fail_reason is ignored unless new_state == DICT_FAILED. */
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
+                               uint32_t now_ms);
+
+/* Attach a note slot to the current pipeline (called when SD WAV starts).
+ * Persists through subsequent transitions until next IDLE. */
+void voice_dictation_set_note_slot(int slot);
+
+/* Snapshot current state.  Thread-safe (returns a copy under lock). */
+dict_event_t voice_dictation_get(void);
+
+/* Human-readable state/reason names — useful for logs, debug endpoint,
+ * and live verification.  Static strings; do not free. */
+const char *voice_dictation_state_name(dict_state_t s);
+const char *voice_dictation_fail_name(dict_fail_t f);
+
+#ifdef __cplusplus
+}
+#endif
+```
+
+- [ ] **Step 2: Commit the header (compiles standalone — no implementation yet)**
+
+```bash
+cd ~/projects/TinkerTab
+git add main/voice_dictation.h
+git commit -m "feat(dictation): voice_dictation.h public API"
+```
+
+---
+
+### Task 2 — Empty implementation + minimal host test
+
+**Files:**
+- Create: `main/voice_dictation.c`
+- Create: `tests/host/test_voice_dictation.c`
+- Modify: `tests/host/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test first**
+
+Create `tests/host/test_voice_dictation.c`:
+
+```c
+/* Host-targeted unit tests for main/voice_dictation.c.
+ *
+ * Pure-C state machine — zero ESP-IDF deps in the module under test;
+ * this file uses plain assert.h / stdio just like test_md_strip.c. */
+
+#include "voice_dictation.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int g_pass = 0;
+
+#define CHECK(cond)                                                       \
+   do {                                                                   \
+      if (!(cond)) {                                                      \
+         fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);  \
+         return 1;                                                        \
+      }                                                                   \
+      g_pass++;                                                           \
+   } while (0)
+
+#define CHECK_EQ(a, b)                                                              \
+   do {                                                                             \
+      if ((a) != (b)) {                                                             \
+         fprintf(stderr, "FAIL %s:%d  %s != %s  (%d vs %d)\n", __FILE__, __LINE__,  \
+                 #a, #b, (int)(a), (int)(b));                                       \
+         return 1;                                                                  \
+      }                                                                             \
+      g_pass++;                                                                     \
+   } while (0)
+
+static int test_init_state_is_idle(void) {
+   voice_dictation_init();
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_IDLE);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);
+   CHECK_EQ(e.note_slot, -1);
+   return 0;
+}
+
+int main(void) {
+   if (test_init_state_is_idle()) return 1;
+   fprintf(stderr, "ok  %d checks passed\n", g_pass);
+   return 0;
+}
+```
+
+- [ ] **Step 2: Verify the test fails to build (no implementation yet)**
+
+Add to `tests/host/CMakeLists.txt` (append at end, before any closing markers):
+
+```cmake
+# voice_dictation — pipeline state machine (PR 1).
+add_executable(test_voice_dictation
+    test_voice_dictation.c
+    ${MAIN_DIR}/voice_dictation.c
+)
+target_include_directories(test_voice_dictation PRIVATE ${MAIN_DIR})
+add_test(NAME voice_dictation COMMAND test_voice_dictation)
+```
+
+Run:
+
+```bash
+cd ~/projects/TinkerTab/tests/host
+cmake -S . -B build && cmake --build build 2>&1 | tail -20
+```
+
+Expected: FAIL — `voice_dictation.c: No such file or directory`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `main/voice_dictation.c`:
+
+```c
+/* main/voice_dictation.c — dictation pipeline state machine.
+ *
+ * Pure C, zero ESP-IDF deps so it runs under tests/host/.  Callers
+ * (voice.c, ui_notes.c, debug_server_dictation.c) supply monotonic
+ * timestamps via voice_dictation_set_state(state, reason, now_ms).
+ *
+ * Thread safety: target build wraps the global with a FreeRTOS mutex
+ * (acquired/released around every public call); host build uses a
+ * shim no-op mutex.  See `dict_lock()` / `dict_unlock()` below. */
+
+#include "voice_dictation.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define DICT_MAX_SUBSCRIBERS 4
+
+typedef struct {
+   dict_subscriber_t cb;
+   void             *user_data;
+   bool              in_use;
+} dict_sub_t;
+
+static dict_event_t s_event;
+static dict_sub_t   s_subs[DICT_MAX_SUBSCRIBERS];
+
+void voice_dictation_init(void) {
+   memset(&s_event, 0, sizeof(s_event));
+   s_event.state = DICT_IDLE;
+   s_event.fail_reason = DICT_FAIL_NONE;
+   s_event.note_slot = -1;
+   memset(s_subs, 0, sizeof(s_subs));
+}
+
+int voice_dictation_subscribe(dict_subscriber_t cb, void *user_data) {
+   if (!cb) return -1;
+   for (int i = 0; i < DICT_MAX_SUBSCRIBERS; i++) {
+      if (!s_subs[i].in_use) {
+         s_subs[i].cb = cb;
+         s_subs[i].user_data = user_data;
+         s_subs[i].in_use = true;
+         return i;
+      }
+   }
+   return -1;
+}
+
+void voice_dictation_unsubscribe(int handle) {
+   if (handle < 0 || handle >= DICT_MAX_SUBSCRIBERS) return;
+   s_subs[handle].in_use = false;
+   s_subs[handle].cb = NULL;
+   s_subs[handle].user_data = NULL;
+}
+
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
+                               uint32_t now_ms) {
+   /* Implemented in Task 4. */
+   (void)new_state; (void)fail_reason; (void)now_ms;
+}
+
+void voice_dictation_set_note_slot(int slot) {
+   s_event.note_slot = slot;
+}
+
+dict_event_t voice_dictation_get(void) {
+   return s_event;
+}
+
+const char *voice_dictation_state_name(dict_state_t s) {
+   switch (s) {
+   case DICT_IDLE:         return "IDLE";
+   case DICT_RECORDING:    return "RECORDING";
+   case DICT_UPLOADING:    return "UPLOADING";
+   case DICT_TRANSCRIBING: return "TRANSCRIBING";
+   case DICT_SAVED:        return "SAVED";
+   case DICT_FAILED:       return "FAILED";
+   }
+   return "UNKNOWN";
+}
+
+const char *voice_dictation_fail_name(dict_fail_t f) {
+   switch (f) {
+   case DICT_FAIL_NONE:      return "NONE";
+   case DICT_FAIL_AUTH:      return "AUTH";
+   case DICT_FAIL_NETWORK:   return "NETWORK";
+   case DICT_FAIL_EMPTY:     return "EMPTY";
+   case DICT_FAIL_NO_AUDIO:  return "NO_AUDIO";
+   case DICT_FAIL_TOO_LONG:  return "TOO_LONG";
+   case DICT_FAIL_CANCELLED: return "CANCELLED";
+   }
+   return "UNKNOWN";
+}
+```
+
+- [ ] **Step 4: Run the test — it should pass now**
+
+```bash
+cd ~/projects/TinkerTab/tests/host
+cmake --build build && ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: `ok  3 checks passed` + `1/1 tests passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/projects/TinkerTab
+git add main/voice_dictation.c tests/host/test_voice_dictation.c tests/host/CMakeLists.txt
+git commit -m "feat(dictation): voice_dictation.c minimal scaffold + host test"
+```
+
+---
+
+### Task 3 — IDLE → RECORDING transition + subscriber callback
+
+**Files:**
+- Modify: `main/voice_dictation.c`
+- Modify: `tests/host/test_voice_dictation.c`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/host/test_voice_dictation.c` before `main()`:
+
+```c
+/* Subscriber that records the last event it saw. */
+typedef struct {
+   int           call_count;
+   dict_event_t  last;
+} mock_sub_t;
+
+static void mock_cb(const dict_event_t *e, void *ud) {
+   mock_sub_t *m = (mock_sub_t *)ud;
+   m->call_count++;
+   m->last = *e;
+}
+
+static int test_idle_to_recording_fires_subscriber(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   int h = voice_dictation_subscribe(mock_cb, &m);
+   CHECK(h >= 0);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 12345);
+
+   CHECK_EQ(m.call_count, 1);
+   CHECK_EQ(m.last.state, DICT_RECORDING);
+   CHECK_EQ((int)m.last.started_ms, 12345);
+   CHECK_EQ((int)m.last.last_change_ms, 12345);
+
+   dict_event_t snapshot = voice_dictation_get();
+   CHECK_EQ(snapshot.state, DICT_RECORDING);
+   return 0;
+}
+```
+
+Add to `main()` after the existing call:
+
+```c
+   if (test_idle_to_recording_fires_subscriber()) return 1;
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd ~/projects/TinkerTab/tests/host
+cmake --build build && ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: FAIL with `m.call_count != 1 (0 vs 1)` — set_state is still a stub.
+
+- [ ] **Step 3: Implement transition + dispatch**
+
+Replace the stub `voice_dictation_set_state` in `main/voice_dictation.c` with:
+
+```c
+static void dict_dispatch(void) {
+   for (int i = 0; i < DICT_MAX_SUBSCRIBERS; i++) {
+      if (s_subs[i].in_use && s_subs[i].cb) {
+         s_subs[i].cb(&s_event, s_subs[i].user_data);
+      }
+   }
+}
+
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
+                               uint32_t now_ms) {
+   /* Idempotent — same-state re-entry is a no-op (avoids spamming
+    * subscribers during a chatty caller that re-asserts state). */
+   if (new_state == s_event.state && fail_reason == s_event.fail_reason) {
+      return;
+   }
+
+   if (new_state == DICT_RECORDING) {
+      s_event.started_ms = now_ms;
+      s_event.stopped_ms = 0;
+   } else if (s_event.state == DICT_RECORDING) {
+      /* Leaving RECORDING — capture stop time. */
+      s_event.stopped_ms = now_ms;
+   }
+
+   if (new_state == DICT_IDLE) {
+      /* Reset session-specific fields when fully returning to IDLE. */
+      s_event.note_slot = -1;
+   }
+
+   s_event.state = new_state;
+   s_event.fail_reason = (new_state == DICT_FAILED) ? fail_reason : DICT_FAIL_NONE;
+   s_event.last_change_ms = now_ms;
+
+   dict_dispatch();
+}
+```
+
+- [ ] **Step 4: Run — should pass**
+
+```bash
+ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: `ok  9 checks passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice_dictation.c tests/host/test_voice_dictation.c
+git commit -m "feat(dictation): IDLE→RECORDING transition + subscriber dispatch"
+```
+
+---
+
+### Task 4 — Full forward pipeline + transition guard
+
+**Files:**
+- Modify: `main/voice_dictation.c`
+- Modify: `tests/host/test_voice_dictation.c`
+
+- [ ] **Step 1: Write the failing test for the full happy path**
+
+Append before `main()`:
+
+```c
+static int test_full_happy_path(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
+   voice_dictation_set_state(DICT_IDLE,         DICT_FAIL_NONE, 4400);
+
+   CHECK_EQ(m.call_count, 5);
+   CHECK_EQ(m.last.state, DICT_IDLE);
+   CHECK_EQ((int)m.last.started_ms, 1000);
+   CHECK_EQ((int)m.last.stopped_ms, 2000);
+   CHECK_EQ(m.last.note_slot, -1);     /* IDLE reset cleared it */
+   return 0;
+}
+
+static int test_idempotent_same_state(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1500);  /* dup */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000);  /* dup */
+
+   CHECK_EQ(m.call_count, 1);   /* duplicates suppressed */
+   return 0;
+}
+
+static int test_invalid_backward_transition_blocked(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, 1000);
+   /* Invalid: SAVED → RECORDING (must go through IDLE first). */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000);
+
+   CHECK_EQ(m.last.state, DICT_SAVED);
+   return 0;
+}
+
+static int test_note_slot_persists_through_pipeline(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_note_slot(7);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, 7);
+
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 4400);
+   e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, -1);  /* cleared on IDLE */
+   return 0;
+}
+```
+
+Add calls in `main()`:
+
+```c
+   if (test_full_happy_path()) return 1;
+   if (test_idempotent_same_state()) return 1;
+   if (test_invalid_backward_transition_blocked()) return 1;
+   if (test_note_slot_persists_through_pipeline()) return 1;
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: FAIL on `test_invalid_backward_transition_blocked` — current code doesn't guard transitions.
+
+- [ ] **Step 3: Add transition guard**
+
+In `main/voice_dictation.c`, add a guard helper above `voice_dictation_set_state`:
+
+```c
+/* Return true if going from `cur` to `next` is a valid transition.
+ * Forward through the pipeline + any → FAILED + SAVED/FAILED/IDLE → IDLE.
+ * Bounces (e.g. RECORDING → RECORDING) are filtered by the dup check
+ * in set_state itself, so we don't list them here. */
+static bool dict_transition_allowed(dict_state_t cur, dict_state_t next) {
+   /* Failures terminate any in-flight state. */
+   if (next == DICT_FAILED) return cur != DICT_IDLE;
+   /* IDLE accepts from any terminal state. */
+   if (next == DICT_IDLE) return cur == DICT_SAVED || cur == DICT_FAILED ||
+                                 cur == DICT_RECORDING;
+   switch (cur) {
+   case DICT_IDLE:         return next == DICT_RECORDING;
+   case DICT_RECORDING:    return next == DICT_UPLOADING || next == DICT_TRANSCRIBING;
+   case DICT_UPLOADING:    return next == DICT_TRANSCRIBING;
+   case DICT_TRANSCRIBING: return next == DICT_SAVED;
+   case DICT_SAVED:        return next == DICT_IDLE;
+   case DICT_FAILED:       return next == DICT_UPLOADING || next == DICT_RECORDING;
+                           /* retry resumes upload (REST) or restarts recording */
+   }
+   return false;
+}
+```
+
+Update the head of `voice_dictation_set_state` to use the guard (insert after the same-state-dup check):
+
+```c
+   if (!dict_transition_allowed(s_event.state, new_state)) {
+      /* Refused — log via the host shim print so it's visible during
+       * host tests, but don't abort: callers may race and we want the
+       * state machine resilient.  On target, this maps to ESP_LOGW
+       * once we add an esp_log shim in tests/host/. */
+      fprintf(stderr, "voice_dictation: refused %s -> %s\n",
+              voice_dictation_state_name(s_event.state),
+              voice_dictation_state_name(new_state));
+      return;
+   }
+```
+
+- [ ] **Step 4: Run — should pass**
+
+```bash
+ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: all checks pass (count ≈ 25+).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice_dictation.c tests/host/test_voice_dictation.c
+git commit -m "feat(dictation): full pipeline transitions + guard"
+```
+
+---
+
+### Task 5 — FAILED transitions + retry path
+
+**Files:**
+- Modify: `tests/host/test_voice_dictation.c`
+
+- [ ] **Step 1: Write tests**
+
+Append before `main()`:
+
+```c
+static int test_failed_from_uploading_auth(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_FAILED,    DICT_FAIL_AUTH, 2100);
+
+   CHECK_EQ(m.last.state, DICT_FAILED);
+   CHECK_EQ(m.last.fail_reason, DICT_FAIL_AUTH);
+   return 0;
+}
+
+static int test_failed_from_transcribing_empty(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_FAILED,       DICT_FAIL_EMPTY, 2400);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_FAILED);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_EMPTY);
+   return 0;
+}
+
+static int test_retry_from_failed(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_FAILED,    DICT_FAIL_NETWORK, 1100);
+   /* User taps retry → caller drives UPLOADING. */
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 5000);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_UPLOADING);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);   /* cleared on leave-FAILED */
+   return 0;
+}
+
+static int test_cancel_from_recording(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED, 1500);
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 1600);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_IDLE);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);
+   return 0;
+}
+
+static int test_failed_clears_reason_on_idle(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_AUTH, 2000);
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 3000);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);
+   return 0;
+}
+```
+
+Add to `main()`:
+
+```c
+   if (test_failed_from_uploading_auth()) return 1;
+   if (test_failed_from_transcribing_empty()) return 1;
+   if (test_retry_from_failed()) return 1;
+   if (test_cancel_from_recording()) return 1;
+   if (test_failed_clears_reason_on_idle()) return 1;
+```
+
+- [ ] **Step 2: Run — should already pass (Task 4's transition table already covers FAILED → UPLOADING and SAVED/FAILED → IDLE)**
+
+```bash
+cmake --build build && ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: pass. If not, the most likely fix is in `dict_transition_allowed` — re-read Task 4's guard logic and confirm `FAILED → UPLOADING` is allowed and `FAILED → IDLE` is allowed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/host/test_voice_dictation.c
+git commit -m "test(dictation): FAILED transitions + retry + cancel coverage"
+```
+
+---
+
+### Task 6 — Multi-subscriber + unsubscribe
+
+**Files:**
+- Modify: `tests/host/test_voice_dictation.c`
+
+- [ ] **Step 1: Write tests**
+
+```c
+static int test_multiple_subscribers_all_fire(void) {
+   voice_dictation_init();
+   mock_sub_t a = {0}, b = {0};
+   voice_dictation_subscribe(mock_cb, &a);
+   voice_dictation_subscribe(mock_cb, &b);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+
+   CHECK_EQ(a.call_count, 1);
+   CHECK_EQ(b.call_count, 1);
+   return 0;
+}
+
+static int test_unsubscribe_stops_callbacks(void) {
+   voice_dictation_init();
+   mock_sub_t a = {0}, b = {0};
+   int ha = voice_dictation_subscribe(mock_cb, &a);
+   voice_dictation_subscribe(mock_cb, &b);
+
+   voice_dictation_unsubscribe(ha);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+
+   CHECK_EQ(a.call_count, 0);
+   CHECK_EQ(b.call_count, 1);
+   return 0;
+}
+
+static int test_subscriber_table_full_returns_minus_one(void) {
+   voice_dictation_init();
+   mock_sub_t dummy[8] = {0};
+   int handles[8] = {0};
+   int got_full = 0;
+   for (int i = 0; i < 8; i++) {
+      handles[i] = voice_dictation_subscribe(mock_cb, &dummy[i]);
+      if (handles[i] == -1) got_full = 1;
+   }
+   CHECK_EQ(got_full, 1);   /* DICT_MAX_SUBSCRIBERS is 4 */
+   return 0;
+}
+```
+
+Add to `main()`:
+
+```c
+   if (test_multiple_subscribers_all_fire()) return 1;
+   if (test_unsubscribe_stops_callbacks()) return 1;
+   if (test_subscriber_table_full_returns_minus_one()) return 1;
+```
+
+- [ ] **Step 2: Run — should pass with existing implementation**
+
+```bash
+ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/host/test_voice_dictation.c
+git commit -m "test(dictation): multi-subscriber + unsubscribe + table-full"
+```
+
+---
+
+### Task 7 — Wire module into component build + boot init
+
+**Files:**
+- Modify: `main/CMakeLists.txt`
+- Modify: `main/main.c`
+
+- [ ] **Step 1: Add to component sources**
+
+Open `main/CMakeLists.txt`, find the existing `idf_component_register` SRCS list (alphabetically grouped), insert `"voice_dictation.c"` near other `voice_*.c` entries:
+
+```cmake
+# (existing line context — find the voice_* group)
+        "voice.c"
+        "voice_billing.c"
+        "voice_codec.c"
+        "voice_dictation.c"        # NEW — PR 1
+        "voice_m5_llm.c"
+        "voice_messages_sync.c"
+        # …
+```
+
+- [ ] **Step 2: Run target build, confirm no compile errors**
+
+```bash
+cd ~/projects/TinkerTab
+. /home/rebelforce/esp/esp-idf/export.sh
+idf.py build 2>&1 | tail -20
+```
+
+Expected: build succeeds (no link errors, no unused-symbol warnings).
+
+- [ ] **Step 3: Call init from boot**
+
+In `main/main.c`, find the boot sequence after `voice_init` (search `grep -n voice_init main/main.c`) and add:
+
+```c
+   /* PR 1: dictation pipeline state machine.  Idempotent; subscribers
+    * register lazily once their owning screen / surface is created.
+    * Must run after voice_init since transitions are driven from voice.c. */
+   voice_dictation_init();
+```
+
+Add the include at the top of `main/main.c` near other voice includes:
+
+```c
+#include "voice_dictation.h"
+```
+
+- [ ] **Step 4: Rebuild + flash, confirm boot completes**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -8
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before no_reset --after watchdog_reset read_mac 2>&1 | tail -3
+sleep 18
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" http://192.168.1.90:8080/info | head -c 200
+```
+
+Expected: device responds normally.  No PANIC.  Heap monitor reports normal numbers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/CMakeLists.txt main/main.c
+git commit -m "feat(dictation): wire voice_dictation into component + boot init"
+```
+
+---
+
+### Task 8 — Instrument `voice_start_dictation`
+
+**Files:**
+- Modify: `main/voice.c`
+
+- [ ] **Step 1: Read the current path**
+
+Open `main/voice.c` and find `voice_start_dictation` (around line 1592).  We're inserting at TWO sites: just before `voice_set_state(VOICE_STATE_LISTENING, ...)` near the end (around line 1689), and storing the note slot on the offline path so `voice_dictation_set_note_slot` gets the right index.
+
+- [ ] **Step 2: Add the include at the top of voice.c**
+
+Find the existing `#include "voice_..."` block (sorted alphabetically) and add:
+
+```c
+#include "voice_dictation.h"
+```
+
+- [ ] **Step 3: Add the transition at the end of voice_start_dictation**
+
+In `voice_start_dictation`, immediately before the existing line:
+
+```c
+    voice_set_state(VOICE_STATE_LISTENING, offline ? "offline" : NULL);
+    return ESP_OK;
+}
+```
+
+insert:
+
+```c
+    /* PR 1: drive the dictation pipeline state machine.  The pipeline
+     * is a separate higher-level state; the existing voice_state_t
+     * (LISTENING/PROCESSING/READY) is unchanged. */
+    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE,
+                              (uint32_t)(esp_timer_get_time() / 1000));
+```
+
+- [ ] **Step 4: Build + verify no warnings**
+
+```bash
+idf.py build 2>&1 | tail -10
+```
+
+Expected: success.  If there's an `esp_timer_get_time` undefined, the include is already there (used elsewhere in voice.c) — just confirm.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice.c
+git commit -m "feat(dictation): instrument voice_start_dictation → DICT_RECORDING"
+```
+
+---
+
+### Task 9 — Instrument `voice_stop_listening` for the dictate path
+
+**Files:**
+- Modify: `main/voice.c`
+
+- [ ] **Step 1: Locate `voice_stop_listening`**
+
+It starts around line 1786.  We need to add a transition AFTER the function decides it's actually stopping a dictation (mode == DICTATE).  The branch points:
+
+- offline_dictate path → DICT_UPLOADING (REST handoff happens later from ui_notes.c)
+- WS dictate path → DICT_TRANSCRIBING (mic stops; Dragon already has the audio; we're waiting on `dictation_summary`)
+
+- [ ] **Step 2: Add the transition near the end of voice_stop_listening**
+
+Find the function's final `return ESP_OK;` (or the equivalent).  Just before it, add:
+
+```c
+    /* PR 1: pipeline transition driven by mode.  Skip if this wasn't a
+     * dictation stop (e.g. voice-ask path, which doesn't touch the
+     * dictation pipeline at all). */
+    if (voice_get_mode() == VOICE_MODE_DICTATE) {
+       dict_state_t next = offline_dictate ? DICT_UPLOADING : DICT_TRANSCRIBING;
+       voice_dictation_set_state(next, DICT_FAIL_NONE,
+                                 (uint32_t)(esp_timer_get_time() / 1000));
+    }
+```
+
+The variable `offline_dictate` is already in scope from the function's earlier branch (line ~1807).  If that variable name was renamed in a follow-up, search the function body for its definition and use the matching name.
+
+- [ ] **Step 3: Build + verify**
+
+```bash
+idf.py build 2>&1 | tail -5
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/voice.c
+git commit -m "feat(dictation): instrument voice_stop_listening → UPLOADING/TRANSCRIBING"
+```
+
+---
+
+### Task 10 — Instrument VAD auto-stop + add 5-min hard cap to WS path
+
+**Files:**
+- Modify: `main/voice.c`
+
+- [ ] **Step 1: Locate the VAD auto-stop block**
+
+Around line 831 in `main/voice.c`:
+
+```c
+              if (had_speech && total_silence_frames >= DICTATION_AUTO_STOP_FRAMES) {
+                 ESP_LOGI(TAG, "Dictation: auto-stop after %dms of silence",
+                          DICTATION_AUTO_STOP_FRAMES * TAB5_VOICE_CHUNK_MS / 1000);
+                 /* … existing auto-stop send logic … */
+              }
+```
+
+Around line 770, the ASK-mode hard cap:
+
+```c
+           if (voice_get_mode() == VOICE_MODE_ASK && frames_sent >= MAX_RECORD_FRAMES_ASK) {
+              ESP_LOGI(TAG, "Max recording duration reached (%ds)", MAX_RECORD_FRAMES_ASK * TAB5_VOICE_CHUNK_MS / 1000);
+```
+
+DICTATE mode currently has no hard cap.  We add one matching the spec's 5-min ceiling (15 000 frames at 20 ms/frame).
+
+- [ ] **Step 2: Add a constant near the existing MAX_RECORD_FRAMES_ASK definition (around line 185)**
+
+```c
+#define MAX_RECORD_FRAMES_ASK       1500
+#define MAX_RECORD_FRAMES_DICT      15000   /* PR 1: 5 min hard cap on dictation */
+```
+
+- [ ] **Step 3: Add the dictation cap branch alongside the ASK cap**
+
+Replace the existing ASK cap block with:
+
+```c
+           if (voice_get_mode() == VOICE_MODE_ASK && frames_sent >= MAX_RECORD_FRAMES_ASK) {
+              ESP_LOGI(TAG, "Max recording duration reached (%ds)",
+                       MAX_RECORD_FRAMES_ASK * TAB5_VOICE_CHUNK_MS / 1000);
+              /* … existing auto-stop fallthrough … */
+              break;
+           }
+           if (voice_get_mode() == VOICE_MODE_DICTATE && frames_sent >= MAX_RECORD_FRAMES_DICT) {
+              ESP_LOGW(TAG, "Dictation hit 5-min cap — auto-stopping");
+              voice_dictation_set_state(DICT_FAILED, DICT_FAIL_TOO_LONG,
+                                        (uint32_t)(esp_timer_get_time() / 1000));
+              /* Fall through to the same stop handler used by VAD auto-stop. */
+              break;
+           }
+```
+
+Adjust the surrounding code so the break exits the mic-write loop into the same `voice_stop_listening`-equivalent finalisation the VAD path uses.  If that finalisation is inline (in the same loop), copy the pattern verbatim from the VAD block.
+
+- [ ] **Step 4: Build + flash + smoke test**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before no_reset --after watchdog_reset read_mac >/dev/null 2>&1
+sleep 18
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice.c
+git commit -m "feat(dictation): 5-min hard cap on dictation + pipeline integration"
+```
+
+---
+
+### Task 11 — Instrument `dictation_summary` handler
+
+**Files:**
+- Modify: `main/voice_ws_proto.c`
+
+- [ ] **Step 1: Open `voice_ws_proto.c` around line 795**
+
+Current handler:
+
+```c
+   } else if (strcmp(type_str, "dictation_summary") == 0) {
+      cJSON *title = cJSON_GetObjectItem(root, "title");
+      cJSON *summary = cJSON_GetObjectItem(root, "summary");
+      if (cJSON_IsString(title)) {
+         strncpy(s_dictation_title, title->valuestring, sizeof(s_dictation_title) - 1);
+         s_dictation_title[sizeof(s_dictation_title) - 1] = '\0';
+      }
+      if (cJSON_IsString(summary)) {
+         strncpy(s_dictation_summary, summary->valuestring, sizeof(s_dictation_summary) - 1);
+         s_dictation_summary[sizeof(s_dictation_summary) - 1] = '\0';
+      }
+      ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
+      voice_set_state(VOICE_STATE_READY, "dictation_summary");
+   }
+```
+
+- [ ] **Step 2: Add include + transition**
+
+Add the include at the top:
+
+```c
+#include "voice_dictation.h"
+```
+
+Replace the handler block with:
+
+```c
+   } else if (strcmp(type_str, "dictation_summary") == 0) {
+      cJSON *title = cJSON_GetObjectItem(root, "title");
+      cJSON *summary = cJSON_GetObjectItem(root, "summary");
+      if (cJSON_IsString(title)) {
+         strncpy(s_dictation_title, title->valuestring, sizeof(s_dictation_title) - 1);
+         s_dictation_title[sizeof(s_dictation_title) - 1] = '\0';
+      }
+      if (cJSON_IsString(summary)) {
+         strncpy(s_dictation_summary, summary->valuestring, sizeof(s_dictation_summary) - 1);
+         s_dictation_summary[sizeof(s_dictation_summary) - 1] = '\0';
+      }
+      ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
+      voice_set_state(VOICE_STATE_READY, "dictation_summary");
+
+      /* PR 1: pipeline transition.  Non-empty summary → SAVED; empty
+       * summary (title also empty) → FAILED(EMPTY). */
+      const uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
+      if (s_dictation_title[0] || s_dictation_summary[0]) {
+         voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, now);
+      } else {
+         voice_dictation_set_state(DICT_FAILED, DICT_FAIL_EMPTY, now);
+      }
+   }
+```
+
+- [ ] **Step 3: Also instrument the cancelled branch (line ~793)**
+
+The existing handler around line 793 of `main/voice_ws_proto.c`:
+
+```c
+   } else if (strcmp(type_str, "dictation_cancelled") == 0) {
+      ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
+      voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
+   } else if (strcmp(type_str, "dictation_summary") == 0) {
+```
+
+Replace with:
+
+```c
+   } else if (strcmp(type_str, "dictation_cancelled") == 0) {
+      ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
+      voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED,
+                                (uint32_t)(esp_timer_get_time() / 1000));
+   } else if (strcmp(type_str, "dictation_summary") == 0) {
+```
+
+- [ ] **Step 4: Build + flash**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before no_reset --after watchdog_reset read_mac >/dev/null 2>&1
+sleep 18
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice_ws_proto.c
+git commit -m "feat(dictation): instrument dictation_summary → SAVED/FAILED(EMPTY)"
+```
+
+---
+
+### Task 12 — Instrument WS disconnect failure path
+
+**Files:**
+- Modify: `main/voice_ws_proto.c`
+
+- [ ] **Step 1: Find the disconnect handler**
+
+`grep -n WEBSOCKET_EVENT_DISCONNECTED main/voice_ws_proto.c` — look for the case branch in the event handler.  The current behaviour transitions voice state to RECONNECTING when in-flight; we want to additionally fail the dictation pipeline if it was active.
+
+- [ ] **Step 2: Add the conditional pipeline transition**
+
+Inside the disconnect case (likely near a `voice_set_state(VOICE_STATE_RECONNECTING, ...)` line), insert:
+
+```c
+         /* PR 1: if a dictation was mid-pipeline, fail it with NETWORK
+          * so the UI surfaces the disconnect.  No-op when pipeline is
+          * already IDLE/SAVED/FAILED. */
+         dict_state_t cur = voice_dictation_get().state;
+         if (cur == DICT_RECORDING || cur == DICT_UPLOADING || cur == DICT_TRANSCRIBING) {
+            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK,
+                                      (uint32_t)(esp_timer_get_time() / 1000));
+         }
+```
+
+- [ ] **Step 3: Build + verify**
+
+```bash
+idf.py build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/voice_ws_proto.c
+git commit -m "feat(dictation): WS disconnect fails in-flight pipeline → NETWORK"
+```
+
+---
+
+### Task 13 — Instrument REST polling task transitions in `ui_notes.c`
+
+**Files:**
+- Modify: `main/ui_notes.c`
+
+The REST polling task is `transcription_queue_task` (around line 999 after PR #517).  Each iteration picks a `NOTE_STATE_RECORDED` note, POSTs to `/api/v1/transcribe`, and either updates the note text + state or sets FAILED with a reason.
+
+We thread the pipeline through it: on entering the upload, transition to UPLOADING; after headers received, transition to TRANSCRIBING; on success → SAVED; on each failure branch → FAILED with the matching reason.
+
+- [ ] **Step 1: Add the include + a helper**
+
+Top of `main/ui_notes.c`, near the other includes:
+
+```c
+#include "voice_dictation.h"
+```
+
+In the polling task, when `slot` is selected and the note is about to be uploaded:
+
+```c
+        note_entry_t *n = &s_notes[slot];
+        ESP_LOGI(TAG, "Transcribing note [%d]: %s", slot, n->audio_path);
+        n->state = NOTE_STATE_TRANSCRIBING;
+        notes_save();
+
+        /* PR 1: pipeline UPLOADING — REST POST begins. */
+        voice_dictation_set_note_slot(slot);
+        voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE,
+                                  (uint32_t)(esp_timer_get_time() / 1000));
+```
+
+- [ ] **Step 2: Transition to TRANSCRIBING right after `esp_http_client_fetch_headers`**
+
+Find the block right after the file write loop (around line 1157 after #517):
+
+```c
+        int content_len = esp_http_client_fetch_headers(client);
+        int status = esp_http_client_get_status_code(client);
+```
+
+Add immediately after:
+
+```c
+        /* PR 1: TRANSCRIBING — request sent, headers received, Dragon
+         * is now running STT.  Even if status != 200 we briefly pass
+         * through TRANSCRIBING; the failure branch below converts to
+         * FAILED with a specific reason. */
+        voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE,
+                                  (uint32_t)(esp_timer_get_time() / 1000));
+```
+
+- [ ] **Step 3: Hook each failure branch + the success branch**
+
+After PR #517's structure, the success branch is around line 1175:
+
+```c
+                    if (text && text[0]) {
+                        strncpy(n->text, text, MAX_NOTE_LEN - 1);
+                        /* … */
+                        n->state = NOTE_STATE_TRANSCRIBED;
+                        n->fail_reason = NOTE_FAIL_NONE;
+                    } else {
+                        snprintf(n->text, MAX_NOTE_LEN, "(Empty transcription)");
+                        n->state = NOTE_STATE_FAILED;
+                        n->fail_reason = NOTE_FAIL_EMPTY;
+                    }
+```
+
+Add pipeline transitions:
+
+```c
+                    if (text && text[0]) {
+                        strncpy(n->text, text, MAX_NOTE_LEN - 1);
+                        n->text[MAX_NOTE_LEN - 1] = '\0';
+                        n->state = NOTE_STATE_TRANSCRIBED;
+                        n->fail_reason = NOTE_FAIL_NONE;
+                        voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE,
+                                                  (uint32_t)(esp_timer_get_time() / 1000));
+                    } else {
+                        snprintf(n->text, MAX_NOTE_LEN, "(Empty transcription)");
+                        n->state = NOTE_STATE_FAILED;
+                        n->fail_reason = NOTE_FAIL_EMPTY;
+                        voice_dictation_set_state(DICT_FAILED, DICT_FAIL_EMPTY,
+                                                  (uint32_t)(esp_timer_get_time() / 1000));
+                    }
+```
+
+The other failure branches (non-200 status, HTTP open fail, init NULL, file open fail, file too small, audio path missing) — each one already sets `n->fail_reason`.  Map each to the matching `dict_fail_t` and add the call:
+
+| Note branch (PR #517) | Pipeline transition |
+|---|---|
+| `n->fail_reason = NOTE_FAIL_NO_AUDIO` (no audio path) | `DICT_FAILED, DICT_FAIL_NO_AUDIO` |
+| `n->fail_reason = NOTE_FAIL_NO_AUDIO` (file open fail) | `DICT_FAILED, DICT_FAIL_NO_AUDIO` |
+| `n->fail_reason = NOTE_FAIL_NO_AUDIO` (file too small) | `DICT_FAILED, DICT_FAIL_NO_AUDIO` |
+| `n->fail_reason = NOTE_FAIL_NETWORK` (http init NULL) | `DICT_FAILED, DICT_FAIL_NETWORK` |
+| `n->fail_reason = NOTE_FAIL_NETWORK` (http open fail) | `DICT_FAILED, DICT_FAIL_NETWORK` |
+| `status == 401 \|\| 403` → `NOTE_FAIL_AUTH` | `DICT_FAILED, DICT_FAIL_AUTH` |
+| other non-200 → `NOTE_FAIL_NETWORK` | `DICT_FAILED, DICT_FAIL_NETWORK` |
+
+Add the call immediately after each existing `n->fail_reason = …`.
+
+- [ ] **Step 4: Build + flash + smoke**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before no_reset --after watchdog_reset read_mac >/dev/null 2>&1
+sleep 18
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" http://192.168.1.90:8080/info | head -c 200
+```
+
+Expected: device responds; no PANIC.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/ui_notes.c
+git commit -m "feat(dictation): instrument REST polling → UPLOADING/TRANSCRIBING/SAVED/FAILED"
+```
+
+---
+
+### Task 14 — `/dictation_pipeline` debug endpoint
+
+**Files:**
+- Modify: `main/debug_server_dictation.c`
+
+This gives PR 2 + PR 3 a way to verify the state machine works without a UI subscriber yet, and lets the live-verification step at the end of this PR confirm transitions are happening.
+
+- [ ] **Step 1: Read the existing handler shape**
+
+`main/debug_server_dictation.c` already registers `/dictation` GET + POST.  Add a sibling GET handler.
+
+- [ ] **Step 2: Add the include + handler**
+
+Top of file, near other includes:
+
+```c
+#include "voice_dictation.h"
+```
+
+Add a new handler function before `debug_server_dictation_register`:
+
+```c
+static esp_err_t pipeline_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   dict_event_t e = voice_dictation_get();
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "state",  voice_dictation_state_name(e.state));
+   cJSON_AddStringToObject(root, "reason", voice_dictation_fail_name(e.fail_reason));
+   cJSON_AddNumberToObject(root, "started_ms",     (double)e.started_ms);
+   cJSON_AddNumberToObject(root, "stopped_ms",     (double)e.stopped_ms);
+   cJSON_AddNumberToObject(root, "last_change_ms", (double)e.last_change_ms);
+   cJSON_AddNumberToObject(root, "note_slot",      (double)e.note_slot);
+   cJSON_AddNumberToObject(root, "now_ms",
+                           (double)(esp_timer_get_time() / 1000));
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_sendstr(req, json);
+   free(json);
+   return ESP_OK;
+}
+```
+
+In `debug_server_dictation_register`, after the existing handler registrations:
+
+```c
+   const httpd_uri_t uri_pipeline = {.uri = "/dictation_pipeline", .method = HTTP_GET, .handler = pipeline_handler};
+   httpd_register_uri_handler(server, &uri_pipeline);
+   ESP_LOGI(TAG, "Dictation pipeline endpoint registered");
+```
+
+- [ ] **Step 3: Build + flash + verify**
+
+```bash
+idf.py build && idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 --before no_reset --after watchdog_reset read_mac >/dev/null 2>&1
+sleep 18
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/dictation_pipeline | python3 -m json.tool
+```
+
+Expected:
+
+```json
+{
+    "state": "IDLE",
+    "reason": "NONE",
+    "started_ms": 0,
+    "stopped_ms": 0,
+    "last_change_ms": 0,
+    "note_slot": -1,
+    "now_ms": 8123
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/debug_server_dictation.c
+git commit -m "feat(dictation): /dictation_pipeline GET debug endpoint"
+```
+
+---
+
+### Task 15 — Live end-to-end verification
+
+**Files:** None.  Verification only.
+
+- [ ] **Step 1: Trigger an actual dictation + watch the pipeline transitions**
+
+Open two terminals.
+
+Terminal 1 (poll the pipeline every 0.4 s):
+
+```bash
+while true; do
+  curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+       http://192.168.1.90:8080/dictation_pipeline | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"{d['state']:<14} reason={d['reason']:<10} note={d['note_slot']}\")"
+  sleep 0.4
+done
+```
+
+Terminal 2 (start a 5-second dictation via the debug endpoint):
+
+```bash
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST "http://192.168.1.90:8080/dictation?action=start"
+sleep 5
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST "http://192.168.1.90:8080/dictation?action=stop"
+```
+
+Expected sequence on Terminal 1:
+
+```
+IDLE            reason=NONE       note=-1
+IDLE            reason=NONE       note=-1
+RECORDING       reason=NONE       note=-1
+RECORDING       reason=NONE       note=-1
+…
+TRANSCRIBING    reason=NONE       note=-1
+TRANSCRIBING    reason=NONE       note=-1
+SAVED           reason=NONE       note=-1
+SAVED           reason=NONE       note=-1
+```
+
+(The exact sequence depends on whether Dragon is reachable.  Offline path: RECORDING → UPLOADING after the 15 s polling task picks the note up.)
+
+- [ ] **Step 2: Trigger a failure case — disconnect Dragon while recording**
+
+```bash
+sshpass -p 'thedragon' ssh radxa@192.168.1.91 'sudo systemctl stop tinkerclaw-voice'
+
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST "http://192.168.1.90:8080/dictation?action=start"
+sleep 3
+# Tab5 should detect WS disconnect; pipeline should transition to FAILED(NETWORK).
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/dictation_pipeline | python3 -m json.tool
+
+sshpass -p 'thedragon' ssh radxa@192.168.1.91 'sudo systemctl start tinkerclaw-voice'
+```
+
+Expected after disconnect: `state: "FAILED", reason: "NETWORK"`.
+
+- [ ] **Step 3: Trigger a notes-screen REST retry to verify the polling-task transitions fire**
+
+Navigate to Notes, tap retry on a FAILED row.  Watch the pipeline state:
+
+```bash
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST "http://192.168.1.90:8080/navigate?screen=notes"
+# tap retry on a FAIL row via /touch — coordinates depend on the live row positions
+
+# Concurrently:
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/dictation_pipeline | python3 -m json.tool
+```
+
+Expected: UPLOADING → TRANSCRIBING → SAVED (or FAILED with reason if the note was problematic).
+
+- [ ] **Step 4: Final heap + state sanity**
+
+```bash
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/heap | python3 -m json.tool | head -20
+```
+
+Internal free ≥ pre-PR baseline; no fragmentation alarm.
+
+- [ ] **Step 5: Update memory with PR 1 completion**
+
+Edit `~/.claude/projects/-home-rebelforce/memory/project_dictation_pipeline_redesign_2026_05_14.md` — change the "Status" section near the bottom to reflect PR 1 landed; note the live-verified transitions.
+
+---
+
+### Task 16 — Format-gate + push + open PR
+
+**Files:** none (CI check).
+
+- [ ] **Step 1: Run the format gate**
+
+```bash
+git fetch origin main:refs/remotes/origin/main
+git-clang-format --binary clang-format-18 --diff origin/main \
+   main/voice_dictation.h main/voice_dictation.c \
+   main/voice.c main/voice_ws_proto.c main/ui_notes.c \
+   main/debug_server_dictation.c main/main.c \
+   tests/host/test_voice_dictation.c
+```
+
+Expected: empty diff or `clang-format did not modify any files`.  If non-empty:
+
+```bash
+git add -u
+git-clang-format --binary clang-format-18 origin/main
+git add -u
+git commit --amend --no-edit
+```
+
+- [ ] **Step 2: File the GH issue + open the PR**
+
+```bash
+# Issue:
+gh issue create --title "Wave: dictation pipeline state model + VAD + instrumentation (PR 1 of 4)" \
+  --body "PR 1 of the dictation pipeline visibility + Notes reimagining design spec at docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md.
+
+## Scope
+Backend wiring only.  No UI changes.  Adds:
+- main/voice_dictation.{c,h} — canonical state machine
+- Instrumentation at every existing dictation entry/exit point (voice.c, voice_ws_proto.c, ui_notes.c)
+- 5-min hard cap on the WS-streaming dictation path
+- /dictation_pipeline GET debug endpoint for verification
+
+## Verification
+Host tests pass.  Live transitions verified on Tab5 192.168.1.90 ↔ Dragon 192.168.1.91 for all six states (IDLE, RECORDING, UPLOADING, TRANSCRIBING, SAVED, FAILED with each reason).
+
+## Follow-ups
+- PR 2: ui_orb.c + Dictate chip on home subscribe to this pipeline
+- PR 3: ui_notes.c processing row at top of Timeline subscribes too
+- PR 4: cross-stack action chips for reminder/list routing"
+
+# Branch + push:
+git checkout -b feat/dictation-pipeline-pr1
+git push -u origin feat/dictation-pipeline-pr1
+
+# PR:
+gh pr create --title "feat(dictation): pipeline state model + VAD + instrumentation (PR 1 of 4)" \
+  --body "\$(cat <<'EOF'
+## Summary
+- Adds canonical dict_pipeline_t state machine in new main/voice_dictation.{c,h}
+- Instruments every existing dictation entry/exit point to drive transitions
+- Adds 5-min hard cap to the WS-streaming dictation path (matches the SD cap from #517)
+- Adds GET /dictation_pipeline debug endpoint for PR 2 + PR 3 verification
+
+Builds the foundation for PR 2 (orb + Dictate chip) and PR 3 (Notes Timeline) without any visible UI change.
+
+## Test plan
+- [x] Host tests pass: ctest --test-dir build -R voice_dictation
+- [x] Live state transitions verified on Tab5 192.168.1.90: IDLE → RECORDING → TRANSCRIBING → SAVED
+- [x] Failure paths verified: WS disconnect mid-recording → FAILED(NETWORK); empty transcription → FAILED(EMPTY)
+- [x] REST polling path emits UPLOADING → TRANSCRIBING → SAVED via retry on a FAIL note
+- [x] git-clang-format --diff origin/main is clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Mark PR 1 done in memory + the spec**
+
+Update `~/.claude/projects/-home-rebelforce/memory/MEMORY.md` index entry to reference PR number once `gh pr create` returns.
+
+---
+
+## Acceptance summary
+
+When all 16 tasks are done:
+
+- [ ] `voice_dictation.{c,h}` exists, fully tested by `test_voice_dictation`
+- [ ] All 4 dictation entry/exit points (`voice_start_dictation`, `voice_stop_listening`, dictation_summary handler, WS disconnect) drive pipeline transitions
+- [ ] REST polling task in `ui_notes.c` drives transitions
+- [ ] 5-min hard cap on dictation
+- [ ] `GET /dictation_pipeline` returns live state
+- [ ] Host tests green, target build clean, format gate green
+- [ ] Live transitions verified on Tab5 for happy path + at least one failure path
+- [ ] PR open against `main`
+- [ ] Memory updated reflecting PR 1 landed
+
+PR 2 (orb + Dictate chip) gets its own plan once this lands and you've user-tested it.

--- a/docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md
@@ -1,0 +1,367 @@
+# Dictation pipeline visibility + Notes screen reimagined
+
+> **Status:** Brainstormed 2026-05-14.  Spec approved, ready to plan implementation.
+>
+> **Successors:** PR #517 closed the Notes-screen 100% FAIL bug by adding bearer auth + reason chips + retry/clear surfaces.  This spec builds the next layer: making dictation pipeline state *visible* across home and Notes, adding a discoverable home entry, and reimagining the Notes IA from a flat-card list to a day-grouped timeline.
+
+## Problem
+
+After PR #517 dictation works again technically — Tab5 voice-notes upload, transcribe, and persist.  But the UX around it is still hostile:
+
+1. **No status visibility while a dictation is in flight.**  After tapping a Retry or starting a new recording the user has no idea what state the pipeline is in — recording? uploading? Dragon thinking? saved? — until the row's badge eventually changes.  User words: *"i want it to give me status like transcribing, sent, something that shows me whats going on."*
+
+2. **No discoverable home-screen launcher.**  Dictation today launches only via long-press orb (invisible affordance, often confused with voice-ask) or the Notes-screen `+ NEW VOICE NOTE` button (requires a nav).  User wants a *visible* home-screen entry.
+
+3. **Notes screen IA is janky.**  Flat reverse-chronological card list, ~110 px per row, ~200 px of fixed chrome (topbar + new-note buttons + search bar) before the first note, 5–6 visible cards max.  No grouping, no filtering, no signal that any item was a reminder / list / actionable.  User words: *"the notes should be reimagined.  its very janky."*
+
+4. **No surfaces for the four use-cases the user actually wants.**  All four were named: quick capture, long-form thinking, actionable items (reminders / todos / lists), searchable journal.  Today everything lands as an undifferentiated voice-note.  Reminders and lists don't exist as types.
+
+## Goals
+
+- **One mental model for dictation state, surfaced consistently** across the heroic orb on home, a compact chip on home, and a mini-orb echo on the Notes processing row.
+- **Visible home entry** for dictation in the existing visual language (mode-chip-style dark pill, no saturated gradient).
+- **Notes screen rebuilt** as a day-grouped timeline with type-coloured rows, filter pills, a compact 44 px row, an amber FAB, and a top processing section that mirrors the orb state for in-flight items.
+- **Post-hoc routing via action chips:** every dictation lands as a NOTE first; Dragon's classifier proposes a conversion to REMINDER or LIST and the user confirms with one tap.  Wrong classifications cost one ✕ tap to dismiss.
+
+## Non-goals (deferred, not blockers)
+
+- **Task type** as a first-class category (overlap with Reminder; revisit if real demand emerges)
+- **Search redesign** — current search stays in place during the Notes rebuild; collapse to a topbar icon is a nice-to-have follow-up
+- **Multi-select / bulk-delete row gesture** in Notes — long-press behavior beyond row-tap stays as today
+- **Cross-screen status chip** for screens that aren't home or Notes — dictation happens on home; the user would be on Notes anyway to see in-flight items.  Add later if the gap appears.
+- **Public scheduler UI** for non-dictation reminders — `POST /api/v1/scheduler/notifications` already exists on Dragon, just no UI today.  Out of scope here.
+
+## Locked design decisions (from brainstorm round)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Routing model | **Always a note, then convert** | Lowest risk of misrouting; one frictionless launch.  Action chips do the conversion post-save. |
+| Use-case scope | All four (note / reminder / list / journal) | User picked "all"; system supports without forcing pre-classification. |
+| Home entry | **Dictate chip in mode-chip language** (dark pill, thin border, monospace caption, red breathing dot, "Dictate · TAP TO START · 🎤") | Earlier amber gradient pills clashed with the muted home; user rejected.  Mode-chip style fits the existing language. |
+| Orb status grammar | **Full morph** (body tint + breathing + ripple + caption) | User picked option C; expressive enough to read across the room. |
+| Notes IA | **Timeline** — day-grouped (TODAY / YESTERDAY / THIS WEEK / OLDER), 44 px rows, type-dot color (amber/blue/green/red), filter pills, amber FAB | User picked option A; information density over per-row context. |
+| Cross-screen status | **Mini-orb echo on Notes processing row** + heroic orb on home (no separate top-status-bar chip in v1) | Dictation happens on home; user would be on Notes anyway to see in-flight items.  Single visual grammar across surfaces. |
+| Auto-stop | **VAD silence (4 s) + 5 min hard cap** | Port existing dictation-mode VAD to the new pipeline.  Hard cap from PR #517 extended to live path. |
+| Action chip scope v1 | **Reminder + List only** | Reminder uses existing `POST /api/v1/scheduler/notifications`.  List = note with `note_type_t = LIST` + comma/and/newline split.  Task and others deferred. |
+| Action chip threshold | confidence ≥ 0.75 | Below the bar = plain note, no chip.  Don't pester the user with iffy guesses. |
+
+## Architecture
+
+### Pipeline state model (new)
+
+`dictation_pipeline_t` becomes the canonical state for any in-flight dictation.  Lives in `voice.c` (or a new `voice_dictation.c` if cleaner — TBD during planning).
+
+```c
+typedef enum {
+    DICT_IDLE      = 0,
+    DICT_RECORDING,
+    DICT_UPLOADING,
+    DICT_TRANSCRIBING,
+    DICT_SAVED,           /* terminal — auto-transitions to IDLE after 2 s */
+    DICT_FAILED,          /* terminal — manual retry only */
+} dict_state_t;
+
+typedef enum {
+    DICT_FAIL_NONE = 0,
+    DICT_FAIL_AUTH,
+    DICT_FAIL_NETWORK,
+    DICT_FAIL_EMPTY,
+    DICT_FAIL_NO_AUDIO,
+    DICT_FAIL_TOO_LONG,
+} dict_fail_t;
+
+typedef struct {
+    dict_state_t  state;
+    dict_fail_t   fail_reason;
+    uint32_t      started_ms;        /* esp_timer_get_time / 1000 */
+    uint32_t      stopped_ms;        /* 0 until RECORDING ends */
+    uint32_t      duration_ms;       /* computed continuously while RECORDING */
+    int           note_slot;         /* -1 if no note created yet; >=0 once SD WAV started */
+    char          partial[256];      /* live stt_partial preview (if available) */
+} dict_pipeline_t;
+```
+
+**Single global instance** (one dictation at a time in v1).  Module-level mutex (`s_dict_mutex`) guards transitions.  Subscribers register a callback that fires on state changes; UI surfaces subscribe (orb + Dictate chip + Notes processing row).
+
+**State transitions:**
+
+```
+IDLE  --tap Dictate-->  RECORDING
+RECORDING  --VAD silence 4s OR tap-stop OR 5min cap-->  UPLOADING
+RECORDING  --tap cancel-->  IDLE (discard SD WAV)
+UPLOADING  --HTTP 200-->  TRANSCRIBING
+UPLOADING  --HTTP 401 / 4xx-->  FAILED (AUTH / NETWORK)
+UPLOADING  --HTTP open fail-->  FAILED (NETWORK)
+TRANSCRIBING  --200 + non-empty text-->  SAVED  --2 s timer-->  IDLE
+TRANSCRIBING  --200 + empty text-->  FAILED (EMPTY)
+TRANSCRIBING  --5xx-->  FAILED (NETWORK)
+SAVED  --auto 2 s-->  IDLE
+FAILED  --tap retry-->  UPLOADING
+```
+
+**The existing Notes-side polling task (15 s sweep) is preserved as a backup** for notes that get stuck in `NOTE_STATE_RECORDED` — e.g. after a reboot mid-pipeline.  The new pipeline is the foreground path; the polling task is the safety net.  PR #517's bearer-auth fix applies to both.
+
+### UI surface contract
+
+Three surfaces consume the pipeline state via a single `dict_subscribe(cb, user_data)` API:
+
+| Surface | File | Renders |
+|---|---|---|
+| Heroic orb on home | `ui_orb.c` | Body gradient + breath rate + ripple + halo + caption-line under orb |
+| Dictate chip on home | `ui_home.c` (new widget) | Dark pill, red dot pulse, label/caption swaps in place |
+| Mini-orb echo on Notes | `ui_notes.c` (new processing-row widget) | 28 px mini orb + state caption + duration + cancel × |
+
+All three surfaces *render the same state object*.  They never disagree — the pipeline is canonical.
+
+Visual mapping per state:
+
+| State | Orb body | Halo / ripple | Caption | Mini-orb | Dictate chip label |
+|---|---|---|---|---|---|
+| IDLE | circadian | normal breath | (none — say-pill text) | hidden | `Dictate · TAP TO START · 🎤` |
+| RECORDING | red gradient + 0.85 s bloom | red halo on mic RMS + internal ripple rings | `● RECORDING 0:23` | red gradient, mini ripple | `● RECORDING · 0:23 · ×` |
+| UPLOADING | amber gradient | amber arc 0→100 % | `UPLOADING…` | amber gradient | `UPLOADING…` |
+| TRANSCRIBING | amber gradient | amber comet (existing PROCESSING animation, repurposed) | `TRANSCRIBING…` | amber gradient + comet | `TRANSCRIBING…` |
+| SAVED (2 s) | green pulse | green ring expanding | `✓ Saved to Notes` | green pulse | `✓ Saved` |
+| FAILED | red flat | none | `● AUTH — tap to retry` (reason varies) | red flat | `● AUTH — tap to retry` |
+
+### Home layout
+
+The current home stays exactly as it is today (after the wave-1.6 / 1.8 / 1.9 cleanup), with **one addition**: a new `s_dictate_chip` widget directly below the existing `s_mode_chip`, 12 px gap, same width (~280 px), same 36 px height, same dark-pill aesthetic.  No other chrome moves.
+
+```
+┌──────────────────────────────────────────┐
+│  ● Remote (ngrok)        Thu · 19:18    │   status bar (unchanged)
+│                                          │
+│                                          │
+│                 [orb]                    │   orb at y=320 (unchanged)
+│                                          │
+│                                          │
+│        Evening, Emile —                  │   italic greeting (unchanged)
+│        what's on your mind?              │
+│                                          │
+│        [● Local   ON-DEVICE   ⌄]         │   mode chip (unchanged)
+│        [● Dictate TAP TO START 🎤]       │   ← NEW chip (this design)
+│                                          │
+│                                          │
+│                                          │
+│        Hold orb for modes      ⋮⋮        │   bottom say-pill + nav chevron
+└──────────────────────────────────────────┘   (unchanged per user constraint)
+```
+
+The mode chip and Dictate chip together form a two-row stack of "what's the system doing" controls.
+
+### Notes layout
+
+Total rebuild of `refresh_list` + `add_note_card` in `ui_notes.c`.  Same file, same persistence layer, same load/save semantics — render path is what changes.
+
+```
+┌──────────────────────────────────────────┐
+│  Notes              CLEAR N FAILED  7 ▴  │   topbar — preserves #517's clear button
+├──────────────────────────────────────────┤
+│  ● [mini-orb] RECORDING   0:23   ✕      │   processing row, only when in-flight
+│                                          │   (single instance in v1 — see risk 6)
+├──────────────────────────────────────────┤
+│  [ALL] [NOTES] [REMINDERS] [LISTS]       │   filter pills (44 px)
+├──────────────────────────────────────────┤
+│  TODAY                                   │   day-section header (24 px)
+│  ● 18:32  Roger.                  VOICE  │   row (44 px)
+│  ● 17:05  Call mom Tuesday 6 PM REMIND   │
+│      ┌───────────────────────────────┐   │   ← action chip on row above
+│      │ 📅 Set reminder Tue 6 PM ✓ ✕  │   │
+│      └───────────────────────────────┘   │
+│  ● 14:21  Eggs, bread, butter…    LIST   │
+│  YESTERDAY                               │
+│  ● 22:14  Idea: revisit orb halo  VOICE  │
+│  ● 11:03  en                       TEXT  │
+│  THIS WEEK                               │
+│  …                                       │
+│                                          │
+│                                  [🎤]    │   amber FAB, bottom-right
+└──────────────────────────────────────────┘
+```
+
+**Removed permanent chrome** (vs today):
+- `+ NEW VOICE NOTE` / `+ NEW TEXT NOTE` row (80 px)
+- Always-on search bar (56 px)
+- Voice/text buttons → replaced by amber FAB (long-press FAB = "new text note")
+
+**Net vertical chrome:** today ≈ 200 px before first row.  New ≈ 88 px (topbar 44 + filter pills 44).  Plus the processing row (60 px) when active.  About 2.5 more rows visible.
+
+**Row anatomy (44 px):**
+```
+●     18:32     Roger.                                 VOICE
+└┐    └┐        └┐                                     └┐
+type   time    body (single line, ellipsis on overflow)  state/type badge
+6 px  40 px   flex                                       right-align
+```
+
+Tap a row → existing edit overlay (no redesign here).  Tap retry-button on FAILED row → flips state back to `NOTE_STATE_RECORDED` (existing #517 behaviour).
+
+**Filter pills:** All / Notes / Reminders / Lists.  Tapping a pill filters in place.  No "Failed" pill — the topbar's CLEAR FAILED button already toggles the failed view when tapped (cycles: ALL → FAILED only → ALL).
+
+**Persistence schema additions:**
+
+```c
+typedef enum {
+    NOTE_TYPE_NOTE = 0,       /* default */
+    NOTE_TYPE_REMINDER,
+    NOTE_TYPE_LIST,
+} note_type_t;
+
+typedef struct {
+    /* … existing fields from ui_notes.c (after #517) … */
+    note_type_t  type;        /* persisted as "ty" — defaults to NOTE on missing */
+    /* action chip pending state — cleared on confirm or dismiss */
+    struct {
+        uint8_t kind;         /* 0=none, 1=reminder, 2=list */
+        uint8_t confidence;   /* 0-100, /100 from Dragon's float */
+        char    payload[128]; /* ISO date for reminder, item-count + delimiter info for list */
+    } pending_chip;           /* persisted as "pc" object */
+} note_entry_t;
+```
+
+Both fields are forward-compatible (missing on disk = absent / NOTE).  No migration needed.
+
+### Action chip data flow
+
+Today Dragon already sends `dictation_summary` with `title` + `summary` after STT.  We extend it with a `proposed_action`:
+
+```json
+{
+  "type": "dictation_summary",
+  "title": "Call mom Tuesday",
+  "summary": "Reminder to call mom about the July trip",
+  "proposed_action": {
+    "kind": "reminder",          /* "reminder" | "list" | "none" */
+    "confidence": 0.86,
+    "payload": {
+      "when": "2026-05-19T18:00",
+      "label": "Call mom"
+    }
+  }
+}
+```
+
+**Dragon side:** new classifier pass after STT in `pipeline._post_process_dictation`.  Cheap local LLM call (ministral-3:3b, ~1 s).  System prompt asks for `{kind, confidence, payload}` JSON output.  NL date parsing for reminders re-uses the existing `dragon_voice/scheduler/parser.py`.
+
+**Tab5 side:** Tab5 stores `pending_chip` on the note.  Notes screen renders the chip below the row body if confidence ≥ 0.75.  Tap ✓ → fires `POST /api/v1/scheduler/notifications` for reminders, in-place type flip for lists; chip cleared and persisted.  Tap ✕ → chip cleared, note stays NOTE.
+
+**One chip per note maximum.**  If Dragon's classifier returns both reminder and list candidates, it picks the higher-confidence one before sending.
+
+## Phasing
+
+Four PRs, each branched off `main` after the prior PR merges (not stacked branches — #513→#514→#515 stacking was painful):
+
+**Merge order:** PR 1 → PR 2 + PR 3 (can land in parallel, both depend only on PR 1) → PR 4 (depends on PR 3's schema additions).  Each PR is independently revertable.
+
+### PR 1 — `feat(voice): dictation pipeline state model + VAD auto-stop`
+
+Backend wiring only.  No visible UI change.
+
+**Files:**
+- `main/voice.c` (or new `main/voice_dictation.c`) — `dict_pipeline_t` state machine + transitions + subscriber registry
+- `main/voice.h` — public API: `dict_get_state`, `dict_start`, `dict_stop`, `dict_cancel`, `dict_subscribe`
+- `main/voice_ws_proto.c` — hook into existing `dictation_summary` handler to drive `DICT_TRANSCRIBING → DICT_SAVED`
+- Existing dictation/notes paths instrument transitions; visible behaviour unchanged
+
+**Acceptance:**
+- Long-press orb (existing path) drives the new state machine; `/dictation` debug GET returns the new state name
+- VAD silence auto-stops at 4 s (matches today's dictation-mode behaviour)
+- 5 min hard cap auto-stops with `DICT_FAIL_TOO_LONG`
+- All existing dictation tests pass; new unit test for state-machine transitions
+
+### PR 2 — `feat(ui): orb + Dictate chip surface the pipeline state`
+
+Visible win — heroic orb morphs through pipeline states; new Dictate chip on home.
+
+**Files:**
+- `main/ui_orb.c` — new `ui_orb_set_pipeline_state(state, fail_reason, duration_ms)` API; new gradient/halo/ripple/comet variants per state; caption-line under orb
+- `main/ui_orb.h` — exports above
+- `main/ui_home.c` — new `s_dictate_chip` widget below mode chip; subscribes to pipeline; renders state-appropriate label
+- `main/ui_home.h` — no new public exports
+
+**Acceptance:**
+- Tap Dictate chip → orb morphs RECORDING → UPLOADING → TRANSCRIBING → SAVED → IDLE
+- Mic RMS visibly drives the red halo bloom rate during RECORDING
+- Cancel × on chip aborts the pipeline cleanly (no orphan SD WAV)
+- Live verification on Tab5 192.168.1.90 — visual confirmation of all five states
+- No regression in voice-ask (orb's existing LISTENING/PROCESSING/SPEAKING states unaffected)
+
+### PR 3 — `feat(ui): Notes screen reimagined — Timeline IA + processing row + FAB`
+
+Full Notes rerender.
+
+**Files:**
+- `main/ui_notes.c` — rebuild `refresh_list` + `add_note_card`; add day-section logic + filter-pill state + processing-row widget + amber FAB; remove old voice/text button row + always-on search bar
+- `main/ui_notes.h` — minor additions if any (likely none)
+
+**Schema additions** (forward-compatible):
+- `note_type_t` enum + `type` field on `note_entry_t` + `"ty"` JSON key
+- `pending_chip` substruct + `"pc"` JSON key (populated by PR 4; PR 3 just allocates space)
+
+**Acceptance:**
+- 14 existing notes render correctly in the new timeline (no missing rows, no crashes)
+- Filter pills correctly filter by type
+- Tap FAB → triggers the same pipeline as the home Dictate chip
+- Processing row appears at top when any dictation is in flight; mini-orb mirrors heroic orb state
+- Empty / loading / search-active states render without breakage
+- Hide/show pattern preserved for the screen-recreate path (per CLAUDE.md fragmentation rules)
+- No PANIC across 50 fast home↔notes navs
+
+### PR 4 — `feat(notes): action chips for reminder + list conversion`
+
+Cross-stack (Dragon + Tab5).
+
+**Dragon files:**
+- `dragon_voice/pipeline.py` — extend `_post_process_dictation` with classifier pass
+- `dragon_voice/dictation/classifier.py` (new) — local LLM call + JSON validation + confidence floor
+- `dragon_voice/protocol/dictation_summary.py` (or wherever the frame is built) — add `proposed_action` field
+- Tests for classifier + protocol shape
+
+**Tab5 files:**
+- `main/voice_ws_proto.c` — parse `proposed_action` from `dictation_summary`; persist as `pending_chip` on the matching note
+- `main/ui_notes.c` — chip widget rendering + tap handlers (✓ confirms + fires REST call or flips type, ✕ dismisses)
+- `main/voice.c` (or new helper) — `POST /api/v1/scheduler/notifications` call for reminder confirmation
+
+**Acceptance:**
+- Live: dictate "call mom Tuesday at six pm" → chip appears with parsed date → ✓ creates scheduled notification on Dragon
+- Live: dictate "eggs, bread, butter, oat milk" → list chip → ✓ splits transcript into 4 bullet items + type flips to LIST
+- Confidence < 0.75 → no chip (verified by dictating a vague utterance)
+- ✕ dismiss clears chip + persists; reopen Notes confirms it's gone
+- Dragon predates Tab5 update: Tab5 ignores `proposed_action` field gracefully, no chip rendered (forward-compat)
+- Tab5 predates Dragon update: existing `dictation_summary` shape continues to work, no errors
+
+## Risks + open questions
+
+1. **Mic RMS for orb bloom during RECORDING** — exists today on the LISTENING state.  Reuse should be straightforward but PR 2 needs to verify the wiring works for the new pipeline state path.
+2. **VAD silence-detection accuracy** — the existing dictation-mode VAD has been live a while; porting should be low-risk but the new pipeline's 4 s threshold is a tuning knob to live-validate.
+3. **Notes 14-row rerender perf** — the timeline render path is more complex (day-grouping + filter check + chip widget per row).  44 px rows mean 12+ visible; LVGL render budget should be fine but profile during PR 3.
+4. **Action-chip confidence calibration** — 0.75 is a guess.  Real-world tuning during PR 4; may move up if false positives are annoying.
+5. **What happens on Dragon disconnect mid-dictation?** — RECORDING continues to SD (existing fallback path).  When WS recovers, the SD WAV gets picked up by the 15 s polling task and goes through REST `/api/v1/transcribe` with bearer (#517 fix).  The pipeline state during disconnect should transition to a special `OFFLINE_QUEUED` state, or just stay UPLOADING with a longer timeout.  TBD during PR 1.
+6. **Concurrent multi-dictation** — v1 is single-instance.  If user starts a second dictation while the first is uploading, second blocks with a toast "wait — still saving last one".  Probably fine for v1; revisit if real demand emerges.
+
+## Verification
+
+Per-PR live-on-device verification on Tab5 192.168.1.90 ↔ Dragon 192.168.1.91.  No PR ships without a screenshot proving the state transitions visibly work.  Notes screen passes the "no missing rows on 14 existing entries" check before merge.
+
+End-to-end happy path (post-PR 4):
+
+1. Tap Dictate chip on home
+2. Say "Call mom Tuesday at six pm"
+3. Stop talking
+4. Orb cycles RECORDING (red, ripple) → UPLOADING (amber arc) → TRANSCRIBING (amber comet) → SAVED (green pulse) → IDLE
+5. Navigate to Notes
+6. New row at top of TODAY group with the transcript
+7. Reminder chip below the row with parsed date
+8. Tap ✓ → chip disappears, type-dot turns blue, badge says REMIND
+9. Scheduled notification fires on Tuesday at 6 PM via existing Dragon scheduler
+
+If this works, the original "i want it to give me status like transcribing, sent, something that shows me whats going on" + "see whats being processed in notes" + "notes should be reimagined" are all closed.
+
+## Cross-links
+
+- [PR #517](https://github.com/lorcan35/TinkerTab/pull/517) — bearer-auth + reason chips + retry/clear surfaces (this spec builds on it)
+- [Notes/dictation audit memory](../../../.claude/projects/-home-rebelforce/memory/project_dictation_audit_2026_05_14.md) — root-cause + live verification of the 401 bug that motivated this work
+- [Orb redesign spec 2026-05-14](2026-05-14-orb-redesign-design.md) — orb state machine + visual language that this builds on
+- TinkerTab `CLAUDE.md` — NVS schema, dictation-mode VAD details, scheduler endpoint signature
+- TinkerBox `CLAUDE.md` — `POST /api/v1/scheduler/notifications` shape, `dictation_summary` WS frame

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "voice_messages_sync.c" "mode_manager.c"
+             "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_dictation.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "voice_messages_sync.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"

--- a/main/debug_server_dictation.c
+++ b/main/debug_server_dictation.c
@@ -17,7 +17,9 @@
 #include "esp_err.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "voice.h" /* voice_start_dictation, voice_stop_listening, voice_get_dictation_text, voice_get_state */
+#include "voice_dictation.h"
 
 static const char *TAG = "debug_dictation";
 
@@ -64,10 +66,40 @@ static esp_err_t dictation_handler(httpd_req_t *req) {
    return ESP_OK;
 }
 
+/* ── Dictation pipeline state snapshot ───────────────────────────────── */
+/* GET /dictation_pipeline — live snapshot of the dict_event_t state held
+ * by voice_dictation.c.  Used by PR 2 (orb + Dictate chip), PR 3 (Notes
+ * Timeline), and the end-to-end verification step at the close of PR 1. */
+static esp_err_t pipeline_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+
+   dict_event_t e = voice_dictation_get();
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "state", voice_dictation_state_name(e.state));
+   cJSON_AddStringToObject(root, "reason", voice_dictation_fail_name(e.fail_reason));
+   cJSON_AddNumberToObject(root, "started_ms", (double)e.started_ms);
+   cJSON_AddNumberToObject(root, "stopped_ms", (double)e.stopped_ms);
+   cJSON_AddNumberToObject(root, "last_change_ms", (double)e.last_change_ms);
+   cJSON_AddNumberToObject(root, "note_slot", (double)e.note_slot);
+   cJSON_AddNumberToObject(root, "now_ms", (double)(esp_timer_get_time() / 1000));
+
+   char *json = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   httpd_resp_set_type(req, "application/json");
+   httpd_resp_sendstr(req, json);
+   free(json);
+   return ESP_OK;
+}
+
 void debug_server_dictation_register(httpd_handle_t server) {
    const httpd_uri_t uri_dictation_post = {.uri = "/dictation", .method = HTTP_POST, .handler = dictation_handler};
    const httpd_uri_t uri_dictation_get = {.uri = "/dictation", .method = HTTP_GET, .handler = dictation_handler};
    httpd_register_uri_handler(server, &uri_dictation_post);
    httpd_register_uri_handler(server, &uri_dictation_get);
    ESP_LOGI(TAG, "Dictation endpoint family registered (2 URIs, 1 handler)");
+
+   const httpd_uri_t uri_pipeline = {.uri = "/dictation_pipeline", .method = HTTP_GET, .handler = pipeline_handler};
+   httpd_register_uri_handler(server, &uri_pipeline);
+   ESP_LOGI(TAG, "Dictation pipeline endpoint registered");
 }

--- a/main/main.c
+++ b/main/main.c
@@ -56,6 +56,7 @@
 #include "ui_theme.h"
 #include "ui_voice.h"
 #include "voice.h"
+#include "voice_dictation.h"
 #include "voice_m5_llm.h"
 #include "voice_onboard.h"
 #include "voice_solo.h"
@@ -111,6 +112,10 @@ static void deferred_overlay_init_cb(lv_timer_t *t)
      * Runs after voice_init() (which ui_voice_init wraps) so the worker
      * queue + voice state machine are up. */
     voice_solo_init();
+    /* PR 1: dictation pipeline state machine.  Idempotent; subscribers
+     * register lazily once their owning screen / surface is created.
+     * Must run after voice_init since transitions are driven from voice.c. */
+    voice_dictation_init();
     /* TT #328 Wave 10 — persistent floating home button on lv_layer_top.
      * Hidden by default; non-home screens toggle it via
      * ui_chrome_set_home_visible(true) on show, (false) on destroy. */

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -24,6 +24,7 @@
 #include "esp_heap_caps.h"
 #include "esp_http_client.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "mode_manager.h"
@@ -36,6 +37,7 @@
 #include "ui_keyboard.h"
 #include "ui_voice.h"
 #include "voice.h"
+#include "voice_dictation.h"
 #include "wifi.h"
 
 static const char *TAG = "ui_notes";
@@ -1060,6 +1062,7 @@ static void transcription_queue_task(void *arg)
             if (!s_notes[i].audio_path[0]) {
                 s_notes[i].state = NOTE_STATE_FAILED;
                 s_notes[i].fail_reason = NOTE_FAIL_NO_AUDIO;
+                voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NO_AUDIO, (uint32_t)(esp_timer_get_time() / 1000));
                 snprintf(s_notes[i].text, MAX_NOTE_LEN, "(No audio file)");
                 notes_save();
                 continue;
@@ -1074,12 +1077,17 @@ static void transcription_queue_task(void *arg)
         n->state = NOTE_STATE_TRANSCRIBING;
         notes_save();
 
+        /* PR 1: pipeline UPLOADING — REST POST about to begin. */
+        voice_dictation_set_note_slot(slot);
+        voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
+
         /* Read WAV file from SD */
         FILE *f = fopen(n->audio_path, "rb");
         if (!f) {
             ESP_LOGW(TAG, "Cannot open WAV: %s", n->audio_path);
             n->state = NOTE_STATE_FAILED;
             n->fail_reason = NOTE_FAIL_NO_AUDIO;
+            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NO_AUDIO, (uint32_t)(esp_timer_get_time() / 1000));
             notes_save();
             continue;
         }
@@ -1093,6 +1101,7 @@ static void transcription_queue_task(void *arg)
             fclose(f);
             n->state = NOTE_STATE_FAILED;
             n->fail_reason = NOTE_FAIL_NO_AUDIO;
+            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NO_AUDIO, (uint32_t)(esp_timer_get_time() / 1000));
             snprintf(n->text, MAX_NOTE_LEN, "(Empty recording)");
             notes_save();
             continue;
@@ -1154,6 +1163,7 @@ static void transcription_queue_task(void *arg)
             fclose(f);
             n->state = NOTE_STATE_FAILED;
             n->fail_reason = NOTE_FAIL_NETWORK;
+            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
             notes_save();
             continue;
         }
@@ -1176,6 +1186,7 @@ static void transcription_queue_task(void *arg)
             fclose(f);
             n->state = NOTE_STATE_FAILED;
             n->fail_reason = NOTE_FAIL_NETWORK;
+            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
             notes_save();
             continue;
         }
@@ -1201,6 +1212,9 @@ static void transcription_queue_task(void *arg)
         int content_len = esp_http_client_fetch_headers(client);
         int status = esp_http_client_get_status_code(client);
 
+        /* PR 1: TRANSCRIBING — request fully sent, Dragon now running STT. */
+        voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
+
         if (status == 200 && content_len > 0 && content_len < 8192) {
             char *resp = malloc(content_len + 1);
             if (resp) {
@@ -1217,11 +1231,14 @@ static void transcription_queue_task(void *arg)
                         n->text[MAX_NOTE_LEN - 1] = '\0';
                         n->state = NOTE_STATE_TRANSCRIBED;
                         n->fail_reason = NOTE_FAIL_NONE;
+                        voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
                         ESP_LOGI(TAG, "Transcription done [%d]: %.60s", slot, text);
                     } else {
                         snprintf(n->text, MAX_NOTE_LEN, "(Empty transcription)");
                         n->state = NOTE_STATE_FAILED;
                         n->fail_reason = NOTE_FAIL_EMPTY;
+                        voice_dictation_set_state(DICT_FAILED, DICT_FAIL_EMPTY,
+                                                  (uint32_t)(esp_timer_get_time() / 1000));
                     }
                     cJSON_Delete(root);
                 }
@@ -1231,6 +1248,9 @@ static void transcription_queue_task(void *arg)
             ESP_LOGW(TAG, "Transcribe HTTP %d (len=%d)", status, content_len);
             n->state = NOTE_STATE_FAILED;
             n->fail_reason = (status == 401 || status == 403) ? NOTE_FAIL_AUTH : NOTE_FAIL_NETWORK;
+            voice_dictation_set_state(DICT_FAILED,
+                                      (status == 401 || status == 403) ? DICT_FAIL_AUTH : DICT_FAIL_NETWORK,
+                                      (uint32_t)(esp_timer_get_time() / 1000));
         }
 
         esp_http_client_close(client);

--- a/main/voice.c
+++ b/main/voice.c
@@ -189,7 +189,7 @@ const char *voice_current_turn_id(void) { return s_current_turn_id[0] ? s_curren
  * mid-PTT" without auto-cutting normal questions.  60 s leaves
  * generous headroom for longer thoughts. */
 #define MAX_RECORD_FRAMES_ASK 3000
-#define MAX_RECORD_FRAMES_DICT       15000   /* PR 1: 5 min hard cap on dictation */
+#define MAX_RECORD_FRAMES_DICT 15000 /* PR 1: 5 min hard cap on dictation */
 
 // ---------------------------------------------------------------------------
 // State
@@ -786,8 +786,7 @@ static void mic_capture_task(void *arg)
             * using the same pattern that's proven safe in ASK mode. */
            if (voice_get_mode() == VOICE_MODE_DICTATE && frames_sent >= MAX_RECORD_FRAMES_DICT) {
               ESP_LOGW(TAG, "Dictation hit 5-min cap — auto-stopping");
-              voice_dictation_set_state(DICT_FAILED, DICT_FAIL_TOO_LONG,
-                                        (uint32_t)(esp_timer_get_time() / 1000));
+              voice_dictation_set_state(DICT_FAILED, DICT_FAIL_TOO_LONG, (uint32_t)(esp_timer_get_time() / 1000));
               break;
            }
 
@@ -1707,8 +1706,7 @@ esp_err_t voice_start_dictation(void)
     /* PR 1: drive the dictation pipeline state machine.  The pipeline
      * is a separate higher-level state; the existing voice_state_t
      * (LISTENING/PROCESSING/READY) is unchanged. */
-    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE,
-                              (uint32_t)(esp_timer_get_time() / 1000));
+    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
 
     voice_set_state(VOICE_STATE_LISTENING, offline ? "offline" : NULL);
     return ESP_OK;
@@ -1873,8 +1871,7 @@ esp_err_t voice_stop_listening(void)
        * Dragon-returns retry, so the higher-level state is UPLOADING.
        * Fire BEFORE the mode flip back to ASK so the gate (mode ==
        * DICTATE) is still true. */
-      voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE,
-                                (uint32_t)(esp_timer_get_time() / 1000));
+      voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
       voice_modes_set_internal(VOICE_MODE_ASK);
       return ESP_OK;
    }
@@ -1925,8 +1922,7 @@ esp_err_t voice_stop_listening(void)
          * silently stuck in DICT_RECORDING.  Sprint D's disconnect hook
          * in voice_ws_proto.c may not fire before this return path. */
         if (voice_get_mode() == VOICE_MODE_DICTATE) {
-            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK,
-                                      (uint32_t)(esp_timer_get_time() / 1000));
+           voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
         }
         voice_set_state(VOICE_STATE_IDLE, "Connection lost");
         return ESP_FAIL;
@@ -1938,8 +1934,7 @@ esp_err_t voice_stop_listening(void)
      * a dictation stop (e.g. voice-ask path, which doesn't touch the
      * dictation pipeline at all). */
     if (voice_get_mode() == VOICE_MODE_DICTATE) {
-       voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE,
-                                 (uint32_t)(esp_timer_get_time() / 1000));
+       voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
     }
 
     voice_set_state(VOICE_STATE_PROCESSING, NULL);

--- a/main/voice.c
+++ b/main/voice.c
@@ -58,6 +58,7 @@
 #include "ui_voice.h"
 #include "voice_billing.h"   /* SOLID-audit SRP-3: receipt + budget + cap-downgrade */
 #include "voice_codec.h"     /* #262: OPUS encode/decode wrapper */
+#include "voice_dictation.h" /* PR 1: dictation pipeline state machine */
 #include "voice_m5_llm.h"    /* TT #317 Phase 4: K144 LLM Module failover */
 #include "voice_modes.h"     /* TT #331 Wave 23 SRP-A2: 5-tier mode dispatch */
 #include "voice_solo.h"      /* W4-B (TT #375): vmode=5 SOLO_DIRECT mic-audio dispatch */
@@ -1690,6 +1691,12 @@ esp_err_t voice_start_dictation(void)
     s_mic_running = true;
     /* #284: signal persistent mic task. */
     if (s_mic_event_sem) xSemaphoreGive(s_mic_event_sem);
+
+    /* PR 1: drive the dictation pipeline state machine.  The pipeline
+     * is a separate higher-level state; the existing voice_state_t
+     * (LISTENING/PROCESSING/READY) is unchanged. */
+    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE,
+                              (uint32_t)(esp_timer_get_time() / 1000));
 
     voice_set_state(VOICE_STATE_LISTENING, offline ? "offline" : NULL);
     return ESP_OK;

--- a/main/voice.c
+++ b/main/voice.c
@@ -189,6 +189,7 @@ const char *voice_current_turn_id(void) { return s_current_turn_id[0] ? s_curren
  * mid-PTT" without auto-cutting normal questions.  60 s leaves
  * generous headroom for longer thoughts. */
 #define MAX_RECORD_FRAMES_ASK 3000
+#define MAX_RECORD_FRAMES_DICT       15000   /* PR 1: 5 min hard cap on dictation */
 
 // ---------------------------------------------------------------------------
 // State
@@ -776,6 +777,17 @@ static void mic_capture_task(void *arg)
            if (voice_get_mode() == VOICE_MODE_ASK && frames_sent >= MAX_RECORD_FRAMES_ASK) {
               ESP_LOGI(TAG, "Max recording duration reached (%ds)", MAX_RECORD_FRAMES_ASK * TAB5_VOICE_CHUNK_MS / 1000);
               voice_set_state(VOICE_STATE_LISTENING, "max_duration");
+              break;
+           }
+
+           /* PR 1: parallel 5-min hard cap on dictation.  Mirrors the ASK
+            * cap above — log, drive the pipeline state machine into
+            * FAILED with reason TOO_LONG, and break out of the mic loop
+            * using the same pattern that's proven safe in ASK mode. */
+           if (voice_get_mode() == VOICE_MODE_DICTATE && frames_sent >= MAX_RECORD_FRAMES_DICT) {
+              ESP_LOGW(TAG, "Dictation hit 5-min cap — auto-stopping");
+              voice_dictation_set_state(DICT_FAILED, DICT_FAIL_TOO_LONG,
+                                        (uint32_t)(esp_timer_get_time() / 1000));
               break;
            }
 

--- a/main/voice.c
+++ b/main/voice.c
@@ -1857,6 +1857,12 @@ esp_err_t voice_stop_listening(void)
       ui_home_show_toast("Saved offline — will sync to Notes when Dragon's back");
       voice_reset_activity_timestamp();
       voice_set_state(VOICE_STATE_READY, "offline_saved");
+      /* PR 1: pipeline transition — offline path queues an upload-when-
+       * Dragon-returns retry, so the higher-level state is UPLOADING.
+       * Fire BEFORE the mode flip back to ASK so the gate (mode ==
+       * DICTATE) is still true. */
+      voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE,
+                                (uint32_t)(esp_timer_get_time() / 1000));
       voice_modes_set_internal(VOICE_MODE_ASK);
       return ESP_OK;
    }
@@ -1907,6 +1913,14 @@ esp_err_t voice_stop_listening(void)
     }
 
     voice_reset_activity_timestamp();
+
+    /* PR 1: pipeline transition driven by mode.  Skip if this wasn't
+     * a dictation stop (e.g. voice-ask path, which doesn't touch the
+     * dictation pipeline at all). */
+    if (voice_get_mode() == VOICE_MODE_DICTATE) {
+       voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE,
+                                 (uint32_t)(esp_timer_get_time() / 1000));
+    }
 
     voice_set_state(VOICE_STATE_PROCESSING, NULL);
     return ESP_OK;

--- a/main/voice.c
+++ b/main/voice.c
@@ -1920,6 +1920,14 @@ esp_err_t voice_stop_listening(void)
     esp_err_t err = voice_ws_send_text("{\"type\":\"stop\"}");
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "Stop signal failed — connection lost");
+        /* PR 1: WS send failed mid-dictation — fail the pipeline now so
+         * the in-flight dictation surfaces NETWORK instead of getting
+         * silently stuck in DICT_RECORDING.  Sprint D's disconnect hook
+         * in voice_ws_proto.c may not fire before this return path. */
+        if (voice_get_mode() == VOICE_MODE_DICTATE) {
+            voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK,
+                                      (uint32_t)(esp_timer_get_time() / 1000));
+        }
         voice_set_state(VOICE_STATE_IDLE, "Connection lost");
         return ESP_FAIL;
     }

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -52,10 +52,40 @@ void voice_dictation_unsubscribe(int handle) {
    s_subs[handle].user_data = NULL;
 }
 
+static void dict_dispatch(void) {
+   for (int i = 0; i < DICT_MAX_SUBSCRIBERS; i++) {
+      if (s_subs[i].in_use && s_subs[i].cb) {
+         s_subs[i].cb(&s_event, s_subs[i].user_data);
+      }
+   }
+}
+
 void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
                                uint32_t now_ms) {
-   /* Implemented in Task 3. */
-   (void)new_state; (void)fail_reason; (void)now_ms;
+   /* Idempotent — same-state re-entry is a no-op (avoids spamming
+    * subscribers during a chatty caller that re-asserts state). */
+   if (new_state == s_event.state && fail_reason == s_event.fail_reason) {
+      return;
+   }
+
+   if (new_state == DICT_RECORDING) {
+      s_event.started_ms = now_ms;
+      s_event.stopped_ms = 0;
+   } else if (s_event.state == DICT_RECORDING) {
+      /* Leaving RECORDING — capture stop time. */
+      s_event.stopped_ms = now_ms;
+   }
+
+   if (new_state == DICT_IDLE) {
+      /* Reset session-specific fields when fully returning to IDLE. */
+      s_event.note_slot = -1;
+   }
+
+   s_event.state = new_state;
+   s_event.fail_reason = (new_state == DICT_FAILED) ? fail_reason : DICT_FAIL_NONE;
+   s_event.last_change_ms = now_ms;
+
+   dict_dispatch();
 }
 
 void voice_dictation_set_note_slot(int slot) {

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -26,12 +26,12 @@
 
 typedef struct {
    dict_subscriber_t cb;
-   void             *user_data;
-   bool              in_use;
+   void *user_data;
+   bool in_use;
 } dict_sub_t;
 
-static dict_event_t      s_event;
-static dict_sub_t        s_subs[DICT_MAX_SUBSCRIBERS];
+static dict_event_t s_event;
+static dict_sub_t s_subs[DICT_MAX_SUBSCRIBERS];
 static SemaphoreHandle_t s_lock = NULL;
 
 /* Lock / unlock the module-wide recursive mutex.  On host these collapse
@@ -112,22 +112,31 @@ static bool dict_transition_allowed(dict_state_t cur, dict_state_t next) {
    /* Failures terminate any in-flight state. */
    if (next == DICT_FAILED) return cur != DICT_IDLE;
    /* IDLE accepts from any terminal state. */
-   if (next == DICT_IDLE) return cur == DICT_SAVED || cur == DICT_FAILED ||
-                                 cur == DICT_RECORDING;
+   if (next == DICT_IDLE) return cur == DICT_SAVED || cur == DICT_FAILED || cur == DICT_RECORDING;
    switch (cur) {
-   case DICT_IDLE:         return next == DICT_RECORDING;
-   case DICT_RECORDING:    return next == DICT_UPLOADING || next == DICT_TRANSCRIBING;
-   case DICT_UPLOADING:    return next == DICT_TRANSCRIBING;
-   case DICT_TRANSCRIBING: return next == DICT_SAVED;
-   case DICT_SAVED:        return next == DICT_IDLE;
-   case DICT_FAILED:       return next == DICT_UPLOADING || next == DICT_RECORDING;
-                           /* retry resumes upload (REST) or restarts recording */
+      case DICT_IDLE:
+         return next == DICT_RECORDING;
+      case DICT_RECORDING:
+         return next == DICT_UPLOADING || next == DICT_TRANSCRIBING;
+      case DICT_UPLOADING:
+         return next == DICT_TRANSCRIBING;
+      case DICT_TRANSCRIBING:
+         return next == DICT_SAVED;
+      case DICT_SAVED:
+         return next == DICT_IDLE || next == DICT_RECORDING;
+         /* SAVED is a terminal display state (UI auto-fades to
+          * IDLE after ~2 s).  PR 1 doesn't ship a UI subscriber
+          * to drive that fade yet, so allow directly starting
+          * a new dictation from SAVED without forcing callers
+          * to interleave an explicit IDLE transition. */
+      case DICT_FAILED:
+         return next == DICT_UPLOADING || next == DICT_RECORDING;
+         /* retry resumes upload (REST) or restarts recording */
    }
    return false;
 }
 
-void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
-                               uint32_t now_ms) {
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason, uint32_t now_ms) {
    dict_lock();
 
    /* Idempotent — same-state re-entry is a no-op (avoids spamming
@@ -142,8 +151,7 @@ void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
        * host tests, but don't abort: callers may race and we want the
        * state machine resilient.  On target, this maps to ESP_LOGW
        * once we add an esp_log shim in tests/host/. */
-      fprintf(stderr, "voice_dictation: refused %s -> %s\n",
-              voice_dictation_state_name(s_event.state),
+      fprintf(stderr, "voice_dictation: refused %s -> %s\n", voice_dictation_state_name(s_event.state),
               voice_dictation_state_name(new_state));
       dict_unlock();
       return;
@@ -195,25 +203,38 @@ dict_event_t voice_dictation_get(void) {
  * a static string literal. */
 const char *voice_dictation_state_name(dict_state_t s) {
    switch (s) {
-   case DICT_IDLE:         return "IDLE";
-   case DICT_RECORDING:    return "RECORDING";
-   case DICT_UPLOADING:    return "UPLOADING";
-   case DICT_TRANSCRIBING: return "TRANSCRIBING";
-   case DICT_SAVED:        return "SAVED";
-   case DICT_FAILED:       return "FAILED";
+      case DICT_IDLE:
+         return "IDLE";
+      case DICT_RECORDING:
+         return "RECORDING";
+      case DICT_UPLOADING:
+         return "UPLOADING";
+      case DICT_TRANSCRIBING:
+         return "TRANSCRIBING";
+      case DICT_SAVED:
+         return "SAVED";
+      case DICT_FAILED:
+         return "FAILED";
    }
    return "UNKNOWN";
 }
 
 const char *voice_dictation_fail_name(dict_fail_t f) {
    switch (f) {
-   case DICT_FAIL_NONE:      return "NONE";
-   case DICT_FAIL_AUTH:      return "AUTH";
-   case DICT_FAIL_NETWORK:   return "NETWORK";
-   case DICT_FAIL_EMPTY:     return "EMPTY";
-   case DICT_FAIL_NO_AUDIO:  return "NO_AUDIO";
-   case DICT_FAIL_TOO_LONG:  return "TOO_LONG";
-   case DICT_FAIL_CANCELLED: return "CANCELLED";
+      case DICT_FAIL_NONE:
+         return "NONE";
+      case DICT_FAIL_AUTH:
+         return "AUTH";
+      case DICT_FAIL_NETWORK:
+         return "NETWORK";
+      case DICT_FAIL_EMPTY:
+         return "EMPTY";
+      case DICT_FAIL_NO_AUDIO:
+         return "NO_AUDIO";
+      case DICT_FAIL_TOO_LONG:
+         return "TOO_LONG";
+      case DICT_FAIL_CANCELLED:
+         return "CANCELLED";
    }
    return "UNKNOWN";
 }

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -60,11 +60,44 @@ static void dict_dispatch(void) {
    }
 }
 
+/* Return true if going from `cur` to `next` is a valid transition.
+ * Forward through the pipeline + any → FAILED + SAVED/FAILED/IDLE → IDLE.
+ * Bounces (e.g. RECORDING → RECORDING) are filtered by the dup check
+ * in set_state itself, so we don't list them here. */
+static bool dict_transition_allowed(dict_state_t cur, dict_state_t next) {
+   /* Failures terminate any in-flight state. */
+   if (next == DICT_FAILED) return cur != DICT_IDLE;
+   /* IDLE accepts from any terminal state. */
+   if (next == DICT_IDLE) return cur == DICT_SAVED || cur == DICT_FAILED ||
+                                 cur == DICT_RECORDING;
+   switch (cur) {
+   case DICT_IDLE:         return next == DICT_RECORDING;
+   case DICT_RECORDING:    return next == DICT_UPLOADING || next == DICT_TRANSCRIBING;
+   case DICT_UPLOADING:    return next == DICT_TRANSCRIBING;
+   case DICT_TRANSCRIBING: return next == DICT_SAVED;
+   case DICT_SAVED:        return next == DICT_IDLE;
+   case DICT_FAILED:       return next == DICT_UPLOADING || next == DICT_RECORDING;
+                           /* retry resumes upload (REST) or restarts recording */
+   }
+   return false;
+}
+
 void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
                                uint32_t now_ms) {
    /* Idempotent — same-state re-entry is a no-op (avoids spamming
     * subscribers during a chatty caller that re-asserts state). */
    if (new_state == s_event.state && fail_reason == s_event.fail_reason) {
+      return;
+   }
+
+   if (!dict_transition_allowed(s_event.state, new_state)) {
+      /* Refused — log via the host shim print so it's visible during
+       * host tests, but don't abort: callers may race and we want the
+       * state machine resilient.  On target, this maps to ESP_LOGW
+       * once we add an esp_log shim in tests/host/. */
+      fprintf(stderr, "voice_dictation: refused %s -> %s\n",
+              voice_dictation_state_name(s_event.state),
+              voice_dictation_state_name(new_state));
       return;
    }
 

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -1,0 +1,92 @@
+/* main/voice_dictation.c — dictation pipeline state machine.
+ *
+ * Pure C, zero ESP-IDF deps so it runs under tests/host/.  Callers
+ * (voice.c, ui_notes.c, debug_server_dictation.c) supply monotonic
+ * timestamps via voice_dictation_set_state(state, reason, now_ms).
+ *
+ * Thread safety: target build wraps the global with a FreeRTOS mutex
+ * (acquired/released around every public call); host build uses a
+ * shim no-op mutex.  See `dict_lock()` / `dict_unlock()` below. */
+
+#include "voice_dictation.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define DICT_MAX_SUBSCRIBERS 4
+
+typedef struct {
+   dict_subscriber_t cb;
+   void             *user_data;
+   bool              in_use;
+} dict_sub_t;
+
+static dict_event_t s_event;
+static dict_sub_t   s_subs[DICT_MAX_SUBSCRIBERS];
+
+void voice_dictation_init(void) {
+   memset(&s_event, 0, sizeof(s_event));
+   s_event.state = DICT_IDLE;
+   s_event.fail_reason = DICT_FAIL_NONE;
+   s_event.note_slot = -1;
+   memset(s_subs, 0, sizeof(s_subs));
+}
+
+int voice_dictation_subscribe(dict_subscriber_t cb, void *user_data) {
+   if (!cb) return -1;
+   for (int i = 0; i < DICT_MAX_SUBSCRIBERS; i++) {
+      if (!s_subs[i].in_use) {
+         s_subs[i].cb = cb;
+         s_subs[i].user_data = user_data;
+         s_subs[i].in_use = true;
+         return i;
+      }
+   }
+   return -1;
+}
+
+void voice_dictation_unsubscribe(int handle) {
+   if (handle < 0 || handle >= DICT_MAX_SUBSCRIBERS) return;
+   s_subs[handle].in_use = false;
+   s_subs[handle].cb = NULL;
+   s_subs[handle].user_data = NULL;
+}
+
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
+                               uint32_t now_ms) {
+   /* Implemented in Task 3. */
+   (void)new_state; (void)fail_reason; (void)now_ms;
+}
+
+void voice_dictation_set_note_slot(int slot) {
+   s_event.note_slot = slot;
+}
+
+dict_event_t voice_dictation_get(void) {
+   return s_event;
+}
+
+const char *voice_dictation_state_name(dict_state_t s) {
+   switch (s) {
+   case DICT_IDLE:         return "IDLE";
+   case DICT_RECORDING:    return "RECORDING";
+   case DICT_UPLOADING:    return "UPLOADING";
+   case DICT_TRANSCRIBING: return "TRANSCRIBING";
+   case DICT_SAVED:        return "SAVED";
+   case DICT_FAILED:       return "FAILED";
+   }
+   return "UNKNOWN";
+}
+
+const char *voice_dictation_fail_name(dict_fail_t f) {
+   switch (f) {
+   case DICT_FAIL_NONE:      return "NONE";
+   case DICT_FAIL_AUTH:      return "AUTH";
+   case DICT_FAIL_NETWORK:   return "NETWORK";
+   case DICT_FAIL_EMPTY:     return "EMPTY";
+   case DICT_FAIL_NO_AUDIO:  return "NO_AUDIO";
+   case DICT_FAIL_TOO_LONG:  return "TOO_LONG";
+   case DICT_FAIL_CANCELLED: return "CANCELLED";
+   }
+   return "UNKNOWN";
+}

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -1,17 +1,26 @@
 /* main/voice_dictation.c — dictation pipeline state machine.
  *
- * Pure C, zero ESP-IDF deps so it runs under tests/host/.  Callers
- * (voice.c, ui_notes.c, debug_server_dictation.c) supply monotonic
- * timestamps via voice_dictation_set_state(state, reason, now_ms).
+ * Pure C, zero ESP-IDF deps beyond the freertos/semphr.h primitives,
+ * which the host build shims to no-ops under tests/host/shim/freertos/.
+ * Callers (voice.c, ui_notes.c, debug_server_dictation.c) supply
+ * monotonic timestamps via voice_dictation_set_state(state, reason,
+ * now_ms).
  *
- * Thread safety: target build wraps the global with a FreeRTOS mutex
- * (acquired/released around every public call); host build uses a
- * shim no-op mutex.  See `dict_lock()` / `dict_unlock()` below. */
+ * Thread safety: target build wraps every public call with a FreeRTOS
+ * recursive mutex (lazily created in voice_dictation_init()); host
+ * build uses the no-op shim in tests/host/shim/freertos/semphr.h.
+ * The mutex is recursive because dispatching to subscribers may re-
+ * enter via voice_dictation_get() or voice_dictation_set_state() — a
+ * documented and supported pattern.  See `dict_lock()` /
+ * `dict_unlock()` below. */
 
 #include "voice_dictation.h"
 
 #include <stdio.h>
 #include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 #define DICT_MAX_SUBSCRIBERS 4
 
@@ -21,38 +30,73 @@ typedef struct {
    bool              in_use;
 } dict_sub_t;
 
-static dict_event_t s_event;
-static dict_sub_t   s_subs[DICT_MAX_SUBSCRIBERS];
+static dict_event_t      s_event;
+static dict_sub_t        s_subs[DICT_MAX_SUBSCRIBERS];
+static SemaphoreHandle_t s_lock = NULL;
+
+/* Lock / unlock the module-wide recursive mutex.  On host these collapse
+ * to no-ops via the semphr.h shim, so the test suite exercises the same
+ * code path without any compile-time switch. */
+static inline void dict_lock(void) {
+   if (s_lock) {
+      xSemaphoreTakeRecursive(s_lock, portMAX_DELAY);
+   }
+}
+static inline void dict_unlock(void) {
+   if (s_lock) {
+      xSemaphoreGiveRecursive(s_lock);
+   }
+}
 
 void voice_dictation_init(void) {
+   /* Lazily create the mutex on first call.  Subsequent calls reuse the
+    * existing handle so init remains idempotent.  We deliberately do NOT
+    * destroy + recreate because callers in other tasks may already be
+    * spinning on a take. */
+   if (s_lock == NULL) {
+      s_lock = xSemaphoreCreateRecursiveMutex();
+   }
+
+   dict_lock();
    memset(&s_event, 0, sizeof(s_event));
    s_event.state = DICT_IDLE;
    s_event.fail_reason = DICT_FAIL_NONE;
    s_event.note_slot = -1;
    memset(s_subs, 0, sizeof(s_subs));
+   dict_unlock();
 }
 
 int voice_dictation_subscribe(dict_subscriber_t cb, void *user_data) {
    if (!cb) return -1;
+   dict_lock();
+   int handle = -1;
    for (int i = 0; i < DICT_MAX_SUBSCRIBERS; i++) {
       if (!s_subs[i].in_use) {
          s_subs[i].cb = cb;
          s_subs[i].user_data = user_data;
          s_subs[i].in_use = true;
-         return i;
+         handle = i;
+         break;
       }
    }
-   return -1;
+   dict_unlock();
+   return handle;
 }
 
 void voice_dictation_unsubscribe(int handle) {
    if (handle < 0 || handle >= DICT_MAX_SUBSCRIBERS) return;
+   dict_lock();
    s_subs[handle].in_use = false;
    s_subs[handle].cb = NULL;
    s_subs[handle].user_data = NULL;
+   dict_unlock();
 }
 
-static void dict_dispatch(void) {
+/* MUST be called with dict_lock() held.  Iterates the subscriber table
+ * and fires every active callback with the current `s_event`.  The lock
+ * remains held during dispatch — subscribers may re-enter (it's a
+ * recursive mutex) but they may not mutate the subscriber table. */
+static void dict_dispatch_locked(void) {
    for (int i = 0; i < DICT_MAX_SUBSCRIBERS; i++) {
       if (s_subs[i].in_use && s_subs[i].cb) {
          s_subs[i].cb(&s_event, s_subs[i].user_data);
@@ -84,9 +128,12 @@ static bool dict_transition_allowed(dict_state_t cur, dict_state_t next) {
 
 void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
                                uint32_t now_ms) {
+   dict_lock();
+
    /* Idempotent — same-state re-entry is a no-op (avoids spamming
     * subscribers during a chatty caller that re-asserts state). */
    if (new_state == s_event.state && fail_reason == s_event.fail_reason) {
+      dict_unlock();
       return;
    }
 
@@ -98,6 +145,7 @@ void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
       fprintf(stderr, "voice_dictation: refused %s -> %s\n",
               voice_dictation_state_name(s_event.state),
               voice_dictation_state_name(new_state));
+      dict_unlock();
       return;
    }
 
@@ -118,17 +166,33 @@ void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
    s_event.fail_reason = (new_state == DICT_FAILED) ? fail_reason : DICT_FAIL_NONE;
    s_event.last_change_ms = now_ms;
 
-   dict_dispatch();
+   dict_dispatch_locked();
+   dict_unlock();
 }
 
 void voice_dictation_set_note_slot(int slot) {
-   s_event.note_slot = slot;
+   /* Clamp any "out-of-band negative" to the canonical sentinel. */
+   if (slot < -1) slot = -1;
+
+   dict_lock();
+   /* Only honour during the window where a note_slot has meaning. */
+   if (s_event.state == DICT_RECORDING || s_event.state == DICT_UPLOADING) {
+      s_event.note_slot = slot;
+   }
+   dict_unlock();
 }
 
 dict_event_t voice_dictation_get(void) {
-   return s_event;
+   dict_lock();
+   dict_event_t snapshot = s_event;
+   dict_unlock();
+   return snapshot;
 }
 
+/* Pure-function name lookups — no shared state touched, no lock needed.
+ * Skipping the lock here is the deliberate choice: callers from log/
+ * diagnostic paths shouldn't pay a mutex-take just to map an enum to
+ * a static string literal. */
 const char *voice_dictation_state_name(dict_state_t s) {
    switch (s) {
    case DICT_IDLE:         return "IDLE";

--- a/main/voice_dictation.h
+++ b/main/voice_dictation.h
@@ -48,21 +48,21 @@ typedef enum {
 
 typedef enum {
    DICT_FAIL_NONE = 0,
-   DICT_FAIL_AUTH,        /* Dragon returned 401 / 403 */
-   DICT_FAIL_NETWORK,     /* Other HTTP error / WS disconnect / open failed */
-   DICT_FAIL_EMPTY,       /* Dragon returned 200 with empty STT text */
-   DICT_FAIL_NO_AUDIO,    /* WAV missing or unreadable / Dragon got no PCM */
-   DICT_FAIL_TOO_LONG,    /* hit 5-min hard cap during recording */
-   DICT_FAIL_CANCELLED,   /* user tapped cancel */
+   DICT_FAIL_AUTH,      /* Dragon returned 401 / 403 */
+   DICT_FAIL_NETWORK,   /* Other HTTP error / WS disconnect / open failed */
+   DICT_FAIL_EMPTY,     /* Dragon returned 200 with empty STT text */
+   DICT_FAIL_NO_AUDIO,  /* WAV missing or unreadable / Dragon got no PCM */
+   DICT_FAIL_TOO_LONG,  /* hit 5-min hard cap during recording */
+   DICT_FAIL_CANCELLED, /* user tapped cancel */
 } dict_fail_t;
 
 typedef struct {
    dict_state_t state;
-   dict_fail_t  fail_reason;     /* meaningful only when state == DICT_FAILED */
-   uint32_t     started_ms;      /* time of last IDLE→RECORDING (0 if never recorded) */
-   uint32_t     stopped_ms;      /* time of RECORDING→next (0 while still recording) */
-   uint32_t     last_change_ms;  /* time of most recent transition */
-   int          note_slot;       /* -1 until SD WAV slot allocated; >=0 after */
+   dict_fail_t fail_reason; /* meaningful only when state == DICT_FAILED */
+   uint32_t started_ms;     /* time of last IDLE→RECORDING (0 if never recorded) */
+   uint32_t stopped_ms;     /* time of RECORDING→next (0 while still recording) */
+   uint32_t last_change_ms; /* time of most recent transition */
+   int note_slot;           /* -1 until SD WAV slot allocated; >=0 after */
 } dict_event_t;
 
 typedef void (*dict_subscriber_t)(const dict_event_t *event, void *user_data);
@@ -84,8 +84,7 @@ void voice_dictation_unsubscribe(int handle);
  * the explicit SAVED→IDLE / FAILED→IDLE retry paths.
  *
  * fail_reason is ignored unless new_state == DICT_FAILED. */
-void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
-                               uint32_t now_ms);
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason, uint32_t now_ms);
 
 /* Attach a note slot to the current pipeline (called when SD WAV starts).
  * Persists through subsequent transitions until next IDLE.

--- a/main/voice_dictation.h
+++ b/main/voice_dictation.h
@@ -1,0 +1,84 @@
+/* main/voice_dictation.h — Canonical state machine for a dictation
+ * pipeline (RECORDING → UPLOADING → TRANSCRIBING → SAVED, with FAILED
+ * as a terminal branch).  Multiple UI surfaces subscribe and render
+ * the same state.
+ *
+ * Designed for host-testability: zero ESP-IDF deps in voice_dictation.c.
+ * Callers pass monotonic timestamps in ms.  See spec at
+ * docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+   DICT_IDLE = 0,
+   DICT_RECORDING,
+   DICT_UPLOADING,
+   DICT_TRANSCRIBING,
+   DICT_SAVED,
+   DICT_FAILED,
+} dict_state_t;
+
+typedef enum {
+   DICT_FAIL_NONE = 0,
+   DICT_FAIL_AUTH,        /* Dragon returned 401 / 403 */
+   DICT_FAIL_NETWORK,     /* Other HTTP error / WS disconnect / open failed */
+   DICT_FAIL_EMPTY,       /* Dragon returned 200 with empty STT text */
+   DICT_FAIL_NO_AUDIO,    /* WAV missing or unreadable / Dragon got no PCM */
+   DICT_FAIL_TOO_LONG,    /* hit 5-min hard cap during recording */
+   DICT_FAIL_CANCELLED,   /* user tapped cancel */
+} dict_fail_t;
+
+typedef struct {
+   dict_state_t state;
+   dict_fail_t  fail_reason;     /* meaningful only when state == DICT_FAILED */
+   uint32_t     started_ms;      /* time of last IDLE→RECORDING (0 if never recorded) */
+   uint32_t     stopped_ms;      /* time of RECORDING→next (0 while still recording) */
+   uint32_t     last_change_ms;  /* time of most recent transition */
+   int          note_slot;       /* -1 until SD WAV slot allocated; >=0 after */
+} dict_event_t;
+
+typedef void (*dict_subscriber_t)(const dict_event_t *event, void *user_data);
+
+/* Boot-time init.  Idempotent.  Safe to call before FreeRTOS scheduler.
+ * Initialises state to DICT_IDLE, clears subscriber list. */
+void voice_dictation_init(void);
+
+/* Register a subscriber.  Returns >=0 handle on success, -1 if the
+ * subscriber table is full (compile-time constant DICT_MAX_SUBSCRIBERS). */
+int voice_dictation_subscribe(dict_subscriber_t cb, void *user_data);
+
+/* Remove a subscriber by handle.  No-op if handle is invalid. */
+void voice_dictation_unsubscribe(int handle);
+
+/* Drive a state transition.  Caller supplies monotonic time in ms.
+ * Invalid transitions (e.g. SAVED → RECORDING directly) log a warning
+ * and are NO-OPs — the state machine never moves backward except via
+ * the explicit SAVED→IDLE / FAILED→IDLE retry paths.
+ *
+ * fail_reason is ignored unless new_state == DICT_FAILED. */
+void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
+                               uint32_t now_ms);
+
+/* Attach a note slot to the current pipeline (called when SD WAV starts).
+ * Persists through subsequent transitions until next IDLE. */
+void voice_dictation_set_note_slot(int slot);
+
+/* Snapshot current state.  Thread-safe (returns a copy under lock). */
+dict_event_t voice_dictation_get(void);
+
+/* Human-readable state/reason names — useful for logs, debug endpoint,
+ * and live verification.  Static strings; do not free. */
+const char *voice_dictation_state_name(dict_state_t s);
+const char *voice_dictation_fail_name(dict_fail_t f);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/voice_dictation.h
+++ b/main/voice_dictation.h
@@ -3,9 +3,29 @@
  * as a terminal branch).  Multiple UI surfaces subscribe and render
  * the same state.
  *
- * Designed for host-testability: zero ESP-IDF deps in voice_dictation.c.
- * Callers pass monotonic timestamps in ms.  See spec at
+ * Designed for host-testability: zero ESP-IDF deps beyond the freertos
+ * semphr.h primitives in voice_dictation.c (which the host build shims
+ * to no-ops under tests/host/shim/freertos/).  Callers pass monotonic
+ * timestamps in ms.  See spec at
  * docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md
+ *
+ * THREAD SAFETY:
+ *   - All public functions are thread-safe.  The module is protected by
+ *     a single FreeRTOS recursive mutex created lazily on first init.
+ *     Multiple concurrent FreeRTOS tasks (mic capture, WS event handler,
+ *     ui_notes transcription_queue_task, httpd) may call any function
+ *     freely.
+ *   - Subscribers MAY call `voice_dictation_get()` or
+ *     `voice_dictation_set_state()` from within their callback — the
+ *     mutex is recursive, so re-entry from the dispatch path is safe.
+ *   - Subscribers MUST NOT block indefinitely in their callback.  The
+ *     mutex is held for the entire dispatch loop, so a blocking
+ *     subscriber blocks every other caller in the system.  Subscribers
+ *     should defer real work to a worker task (e.g. tab5_worker).
+ *   - Subscribers SHOULD NOT call `voice_dictation_subscribe()` or
+ *     `voice_dictation_unsubscribe()` from within a callback — mutating
+ *     the subscriber table while the dispatch loop is iterating is
+ *     undefined.
  */
 #pragma once
 
@@ -68,7 +88,14 @@ void voice_dictation_set_state(dict_state_t new_state, dict_fail_t fail_reason,
                                uint32_t now_ms);
 
 /* Attach a note slot to the current pipeline (called when SD WAV starts).
- * Persists through subsequent transitions until next IDLE. */
+ * Persists through subsequent transitions until next IDLE.
+ *
+ * Contract:
+ *   - Only honoured when current state is DICT_RECORDING or DICT_UPLOADING
+ *     (the window during which a note slot has meaning).  Outside that
+ *     window the call is silently ignored.
+ *   - Any `slot < -1` is clamped to -1 (clear).  Negative values other
+ *     than -1 are not meaningful and reserved. */
 void voice_dictation_set_note_slot(int slot);
 
 /* Snapshot current state.  Thread-safe (returns a copy under lock). */

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -35,6 +35,7 @@
 #include "voice.h"               /* g_voice_ws extern + voice_set_state */
 #include "voice_billing.h"       /* receipt + budget */
 #include "voice_codec.h"         /* VOICE_CODEC_OPUS_UPLINK_ENABLED */
+#include "voice_dictation.h"     /* PR 1: pipeline state machine transitions */
 #include "voice_messages_sync.h" /* W3-C-d: drain offline queue on reconnect */
 #include "voice_onboard.h"       /* K144 failover hooks */
 #include "voice_video.h"         /* VID0 magic peek + downlink decode */
@@ -792,6 +793,9 @@ void voice_ws_proto_handle_text(const char *data, int len) {
        * few ms later anyway, no UI flicker visible. */
       ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
       voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
+      /* PR 1: pipeline transition for the cancelled path. */
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED,
+                                (uint32_t)(esp_timer_get_time() / 1000));
    } else if (strcmp(type_str, "dictation_summary") == 0) {
       cJSON *title = cJSON_GetObjectItem(root, "title");
       cJSON *summary = cJSON_GetObjectItem(root, "summary");
@@ -805,6 +809,15 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       }
       ESP_LOGI(TAG, "Dictation summary: \"%s\"", s_dictation_title);
       voice_set_state(VOICE_STATE_READY, "dictation_summary");
+
+      /* PR 1: pipeline transition.  Non-empty summary → SAVED; empty
+       * both → FAILED(EMPTY). */
+      const uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
+      if (s_dictation_title[0] || s_dictation_summary[0]) {
+         voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, now);
+      } else {
+         voice_dictation_set_state(DICT_FAILED, DICT_FAIL_EMPTY, now);
+      }
    } else if (strcmp(type_str, "note_created") == 0) {
       cJSON *nid = cJSON_GetObjectItem(root, "note_id");
       cJSON *ntitle = cJSON_GetObjectItem(root, "title");

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -794,8 +794,7 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       ESP_LOGI(TAG, "Dictation post-process cancelled (superseded or aborted)");
       voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
       /* PR 1: pipeline transition for the cancelled path. */
-      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED,
-                                (uint32_t)(esp_timer_get_time() / 1000));
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED, (uint32_t)(esp_timer_get_time() / 1000));
    } else if (strcmp(type_str, "dictation_summary") == 0) {
       cJSON *title = cJSON_GetObjectItem(root, "title");
       cJSON *summary = cJSON_GetObjectItem(root, "summary");
@@ -1416,10 +1415,8 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t even
           * already IDLE/SAVED/FAILED. */
          {
             dict_state_t cur_dict = voice_dictation_get().state;
-            if (cur_dict == DICT_RECORDING || cur_dict == DICT_UPLOADING ||
-                cur_dict == DICT_TRANSCRIBING) {
-               voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK,
-                                         (uint32_t)(esp_timer_get_time() / 1000));
+            if (cur_dict == DICT_RECORDING || cur_dict == DICT_UPLOADING || cur_dict == DICT_TRANSCRIBING) {
+               voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
             }
          }
          /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -1411,6 +1411,17 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t even
          /* Flush playback so we don't keep speaking into a dead pipe. */
          voice_playback_buf_reset();
          tab5_audio_speaker_enable(false);
+         /* PR 1: if a dictation was mid-pipeline, fail it with NETWORK
+          * so the UI surfaces the disconnect.  No-op when pipeline is
+          * already IDLE/SAVED/FAILED. */
+         {
+            dict_state_t cur_dict = voice_dictation_get().state;
+            if (cur_dict == DICT_RECORDING || cur_dict == DICT_UPLOADING ||
+                cur_dict == DICT_TRANSCRIBING) {
+               voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK,
+                                         (uint32_t)(esp_timer_get_time() / 1000));
+            }
+         }
          /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice
           * state was PROCESSING or SPEAKING), surface a toast so the user
           * knows why the reply stopped.  Previously a mid-turn Dragon

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -44,10 +44,11 @@ target_compile_options(test_spring_anim PRIVATE -Wno-unused-variable -Wno-unused
 target_link_libraries(test_spring_anim PRIVATE m)
 add_test(NAME spring_anim COMMAND test_spring_anim)
 
-# voice_dictation — pipeline state machine (PR 1).
+# voice_dictation — pipeline state machine (PR 1).  Picks up the
+# tests/host/shim/freertos/ no-op recursive-mutex shim from SHIM_DIR.
 add_executable(test_voice_dictation
     test_voice_dictation.c
     ${MAIN_DIR}/voice_dictation.c
 )
-target_include_directories(test_voice_dictation PRIVATE ${MAIN_DIR})
+target_include_directories(test_voice_dictation PRIVATE ${SHIM_DIR} ${MAIN_DIR})
 add_test(NAME voice_dictation COMMAND test_voice_dictation)

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -43,3 +43,11 @@ target_compile_definitions(test_spring_anim PRIVATE HOST_LOG_QUIET=1)
 target_compile_options(test_spring_anim PRIVATE -Wno-unused-variable -Wno-unused-const-variable)
 target_link_libraries(test_spring_anim PRIVATE m)
 add_test(NAME spring_anim COMMAND test_spring_anim)
+
+# voice_dictation — pipeline state machine (PR 1).
+add_executable(test_voice_dictation
+    test_voice_dictation.c
+    ${MAIN_DIR}/voice_dictation.c
+)
+target_include_directories(test_voice_dictation PRIVATE ${MAIN_DIR})
+add_test(NAME voice_dictation COMMAND test_voice_dictation)

--- a/tests/host/shim/freertos/FreeRTOS.h
+++ b/tests/host/shim/freertos/FreeRTOS.h
@@ -1,0 +1,4 @@
+/* Host shim for freertos/FreeRTOS.h — empty include so headers that
+ * unconditionally #include "freertos/FreeRTOS.h" before semphr.h still
+ * compile under tests/host/.  All real types live in semphr.h. */
+#pragma once

--- a/tests/host/shim/freertos/semphr.h
+++ b/tests/host/shim/freertos/semphr.h
@@ -21,7 +21,7 @@ typedef int *SemaphoreHandle_t;
 #endif
 
 typedef unsigned int TickType_t;
-typedef int          BaseType_t;
+typedef int BaseType_t;
 
 static inline SemaphoreHandle_t xSemaphoreCreateRecursiveMutex(void) {
    /* Sentinel non-NULL pointer so callers' NULL-check passes.  Never
@@ -31,7 +31,8 @@ static inline SemaphoreHandle_t xSemaphoreCreateRecursiveMutex(void) {
 }
 
 static inline BaseType_t xSemaphoreTakeRecursive(SemaphoreHandle_t h, TickType_t t) {
-   (void)h; (void)t;
+   (void)h;
+   (void)t;
    return pdTRUE;
 }
 
@@ -40,6 +41,4 @@ static inline BaseType_t xSemaphoreGiveRecursive(SemaphoreHandle_t h) {
    return pdTRUE;
 }
 
-static inline void vSemaphoreDelete(SemaphoreHandle_t h) {
-   (void)h;
-}
+static inline void vSemaphoreDelete(SemaphoreHandle_t h) { (void)h; }

--- a/tests/host/shim/freertos/semphr.h
+++ b/tests/host/shim/freertos/semphr.h
@@ -1,0 +1,45 @@
+/* Host shim for freertos/semphr.h — no-op recursive mutex.
+ *
+ * Host tests are single-threaded, so the recursive-mutex contract collapses
+ * to "always succeeds, never blocks".  The `(void)h` casts keep -Werror
+ * -Wunused-parameter / -Wunused-variable quiet at the call sites. */
+#pragma once
+
+#include <stddef.h>
+
+typedef int *SemaphoreHandle_t;
+
+#ifndef pdTRUE
+#define pdTRUE 1
+#endif
+#ifndef pdFALSE
+#define pdFALSE 0
+#endif
+
+#ifndef portMAX_DELAY
+#define portMAX_DELAY 0xffffffffu
+#endif
+
+typedef unsigned int TickType_t;
+typedef int          BaseType_t;
+
+static inline SemaphoreHandle_t xSemaphoreCreateRecursiveMutex(void) {
+   /* Sentinel non-NULL pointer so callers' NULL-check passes.  Never
+    * dereferenced under host — give/take are no-ops below. */
+   static int s_sentinel = 1;
+   return &s_sentinel;
+}
+
+static inline BaseType_t xSemaphoreTakeRecursive(SemaphoreHandle_t h, TickType_t t) {
+   (void)h; (void)t;
+   return pdTRUE;
+}
+
+static inline BaseType_t xSemaphoreGiveRecursive(SemaphoreHandle_t h) {
+   (void)h;
+   return pdTRUE;
+}
+
+static inline void vSemaphoreDelete(SemaphoreHandle_t h) {
+   (void)h;
+}

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -137,6 +137,69 @@ static int test_note_slot_persists_through_pipeline(void) {
    return 0;
 }
 
+static int test_failed_from_uploading_auth(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_FAILED,    DICT_FAIL_AUTH, 2100);
+
+   CHECK_EQ(m.last.state, DICT_FAILED);
+   CHECK_EQ(m.last.fail_reason, DICT_FAIL_AUTH);
+   return 0;
+}
+
+static int test_failed_from_transcribing_empty(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_FAILED,       DICT_FAIL_EMPTY, 2400);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_FAILED);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_EMPTY);
+   return 0;
+}
+
+static int test_retry_from_failed(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_FAILED,    DICT_FAIL_NETWORK, 1100);
+   /* User taps retry → caller drives UPLOADING. */
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 5000);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_UPLOADING);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);   /* cleared on leave-FAILED */
+   return 0;
+}
+
+static int test_cancel_from_recording(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED, 1500);
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 1600);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_IDLE);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);
+   return 0;
+}
+
+static int test_failed_clears_reason_on_idle(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_AUTH, 2000);
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 3000);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);
+   return 0;
+}
+
 int main(void) {
    if (test_init_state_is_idle()) return 1;
    if (test_idle_to_recording_fires_subscriber()) return 1;
@@ -144,6 +207,11 @@ int main(void) {
    if (test_idempotent_same_state()) return 1;
    if (test_invalid_backward_transition_blocked()) return 1;
    if (test_note_slot_persists_through_pipeline()) return 1;
+   if (test_failed_from_uploading_auth()) return 1;
+   if (test_failed_from_transcribing_empty()) return 1;
+   if (test_retry_from_failed()) return 1;
+   if (test_cancel_from_recording()) return 1;
+   if (test_failed_clears_reason_on_idle()) return 1;
    fprintf(stderr, "ok  %d checks passed\n", g_pass);
    return 0;
 }

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -39,8 +39,39 @@ static int test_init_state_is_idle(void) {
    return 0;
 }
 
+/* Subscriber that records the last event it saw. */
+typedef struct {
+   int           call_count;
+   dict_event_t  last;
+} mock_sub_t;
+
+static void mock_cb(const dict_event_t *e, void *ud) {
+   mock_sub_t *m = (mock_sub_t *)ud;
+   m->call_count++;
+   m->last = *e;
+}
+
+static int test_idle_to_recording_fires_subscriber(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   int h = voice_dictation_subscribe(mock_cb, &m);
+   CHECK(h >= 0);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 12345);
+
+   CHECK_EQ(m.call_count, 1);
+   CHECK_EQ(m.last.state, DICT_RECORDING);
+   CHECK_EQ((int)m.last.started_ms, 12345);
+   CHECK_EQ((int)m.last.last_change_ms, 12345);
+
+   dict_event_t snapshot = voice_dictation_get();
+   CHECK_EQ(snapshot.state, DICT_RECORDING);
+   return 0;
+}
+
 int main(void) {
    if (test_init_state_is_idle()) return 1;
+   if (test_idle_to_recording_fires_subscriber()) return 1;
    fprintf(stderr, "ok  %d checks passed\n", g_pass);
    return 0;
 }

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -3,31 +3,30 @@
  * Pure-C state machine — zero ESP-IDF deps in the module under test;
  * this file uses plain assert.h / stdio just like test_md_strip.c. */
 
-#include "voice_dictation.h"
-
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "voice_dictation.h"
+
 static int g_pass = 0;
 
-#define CHECK(cond)                                                       \
-   do {                                                                   \
-      if (!(cond)) {                                                      \
-         fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);  \
-         return 1;                                                        \
-      }                                                                   \
-      g_pass++;                                                           \
+#define CHECK(cond)                                                      \
+   do {                                                                  \
+      if (!(cond)) {                                                     \
+         fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+         return 1;                                                       \
+      }                                                                  \
+      g_pass++;                                                          \
    } while (0)
 
-#define CHECK_EQ(a, b)                                                              \
-   do {                                                                             \
-      if ((a) != (b)) {                                                             \
-         fprintf(stderr, "FAIL %s:%d  %s != %s  (%d vs %d)\n", __FILE__, __LINE__,  \
-                 #a, #b, (int)(a), (int)(b));                                       \
-         return 1;                                                                  \
-      }                                                                             \
-      g_pass++;                                                                     \
+#define CHECK_EQ(a, b)                                                                                          \
+   do {                                                                                                         \
+      if ((a) != (b)) {                                                                                         \
+         fprintf(stderr, "FAIL %s:%d  %s != %s  (%d vs %d)\n", __FILE__, __LINE__, #a, #b, (int)(a), (int)(b)); \
+         return 1;                                                                                              \
+      }                                                                                                         \
+      g_pass++;                                                                                                 \
    } while (0)
 
 static int test_init_state_is_idle(void) {
@@ -41,8 +40,8 @@ static int test_init_state_is_idle(void) {
 
 /* Subscriber that records the last event it saw. */
 typedef struct {
-   int           call_count;
-   dict_event_t  last;
+   int call_count;
+   dict_event_t last;
 } mock_sub_t;
 
 static void mock_cb(const dict_event_t *e, void *ud) {
@@ -74,17 +73,17 @@ static int test_full_happy_path(void) {
    mock_sub_t m = {0};
    voice_dictation_subscribe(mock_cb, &m);
 
-   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
-   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
    voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
-   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
-   voice_dictation_set_state(DICT_IDLE,         DICT_FAIL_NONE, 4400);
+   voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, 2400);
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 4400);
 
    CHECK_EQ(m.call_count, 5);
    CHECK_EQ(m.last.state, DICT_IDLE);
    CHECK_EQ((int)m.last.started_ms, 1000);
    CHECK_EQ((int)m.last.stopped_ms, 2000);
-   CHECK_EQ(m.last.note_slot, -1);     /* IDLE reset cleared it */
+   CHECK_EQ(m.last.note_slot, -1); /* IDLE reset cleared it */
    return 0;
 }
 
@@ -94,10 +93,10 @@ static int test_idempotent_same_state(void) {
    voice_dictation_subscribe(mock_cb, &m);
 
    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
-   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1500);  /* dup */
-   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000);  /* dup */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1500); /* dup */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000); /* dup */
 
-   CHECK_EQ(m.call_count, 1);   /* duplicates suppressed */
+   CHECK_EQ(m.call_count, 1); /* duplicates suppressed */
    return 0;
 }
 
@@ -106,17 +105,17 @@ static int test_invalid_backward_transition_blocked(void) {
    mock_sub_t m = {0};
    voice_dictation_subscribe(mock_cb, &m);
 
-   /* Walk the pipeline forward to reach SAVED (the strict guard table
-    * disallows IDLE → SAVED jumps, so we use the canonical path). */
-   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 100);
-   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 200);
+   /* Walk forward to TRANSCRIBING (the strict guard table disallows
+    * IDLE → TRANSCRIBING jumps, so we use the canonical path). */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 100);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 200);
    voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 300);
-   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 400);
 
-   /* Invalid: SAVED → RECORDING (must go through IDLE first). */
+   /* Invalid: TRANSCRIBING → RECORDING (no resume mid-flight without
+    * going through SAVED or FAILED first). */
    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000);
 
-   CHECK_EQ(m.last.state, DICT_SAVED);
+   CHECK_EQ(m.last.state, DICT_TRANSCRIBING);
    return 0;
 }
 
@@ -124,16 +123,16 @@ static int test_note_slot_persists_through_pipeline(void) {
    voice_dictation_init();
    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
    voice_dictation_set_note_slot(7);
-   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
    voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
-   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
+   voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, 2400);
 
    dict_event_t e = voice_dictation_get();
    CHECK_EQ(e.note_slot, 7);
 
    voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 4400);
    e = voice_dictation_get();
-   CHECK_EQ(e.note_slot, -1);  /* cleared on IDLE */
+   CHECK_EQ(e.note_slot, -1); /* cleared on IDLE */
    return 0;
 }
 
@@ -144,7 +143,7 @@ static int test_failed_from_uploading_auth(void) {
 
    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
    voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
-   voice_dictation_set_state(DICT_FAILED,    DICT_FAIL_AUTH, 2100);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_AUTH, 2100);
 
    CHECK_EQ(m.last.state, DICT_FAILED);
    CHECK_EQ(m.last.fail_reason, DICT_FAIL_AUTH);
@@ -153,10 +152,10 @@ static int test_failed_from_uploading_auth(void) {
 
 static int test_failed_from_transcribing_empty(void) {
    voice_dictation_init();
-   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
-   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
    voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
-   voice_dictation_set_state(DICT_FAILED,       DICT_FAIL_EMPTY, 2400);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_EMPTY, 2400);
 
    dict_event_t e = voice_dictation_get();
    CHECK_EQ(e.state, DICT_FAILED);
@@ -167,13 +166,13 @@ static int test_failed_from_transcribing_empty(void) {
 static int test_retry_from_failed(void) {
    voice_dictation_init();
    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
-   voice_dictation_set_state(DICT_FAILED,    DICT_FAIL_NETWORK, 1100);
+   voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, 1100);
    /* User taps retry → caller drives UPLOADING. */
    voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 5000);
 
    dict_event_t e = voice_dictation_get();
    CHECK_EQ(e.state, DICT_UPLOADING);
-   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);   /* cleared on leave-FAILED */
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE); /* cleared on leave-FAILED */
    return 0;
 }
 
@@ -236,15 +235,15 @@ static int test_subscriber_table_full_returns_minus_one(void) {
       handles[i] = voice_dictation_subscribe(mock_cb, &dummy[i]);
       if (handles[i] == -1) got_full = 1;
    }
-   CHECK_EQ(got_full, 1);   /* DICT_MAX_SUBSCRIBERS is 4 */
+   CHECK_EQ(got_full, 1); /* DICT_MAX_SUBSCRIBERS is 4 */
    return 0;
 }
 
 static int test_set_note_slot_rejected_in_idle(void) {
    voice_dictation_init();
-   voice_dictation_set_note_slot(42);            /* in IDLE — should be ignored */
+   voice_dictation_set_note_slot(42); /* in IDLE — should be ignored */
    dict_event_t e = voice_dictation_get();
-   CHECK_EQ(e.note_slot, -1);                    /* unchanged */
+   CHECK_EQ(e.note_slot, -1); /* unchanged */
    return 0;
 }
 
@@ -269,14 +268,14 @@ static int test_set_note_slot_accepted_in_uploading(void) {
 
 static int test_set_note_slot_rejected_after_saved(void) {
    voice_dictation_init();
-   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
-   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
    voice_dictation_set_note_slot(13);
    voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
-   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
-   voice_dictation_set_note_slot(99);            /* should be ignored — past upload window */
+   voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, 2400);
+   voice_dictation_set_note_slot(99); /* should be ignored — past upload window */
    dict_event_t e = voice_dictation_get();
-   CHECK_EQ(e.note_slot, 13);                    /* still the legit one from UPLOADING */
+   CHECK_EQ(e.note_slot, 13); /* still the legit one from UPLOADING */
    return 0;
 }
 
@@ -284,8 +283,9 @@ static int test_set_note_slot_rejected_after_saved(void) {
  * recursive lock works. */
 static int g_reentrant_get_state = -1;
 static void reentrant_cb(const dict_event_t *e, void *ud) {
-   (void)e; (void)ud;
-   dict_event_t inner = voice_dictation_get();   /* MUST not deadlock */
+   (void)e;
+   (void)ud;
+   dict_event_t inner = voice_dictation_get(); /* MUST not deadlock */
    g_reentrant_get_state = (int)inner.state;
 }
 
@@ -294,6 +294,29 @@ static int test_subscriber_can_reenter_get(void) {
    voice_dictation_subscribe(reentrant_cb, NULL);
    voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
    CHECK_EQ(g_reentrant_get_state, (int)DICT_RECORDING);
+   return 0;
+}
+
+static int test_saved_to_recording_allowed(void) {
+   /* After a successful dictation, the next user-driven dictation must
+    * be able to start without needing the caller to first explicitly
+    * transition through IDLE.  PR 1 doesn't ship the UI's 2 s SAVED→IDLE
+    * fade yet, so SAVED→RECORDING must be a legal direct edge. */
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, 2400);
+
+   /* User immediately taps Dictate again. */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 5000);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_RECORDING);
+   CHECK_EQ((int)e.started_ms, 5000); /* fresh start timestamp */
    return 0;
 }
 
@@ -317,6 +340,7 @@ int main(void) {
    if (test_set_note_slot_accepted_in_uploading()) return 1;
    if (test_set_note_slot_rejected_after_saved()) return 1;
    if (test_subscriber_can_reenter_get()) return 1;
+   if (test_saved_to_recording_allowed()) return 1;
    fprintf(stderr, "ok  %d checks passed\n", g_pass);
    return 0;
 }

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -200,6 +200,46 @@ static int test_failed_clears_reason_on_idle(void) {
    return 0;
 }
 
+static int test_multiple_subscribers_all_fire(void) {
+   voice_dictation_init();
+   mock_sub_t a = {0}, b = {0};
+   voice_dictation_subscribe(mock_cb, &a);
+   voice_dictation_subscribe(mock_cb, &b);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+
+   CHECK_EQ(a.call_count, 1);
+   CHECK_EQ(b.call_count, 1);
+   return 0;
+}
+
+static int test_unsubscribe_stops_callbacks(void) {
+   voice_dictation_init();
+   mock_sub_t a = {0}, b = {0};
+   int ha = voice_dictation_subscribe(mock_cb, &a);
+   voice_dictation_subscribe(mock_cb, &b);
+
+   voice_dictation_unsubscribe(ha);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+
+   CHECK_EQ(a.call_count, 0);
+   CHECK_EQ(b.call_count, 1);
+   return 0;
+}
+
+static int test_subscriber_table_full_returns_minus_one(void) {
+   voice_dictation_init();
+   mock_sub_t dummy[8] = {0};
+   int handles[8] = {0};
+   int got_full = 0;
+   for (int i = 0; i < 8; i++) {
+      handles[i] = voice_dictation_subscribe(mock_cb, &dummy[i]);
+      if (handles[i] == -1) got_full = 1;
+   }
+   CHECK_EQ(got_full, 1);   /* DICT_MAX_SUBSCRIBERS is 4 */
+   return 0;
+}
+
 int main(void) {
    if (test_init_state_is_idle()) return 1;
    if (test_idle_to_recording_fires_subscriber()) return 1;
@@ -212,6 +252,9 @@ int main(void) {
    if (test_retry_from_failed()) return 1;
    if (test_cancel_from_recording()) return 1;
    if (test_failed_clears_reason_on_idle()) return 1;
+   if (test_multiple_subscribers_all_fire()) return 1;
+   if (test_unsubscribe_stops_callbacks()) return 1;
+   if (test_subscriber_table_full_returns_minus_one()) return 1;
    fprintf(stderr, "ok  %d checks passed\n", g_pass);
    return 0;
 }

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -69,9 +69,81 @@ static int test_idle_to_recording_fires_subscriber(void) {
    return 0;
 }
 
+static int test_full_happy_path(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
+   voice_dictation_set_state(DICT_IDLE,         DICT_FAIL_NONE, 4400);
+
+   CHECK_EQ(m.call_count, 5);
+   CHECK_EQ(m.last.state, DICT_IDLE);
+   CHECK_EQ((int)m.last.started_ms, 1000);
+   CHECK_EQ((int)m.last.stopped_ms, 2000);
+   CHECK_EQ(m.last.note_slot, -1);     /* IDLE reset cleared it */
+   return 0;
+}
+
+static int test_idempotent_same_state(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1500);  /* dup */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000);  /* dup */
+
+   CHECK_EQ(m.call_count, 1);   /* duplicates suppressed */
+   return 0;
+}
+
+static int test_invalid_backward_transition_blocked(void) {
+   voice_dictation_init();
+   mock_sub_t m = {0};
+   voice_dictation_subscribe(mock_cb, &m);
+
+   /* Walk the pipeline forward to reach SAVED (the strict guard table
+    * disallows IDLE → SAVED jumps, so we use the canonical path). */
+   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 100);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 200);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 300);
+   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 400);
+
+   /* Invalid: SAVED → RECORDING (must go through IDLE first). */
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 2000);
+
+   CHECK_EQ(m.last.state, DICT_SAVED);
+   return 0;
+}
+
+static int test_note_slot_persists_through_pipeline(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_note_slot(7);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
+
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, 7);
+
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, 4400);
+   e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, -1);  /* cleared on IDLE */
+   return 0;
+}
+
 int main(void) {
    if (test_init_state_is_idle()) return 1;
    if (test_idle_to_recording_fires_subscriber()) return 1;
+   if (test_full_happy_path()) return 1;
+   if (test_idempotent_same_state()) return 1;
+   if (test_invalid_backward_transition_blocked()) return 1;
+   if (test_note_slot_persists_through_pipeline()) return 1;
    fprintf(stderr, "ok  %d checks passed\n", g_pass);
    return 0;
 }

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -1,0 +1,46 @@
+/* Host-targeted unit tests for main/voice_dictation.c.
+ *
+ * Pure-C state machine — zero ESP-IDF deps in the module under test;
+ * this file uses plain assert.h / stdio just like test_md_strip.c. */
+
+#include "voice_dictation.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int g_pass = 0;
+
+#define CHECK(cond)                                                       \
+   do {                                                                   \
+      if (!(cond)) {                                                      \
+         fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);  \
+         return 1;                                                        \
+      }                                                                   \
+      g_pass++;                                                           \
+   } while (0)
+
+#define CHECK_EQ(a, b)                                                              \
+   do {                                                                             \
+      if ((a) != (b)) {                                                             \
+         fprintf(stderr, "FAIL %s:%d  %s != %s  (%d vs %d)\n", __FILE__, __LINE__,  \
+                 #a, #b, (int)(a), (int)(b));                                       \
+         return 1;                                                                  \
+      }                                                                             \
+      g_pass++;                                                                     \
+   } while (0)
+
+static int test_init_state_is_idle(void) {
+   voice_dictation_init();
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.state, DICT_IDLE);
+   CHECK_EQ(e.fail_reason, DICT_FAIL_NONE);
+   CHECK_EQ(e.note_slot, -1);
+   return 0;
+}
+
+int main(void) {
+   if (test_init_state_is_idle()) return 1;
+   fprintf(stderr, "ok  %d checks passed\n", g_pass);
+   return 0;
+}

--- a/tests/host/test_voice_dictation.c
+++ b/tests/host/test_voice_dictation.c
@@ -240,6 +240,63 @@ static int test_subscriber_table_full_returns_minus_one(void) {
    return 0;
 }
 
+static int test_set_note_slot_rejected_in_idle(void) {
+   voice_dictation_init();
+   voice_dictation_set_note_slot(42);            /* in IDLE — should be ignored */
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, -1);                    /* unchanged */
+   return 0;
+}
+
+static int test_set_note_slot_accepted_in_recording(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_note_slot(7);
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, 7);
+   return 0;
+}
+
+static int test_set_note_slot_accepted_in_uploading(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING, DICT_FAIL_NONE, 2000);
+   voice_dictation_set_note_slot(11);
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, 11);
+   return 0;
+}
+
+static int test_set_note_slot_rejected_after_saved(void) {
+   voice_dictation_init();
+   voice_dictation_set_state(DICT_RECORDING,    DICT_FAIL_NONE, 1000);
+   voice_dictation_set_state(DICT_UPLOADING,    DICT_FAIL_NONE, 2000);
+   voice_dictation_set_note_slot(13);
+   voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, 2100);
+   voice_dictation_set_state(DICT_SAVED,        DICT_FAIL_NONE, 2400);
+   voice_dictation_set_note_slot(99);            /* should be ignored — past upload window */
+   dict_event_t e = voice_dictation_get();
+   CHECK_EQ(e.note_slot, 13);                    /* still the legit one from UPLOADING */
+   return 0;
+}
+
+/* Subscriber that re-enters into voice_dictation_get() to verify the
+ * recursive lock works. */
+static int g_reentrant_get_state = -1;
+static void reentrant_cb(const dict_event_t *e, void *ud) {
+   (void)e; (void)ud;
+   dict_event_t inner = voice_dictation_get();   /* MUST not deadlock */
+   g_reentrant_get_state = (int)inner.state;
+}
+
+static int test_subscriber_can_reenter_get(void) {
+   voice_dictation_init();
+   voice_dictation_subscribe(reentrant_cb, NULL);
+   voice_dictation_set_state(DICT_RECORDING, DICT_FAIL_NONE, 1000);
+   CHECK_EQ(g_reentrant_get_state, (int)DICT_RECORDING);
+   return 0;
+}
+
 int main(void) {
    if (test_init_state_is_idle()) return 1;
    if (test_idle_to_recording_fires_subscriber()) return 1;
@@ -255,6 +312,11 @@ int main(void) {
    if (test_multiple_subscribers_all_fire()) return 1;
    if (test_unsubscribe_stops_callbacks()) return 1;
    if (test_subscriber_table_full_returns_minus_one()) return 1;
+   if (test_set_note_slot_rejected_in_idle()) return 1;
+   if (test_set_note_slot_accepted_in_recording()) return 1;
+   if (test_set_note_slot_accepted_in_uploading()) return 1;
+   if (test_set_note_slot_rejected_after_saved()) return 1;
+   if (test_subscriber_can_reenter_get()) return 1;
    fprintf(stderr, "ok  %d checks passed\n", g_pass);
    return 0;
 }


### PR DESCRIPTION
## Summary
- Adds canonical `dict_pipeline_t` state machine in new `main/voice_dictation.{c,h}` — pure C with recursive mutex, host-tested (39 checks across 17 functions)
- Instruments every existing dictation entry/exit point: voice.c (start, stop, VAD cap, WS-send-fail), voice_ws_proto.c (summary, cancelled, disconnect), ui_notes.c REST polling task (8 transition points)
- New `GET /dictation_pipeline` debug endpoint exposes live state for PR 2/3 verification
- 5-min hard cap on dictation (matches the SD-recording cap from #517)

Foundation for PR 2 (orb morphs + Dictate chip) and PR 3 (Notes Timeline).  No visible UI change in this PR; the module is consumed by future PRs.  Closes #518.

Design: docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md
Plan:   docs/superpowers/plans/2026-05-14-dictation-pipeline-pr1.md

## Test plan
- [x] Host tests: ctest --test-dir tests/host/build → all 4 tests pass (voice_dictation prints \`ok 39 checks passed\`)
- [x] idf.py build clean, no warnings on new modules
- [x] git-clang-format --diff origin/main clean (CI format gate green)
- [x] Live on Tab5 192.168.1.90:
  - GET /dictation_pipeline on boot → state: \"IDLE\"
  - POST /dictation?action=start → state: \"RECORDING\", started_ms populated
  - POST /dictation?action=stop  → state: \"TRANSCRIBING\", stopped_ms populated
  - After Dragon's dictation_summary arrives → state: \"SAVED\"
- [x] No PANIC across multiple dictation cycles
- [x] Heap stable: internal ~98 KB free, no fragmentation alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)