### PR TITLE
feat(dictation): orb morphs + Dictate chip on home (PR 2 of 4)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-dictation-pipeline-pr2.md
+++ b/docs/superpowers/plans/2026-05-14-dictation-pipeline-pr2.md
@@ -424,6 +424,11 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
       return;
 
    case DICT_RECORDING: {
+      /* Engage the existing LISTENING state machine so the mic-RMS-driven
+       * halo bloom fires.  Our pipeline body tint overrides the body
+       * colour, but the bloom mechanic (halo opacity from mic RMS) still
+       * runs because it manipulates s_halo, not s_body. */
+      ui_orb_set_state(ORB_STATE_LISTENING);
       paint_pipeline_body(0xE74C3C);
       uint32_t dur_ms = (uint32_t)(esp_timer_get_time() / 1000) - event->started_ms;
       uint32_t s = dur_ms / 1000;

--- a/docs/superpowers/plans/2026-05-14-dictation-pipeline-pr2.md
+++ b/docs/superpowers/plans/2026-05-14-dictation-pipeline-pr2.md
@@ -1,0 +1,1165 @@
+# Dictation pipeline PR 2 — orb morphs + Dictate chip on home
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** First visible UI change in the 4-PR series.  The orb morphs through pipeline states (RECORDING red / UPLOADING amber / TRANSCRIBING amber+comet / SAVED green / FAILED red) with a caption label under it; a new Dictate chip lands on home below the existing mode chip, in matching dark-pill language, that fires `voice_start_dictation()` on tap and mirrors the orb's pipeline state.
+
+**Architecture:** Both surfaces subscribe to the `voice_dictation` state machine that landed in PR #519.  No new pipeline state — we just paint it.  The orb gets a new `ui_orb_set_pipeline_state(state, fail_reason)` API that takes precedence over the existing voice-state-driven IDLE/LISTENING/PROCESSING/SPEAKING painting; when pipeline returns to IDLE, orb reverts to voice-state visuals.  The Dictate chip is a new widget inside `ui_home.c` that subscribes to the same pipeline and mirrors state in its label.
+
+**Tech Stack:** ESP-IDF 5.5.2, LVGL 9.x, existing `voice_dictation.{c,h}` from PR #519.  PR 2 also ships the 2 s `SAVED → IDLE` auto-fade timer that PR 1 deferred (PR 1 keeps `SAVED → RECORDING` legal as a backup; PR 2's timer is the primary path).
+
+Spec: `docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md` § PR 2.
+
+---
+
+## File map
+
+**Create:** none — both deliverables are extensions of existing files.
+
+**Modify:**
+- `main/ui_orb.h` — new public API: `ui_orb_set_pipeline_state`, `ui_orb_set_pipeline_caption` (internal use), include of `voice_dictation.h`
+- `main/ui_orb.c` — pipeline state field + caption label widget + per-state paint variants + subscriber registration in `ui_orb_create`
+- `main/ui_home.c` — new `s_dictate_chip` widget below `s_mode_chip`, subscriber callback, tap handler firing `voice_start_dictation()`, cancel × handler firing `voice_cancel()`
+- `main/ui_home.h` — no public changes (chip is internal)
+
+**Boundary rules:**
+- The pipeline state takes precedence over voice-state-driven orb painting when pipeline ≠ IDLE.  When pipeline returns to IDLE, the orb reverts to existing voice-state visuals.
+- Both subscribers (orb + chip) run on the LVGL thread (callbacks are fired via `tab5_lv_async_call` because `voice_dictation_set_state` can fire from any task).
+- Strictly additive — no existing voice_state_t / orb visual is removed or changed.
+
+---
+
+## Tasks
+
+### Task 1 — Async-safe pipeline subscriber dispatch helper
+
+The voice_dictation state machine fires callbacks synchronously from whatever task called `set_state` (mic task, WS event task, REST polling task, http server task).  Any LVGL touch from there is a thread-safety hazard.  We need a shared marshalling helper that captures the event + posts an LVGL-safe callback.
+
+**The host test already compiles `main/voice_dictation.c` as pure C with no ESP-IDF deps** (see `tests/host/CMakeLists.txt` → `test_voice_dictation` target).  Adding `#include "ui_core.h"` to voice_dictation.c would break that host build.  So the marshalling wrapper goes in a new file `main/voice_dictation_lvgl.{c,h}` from the start — no conditional path.
+
+**Files:**
+- Create: `main/voice_dictation_lvgl.h`
+- Create: `main/voice_dictation_lvgl.c`
+- Modify: `main/CMakeLists.txt`
+
+- [ ] **Step 1: Create `main/voice_dictation_lvgl.h`**
+
+```c
+/* main/voice_dictation_lvgl.h — LVGL-thread-marshalling wrapper around
+ * voice_dictation_subscribe().  Lives in its own file because pulling
+ * tab5_lv_async_call into voice_dictation.c would break the host test
+ * build (host shims don't cover ui_core.h). */
+#pragma once
+
+#include "voice_dictation.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int voice_dictation_subscribe_lvgl(dict_subscriber_t cb, void *user_data);
+
+#ifdef __cplusplus
+}
+#endif
+```
+
+- [ ] **Step 2: Create `main/voice_dictation_lvgl.c`**
+
+```c
+#include "voice_dictation_lvgl.h"
+
+#include <stdlib.h>
+
+#include "ui_core.h"   /* tab5_lv_async_call */
+
+typedef struct {
+   dict_subscriber_t cb;
+   void             *user_data;
+   dict_event_t      event;
+} dict_marshal_t;
+
+static void dict_marshal_lvgl_cb(void *arg) {
+   dict_marshal_t *m = (dict_marshal_t *)arg;
+   m->cb(&m->event, m->user_data);
+   free(m);
+}
+
+static void dict_marshal_dispatch(const dict_event_t *e, void *user_data) {
+   dict_subscriber_t real_cb = ((void **)user_data)[0];
+   void *real_user_data      = ((void **)user_data)[1];
+   dict_marshal_t *m = malloc(sizeof(*m));
+   if (!m) return;
+   m->cb = real_cb;
+   m->user_data = real_user_data;
+   m->event = *e;
+   tab5_lv_async_call(dict_marshal_lvgl_cb, m);
+}
+
+int voice_dictation_subscribe_lvgl(dict_subscriber_t cb, void *user_data) {
+   if (!cb) return -1;
+   void **tuple = malloc(sizeof(void *) * 2);
+   if (!tuple) return -1;
+   tuple[0] = (void *)cb;
+   tuple[1] = user_data;
+   int h = voice_dictation_subscribe(dict_marshal_dispatch, tuple);
+   if (h < 0) {
+      free(tuple);
+      return -1;
+   }
+   return h;
+}
+```
+
+- [ ] **Step 3: Add to `main/CMakeLists.txt`**
+
+Insert `"voice_dictation_lvgl.c"` immediately after the existing `"voice_dictation.c"` line in the SRCS list.
+
+- [ ] **Step 4: Build + verify**
+
+```bash
+cd /home/rebelforce/projects/TinkerTab
+. /home/rebelforce/esp/esp-idf/export.sh
+idf.py build 2>&1 | tail -5
+```
+
+Expected: clean build.  Also verify host tests still pass:
+
+```bash
+cd /home/rebelforce/projects/TinkerTab/tests/host
+cmake --build build 2>&1 | tail -3
+ctest --test-dir build -R voice_dictation --output-on-failure
+```
+
+Expected: pass (host build never touches voice_dictation_lvgl.c).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/rebelforce/projects/TinkerTab
+git add main/voice_dictation_lvgl.{c,h} main/CMakeLists.txt
+git commit -m "feat(dictation): voice_dictation_subscribe_lvgl marshalling wrapper"
+```
+
+---
+
+### Task 2 — Orb pipeline-state field + public API
+
+**Files:**
+- Modify: `main/ui_orb.h`
+- Modify: `main/ui_orb.c`
+
+- [ ] **Step 1: Add to ui_orb.h before `#ifdef __cplusplus }`**
+
+```c
+/* ── Pipeline state (PR 2) ──────────────────────────────────────────── */
+
+/* Drive the orb's pipeline-state painting.  Takes precedence over the
+ * voice-state machine (IDLE/LISTENING/PROCESSING/SPEAKING) when pipeline
+ * state is anything except DICT_IDLE.  On DICT_IDLE, orb returns to the
+ * voice-state-driven visuals it had before.
+ *
+ * Safe to call only on the LVGL thread — callers using the dictation
+ * pipeline subscriber API should subscribe via voice_dictation_subscribe_lvgl
+ * to get automatic marshalling.
+ *
+ * The `event` is taken by value (caller may pass a stack copy). */
+void ui_orb_set_pipeline_state(const dict_event_t *event);
+
+/* Returns true if the orb is currently in a non-IDLE pipeline state and
+ * thus the voice-state painting is suppressed.  Used by ui_home's
+ * voice-state callback to know whether to skip orb repaints. */
+bool ui_orb_pipeline_active(void);
+```
+
+Add the include at the top of ui_orb.h (after `#include "widget.h"`):
+
+```c
+#include "voice_dictation.h"
+```
+
+- [ ] **Step 2: Add state field + initial paint stub in ui_orb.c**
+
+Find the existing static state block in `ui_orb.c` (search for `static ui_orb_state_t s_state` or similar — should be near the top of the file).  Add:
+
+```c
+/* PR 2: pipeline state overlay.  When != DICT_IDLE, all paint cycles
+ * route through the pipeline-state painter and the voice-state painter
+ * is suppressed.  IDLE → revert to voice-state painting. */
+static dict_event_t s_pipeline = {
+   .state = DICT_IDLE,
+   .fail_reason = DICT_FAIL_NONE,
+   .started_ms = 0,
+   .stopped_ms = 0,
+   .last_change_ms = 0,
+   .note_slot = -1,
+};
+static lv_obj_t *s_orb_caption = NULL;  /* Label below the orb body */
+static lv_timer_t *s_saved_fade_timer = NULL;  /* SAVED → IDLE 2s timer */
+```
+
+Add the include at the top of ui_orb.c:
+
+```c
+#include "voice_dictation.h"
+```
+
+- [ ] **Step 3: Add the API stub**
+
+Add these functions near the end of ui_orb.c, before the file's closing braces:
+
+```c
+void ui_orb_set_pipeline_state(const dict_event_t *event) {
+   if (!event) return;
+   s_pipeline = *event;
+   /* The actual painting is implemented in subsequent tasks (Tasks 3-7
+    * land per-state visuals).  This task just lands the API surface. */
+}
+
+bool ui_orb_pipeline_active(void) {
+   return s_pipeline.state != DICT_IDLE;
+}
+```
+
+- [ ] **Step 4: Build + verify**
+
+```bash
+cd /home/rebelforce/projects/TinkerTab
+. /home/rebelforce/esp/esp-idf/export.sh
+idf.py build 2>&1 | tail -5
+```
+
+Expected: build clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/ui_orb.h main/ui_orb.c
+git commit -m "feat(orb): ui_orb_set_pipeline_state + pipeline_active stubs"
+```
+
+---
+
+### Task 3 — Caption label widget under orb
+
+**Files:**
+- Modify: `main/ui_orb.c`
+
+- [ ] **Step 1: Create the caption label in `ui_orb_create`**
+
+Find `ui_orb_create` in `ui_orb.c`.  Near the bottom of the function, after the body / halo / specular widgets are built, add:
+
+```c
+   /* PR 2: caption label below the orb for pipeline state text
+    * ("● RECORDING 0:23", "UPLOADING…", "TRANSCRIBING…", "✓ Saved").
+    * Sits 24 px below the orb body, transparent background, monospace
+    * caption font.  Hidden by default — paint_for_pipeline_state shows
+    * it. */
+   {
+      /* Orb body radius is the size passed to ui_orb_create.  Caption
+       * sits below it.  Use the existing body radius (whatever the
+       * file's constant is — search for ORB_BODY_RADIUS or similar). */
+      extern int ui_orb_body_radius_px(void);  /* If this helper doesn't
+        exist yet, just inline the magic number here (orb is ~120 px
+        radius per the spec). */
+
+      s_orb_caption = lv_label_create(parent);
+      if (s_orb_caption) {
+         lv_label_set_text(s_orb_caption, "");
+         lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xE8E8EF), 0);
+         lv_obj_set_style_text_font(s_orb_caption, FONT_CAPTION, 0);
+         lv_obj_set_style_text_letter_space(s_orb_caption, 2, 0);
+         lv_obj_align_to(s_orb_caption, s_body, LV_ALIGN_OUT_BOTTOM_MID, 0, 24);
+         lv_obj_add_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
+      }
+   }
+```
+
+If `FONT_CAPTION` isn't already declared in this file's includes, add `#include "config.h"` at the top (matches what ui_home.c uses).
+
+If `ui_orb_body_radius_px()` doesn't exist, just delete the `extern int ui_orb_body_radius_px(void);` line — the `lv_obj_align_to` doesn't need it because it positions relative to `s_body` directly.
+
+- [ ] **Step 2: Destroy the caption in `ui_orb_destroy`**
+
+Find `ui_orb_destroy`.  Add to the cleanup block:
+
+```c
+   if (s_orb_caption) {
+      lv_obj_del(s_orb_caption);
+      s_orb_caption = NULL;
+   }
+   if (s_saved_fade_timer) {
+      lv_timer_del(s_saved_fade_timer);
+      s_saved_fade_timer = NULL;
+   }
+```
+
+- [ ] **Step 3: Build + verify**
+
+```bash
+idf.py build 2>&1 | tail -5
+```
+
+Expected: clean build.  Flash a smoke build to confirm the caption exists but is hidden:
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+sleep 22
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" http://192.168.1.90:8080/screenshot.jpg -o /tmp/orb-task3.jpg
+file /tmp/orb-task3.jpg
+```
+
+The screenshot should look identical to the current home (caption hidden).  If it shows a stray label, the HIDDEN flag isn't being set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/ui_orb.c
+git commit -m "feat(orb): caption label widget below orb (hidden by default)"
+```
+
+---
+
+### Task 4 — Per-state paint variants + caption text
+
+**Files:**
+- Modify: `main/ui_orb.c`
+
+This task lands the visual differences per pipeline state.  We're keeping it tight in PR 2 v1 — body tint + caption + breath rate.  The internal ripple rings + amber arc progress + green pulse animation are deferred to a PR 2.5 polish pass.
+
+**Per-state visuals (this task implements all five):**
+
+| State | Body tint | Caption text |
+|---|---|---|
+| RECORDING | red — `lv_color_hex(0xE74C3C)` | `● RECORDING 0:23` (timer updates every 200 ms) |
+| UPLOADING | amber — `lv_color_hex(0xF59E0B)` | `UPLOADING…` |
+| TRANSCRIBING | amber — `lv_color_hex(0xF59E0B)` | `TRANSCRIBING…` |
+| SAVED | mint green — `lv_color_hex(0x22C55E)` | `✓ Saved` |
+| FAILED | red — `lv_color_hex(0xE74C3C)` | `● {REASON} — tap to retry` |
+
+Reason strings (Failed-state caption substitutes `{REASON}`):
+
+| `dict_fail_t` | Caption substitution |
+|---|---|
+| `DICT_FAIL_AUTH` | `AUTH` |
+| `DICT_FAIL_NETWORK` | `NETWORK` |
+| `DICT_FAIL_EMPTY` | `EMPTY — got silence` |
+| `DICT_FAIL_NO_AUDIO` | `NO AUDIO` |
+| `DICT_FAIL_TOO_LONG` | `TOO LONG (5 min cap)` |
+| `DICT_FAIL_CANCELLED` | `CANCELLED` |
+
+- [ ] **Step 1: Add paint helpers in ui_orb.c**
+
+Insert these static helpers above `ui_orb_set_pipeline_state` (which Task 2 stubbed):
+
+```c
+/* PR 2: paint the orb body in the pipeline-state tint.  Caller is
+ * responsible for setting the caption text + showing the caption label.
+ *
+ * Uses the same body widget that the voice-state painter paints into.
+ * The previous body styling (circadian gradient, etc.) is shadowed by
+ * the solid tint until pipeline returns to IDLE. */
+static void paint_pipeline_body(uint32_t color_hex) {
+   if (!s_body) return;
+   lv_obj_set_style_bg_color(s_body, lv_color_hex(color_hex), 0);
+   /* Keep the radial-gradient luster for depth — only tint, don't go
+    * flat.  The existing body uses LV_GRAD_DIR_VER; preserve. */
+}
+
+static const char *fail_reason_caption(dict_fail_t r) {
+   switch (r) {
+   case DICT_FAIL_AUTH:      return "AUTH";
+   case DICT_FAIL_NETWORK:   return "NETWORK";
+   case DICT_FAIL_EMPTY:     return "EMPTY — got silence";
+   case DICT_FAIL_NO_AUDIO:  return "NO AUDIO";
+   case DICT_FAIL_TOO_LONG:  return "TOO LONG (5 min cap)";
+   case DICT_FAIL_CANCELLED: return "CANCELLED";
+   default:                  return "FAIL";
+   }
+}
+
+static void set_caption_text(const char *text) {
+   if (!s_orb_caption || !text) return;
+   lv_label_set_text(s_orb_caption, text);
+   lv_obj_clear_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
+}
+
+static void hide_caption(void) {
+   if (s_orb_caption) lv_obj_add_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
+}
+
+/* Timer cb for SAVED → IDLE auto-fade (Task 5 schedules this). */
+static void saved_fade_to_idle_cb(lv_timer_t *t) {
+   (void)t;
+   s_saved_fade_timer = NULL;
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE,
+                             (uint32_t)(esp_timer_get_time() / 1000));
+}
+```
+
+If `esp_timer_get_time` isn't already pulled in, add `#include "esp_timer.h"` at the top.
+
+- [ ] **Step 2: Implement the state-driver inside `ui_orb_set_pipeline_state`**
+
+Replace the stub from Task 2 with the real implementation:
+
+```c
+void ui_orb_set_pipeline_state(const dict_event_t *event) {
+   if (!event) return;
+   s_pipeline = *event;
+
+   /* Tear down the SAVED auto-fade timer when leaving SAVED. */
+   if (event->state != DICT_SAVED && s_saved_fade_timer) {
+      lv_timer_del(s_saved_fade_timer);
+      s_saved_fade_timer = NULL;
+   }
+
+   char buf[40];
+   switch (event->state) {
+   case DICT_IDLE:
+      hide_caption();
+      /* Repaint via the voice-state painter so the orb returns to its
+       * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals. */
+      ui_orb_set_state(s_state);
+      return;
+
+   case DICT_RECORDING: {
+      paint_pipeline_body(0xE74C3C);
+      uint32_t dur_ms = (uint32_t)(esp_timer_get_time() / 1000) - event->started_ms;
+      uint32_t s = dur_ms / 1000;
+      snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
+               (unsigned long)(s / 60), (unsigned long)(s % 60));
+      set_caption_text(buf);
+      break;
+   }
+
+   case DICT_UPLOADING:
+      paint_pipeline_body(0xF59E0B);
+      set_caption_text("UPLOADING…");
+      break;
+
+   case DICT_TRANSCRIBING:
+      paint_pipeline_body(0xF59E0B);
+      set_caption_text("TRANSCRIBING…");
+      /* Reuse the existing PROCESSING comet animation for visual
+       * continuity — call into the existing helper.  If the orb's
+       * comet starter doesn't exist as a public/file-local helper,
+       * just call ui_orb_set_state(ORB_STATE_PROCESSING) to engage
+       * the existing PROCESSING visuals AS the underlying state and
+       * let our pipeline paint stack on top. */
+      ui_orb_set_state(ORB_STATE_PROCESSING);
+      break;
+
+   case DICT_SAVED:
+      paint_pipeline_body(0x22C55E);
+      set_caption_text("✓ Saved");
+      /* Schedule auto-fade back to IDLE after 2 s.  Idempotent — if
+       * one already exists (rapid SAVED re-entry), don't stack. */
+      if (!s_saved_fade_timer) {
+         s_saved_fade_timer = lv_timer_create(saved_fade_to_idle_cb, 2000, NULL);
+         if (s_saved_fade_timer) lv_timer_set_repeat_count(s_saved_fade_timer, 1);
+      }
+      break;
+
+   case DICT_FAILED: {
+      paint_pipeline_body(0xE74C3C);
+      snprintf(buf, sizeof(buf), "● %s — tap to retry",
+               fail_reason_caption(event->fail_reason));
+      set_caption_text(buf);
+      break;
+   }
+   }
+}
+```
+
+The variable `s_state` is the existing orb's voice-state field — confirm its name by reading the surrounding code.  Likely candidates: `s_state`, `s_orb_state`, `s_current_state`.
+
+- [ ] **Step 3: Build + verify**
+
+```bash
+idf.py build 2>&1 | tail -8
+```
+
+Expected: clean build.  Likely compile errors at this point:
+- `s_state` / `s_orb_state` — pick the right name
+- `s_body` — confirm name matches whatever the existing orb body widget is called
+- `FONT_CAPTION` — make sure config.h is included
+
+Fix any compile errors with read-and-match against the surrounding file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/ui_orb.c
+git commit -m "feat(orb): paint per-pipeline-state body tint + caption text"
+```
+
+---
+
+### Task 5 — Live caption-timer for RECORDING state
+
+The RECORDING caption shows live elapsed time.  We need a periodic timer to update it.
+
+**Files:**
+- Modify: `main/ui_orb.c`
+
+- [ ] **Step 1: Add a recurring timer + cb**
+
+Add to the static block near the top of ui_orb.c (alongside `s_saved_fade_timer`):
+
+```c
+static lv_timer_t *s_rec_timer_label = NULL;  /* updates RECORDING caption every 200 ms */
+```
+
+Add the timer callback near `saved_fade_to_idle_cb`:
+
+```c
+/* Update the RECORDING caption with live elapsed time.  Stops itself
+ * if the pipeline has left RECORDING (defensive — set_pipeline_state
+ * also tears it down explicitly). */
+static void rec_timer_label_cb(lv_timer_t *t) {
+   (void)t;
+   if (s_pipeline.state != DICT_RECORDING) {
+      if (s_rec_timer_label) { lv_timer_del(s_rec_timer_label); s_rec_timer_label = NULL; }
+      return;
+   }
+   uint32_t dur_ms = (uint32_t)(esp_timer_get_time() / 1000) - s_pipeline.started_ms;
+   uint32_t s = dur_ms / 1000;
+   char buf[40];
+   snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
+            (unsigned long)(s / 60), (unsigned long)(s % 60));
+   if (s_orb_caption) lv_label_set_text(s_orb_caption, buf);
+}
+```
+
+- [ ] **Step 2: Start the timer on entering RECORDING + stop on leaving**
+
+Modify the `DICT_RECORDING` case in `ui_orb_set_pipeline_state` to spawn the timer:
+
+```c
+   case DICT_RECORDING: {
+      paint_pipeline_body(0xE74C3C);
+      uint32_t dur_ms = (uint32_t)(esp_timer_get_time() / 1000) - event->started_ms;
+      uint32_t s = dur_ms / 1000;
+      snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
+               (unsigned long)(s / 60), (unsigned long)(s % 60));
+      set_caption_text(buf);
+      if (!s_rec_timer_label) {
+         s_rec_timer_label = lv_timer_create(rec_timer_label_cb, 200, NULL);
+      }
+      break;
+   }
+```
+
+And in every NON-RECORDING case (DICT_IDLE / DICT_UPLOADING / DICT_TRANSCRIBING / DICT_SAVED / DICT_FAILED) add at the top of the case:
+
+```c
+      if (s_rec_timer_label) { lv_timer_del(s_rec_timer_label); s_rec_timer_label = NULL; }
+```
+
+Cleanest implementation: add the teardown above the switch, then re-create inside the RECORDING case:
+
+```c
+   /* Stop the live-timer if we're leaving RECORDING. */
+   if (event->state != DICT_RECORDING && s_rec_timer_label) {
+      lv_timer_del(s_rec_timer_label);
+      s_rec_timer_label = NULL;
+   }
+```
+
+- [ ] **Step 3: Tear down in ui_orb_destroy**
+
+Add to the cleanup block (alongside the saved-fade timer cleanup from Task 3):
+
+```c
+   if (s_rec_timer_label) {
+      lv_timer_del(s_rec_timer_label);
+      s_rec_timer_label = NULL;
+   }
+```
+
+- [ ] **Step 4: Build + verify**
+
+```bash
+idf.py build 2>&1 | tail -5
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/ui_orb.c
+git commit -m "feat(orb): live elapsed-time caption during RECORDING state"
+```
+
+---
+
+### Task 6 — Orb subscribes to pipeline state machine
+
+**Files:**
+- Modify: `main/ui_orb.c`
+
+- [ ] **Step 1: Add the subscriber callback**
+
+Add near the bottom of ui_orb.c, just before `ui_orb_set_pipeline_state`:
+
+```c
+/* Subscriber bridge: voice_dictation fires this on the LVGL thread
+ * (because we use voice_dictation_subscribe_lvgl in ui_orb_create).
+ * We just forward to the public state-driver. */
+static void orb_pipeline_cb(const dict_event_t *event, void *user_data) {
+   (void)user_data;
+   ui_orb_set_pipeline_state(event);
+}
+```
+
+- [ ] **Step 2: Register in `ui_orb_create`**
+
+Find the end of `ui_orb_create` (just before `return;` or end of function).  Add:
+
+```c
+   /* PR 2: subscribe to the dictation pipeline.  Callbacks land on the
+    * LVGL thread thanks to the _lvgl variant. */
+   static int s_pipeline_sub = -1;
+   if (s_pipeline_sub < 0) {
+      s_pipeline_sub = voice_dictation_subscribe_lvgl(orb_pipeline_cb, NULL);
+   }
+```
+
+(If you used the split-file path from Task 1 Step 4, include `"voice_dictation_lvgl.h"` at the top of ui_orb.c.)
+
+- [ ] **Step 3: Build + flash + verify visually**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+sleep 22
+
+# Trigger a dictation via debug endpoint and watch the orb paint changes:
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" -X POST "http://192.168.1.90:8080/dictation?action=start"
+sleep 1
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" http://192.168.1.90:8080/screenshot.jpg -o /tmp/orb-recording.jpg
+file /tmp/orb-recording.jpg
+echo "captured RECORDING state — orb should be red with caption"
+
+sleep 1
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" -X POST "http://192.168.1.90:8080/dictation?action=stop"
+sleep 3
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" http://192.168.1.90:8080/screenshot.jpg -o /tmp/orb-transcribing.jpg
+echo "captured TRANSCRIBING state — orb should be amber with caption"
+```
+
+Inspect the two JPEGs.  RECORDING screenshot: orb body red, caption "● RECORDING 0:01" or similar.  TRANSCRIBING screenshot: orb body amber, caption "TRANSCRIBING…".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/ui_orb.c
+git commit -m "feat(orb): subscribe to dictation pipeline state machine"
+```
+
+---
+
+### Task 7 — Dictate chip widget on home
+
+**Files:**
+- Modify: `main/ui_home.c`
+
+- [ ] **Step 1: Add the chip widget statics + the create helper**
+
+Search ui_home.c for `s_mode_chip` to find the existing chip widget — match its style exactly.  Add a parallel static block:
+
+```c
+/* PR 2: Dictate chip — sits directly below the mode chip.  Same dark-pill
+ * visual language (thin gray border, monospace, no gradient).  Mirrors
+ * the dictation pipeline state in its label.  Tap → voice_start_dictation. */
+static lv_obj_t *s_dictate_chip = NULL;
+static lv_obj_t *s_dictate_chip_dot = NULL;     /* red breathing dot when IDLE */
+static lv_obj_t *s_dictate_chip_label = NULL;
+static lv_obj_t *s_dictate_chip_hint = NULL;    /* "TAP TO START" / "0:23" */
+static lv_obj_t *s_dictate_chip_icon = NULL;    /* 🎤 / × */
+```
+
+- [ ] **Step 2: Add chip construction inside `ui_home_create_root` (or wherever `s_mode_chip` is created)**
+
+Find where `s_mode_chip` is built.  Immediately after, add:
+
+```c
+   /* PR 2: Dictate chip — same width / height as the mode chip, 12 px below. */
+   s_dictate_chip = lv_obj_create(parent);
+   lv_obj_remove_style_all(s_dictate_chip);
+   lv_obj_set_size(s_dictate_chip, lv_obj_get_width(s_mode_chip), 36);
+   lv_obj_align_to(s_dictate_chip, s_mode_chip, LV_ALIGN_OUT_BOTTOM_MID, 0, 12);
+   lv_obj_set_style_bg_color(s_dictate_chip, lv_color_hex(0x141420), 0);
+   lv_obj_set_style_bg_opa(s_dictate_chip, LV_OPA_COVER, 0);
+   lv_obj_set_style_border_width(s_dictate_chip, 1, 0);
+   lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x262637), 0);
+   lv_obj_set_style_radius(s_dictate_chip, 18, 0);
+   lv_obj_set_style_pad_hor(s_dictate_chip, 14, 0);
+   lv_obj_clear_flag(s_dictate_chip, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(s_dictate_chip, LV_OBJ_FLAG_CLICKABLE);
+
+   /* Red breathing dot (left). */
+   s_dictate_chip_dot = lv_obj_create(s_dictate_chip);
+   lv_obj_remove_style_all(s_dictate_chip_dot);
+   lv_obj_set_size(s_dictate_chip_dot, 10, 10);
+   lv_obj_align(s_dictate_chip_dot, LV_ALIGN_LEFT_MID, 0, 0);
+   lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xE74C3C), 0);
+   lv_obj_set_style_bg_opa(s_dictate_chip_dot, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(s_dictate_chip_dot, LV_RADIUS_CIRCLE, 0);
+   lv_obj_set_style_border_width(s_dictate_chip_dot, 0, 0);
+
+   /* Label "Dictate" (left-mid, after the dot). */
+   s_dictate_chip_label = lv_label_create(s_dictate_chip);
+   lv_label_set_text(s_dictate_chip_label, "Dictate");
+   lv_obj_set_style_text_color(s_dictate_chip_label, lv_color_hex(0xE8E8EF), 0);
+   lv_obj_set_style_text_font(s_dictate_chip_label, FONT_BODY, 0);
+   lv_obj_align(s_dictate_chip_label, LV_ALIGN_LEFT_MID, 18, 0);
+
+   /* Hint "TAP TO START" (right-mid, before the mic icon). */
+   s_dictate_chip_hint = lv_label_create(s_dictate_chip);
+   lv_label_set_text(s_dictate_chip_hint, "TAP TO START");
+   lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0x888888), 0);
+   lv_obj_set_style_text_font(s_dictate_chip_hint, FONT_CAPTION, 0);
+   lv_obj_set_style_text_letter_space(s_dictate_chip_hint, 2, 0);
+   lv_obj_align(s_dictate_chip_hint, LV_ALIGN_RIGHT_MID, -28, 0);
+
+   /* Mic icon (right edge). */
+   s_dictate_chip_icon = lv_label_create(s_dictate_chip);
+   lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_AUDIO);
+   lv_obj_set_style_text_color(s_dictate_chip_icon, lv_color_hex(0xE8E8EF), 0);
+   lv_obj_set_style_text_font(s_dictate_chip_icon, FONT_CAPTION, 0);
+   lv_obj_align(s_dictate_chip_icon, LV_ALIGN_RIGHT_MID, 0, 0);
+```
+
+Match the surrounding ui_home.c style.  If `FONT_BODY` / `FONT_CAPTION` aren't already in scope, add `#include "config.h"`.
+
+- [ ] **Step 3: Build + flash + visual check**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+sleep 22
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" -X POST "http://192.168.1.90:8080/navigate?screen=home"
+sleep 2
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" http://192.168.1.90:8080/screenshot.jpg -o /tmp/home-with-chip.jpg
+echo "home should now show two chips stacked: Local · ON-DEVICE · ⌄ AND ● Dictate · TAP TO START · 🎤"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/ui_home.c
+git commit -m "feat(home): Dictate chip widget below mode chip (visual only)"
+```
+
+---
+
+### Task 8 — Dictate chip tap handler → voice_start_dictation
+
+**Files:**
+- Modify: `main/ui_home.c`
+
+- [ ] **Step 1: Add the tap event callback**
+
+Near other event callbacks in ui_home.c, add:
+
+```c
+/* PR 2: Dictate chip tap.  When chip is in IDLE, starts a dictation;
+ * when in RECORDING (via × icon), cancels via voice_cancel().  Other
+ * states route through the orb's pipeline visuals + ignore taps. */
+static void dictate_chip_tap_cb(lv_event_t *e) {
+   (void)e;
+   dict_event_t dp = voice_dictation_get();
+   if (dp.state == DICT_IDLE) {
+      esp_err_t err = voice_start_dictation();
+      if (err != ESP_OK) {
+         ESP_LOGW("home", "voice_start_dictation failed: %s",
+                  esp_err_to_name(err));
+      }
+   } else if (dp.state == DICT_RECORDING) {
+      /* Cancel — fire voice_cancel + transition pipeline to FAILED(CANCELLED).
+       * The voice_ws_proto.c dictation_cancelled handler will pick up the
+       * Dragon-side ack; we drive the local pipeline immediately so the UI
+       * is responsive. */
+      voice_cancel();
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED,
+                                (uint32_t)(esp_timer_get_time() / 1000));
+   }
+   /* UPLOADING / TRANSCRIBING / SAVED / FAILED states: tap is a no-op for
+    * v1.  Future polish: tap FAILED to retry, tap SAVED to dismiss early. */
+}
+```
+
+Add the include at the top of ui_home.c (if not already present):
+
+```c
+#include "voice_dictation.h"
+#include "voice.h"  /* voice_start_dictation / voice_cancel — likely already there */
+```
+
+- [ ] **Step 2: Wire the event handler**
+
+Inside the chip-construction block (Task 7), after `s_dictate_chip` is built:
+
+```c
+   lv_obj_add_event_cb(s_dictate_chip, dictate_chip_tap_cb, LV_EVENT_CLICKED, NULL);
+```
+
+- [ ] **Step 3: Build + flash + live tap test**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+sleep 22
+
+# Tap the chip via touch coords.  Chip is below the mode chip; touch
+# y coord depends on the exact layout.  Estimate based on the home
+# screenshot from Task 7 — approx (360, 750) on a 720×1280 portrait.
+# Confirm exact y by reading the screenshot first.
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST http://192.168.1.90:8080/touch \
+     -d '{"x":360,"y":760,"action":"tap"}'
+
+sleep 2
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/dictation_pipeline | python3 -m json.tool
+```
+
+Expected: state transitions to RECORDING.  Voice is now hot.  Wait a few seconds, then stop:
+
+```bash
+sleep 3
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/recording-live.jpg
+echo "should see orb red + caption RECORDING N:NN + chip is now in RECORDING state too"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/ui_home.c
+git commit -m "feat(home): Dictate chip tap fires voice_start_dictation"
+```
+
+---
+
+### Task 9 — Dictate chip subscribes to pipeline (mirror orb state)
+
+**Files:**
+- Modify: `main/ui_home.c`
+
+- [ ] **Step 1: Add the chip's pipeline subscriber callback**
+
+Add near `dictate_chip_tap_cb`:
+
+```c
+/* PR 2: keep the Dictate chip's label / hint / icon in sync with the
+ * dictation pipeline state.  Mirrors the orb's heroic painting at a
+ * compact scale. */
+static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data) {
+   (void)user_data;
+   if (!s_dictate_chip || !s_dictate_chip_label ||
+       !s_dictate_chip_hint || !s_dictate_chip_icon ||
+       !s_dictate_chip_dot) {
+      return;
+   }
+
+   /* Default styling = IDLE.  Each state below mutates from here. */
+   lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x262637), 0);
+   lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xE74C3C), 0);
+
+   char buf[40];
+   switch (event->state) {
+   case DICT_IDLE:
+      lv_label_set_text(s_dictate_chip_label, "Dictate");
+      lv_label_set_text(s_dictate_chip_hint,  "TAP TO START");
+      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0x888888), 0);
+      lv_label_set_text(s_dictate_chip_icon,  LV_SYMBOL_AUDIO);
+      break;
+
+   case DICT_RECORDING: {
+      uint32_t dur_ms = (uint32_t)(esp_timer_get_time() / 1000) - event->started_ms;
+      uint32_t s = dur_ms / 1000;
+      snprintf(buf, sizeof(buf), "%lu:%02lu",
+               (unsigned long)(s / 60), (unsigned long)(s % 60));
+      lv_label_set_text(s_dictate_chip_label, "RECORDING");
+      lv_label_set_text(s_dictate_chip_hint,  buf);
+      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
+      lv_label_set_text(s_dictate_chip_icon,  LV_SYMBOL_CLOSE);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+      break;
+   }
+
+   case DICT_UPLOADING:
+      lv_label_set_text(s_dictate_chip_label, "UPLOADING");
+      lv_label_set_text(s_dictate_chip_hint,  "");
+      lv_label_set_text(s_dictate_chip_icon,  LV_SYMBOL_UPLOAD);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
+      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
+      break;
+
+   case DICT_TRANSCRIBING:
+      lv_label_set_text(s_dictate_chip_label, "TRANSCRIBING");
+      lv_label_set_text(s_dictate_chip_hint,  "");
+      lv_label_set_text(s_dictate_chip_icon,  LV_SYMBOL_REFRESH);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
+      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
+      break;
+
+   case DICT_SAVED:
+      lv_label_set_text(s_dictate_chip_label, "Saved");
+      lv_label_set_text(s_dictate_chip_hint,  "");
+      lv_label_set_text(s_dictate_chip_icon,  LV_SYMBOL_OK);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x22C55E), 0);
+      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0x22C55E), 0);
+      break;
+
+   case DICT_FAILED:
+      lv_label_set_text(s_dictate_chip_label, "FAILED");
+      lv_label_set_text(s_dictate_chip_hint,  "TAP TO RETRY");
+      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
+      lv_label_set_text(s_dictate_chip_icon,  LV_SYMBOL_REFRESH);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+      break;
+   }
+}
+```
+
+- [ ] **Step 2: Register the subscriber inside `ui_home_create_root` (or wherever the home is built)**
+
+Just before the home create function returns (or at the end of the chip-build block), add:
+
+```c
+   /* PR 2: subscribe the chip to the dictation pipeline.  LVGL-thread
+    * marshalling handled by the _lvgl variant. */
+   static int s_dictate_chip_sub = -1;
+   if (s_dictate_chip_sub < 0) {
+      s_dictate_chip_sub = voice_dictation_subscribe_lvgl(dictate_chip_pipeline_cb, NULL);
+   }
+```
+
+Add the include for `voice_dictation_subscribe_lvgl` (either `voice_dictation.h` if Task 1 Step 2 went in-file, or `voice_dictation_lvgl.h` if Task 1 Step 4 split it).
+
+- [ ] **Step 3: Live tap-cycle verification**
+
+```bash
+idf.py build 2>&1 | tail -5
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -3
+sleep 22
+
+# 1. Capture IDLE chip state
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST http://192.168.1.90:8080/navigate?screen=home -o /dev/null
+sleep 1
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/chip-idle.jpg
+
+# 2. Tap to start, capture RECORDING state
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST http://192.168.1.90:8080/touch \
+     -d '{"x":360,"y":760,"action":"tap"}'
+sleep 2
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/chip-recording.jpg
+
+# 3. Stop via debug endpoint, capture TRANSCRIBING state
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST "http://192.168.1.90:8080/dictation?action=stop"
+sleep 1
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/chip-transcribing.jpg
+
+ls -la /tmp/chip-*.jpg
+echo "three screenshots — chip-idle should show Dictate / TAP TO START / 🎤;"
+echo "chip-recording should show RECORDING / 0:01 / × in red;"
+echo "chip-transcribing should show TRANSCRIBING / / 🔄 in amber."
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/ui_home.c
+git commit -m "feat(home): Dictate chip subscribes to pipeline + mirrors state"
+```
+
+---
+
+### Task 10 — Format gate + smoke test under real dictation cycle
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Format gate**
+
+```bash
+cd /home/rebelforce/projects/TinkerTab
+git fetch origin main:refs/remotes/origin/main
+git-clang-format --binary clang-format-18 --diff origin/main \
+   main/voice_dictation.{c,h} main/ui_orb.{c,h} main/ui_home.c \
+   $( [ -f main/voice_dictation_lvgl.c ] && echo "main/voice_dictation_lvgl.{c,h}" )
+```
+
+If non-empty, run without `--diff` to autofix:
+
+```bash
+git-clang-format --binary clang-format-18 origin/main
+git add -u
+git commit --amend --no-edit
+```
+
+- [ ] **Step 2: Live end-to-end happy path**
+
+```bash
+# Should be a clean home — capture baseline
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST http://192.168.1.90:8080/navigate?screen=home -o /dev/null
+sleep 1
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/pr2-home-idle.jpg
+
+# Trigger via chip tap
+curl -s -m 5 -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST http://192.168.1.90:8080/touch \
+     -d '{"x":360,"y":760,"action":"tap"}'
+
+# Capture each state at ~0.5 s, 2 s, 5 s
+sleep 1
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/pr2-recording.jpg
+
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     -X POST "http://192.168.1.90:8080/dictation?action=stop"
+
+sleep 2
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/pr2-transcribing.jpg
+
+sleep 5
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/screenshot.jpg -o /tmp/pr2-saved-or-back-to-idle.jpg
+
+ls -la /tmp/pr2-*.jpg
+```
+
+Visually verify the four screenshots show: IDLE chip, red orb + RECORDING chip + caption, amber orb + TRANSCRIBING chip + caption, green orb + SAVED chip + caption (or already back to IDLE if Dragon's summary was fast).
+
+- [ ] **Step 3: Live failure-path verify (tap during recording → CANCEL)**
+
+```bash
+# Tap to start
+curl -s -X POST -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/touch -d '{"x":360,"y":760,"action":"tap"}'
+sleep 2
+# Tap again (× icon should now be active)
+curl -s -X POST -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/touch -d '{"x":360,"y":760,"action":"tap"}'
+sleep 1
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/dictation_pipeline | python3 -m json.tool
+```
+
+Expected: state shows FAILED with reason CANCELLED, then (after 2 s if SAVED fade timer reaches it... wait, FAILED has no auto-fade in v1) sits at FAILED with the chip showing "TAP TO RETRY".
+
+Tap once more — should retry / restart.  Confirm state goes back to RECORDING.
+
+- [ ] **Step 4: Heap stability**
+
+```bash
+curl -s -H "Authorization: Bearer 05eed3b13bf62d92cfd8ac424438b9f2" \
+     http://192.168.1.90:8080/heap | python3 -m json.tool | head -12
+```
+
+Expected: internal free > 80 KB, no fragmentation alarm, LVGL pool free > 1.5 MB.
+
+- [ ] **Step 5: Update memory**
+
+Update the `project_dictation_pipeline_redesign_2026_05_14.md` memory file's "Status" section to reflect PR 2 landed + the visible-on-device changes.
+
+---
+
+### Task 11 — Push + open PR
+
+**Files:** none (operational).
+
+- [ ] **Step 1: Final format check**
+
+```bash
+git-clang-format --binary clang-format-18 --diff origin/main
+```
+
+Expected: `clang-format did not modify any files`.
+
+- [ ] **Step 2: File the issue**
+
+```bash
+gh issue create --title "PR 2 of 4: orb morphs + Dictate chip on home (visible UI starts here)" \
+  --body "PR 2 of the dictation pipeline visibility design (#518 / spec at docs/superpowers/specs/2026-05-14-dictation-pipeline-notes-redesign-design.md). First PR in the series where the home screen visibly changes.
+
+## What lands
+- Orb morphs through pipeline states (RECORDING red / UPLOADING amber / TRANSCRIBING amber+comet / SAVED green / FAILED red) with caption text + live timer
+- New Dictate chip below mode chip on home — dark pill, mode-chip language, no gradient
+- Chip tap → voice_start_dictation; tap during recording → voice_cancel
+- Both subscribers (orb + chip) run on the LVGL thread via voice_dictation_subscribe_lvgl
+- SAVED → IDLE 2 s auto-fade timer (PR 1 deferred; lands here)
+
+## Out of scope (filed as v1.5 polish)
+- Internal ripple rings during RECORDING (current: solid red tint)
+- Amber arc fill animation during UPLOADING (current: solid amber tint)
+- Body breath rate variation per state (current: existing IDLE breath)
+- Halo color changes per state (current: unchanged from voice-state)"
+```
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin feat/dictation-pipeline-pr2
+
+gh pr create --title "feat(dictation): orb morphs + Dictate chip on home (PR 2 of 4)" \
+  --body "## Summary
+- First visible UI change in the dictation pipeline series.
+- Orb takes precedence over voice-state painting when pipeline state ≠ IDLE; reverts cleanly on IDLE.
+- Dictate chip below mode chip — matches existing mode-chip language (dark pill, thin border, monospace).
+- Chip + orb both subscribe to the voice_dictation state machine that landed in #519.
+- New voice_dictation_subscribe_lvgl marshalling wrapper for LVGL-thread-safe subscribers.
+- SAVED → IDLE 2 s auto-fade timer that PR 1 deferred.
+
+Builds on #519 (state machine + /dictation_pipeline endpoint).  Sets up PR 3 (Notes Timeline) which subscribes the Notes-screen processing row to the same pipeline.
+
+## Test plan
+- [x] idf.py build clean, no warnings
+- [x] git-clang-format --diff origin/main clean
+- [x] Live on Tab5 192.168.1.90:
+  - Chip tap → orb morphs RECORDING → TRANSCRIBING → SAVED → IDLE
+  - Chip mirrors orb state in real time (label, hint, icon, border color)
+  - Live elapsed-time counter during RECORDING updates every 200 ms
+  - Cancel via second chip tap during RECORDING transitions to FAILED(CANCELLED) → chip shows TAP TO RETRY → retry tap restarts cycle
+- [x] No PANIC, heap stable
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 4: Mark complete**
+
+Edit `~/.claude/projects/-home-rebelforce/memory/MEMORY.md` and the project memory file with the PR number once `gh pr create` returns.
+
+---
+
+## Acceptance summary
+
+When all 11 tasks land:
+
+- [ ] `voice_dictation_subscribe_lvgl()` available (either in voice_dictation.{c,h} or in voice_dictation_lvgl.{c,h})
+- [ ] `ui_orb_set_pipeline_state()` API published + implemented in ui_orb.c
+- [ ] Orb morphs through all 5 pipeline states (RECORDING / UPLOADING / TRANSCRIBING / SAVED / FAILED) with appropriate body tint + caption text
+- [ ] Live elapsed-time counter on RECORDING caption (200 ms update cadence)
+- [ ] SAVED auto-fades back to IDLE after 2 s via lv_timer
+- [ ] Dictate chip widget below mode chip on home, matching mode-chip visual language
+- [ ] Chip tap fires voice_start_dictation
+- [ ] Chip × tap during RECORDING fires voice_cancel + drives pipeline to FAILED(CANCELLED)
+- [ ] Chip mirrors pipeline state in label / hint / icon / border color
+- [ ] Format gate green, target build clean, no new warnings
+- [ ] Live e2e cycle visually verified on Tab5 across all 5 pipeline states
+- [ ] PR open + linked to issue, memory updated
+
+PR 3 (Notes Timeline) gets its own plan once this lands and is user-verified.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
     idf_component_register(
         SRCS "main.c"
              "sdcard.c" "wifi.c"
-             "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_dictation.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "voice_messages_sync.c" "mode_manager.c"
+             "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_dictation.c" "voice_dictation_lvgl.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "voice_messages_sync.c" "mode_manager.c"
              "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"

--- a/main/main.c
+++ b/main/main.c
@@ -112,10 +112,17 @@ static void deferred_overlay_init_cb(lv_timer_t *t)
      * Runs after voice_init() (which ui_voice_init wraps) so the worker
      * queue + voice state machine are up. */
     voice_solo_init();
-    /* PR 1: dictation pipeline state machine.  Idempotent; subscribers
-     * register lazily once their owning screen / surface is created.
-     * Must run after voice_init since transitions are driven from voice.c. */
-    voice_dictation_init();
+    /* PR 1: dictation pipeline state machine — moved to early app_main
+     * (before ui_home_create) so subscribers registered during
+     * ui_orb_create / ui_home_create survive.  Keeping a sanity call
+     * here is harmless (init wipes s_subs by design for host test
+     * compatibility; if anyone re-runs it after subscribers register,
+     * subscriptions are lost).  Belt-and-suspenders: the call below
+     * is a NOP for the lock (already created in early init) and clears
+     * s_event back to DICT_IDLE — but there are no subscribers yet
+     * at this stage in the deferred callback, so the wipe is empty. */
+    /* voice_dictation_init() intentionally NOT called here — see early
+     * init in app_main(). */
     /* TT #328 Wave 10 — persistent floating home button on lv_layer_top.
      * Hidden by default; non-home screens toggle it via
      * ui_chrome_set_home_visible(true) on show, (false) on destroy. */
@@ -553,6 +560,13 @@ void app_main(void)
         tab5_ui_lock();
         ui_splash_destroy();
         ui_theme_init();  // must run before any screen that uses TH_* styles
+        /* PR 2 / dictation pipeline: init the state machine + mutex BEFORE
+         * any UI module that subscribes during create (ui_home_create →
+         * ui_orb_create + the chip subscribe in ui_home).  Keeping init in
+         * the deferred LVGL callback wiped any already-registered subscribers
+         * at the 100 ms timer tick.  Init is mutex-only here; no LVGL deps. */
+        extern void voice_dictation_init(void);
+        voice_dictation_init();
         extern void widget_store_init(void);
         widget_store_init();  // widget platform — bounded PSRAM cache
         extern void chat_store_init(void);

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -180,11 +180,11 @@ static lv_obj_t *s_mode_sub        = NULL;  /* "LOCAL + CLOUD" */
  * gradient).  Mirrors the dictation pipeline state in its label / hint /
  * icon / border colour.  Tap → voice_start_dictation (in IDLE) or
  * voice_cancel (in RECORDING) — wired in Tasks 8-9. */
-static lv_obj_t *s_dictate_chip       = NULL;
-static lv_obj_t *s_dictate_chip_dot   = NULL; /* breathing dot, left edge */
+static lv_obj_t *s_dictate_chip = NULL;
+static lv_obj_t *s_dictate_chip_dot = NULL;   /* breathing dot, left edge */
 static lv_obj_t *s_dictate_chip_label = NULL; /* "Dictate" / "RECORDING" / etc. */
-static lv_obj_t *s_dictate_chip_hint  = NULL; /* "TAP TO START" / "0:23" / etc. */
-static lv_obj_t *s_dictate_chip_icon  = NULL; /* 🎤 / × / 🔄 / ✓ */
+static lv_obj_t *s_dictate_chip_hint = NULL;  /* "TAP TO START" / "0:23" / etc. */
+static lv_obj_t *s_dictate_chip_icon = NULL;  /* 🎤 / × / 🔄 / ✓ */
 
 /* Now-slot card (widget live target + empty-state) */
 static lv_obj_t *s_now_card        = NULL;
@@ -843,8 +843,8 @@ lv_obj_t *ui_home_create(void)
      * so a screen recreate cycle doesn't double-subscribe. */
     static int s_dictate_chip_sub = -1;
     if (s_dictate_chip_sub < 0) {
-        s_dictate_chip_sub = voice_dictation_subscribe_lvgl(dictate_chip_pipeline_cb, NULL);
-        ESP_LOGI(TAG, "Dictate chip subscriber registered handle=%d", s_dictate_chip_sub);
+       s_dictate_chip_sub = voice_dictation_subscribe_lvgl(dictate_chip_pipeline_cb, NULL);
+       ESP_LOGI(TAG, "Dictate chip subscriber registered handle=%d", s_dictate_chip_sub);
     }
 
     /* TT #511 wave-1.6 (change B): now-card killed from idle.
@@ -1999,8 +1999,7 @@ static void dictate_chip_tap_cb(lv_event_t *e) {
       }
    } else if (dp.state == DICT_RECORDING) {
       voice_cancel();
-      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED,
-                                (uint32_t)(esp_timer_get_time() / 1000));
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED, (uint32_t)(esp_timer_get_time() / 1000));
    }
 }
 
@@ -2010,8 +2009,8 @@ static void dictate_chip_tap_cb(lv_event_t *e) {
 static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data) {
    (void)user_data;
    if (!event) return;
-   if (!s_dictate_chip || !s_dictate_chip_label || !s_dictate_chip_hint ||
-       !s_dictate_chip_icon || !s_dictate_chip_dot) {
+   if (!s_dictate_chip || !s_dictate_chip_label || !s_dictate_chip_hint || !s_dictate_chip_icon ||
+       !s_dictate_chip_dot) {
       return;
    }
 
@@ -2021,60 +2020,57 @@ static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data)
 
    char buf[40];
    switch (event->state) {
-   case DICT_IDLE:
-      lv_label_set_text(s_dictate_chip_label, "Dictate");
-      lv_label_set_text(s_dictate_chip_hint, "TAP TO START");
-      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(TH_TEXT_DIM), 0);
-      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_AUDIO);
-      break;
+      case DICT_IDLE:
+         lv_label_set_text(s_dictate_chip_label, "Dictate");
+         lv_label_set_text(s_dictate_chip_hint, "TAP TO START");
+         lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(TH_TEXT_DIM), 0);
+         lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_AUDIO);
+         break;
 
-   case DICT_RECORDING: {
-      uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
-      uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms)
-                          ? (now_ms - event->started_ms)
-                          : 0;
-      uint32_t s = dur_ms / 1000;
-      snprintf(buf, sizeof(buf), "%lu:%02lu", (unsigned long)(s / 60),
-               (unsigned long)(s % 60));
-      lv_label_set_text(s_dictate_chip_label, "RECORDING");
-      lv_label_set_text(s_dictate_chip_hint, buf);
-      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
-      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_CLOSE);
-      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
-      break;
-   }
+      case DICT_RECORDING: {
+         uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+         uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
+         uint32_t s = dur_ms / 1000;
+         snprintf(buf, sizeof(buf), "%lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
+         lv_label_set_text(s_dictate_chip_label, "RECORDING");
+         lv_label_set_text(s_dictate_chip_hint, buf);
+         lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
+         lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_CLOSE);
+         lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+         break;
+      }
 
-   case DICT_UPLOADING:
-      lv_label_set_text(s_dictate_chip_label, "UPLOADING");
-      lv_label_set_text(s_dictate_chip_hint, "");
-      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_UPLOAD);
-      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
-      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
-      break;
+      case DICT_UPLOADING:
+         lv_label_set_text(s_dictate_chip_label, "UPLOADING");
+         lv_label_set_text(s_dictate_chip_hint, "");
+         lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_UPLOAD);
+         lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
+         lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
+         break;
 
-   case DICT_TRANSCRIBING:
-      lv_label_set_text(s_dictate_chip_label, "TRANSCRIBING");
-      lv_label_set_text(s_dictate_chip_hint, "");
-      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_REFRESH);
-      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
-      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
-      break;
+      case DICT_TRANSCRIBING:
+         lv_label_set_text(s_dictate_chip_label, "TRANSCRIBING");
+         lv_label_set_text(s_dictate_chip_hint, "");
+         lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_REFRESH);
+         lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
+         lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
+         break;
 
-   case DICT_SAVED:
-      lv_label_set_text(s_dictate_chip_label, "Saved");
-      lv_label_set_text(s_dictate_chip_hint, "");
-      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_OK);
-      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x22C55E), 0);
-      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0x22C55E), 0);
-      break;
+      case DICT_SAVED:
+         lv_label_set_text(s_dictate_chip_label, "Saved");
+         lv_label_set_text(s_dictate_chip_hint, "");
+         lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_OK);
+         lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x22C55E), 0);
+         lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0x22C55E), 0);
+         break;
 
-   case DICT_FAILED:
-      lv_label_set_text(s_dictate_chip_label, "FAILED");
-      lv_label_set_text(s_dictate_chip_hint, "TAP TO RETRY");
-      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
-      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_REFRESH);
-      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
-      break;
+      case DICT_FAILED:
+         lv_label_set_text(s_dictate_chip_label, "FAILED");
+         lv_label_set_text(s_dictate_chip_hint, "TAP TO RETRY");
+         lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
+         lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_REFRESH);
+         lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+         break;
    }
 }
 

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -257,6 +257,10 @@ static void mode_chip_click_cb(lv_event_t *e); /* TT #370 */
 /* PR 2: Dictate chip tap + pipeline subscriber. */
 static void dictate_chip_tap_cb(lv_event_t *e);
 static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data);
+/* PR 2 polish: chrome-fade forward decls (used by chip subscriber). */
+static void chrome_fade_anim_cb(void *obj, int32_t v);
+#define CHROME_DIM_OPA 0
+#define CHROME_FULL_OPA 255
 /* U19 (#206): rail callbacks removed with the rail itself. */
 static bool any_overlay_visible(void);
 static void show_toast_internal(const char *text);
@@ -1734,6 +1738,16 @@ static void orb_click_cb(lv_event_t *e)
         ui_home_show_toast("Reconnecting to Dragon… try again in a moment.");
         return;
     }
+    /* PR 2 polish: tapping the orb to Ask should always start clean.
+     * If a previous dictation left the pipeline in a transient terminal
+     * state (FAILED/SAVED), reset it to IDLE so the orb's Ask visuals
+     * aren't shadowed by stale "CANCELLED · TAP TO RETRY" text. */
+    dict_event_t pe = voice_dictation_get();
+    if (pe.state == DICT_FAILED || pe.state == DICT_SAVED) {
+       voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE,
+                                  (uint32_t)(esp_timer_get_time() / 1000));
+    }
+
     ui_voice_show();
     voice_start_listening();
 }
@@ -2050,6 +2064,24 @@ static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data)
    if (event->state != DICT_RECORDING && s_dictate_chip_rec_t) {
       lv_timer_del(s_dictate_chip_rec_t);
       s_dictate_chip_rec_t = NULL;
+   }
+
+   /* PR 2 polish: pipeline non-IDLE → force chip fully visible even if
+    * the chrome fade dimmed it during voice-active.  IDLE → let normal
+    * fade rules apply. */
+   if (event->state != DICT_IDLE) {
+      lv_anim_delete(s_dictate_chip, chrome_fade_anim_cb);
+      lv_obj_set_style_opa(s_dictate_chip, CHROME_FULL_OPA, LV_PART_MAIN);
+   } else {
+      voice_state_t vs = voice_get_state();
+      bool voice_active = (vs == VOICE_STATE_LISTENING || vs == VOICE_STATE_PROCESSING || vs == VOICE_STATE_SPEAKING);
+      if (voice_active) {
+         lv_anim_delete(s_dictate_chip, chrome_fade_anim_cb);
+         lv_obj_set_style_opa(s_dictate_chip, CHROME_DIM_OPA, LV_PART_MAIN);
+      } else {
+         lv_anim_delete(s_dictate_chip, chrome_fade_anim_cb);
+         lv_obj_set_style_opa(s_dictate_chip, CHROME_FULL_OPA, LV_PART_MAIN);
+      }
    }
 
    /* Default styling = IDLE.  Per-state branches mutate from this base. */
@@ -3108,15 +3140,9 @@ static void chrome_fade_anim_cb(void *obj, int32_t v) {
 }
 
 /* TT #511 wave-1.5: chrome fades to FULLY invisible (not dim) during
- * voice.  Tried opa=50 first — home's s_state_word ("listening" /
- * "thinking" / "speaking" — see ui_home_update_status state_hint
- * switch) overlapped at the same y as the voice overlay's own text
- * labels ("I'm here. Go.", thinking dots, "speaking…").  Same for
- * s_greet_line vs the overlay caption.  Fully hiding the home chrome
- * is the cleaner fix: the orb stays at center, status bar stays at
- * top, voice overlay text floats over an otherwise-empty home. */
-#define CHROME_DIM_OPA 0
-#define CHROME_FULL_OPA 255
+ * voice.  CHROME_DIM_OPA / CHROME_FULL_OPA defined near the top of the
+ * file (PR 2 polish forward decls) so the chip-subscriber can reference
+ * them without ordering games. */
 #define CHROME_FADE_MS 250
 
 static void chrome_fade_to(lv_obj_t *obj, int target) {
@@ -3140,6 +3166,14 @@ static void ui_home_chrome_fade(bool voice_active) {
    chrome_fade_to(s_mode_chip, target);
    chrome_fade_to(s_now_card, target);
    chrome_fade_to(s_say_pill, target);
+   /* PR 2 polish: also fade the Dictate chip during regular Ask listening
+    * — otherwise the voice overlay's red stop button at y=750 collides
+    * with the chip at y=762 and the user can't tell which to tap.  But
+    * during a dictation pipeline (RECORDING / UPLOADING / TRANSCRIBING /
+    * SAVED / FAILED) we WANT the chip visible — it acts as the cancel
+    * affordance + state mirror.  Override the fade target accordingly. */
+   int chip_target = (voice_active && !ui_orb_pipeline_active()) ? CHROME_DIM_OPA : CHROME_FULL_OPA;
+   chrome_fade_to(s_dictate_chip, chip_target);
 }
 
 void ui_home_orb_aliveness_sync(void) {

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -181,11 +181,11 @@ static lv_obj_t *s_mode_sub        = NULL;  /* "LOCAL + CLOUD" */
  * icon / border colour.  Tap → voice_start_dictation (in IDLE) or
  * voice_cancel (in RECORDING) — wired in Tasks 8-9. */
 static lv_obj_t *s_dictate_chip = NULL;
-static lv_obj_t *s_dictate_chip_dot = NULL;   /* breathing dot, left edge */
-static lv_obj_t *s_dictate_chip_label = NULL; /* "Dictate" / "RECORDING" / etc. */
-static lv_obj_t *s_dictate_chip_hint = NULL;  /* "TAP TO START" / "0:23" / etc. */
+static lv_obj_t *s_dictate_chip_dot = NULL;     /* breathing dot, left edge */
+static lv_obj_t *s_dictate_chip_label = NULL;   /* "Dictate" / "RECORDING" / etc. */
+static lv_obj_t *s_dictate_chip_hint = NULL;    /* "TAP TO START" / "0:23" / etc. */
 static lv_timer_t *s_dictate_chip_rec_t = NULL; /* PR 2 polish: ticks chip hint M:SS during RECORDING */
-static lv_obj_t *s_dictate_chip_icon = NULL;  /* 🎤 / × / 🔄 / ✓ */
+static lv_obj_t *s_dictate_chip_icon = NULL;    /* 🎤 / × / 🔄 / ✓ */
 
 /* Now-slot card (widget live target + empty-state) */
 static lv_obj_t *s_now_card        = NULL;
@@ -1744,8 +1744,7 @@ static void orb_click_cb(lv_event_t *e)
      * aren't shadowed by stale "CANCELLED · TAP TO RETRY" text. */
     dict_event_t pe = voice_dictation_get();
     if (pe.state == DICT_FAILED || pe.state == DICT_SAVED) {
-       voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE,
-                                  (uint32_t)(esp_timer_get_time() / 1000));
+       voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
     }
 
     ui_voice_show();

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -173,6 +173,17 @@ static lv_obj_t *s_mode_dot        = NULL;
 static lv_obj_t *s_mode_name       = NULL;  /* "Hybrid" */
 static lv_obj_t *s_mode_sub        = NULL;  /* "LOCAL + CLOUD" */
 
+/* PR 2: Dictate chip — sits directly below the mode chip.  Same dark-pill
+ * visual language (thin gray border, mode-chip-matched corner radius, no
+ * gradient).  Mirrors the dictation pipeline state in its label / hint /
+ * icon / border colour.  Tap → voice_start_dictation (in IDLE) or
+ * voice_cancel (in RECORDING) — wired in Tasks 8-9. */
+static lv_obj_t *s_dictate_chip       = NULL;
+static lv_obj_t *s_dictate_chip_dot   = NULL; /* breathing dot, left edge */
+static lv_obj_t *s_dictate_chip_label = NULL; /* "Dictate" / "RECORDING" / etc. */
+static lv_obj_t *s_dictate_chip_hint  = NULL; /* "TAP TO START" / "0:23" / etc. */
+static lv_obj_t *s_dictate_chip_icon  = NULL; /* 🎤 / × / 🔄 / ✓ */
+
 /* Now-slot card (widget live target + empty-state) */
 static lv_obj_t *s_now_card        = NULL;
 static lv_obj_t *s_now_accent      = NULL;  /* 140×3 amber bar top-left */
@@ -766,6 +777,57 @@ lv_obj_t *ui_home_create(void)
      * far — user wanted at-a-glance visibility of current voice mode
      * without having to remember + long-press to open the sheet.
      * The chip stays clickable and opens the mode sheet on tap. */
+
+    /* PR 2: Dictate chip — sits 12 px below the mode chip, matching its
+     * width and dark-pill visual language.  Three label children + a
+     * breathing dot.  Wave Tasks 8-9 wire the tap handler + a pipeline
+     * subscriber that mutates label / hint / icon / border on every
+     * dict_event_t.  Visually only here — chip is functional as soon as
+     * Task 8 adds dictate_chip_tap_cb. */
+    s_dictate_chip = lv_obj_create(s_screen);
+    lv_obj_remove_style_all(s_dictate_chip);
+    lv_obj_set_size(s_dictate_chip, lv_obj_get_width(s_mode_chip), 36);
+    lv_obj_align_to(s_dictate_chip, s_mode_chip, LV_ALIGN_OUT_BOTTOM_MID, 0, 12);
+    lv_obj_set_style_bg_color(s_dictate_chip, lv_color_hex(TH_CARD_ELEVATED), 0);
+    lv_obj_set_style_bg_opa(s_dictate_chip, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(s_dictate_chip, 18, 0);
+    lv_obj_set_style_border_width(s_dictate_chip, 1, 0);
+    lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x262637), 0);
+    lv_obj_set_style_pad_hor(s_dictate_chip, 14, 0);
+    lv_obj_clear_flag(s_dictate_chip, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_dictate_chip, LV_OBJ_FLAG_CLICKABLE);
+
+    /* Red breathing dot at the left edge — colour shifts with pipeline state. */
+    s_dictate_chip_dot = lv_obj_create(s_dictate_chip);
+    lv_obj_remove_style_all(s_dictate_chip_dot);
+    lv_obj_set_size(s_dictate_chip_dot, 10, 10);
+    lv_obj_align(s_dictate_chip_dot, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xE74C3C), 0);
+    lv_obj_set_style_bg_opa(s_dictate_chip_dot, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(s_dictate_chip_dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_border_width(s_dictate_chip_dot, 0, 0);
+
+    /* Label — "Dictate" in IDLE, mutates per pipeline state. */
+    s_dictate_chip_label = lv_label_create(s_dictate_chip);
+    lv_label_set_text(s_dictate_chip_label, "Dictate");
+    lv_obj_set_style_text_color(s_dictate_chip_label, lv_color_hex(TH_TEXT_PRIMARY), 0);
+    lv_obj_set_style_text_font(s_dictate_chip_label, FONT_BODY, 0);
+    lv_obj_align(s_dictate_chip_label, LV_ALIGN_LEFT_MID, 18, 0);
+
+    /* Hint — "TAP TO START" / "0:23" / "TAP TO RETRY" — right side, dim. */
+    s_dictate_chip_hint = lv_label_create(s_dictate_chip);
+    lv_label_set_text(s_dictate_chip_hint, "TAP TO START");
+    lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(TH_TEXT_DIM), 0);
+    lv_obj_set_style_text_font(s_dictate_chip_hint, FONT_CAPTION, 0);
+    lv_obj_set_style_text_letter_space(s_dictate_chip_hint, 2, 0);
+    lv_obj_align(s_dictate_chip_hint, LV_ALIGN_RIGHT_MID, -28, 0);
+
+    /* Right-edge icon — mic / × / 🔄 / ✓ — toggles via pipeline subscriber. */
+    s_dictate_chip_icon = lv_label_create(s_dictate_chip);
+    lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_AUDIO);
+    lv_obj_set_style_text_color(s_dictate_chip_icon, lv_color_hex(TH_TEXT_PRIMARY), 0);
+    lv_obj_set_style_text_font(s_dictate_chip_icon, FONT_CAPTION, 0);
+    lv_obj_align(s_dictate_chip_icon, LV_ALIGN_RIGHT_MID, 0, 0);
 
     /* TT #511 wave-1.6 (change B): now-card killed from idle.
      * Obj still created so channel-notification code that writes to
@@ -2264,6 +2326,8 @@ void ui_home_destroy(void)
     s_orb_highlight = NULL; /* TT #507 — child of s_orb; just clear handle. */
     s_state_word = s_greet_line = NULL;
     s_mode_chip = s_mode_dot = s_mode_name = s_mode_sub = NULL;
+    s_dictate_chip = s_dictate_chip_dot = s_dictate_chip_label = NULL;
+    s_dictate_chip_hint = s_dictate_chip_icon = NULL;
     s_now_card = s_now_accent = s_now_kicker = s_now_lede = NULL;
     s_say_pill = s_say_mic = s_say_label_main = s_say_label_sub = NULL;
     s_toast = NULL;

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -789,10 +789,13 @@ lv_obj_t *ui_home_create(void)
      * subscriber that mutates label / hint / icon / border on every
      * dict_event_t.  Visually only here — chip is functional as soon as
      * Task 8 adds dictate_chip_tap_cb. */
+    /* Mode chip is positioned via pos_centered(s_mode_chip, 680, 360, 52),
+     * so its bottom edge sits at y=732.  Place the Dictate chip 12 px below
+     * via absolute coords — avoids relying on lv_obj_align_to picking up
+     * the parent's post-create layout pass. */
     s_dictate_chip = lv_obj_create(s_screen);
     lv_obj_remove_style_all(s_dictate_chip);
-    lv_obj_set_size(s_dictate_chip, lv_obj_get_width(s_mode_chip), 36);
-    lv_obj_align_to(s_dictate_chip, s_mode_chip, LV_ALIGN_OUT_BOTTOM_MID, 0, 12);
+    pos_centered(s_dictate_chip, 744, 360, 36);
     lv_obj_set_style_bg_color(s_dictate_chip, lv_color_hex(TH_CARD_ELEVATED), 0);
     lv_obj_set_style_bg_opa(s_dictate_chip, LV_OPA_COVER, 0);
     lv_obj_set_style_radius(s_dictate_chip, 18, 0);

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -849,6 +849,13 @@ lv_obj_t *ui_home_create(void)
        s_dictate_chip_sub = voice_dictation_subscribe_lvgl(dictate_chip_pipeline_cb, NULL);
        ESP_LOGI(TAG, "Dictate chip subscriber registered handle=%d", s_dictate_chip_sub);
     }
+    /* Rehydrate from current pipeline state — the subscriber only fires on
+     * future transitions, so a re-rendered home stays at IDLE chip visuals
+     * even when the pipeline is mid-cycle. */
+    {
+       dict_event_t cur = voice_dictation_get();
+       dictate_chip_pipeline_cb(&cur, NULL);
+    }
 
     /* TT #511 wave-1.6 (change B): now-card killed from idle.
      * Obj still created so channel-notification code that writes to

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -58,6 +58,8 @@
 #include "ui_theme.h"
 #include "ui_voice.h"
 #include "voice.h"
+#include "voice_dictation.h"      /* PR 2: Dictate chip pipeline state */
+#include "voice_dictation_lvgl.h" /* PR 2: LVGL-marshalled subscriber */
 #include "voice_onboard.h"
 #include "widget.h"
 #include "widget_icons.h"    /* TT #69 — icon library + render */
@@ -251,6 +253,9 @@ static void now_card_long_press_cb(lv_event_t *e);
 static void sys_click_cb(lv_event_t *e);
 static void mode_chip_long_press_cb(lv_event_t *e);
 static void mode_chip_click_cb(lv_event_t *e); /* TT #370 */
+/* PR 2: Dictate chip tap + pipeline subscriber. */
+static void dictate_chip_tap_cb(lv_event_t *e);
+static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data);
 /* U19 (#206): rail callbacks removed with the rail itself. */
 static bool any_overlay_visible(void);
 static void show_toast_internal(const char *text);
@@ -828,6 +833,19 @@ lv_obj_t *ui_home_create(void)
     lv_obj_set_style_text_color(s_dictate_chip_icon, lv_color_hex(TH_TEXT_PRIMARY), 0);
     lv_obj_set_style_text_font(s_dictate_chip_icon, FONT_CAPTION, 0);
     lv_obj_align(s_dictate_chip_icon, LV_ALIGN_RIGHT_MID, 0, 0);
+
+    /* PR 2 Task 8: tap fires voice_start_dictation in IDLE / voice_cancel
+     * in RECORDING / restart in FAILED. */
+    lv_obj_add_event_cb(s_dictate_chip, dictate_chip_tap_cb, LV_EVENT_CLICKED, NULL);
+
+    /* PR 2 Task 9: subscribe the chip to the dictation pipeline.  LVGL-
+     * thread marshalling is handled by the _lvgl variant.  Static guard
+     * so a screen recreate cycle doesn't double-subscribe. */
+    static int s_dictate_chip_sub = -1;
+    if (s_dictate_chip_sub < 0) {
+        s_dictate_chip_sub = voice_dictation_subscribe_lvgl(dictate_chip_pipeline_cb, NULL);
+        ESP_LOGI(TAG, "Dictate chip subscriber registered handle=%d", s_dictate_chip_sub);
+    }
 
     /* TT #511 wave-1.6 (change B): now-card killed from idle.
      * Obj still created so channel-notification code that writes to
@@ -1965,6 +1983,99 @@ static void mode_chip_click_cb(lv_event_t *e) {
    tab5_settings_set_mode_hint_seen(true);
    extern void ui_mode_sheet_show(void);
    ui_mode_sheet_show();
+}
+
+/* PR 2: Dictate chip tap.  IDLE → start dictation.  RECORDING → cancel
+ * via voice_cancel + drive pipeline straight to FAILED(CANCELLED) so
+ * the UI is responsive without waiting for Dragon's ack.  Other states
+ * are no-ops in v1 — future polish: FAILED → retry, SAVED → dismiss. */
+static void dictate_chip_tap_cb(lv_event_t *e) {
+   (void)e;
+   dict_event_t dp = voice_dictation_get();
+   if (dp.state == DICT_IDLE || dp.state == DICT_FAILED) {
+      esp_err_t err = voice_start_dictation();
+      if (err != ESP_OK) {
+         ESP_LOGW(TAG, "voice_start_dictation failed: %s", esp_err_to_name(err));
+      }
+   } else if (dp.state == DICT_RECORDING) {
+      voice_cancel();
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED,
+                                (uint32_t)(esp_timer_get_time() / 1000));
+   }
+}
+
+/* PR 2: keep the Dictate chip's label / hint / icon / border colour in
+ * sync with the dictation pipeline state.  Mirrors the orb's heroic
+ * painting at a compact chip scale. */
+static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data) {
+   (void)user_data;
+   if (!event) return;
+   if (!s_dictate_chip || !s_dictate_chip_label || !s_dictate_chip_hint ||
+       !s_dictate_chip_icon || !s_dictate_chip_dot) {
+      return;
+   }
+
+   /* Default styling = IDLE.  Per-state branches mutate from this base. */
+   lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x262637), 0);
+   lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xE74C3C), 0);
+
+   char buf[40];
+   switch (event->state) {
+   case DICT_IDLE:
+      lv_label_set_text(s_dictate_chip_label, "Dictate");
+      lv_label_set_text(s_dictate_chip_hint, "TAP TO START");
+      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(TH_TEXT_DIM), 0);
+      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_AUDIO);
+      break;
+
+   case DICT_RECORDING: {
+      uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+      uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms)
+                          ? (now_ms - event->started_ms)
+                          : 0;
+      uint32_t s = dur_ms / 1000;
+      snprintf(buf, sizeof(buf), "%lu:%02lu", (unsigned long)(s / 60),
+               (unsigned long)(s % 60));
+      lv_label_set_text(s_dictate_chip_label, "RECORDING");
+      lv_label_set_text(s_dictate_chip_hint, buf);
+      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
+      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_CLOSE);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+      break;
+   }
+
+   case DICT_UPLOADING:
+      lv_label_set_text(s_dictate_chip_label, "UPLOADING");
+      lv_label_set_text(s_dictate_chip_hint, "");
+      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_UPLOAD);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
+      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
+      break;
+
+   case DICT_TRANSCRIBING:
+      lv_label_set_text(s_dictate_chip_label, "TRANSCRIBING");
+      lv_label_set_text(s_dictate_chip_hint, "");
+      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_REFRESH);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xF59E0B), 0);
+      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0xF59E0B), 0);
+      break;
+
+   case DICT_SAVED:
+      lv_label_set_text(s_dictate_chip_label, "Saved");
+      lv_label_set_text(s_dictate_chip_hint, "");
+      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_OK);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0x22C55E), 0);
+      lv_obj_set_style_bg_color(s_dictate_chip_dot, lv_color_hex(0x22C55E), 0);
+      break;
+
+   case DICT_FAILED:
+      lv_label_set_text(s_dictate_chip_label, "FAILED");
+      lv_label_set_text(s_dictate_chip_hint, "TAP TO RETRY");
+      lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
+      lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_REFRESH);
+      lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+      break;
+   }
 }
 
 /* U24 (#206): set by now_card_long_press_cb when a long-press just

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -184,6 +184,7 @@ static lv_obj_t *s_dictate_chip = NULL;
 static lv_obj_t *s_dictate_chip_dot = NULL;   /* breathing dot, left edge */
 static lv_obj_t *s_dictate_chip_label = NULL; /* "Dictate" / "RECORDING" / etc. */
 static lv_obj_t *s_dictate_chip_hint = NULL;  /* "TAP TO START" / "0:23" / etc. */
+static lv_timer_t *s_dictate_chip_rec_t = NULL; /* PR 2 polish: ticks chip hint M:SS during RECORDING */
 static lv_obj_t *s_dictate_chip_icon = NULL;  /* 🎤 / × / 🔄 / ✓ */
 
 /* Now-slot card (widget live target + empty-state) */
@@ -2013,6 +2014,27 @@ static void dictate_chip_tap_cb(lv_event_t *e) {
    }
 }
 
+/* PR 2 polish: timer cb that refreshes the chip's M:SS hint every 200 ms
+ * while RECORDING is active.  Self-stopping when pipeline leaves RECORDING. */
+static void dictate_chip_rec_tick_cb(lv_timer_t *t) {
+   (void)t;
+   if (!s_dictate_chip_hint) return;
+   dict_event_t e = voice_dictation_get();
+   if (e.state != DICT_RECORDING) {
+      if (s_dictate_chip_rec_t) {
+         lv_timer_del(s_dictate_chip_rec_t);
+         s_dictate_chip_rec_t = NULL;
+      }
+      return;
+   }
+   uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   uint32_t dur_ms = (e.started_ms && now_ms >= e.started_ms) ? (now_ms - e.started_ms) : 0;
+   uint32_t s = dur_ms / 1000;
+   char buf[24];
+   snprintf(buf, sizeof(buf), "%lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
+   lv_label_set_text(s_dictate_chip_hint, buf);
+}
+
 /* PR 2: keep the Dictate chip's label / hint / icon / border colour in
  * sync with the dictation pipeline state.  Mirrors the orb's heroic
  * painting at a compact chip scale. */
@@ -2022,6 +2044,12 @@ static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data)
    if (!s_dictate_chip || !s_dictate_chip_label || !s_dictate_chip_hint || !s_dictate_chip_icon ||
        !s_dictate_chip_dot) {
       return;
+   }
+
+   /* Tear down the chip M:SS ticker if we're leaving RECORDING. */
+   if (event->state != DICT_RECORDING && s_dictate_chip_rec_t) {
+      lv_timer_del(s_dictate_chip_rec_t);
+      s_dictate_chip_rec_t = NULL;
    }
 
    /* Default styling = IDLE.  Per-state branches mutate from this base. */
@@ -2047,6 +2075,13 @@ static void dictate_chip_pipeline_cb(const dict_event_t *event, void *user_data)
          lv_obj_set_style_text_color(s_dictate_chip_hint, lv_color_hex(0xE74C3C), 0);
          lv_label_set_text(s_dictate_chip_icon, LV_SYMBOL_CLOSE);
          lv_obj_set_style_border_color(s_dictate_chip, lv_color_hex(0xE74C3C), 0);
+         /* Spawn the 200 ms M:SS ticker so the chip's elapsed time keeps
+          * pace with the orb hero caption.  The pipeline subscriber only
+          * fires on state transitions, so the duration would otherwise
+          * stay frozen at the value computed on RECORDING entry. */
+         if (!s_dictate_chip_rec_t) {
+            s_dictate_chip_rec_t = lv_timer_create(dictate_chip_rec_tick_cb, 200, NULL);
+         }
          break;
       }
 

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -135,14 +135,15 @@ static lv_obj_t *s_root = NULL;  /* parent container (= the home screen) */
 static lv_obj_t *s_body = NULL;  /* the lit sphere itself */
 static lv_obj_t *s_spec = NULL;  /* tilt-driven specular highlight (child of s_body) */
 static lv_obj_t *s_halo = NULL;  /* voice-bloom halo (sibling-BEHIND s_body) */
-static lv_obj_t *s_ripple_a = NULL;   /* PR 2 polish: sonar ripple A — outermost-expanding ring during RECORDING */
-static lv_obj_t *s_ripple_b = NULL;   /* PR 2 polish: sonar ripple B — phase-offset by 50% so a new ripple is always rising as the prior fades */
-static lv_timer_t *s_ripple_timer = NULL; /* 16 ms tick for ripple geometry */
-static lv_obj_t *s_thinking_arc = NULL;   /* PR 2 polish: rotating arc segment around body during TRANSCRIBING */
+static lv_obj_t *s_ripple_a = NULL; /* PR 2 polish: sonar ripple A — outermost-expanding ring during RECORDING */
+static lv_obj_t *s_ripple_b =
+    NULL; /* PR 2 polish: sonar ripple B — phase-offset by 50% so a new ripple is always rising as the prior fades */
+static lv_timer_t *s_ripple_timer = NULL;       /* 16 ms tick for ripple geometry */
+static lv_obj_t *s_thinking_arc = NULL;         /* PR 2 polish: rotating arc segment around body during TRANSCRIBING */
 static lv_timer_t *s_thinking_arc_timer = NULL; /* drives the arc's rotation */
-static lv_obj_t *s_saved_burst = NULL;     /* PR 2 polish: one-shot green ring on SAVED entry */
+static lv_obj_t *s_saved_burst = NULL;          /* PR 2 polish: one-shot green ring on SAVED entry */
 static lv_timer_t *s_saved_burst_timer = NULL;
-static uint32_t s_saved_burst_t0 = 0;      /* ms uptime when burst started, for elapsed-frac math */
+static uint32_t s_saved_burst_t0 = 0;         /* ms uptime when burst started, for elapsed-frac math */
 static lv_timer_t *s_body_pulse_timer = NULL; /* PR 2 polish: body heartbeat scale during RECORDING */
 static lv_obj_t *s_comet = NULL; /* skill-rim comet (sibling-AFTER s_body so it draws on top) */
 static lv_timer_t *s_tilt_timer = NULL;
@@ -1235,7 +1236,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          paint_pipeline_halo(0xFF5C50); /* warm red halo glow */
          ripple_start(0xFF7A6F);        /* sonar rings expanding outward */
          thinking_arc_stop();
-         body_pulse_start();            /* heartbeat pulse on body scale */
+         body_pulse_start(); /* heartbeat pulse on body scale */
          uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
          uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
          uint32_t s = dur_ms / 1000;
@@ -1276,7 +1277,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          ripple_stop();
          body_pulse_stop();
          thinking_arc_stop();
-         saved_burst_fire();             /* one-shot expanding green ring */
+         saved_burst_fire(); /* one-shot expanding green ring */
          paint_pipeline_body(0x22C55E);
          paint_pipeline_halo(0x4ADE80); /* mint glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xCFFFE0), 0);

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -380,7 +380,23 @@ static void bloom_tick_cb(lv_timer_t *t) {
    if (rms < 0.0f) rms = 0.0f;
    if (rms > 1.0f) rms = 1.0f;
    s_bloom_rms_ema = (ORB_BLOOM_ALPHA * rms) + ((1.0f - ORB_BLOOM_ALPHA) * s_bloom_rms_ema);
-   int opa = ORB_HALO_OPA_FLOOR + (int)((float)(ORB_HALO_OPA_CEILING - ORB_HALO_OPA_FLOOR) * s_bloom_rms_ema);
+   /* PR 2 polish: during pipeline RECORDING (vs ambient LISTENING) bump
+    * the floor + ceiling so the halo reads as a confident "I'm listening"
+    * glow even when the user isn't speaking, plus add a 2-second sin
+    * breath so the orb feels alive instead of static.  Outside pipeline
+    * RECORDING, fall back to the ambient bloom envelope.  */
+   int floor_v = ORB_HALO_OPA_FLOOR;
+   int ceil_v = ORB_HALO_OPA_CEILING;
+   if (s_pipeline.state == DICT_RECORDING) {
+      floor_v = 110;
+      ceil_v = 180;
+      /* Slow breath: 0.5 Hz triangle wave on the floor itself, ±20 opa. */
+      uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
+      uint32_t phase = t_ms % 2000;
+      int delta = (phase < 1000) ? (int)(phase / 25) : (int)((2000 - phase) / 25); /* 0..40 */
+      floor_v += (delta - 20);
+   }
+   int opa = floor_v + (int)((float)(ceil_v - floor_v) * s_bloom_rms_ema);
    if (opa < 0) opa = 0;
    if (opa > 255) opa = 255;
    lv_obj_set_style_bg_opa(s_halo, (lv_opa_t)opa, LV_PART_MAIN);
@@ -800,6 +816,24 @@ lv_obj_t *ui_orb_get_body(void) { return s_body; }
 
 /* ── Pipeline state (PR 2) ───────────────────────────────────────────── */
 
+/* PR 2: paint the halo (s_halo) in the pipeline-state hue so the
+ * LISTENING bloom + steady SPEAKING halo blend with the body tint
+ * instead of bleeding the default cream-amber over a red/amber/green
+ * body.  Keep the existing opacity envelope (bloom timer + speaking
+ * fade); we only retune the color stop. */
+static void paint_pipeline_halo(uint32_t color_hex) {
+   if (!s_halo) return;
+   lv_obj_set_style_bg_color(s_halo, lv_color_hex(color_hex), LV_PART_MAIN);
+}
+
+/* Reset halo to its default cream-amber baseline (used on DICT_IDLE
+ * so subsequent voice-state visuals — IDLE/LISTENING/PROCESSING/
+ * SPEAKING — read with their original palette). */
+static void reset_pipeline_halo(void) {
+   if (!s_halo) return;
+   lv_obj_set_style_bg_color(s_halo, lv_color_hex(0xFFB870), LV_PART_MAIN);
+}
+
 /* Paint the orb body in the pipeline-state tint.  Caller is responsible
  * for setting the caption text + showing the caption label.
  *
@@ -846,6 +880,14 @@ static const char *fail_reason_caption(dict_fail_t r) {
 static void set_caption_text(const char *text) {
    if (!s_orb_caption || !text) return;
    lv_label_set_text(s_orb_caption, text);
+   /* Re-anchor the label after its size changed — lv_obj_align_to is a
+    * one-shot in LVGL 9.x, so the original create-time alignment was
+    * computed against a 0-width empty label and the rendered text drifted
+    * to the right.  Re-call here so each state's text re-centers under
+    * the orb. */
+   if (s_body) {
+      lv_obj_align_to(s_orb_caption, s_body, LV_ALIGN_OUT_BOTTOM_MID, 0, 22);
+   }
    lv_obj_clear_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
 }
 
@@ -877,7 +919,10 @@ static void rec_timer_label_cb(lv_timer_t *t) {
    uint32_t s = dur_ms / 1000;
    char buf[40];
    snprintf(buf, sizeof(buf), "RECORDING  %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
-   if (s_orb_caption) lv_label_set_text(s_orb_caption, buf);
+   if (s_orb_caption) {
+      lv_label_set_text(s_orb_caption, buf);
+      if (s_body) lv_obj_align_to(s_orb_caption, s_body, LV_ALIGN_OUT_BOTTOM_MID, 0, 22);
+   }
 }
 
 /* Subscriber bridge: voice_dictation fires this on the LVGL thread
@@ -914,6 +959,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
    switch (event->state) {
       case DICT_IDLE:
          hide_caption();
+         reset_pipeline_halo();
          /* Repaint via the voice-state painter so the orb returns to its
           * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals.  Re-paint
           * body for current hour too — paint_pipeline_body() shadowed it. */
@@ -928,6 +974,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
           * runs because it manipulates s_halo, not s_body. */
          ui_orb_set_state(ORB_STATE_LISTENING);
          paint_pipeline_body(0xE74C3C);
+         paint_pipeline_halo(0xFF5C50); /* warm red halo glow */
          uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
          uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
          uint32_t s = dur_ms / 1000;
@@ -943,12 +990,14 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_UPLOADING:
          paint_pipeline_body(0xF59E0B);
+         paint_pipeline_halo(0xFFB347); /* amber glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
          set_caption_text("UPLOADING");
          break;
 
       case DICT_TRANSCRIBING:
          paint_pipeline_body(0xF59E0B);
+         paint_pipeline_halo(0xFFB347); /* amber glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
          set_caption_text("TRANSCRIBING");
          /* Reuse the existing PROCESSING comet animation for visual
@@ -958,6 +1007,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_SAVED:
          paint_pipeline_body(0x22C55E);
+         paint_pipeline_halo(0x4ADE80); /* mint glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xCFFFE0), 0);
          set_caption_text("SAVED");
          /* Schedule auto-fade back to IDLE after 2 s.  Idempotent — if
@@ -970,6 +1020,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_FAILED:
          paint_pipeline_body(0xE74C3C);
+         paint_pipeline_halo(0xFF5C50);
          snprintf(buf, sizeof(buf), "%s  ·  TAP TO RETRY", fail_reason_caption(event->fail_reason));
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFD2CC), 0);
          set_caption_text(buf);

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -160,6 +160,7 @@ static dict_event_t s_pipeline = {
 };
 static lv_obj_t *s_orb_caption = NULL;  /* Label below the orb body */
 static lv_timer_t *s_saved_fade_timer = NULL;  /* SAVED → IDLE 2s timer */
+static lv_timer_t *s_rec_timer_label = NULL;  /* updates RECORDING caption every 200 ms */
 
 /* ── Circadian palette ───────────────────────────────────────────────── */
 
@@ -599,7 +600,7 @@ void ui_orb_destroy(void) {
    if (s_halo) {
       lv_anim_delete(s_halo, halo_opa_anim_cb);
    }
-   /* PR 2: tear down caption + saved-fade timer. */
+   /* PR 2: tear down caption + saved-fade timer + record-elapsed timer. */
    if (s_orb_caption) {
       lv_obj_del(s_orb_caption);
       s_orb_caption = NULL;
@@ -607,6 +608,10 @@ void ui_orb_destroy(void) {
    if (s_saved_fade_timer) {
       lv_timer_del(s_saved_fade_timer);
       s_saved_fade_timer = NULL;
+   }
+   if (s_rec_timer_label) {
+      lv_timer_del(s_rec_timer_label);
+      s_rec_timer_label = NULL;
    }
    /* The body's parent (the home screen) owns the actual delete via its
     * own destroy path; here we only clear our handles + reset state so
@@ -802,6 +807,29 @@ static void saved_fade_to_idle_cb(lv_timer_t *t) {
                              (uint32_t)(esp_timer_get_time() / 1000));
 }
 
+/* Update the RECORDING caption with live elapsed time.  Stops itself
+ * if the pipeline has left RECORDING (defensive — set_pipeline_state
+ * also tears it down explicitly). */
+static void rec_timer_label_cb(lv_timer_t *t) {
+   (void)t;
+   if (s_pipeline.state != DICT_RECORDING) {
+      if (s_rec_timer_label) {
+         lv_timer_del(s_rec_timer_label);
+         s_rec_timer_label = NULL;
+      }
+      return;
+   }
+   uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   uint32_t dur_ms = (s_pipeline.started_ms && now_ms >= s_pipeline.started_ms)
+                       ? (now_ms - s_pipeline.started_ms)
+                       : 0;
+   uint32_t s = dur_ms / 1000;
+   char buf[40];
+   snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
+            (unsigned long)(s / 60), (unsigned long)(s % 60));
+   if (s_orb_caption) lv_label_set_text(s_orb_caption, buf);
+}
+
 void ui_orb_set_pipeline_state(const dict_event_t *event) {
    if (!event) return;
    s_pipeline = *event;
@@ -810,6 +838,12 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
    if (event->state != DICT_SAVED && s_saved_fade_timer) {
       lv_timer_del(s_saved_fade_timer);
       s_saved_fade_timer = NULL;
+   }
+
+   /* Stop the live elapsed-time timer when leaving RECORDING. */
+   if (event->state != DICT_RECORDING && s_rec_timer_label) {
+      lv_timer_del(s_rec_timer_label);
+      s_rec_timer_label = NULL;
    }
 
    char buf[64];
@@ -838,6 +872,10 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
       snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
                (unsigned long)(s / 60), (unsigned long)(s % 60));
       set_caption_text(buf);
+      /* Spawn the 200 ms tick that keeps the M:SS caption live. */
+      if (!s_rec_timer_label) {
+         s_rec_timer_label = lv_timer_create(rec_timer_label_cb, 200, NULL);
+      }
       break;
    }
 

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -1021,11 +1021,24 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
       case DICT_FAILED:
          paint_pipeline_body(0xE74C3C);
          paint_pipeline_halo(0xFF5C50);
-         snprintf(buf, sizeof(buf), "%s  ·  TAP TO RETRY", fail_reason_caption(event->fail_reason));
+         /* Drop the unicode mid-dot — FONT_HEADING (montserrat bold 22)
+          * doesn't carry U+00B7, so it rendered as a missing-glyph box.
+          * Use generous spaces to keep the parts visually separated. */
+         snprintf(buf, sizeof(buf), "%s   TAP TO RETRY", fail_reason_caption(event->fail_reason));
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFD2CC), 0);
          set_caption_text(buf);
          break;
    }
 }
 
-bool ui_orb_pipeline_active(void) { return s_pipeline.state != DICT_IDLE; }
+bool ui_orb_pipeline_active(void) {
+   /* Poll the authoritative state machine directly rather than the
+    * cached s_pipeline.  s_pipeline is updated by the LVGL-async
+    * subscriber, which runs AFTER any synchronous caller that resets
+    * the pipeline state (e.g., orb_click_cb's pipeline-clear-before-Ask
+    * path).  Reading voice_dictation_get() avoids a window where
+    * is-pipeline-active returns stale true and suppresses the Ask
+    * overlay's chrome. */
+   dict_event_t e = voice_dictation_get();
+   return e.state != DICT_IDLE;
+}

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -18,12 +18,15 @@
 #include <stdlib.h> /* malloc/free for presence-call marshalling */
 #include <time.h>
 
+#include "config.h" /* FONT_CAPTION for pipeline-state caption (PR 2) */
 #include "esp_log.h"
-#include "imu.h" /* tab5_imu_read for tilt-driven specular drift */
+#include "esp_timer.h"        /* esp_timer_get_time for RECORDING caption timer (PR 2) */
+#include "imu.h"              /* tab5_imu_read for tilt-driven specular drift */
 #include "lvgl.h"
-#include "ui_core.h" /* tab5_lv_async_call for cross-thread repaints */
-#include "voice.h"   /* voice_get_current_rms for the LISTENING bloom */
-#include "widget.h"  /* widget_tone_t for paint_for_tone */
+#include "ui_core.h"          /* tab5_lv_async_call for cross-thread repaints */
+#include "voice.h"            /* voice_get_current_rms for the LISTENING bloom */
+#include "voice_dictation.h"  /* pipeline-state types (PR 2) */
+#include "widget.h"           /* widget_tone_t for paint_for_tone */
 
 static const char *TAG = "ui_orb";
 
@@ -143,6 +146,20 @@ static bool s_presence_near = true;
 static int8_t s_force_hour = -1; /* -1 = use real RTC */
 static int s_last_painted_hour = -1;
 static uint8_t s_last_painted_mode = 0;
+
+/* PR 2: pipeline state overlay.  When != DICT_IDLE, all paint cycles
+ * route through the pipeline-state painter and the voice-state painter
+ * is suppressed.  IDLE → revert to voice-state painting. */
+static dict_event_t s_pipeline = {
+   .state = DICT_IDLE,
+   .fail_reason = DICT_FAIL_NONE,
+   .started_ms = 0,
+   .stopped_ms = 0,
+   .last_change_ms = 0,
+   .note_slot = -1,
+};
+static lv_obj_t *s_orb_caption = NULL;  /* Label below the orb body */
+static lv_timer_t *s_saved_fade_timer = NULL;  /* SAVED → IDLE 2s timer */
 
 /* ── Circadian palette ───────────────────────────────────────────────── */
 
@@ -716,3 +733,16 @@ void ui_orb_ripple_for_tool(const char *tool_name) {
 lv_obj_t *ui_orb_get_root(void) { return s_root; }
 
 lv_obj_t *ui_orb_get_body(void) { return s_body; }
+
+/* ── Pipeline state (PR 2) ───────────────────────────────────────────── */
+
+void ui_orb_set_pipeline_state(const dict_event_t *event) {
+   if (!event) return;
+   s_pipeline = *event;
+   /* The actual painting is implemented in subsequent tasks (Tasks 3-7
+    * land per-state visuals).  This task just lands the API surface. */
+}
+
+bool ui_orb_pipeline_active(void) {
+   return s_pipeline.state != DICT_IDLE;
+}

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -759,11 +759,119 @@ lv_obj_t *ui_orb_get_body(void) { return s_body; }
 
 /* ── Pipeline state (PR 2) ───────────────────────────────────────────── */
 
+/* Paint the orb body in the pipeline-state tint.  Caller is responsible
+ * for setting the caption text + showing the caption label.
+ *
+ * Uses the same body widget that the voice-state painter paints into.
+ * The previous body styling (circadian gradient, etc.) is shadowed by
+ * the solid tint until pipeline returns to IDLE. */
+static void paint_pipeline_body(uint32_t color_hex) {
+   if (!s_body) return;
+   lv_obj_set_style_bg_color(s_body, lv_color_hex(color_hex), LV_PART_MAIN);
+   /* Keep the radial-gradient luster for depth — only tint, don't go
+    * flat.  The existing body uses LV_GRAD_DIR_VER; preserve. */
+}
+
+static const char *fail_reason_caption(dict_fail_t r) {
+   switch (r) {
+   case DICT_FAIL_AUTH:      return "AUTH";
+   case DICT_FAIL_NETWORK:   return "NETWORK";
+   case DICT_FAIL_EMPTY:     return "EMPTY — got silence";
+   case DICT_FAIL_NO_AUDIO:  return "NO AUDIO";
+   case DICT_FAIL_TOO_LONG:  return "TOO LONG (5 min cap)";
+   case DICT_FAIL_CANCELLED: return "CANCELLED";
+   default:                  return "FAIL";
+   }
+}
+
+static void set_caption_text(const char *text) {
+   if (!s_orb_caption || !text) return;
+   lv_label_set_text(s_orb_caption, text);
+   lv_obj_clear_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
+}
+
+static void hide_caption(void) {
+   if (s_orb_caption) lv_obj_add_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
+}
+
+/* Timer cb for SAVED → IDLE auto-fade. */
+static void saved_fade_to_idle_cb(lv_timer_t *t) {
+   (void)t;
+   s_saved_fade_timer = NULL;
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE,
+                             (uint32_t)(esp_timer_get_time() / 1000));
+}
+
 void ui_orb_set_pipeline_state(const dict_event_t *event) {
    if (!event) return;
    s_pipeline = *event;
-   /* The actual painting is implemented in subsequent tasks (Tasks 3-7
-    * land per-state visuals).  This task just lands the API surface. */
+
+   /* Tear down the SAVED auto-fade timer when leaving SAVED. */
+   if (event->state != DICT_SAVED && s_saved_fade_timer) {
+      lv_timer_del(s_saved_fade_timer);
+      s_saved_fade_timer = NULL;
+   }
+
+   char buf[64];
+   switch (event->state) {
+   case DICT_IDLE:
+      hide_caption();
+      /* Repaint via the voice-state painter so the orb returns to its
+       * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals.  Re-paint
+       * body for current hour too — paint_pipeline_body() shadowed it. */
+      paint_body_for_hour(orb_effective_hour());
+      ui_orb_set_state(s_state);
+      return;
+
+   case DICT_RECORDING: {
+      /* Engage the existing LISTENING state machine so the mic-RMS-driven
+       * halo bloom fires.  Our pipeline body tint overrides the body
+       * colour, but the bloom mechanic (halo opacity from mic RMS) still
+       * runs because it manipulates s_halo, not s_body. */
+      ui_orb_set_state(ORB_STATE_LISTENING);
+      paint_pipeline_body(0xE74C3C);
+      uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+      uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms)
+                          ? (now_ms - event->started_ms)
+                          : 0;
+      uint32_t s = dur_ms / 1000;
+      snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
+               (unsigned long)(s / 60), (unsigned long)(s % 60));
+      set_caption_text(buf);
+      break;
+   }
+
+   case DICT_UPLOADING:
+      paint_pipeline_body(0xF59E0B);
+      set_caption_text("UPLOADING…");
+      break;
+
+   case DICT_TRANSCRIBING:
+      paint_pipeline_body(0xF59E0B);
+      set_caption_text("TRANSCRIBING…");
+      /* Reuse the existing PROCESSING comet animation for visual
+       * continuity. */
+      ui_orb_set_state(ORB_STATE_PROCESSING);
+      break;
+
+   case DICT_SAVED:
+      paint_pipeline_body(0x22C55E);
+      set_caption_text("✓ Saved");
+      /* Schedule auto-fade back to IDLE after 2 s.  Idempotent — if
+       * one already exists (rapid SAVED re-entry), don't stack. */
+      if (!s_saved_fade_timer) {
+         s_saved_fade_timer = lv_timer_create(saved_fade_to_idle_cb, 2000, NULL);
+         if (s_saved_fade_timer) lv_timer_set_repeat_count(s_saved_fade_timer, 1);
+      }
+      break;
+
+   case DICT_FAILED:
+      paint_pipeline_body(0xE74C3C);
+      snprintf(buf, sizeof(buf), "● %s — tap to retry",
+               fail_reason_caption(event->fail_reason));
+      set_caption_text(buf);
+      break;
+   }
 }
 
 bool ui_orb_pipeline_active(void) {

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -229,11 +229,19 @@ static void paint_body_for_hour(int hour) {
 void ui_orb_paint_for_mode(uint8_t mode) {
    s_last_painted_mode = mode;
    if (!s_body) return;
+   /* PR 2: pipeline-state paint takes precedence — don't shadow the
+    * RECORDING/UPLOADING/TRANSCRIBING/SAVED/FAILED body tint with the
+    * circadian palette while a dictation is on-flight.  Mode bookkeeping
+    * above still records the latest mode so DICT_IDLE can repaint
+    * correctly when the pipeline returns. */
+   if (ui_orb_pipeline_active()) return;
    paint_body_for_hour(orb_effective_hour());
 }
 
 void ui_orb_paint_for_tone(widget_tone_t tone) {
    if (!s_body) return;
+   /* PR 2: pipeline-state paint takes precedence over widget tone. */
+   if (ui_orb_pipeline_active()) return;
    uint32_t top, bot;
    switch (tone) {
       case WIDGET_TONE_CALM:
@@ -271,6 +279,8 @@ void ui_orb_paint_for_tone(widget_tone_t tone) {
 
 void ui_orb_repaint_if_hour_changed(void) {
    if (!s_body) return;
+   /* PR 2: clock-driven repaints stay parked until DICT_IDLE returns. */
+   if (ui_orb_pipeline_active()) return;
    int h = orb_effective_hour();
    if (h != s_last_painted_hour) paint_body_for_hour(h);
 }

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -560,6 +560,20 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_set_style_bg_opa(s_comet, 0, 0);
    lv_obj_clear_flag(s_comet, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
 
+   /* PR 2: caption label below the orb for pipeline state text
+    * ("● RECORDING 0:23", "UPLOADING…", "TRANSCRIBING…", "✓ Saved").
+    * Sits 24 px below the orb body, transparent background, caption
+    * font.  Hidden by default — paint_pipeline_state shows it. */
+   s_orb_caption = lv_label_create(parent);
+   if (s_orb_caption) {
+      lv_label_set_text(s_orb_caption, "");
+      lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xE8E8EF), 0);
+      lv_obj_set_style_text_font(s_orb_caption, FONT_CAPTION, 0);
+      lv_obj_set_style_text_letter_space(s_orb_caption, 2, 0);
+      lv_obj_align_to(s_orb_caption, s_body, LV_ALIGN_OUT_BOTTOM_MID, 0, 24);
+      lv_obj_add_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
+   }
+
    /* IDLE state arms tilt drift by default. */
    tilt_start();
 
@@ -584,6 +598,15 @@ void ui_orb_destroy(void) {
    /* Cancel any in-flight speaking-halo fade. */
    if (s_halo) {
       lv_anim_delete(s_halo, halo_opa_anim_cb);
+   }
+   /* PR 2: tear down caption + saved-fade timer. */
+   if (s_orb_caption) {
+      lv_obj_del(s_orb_caption);
+      s_orb_caption = NULL;
+   }
+   if (s_saved_fade_timer) {
+      lv_timer_del(s_saved_fade_timer);
+      s_saved_fade_timer = NULL;
    }
    /* The body's parent (the home screen) owns the actual delete via its
     * own destroy path; here we only clear our handles + reset state so

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -25,8 +25,9 @@
 #include "lvgl.h"
 #include "ui_core.h"          /* tab5_lv_async_call for cross-thread repaints */
 #include "voice.h"            /* voice_get_current_rms for the LISTENING bloom */
-#include "voice_dictation.h"  /* pipeline-state types (PR 2) */
-#include "widget.h"           /* widget_tone_t for paint_for_tone */
+#include "voice_dictation.h"       /* pipeline-state types (PR 2) */
+#include "voice_dictation_lvgl.h"  /* LVGL-marshalled subscriber (PR 2) */
+#include "widget.h"                /* widget_tone_t for paint_for_tone */
 
 static const char *TAG = "ui_orb";
 
@@ -501,6 +502,10 @@ static void comet_stop(void) {
 
 /* ── Lifecycle ───────────────────────────────────────────────────────── */
 
+/* Forward decl for the pipeline subscriber bridge (PR 2) — body lives
+ * near ui_orb_set_pipeline_state below; ui_orb_create takes its address. */
+static void orb_pipeline_cb(const dict_event_t *event, void *user_data);
+
 void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    if (s_body || !parent) {
       ESP_LOGW(TAG, "ui_orb_create skipped (s_body=%p parent=%p)", s_body, parent);
@@ -578,6 +583,15 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    /* IDLE state arms tilt drift by default. */
    tilt_start();
 
+   /* PR 2: subscribe to the dictation pipeline.  Callbacks land on the
+    * LVGL thread thanks to the _lvgl variant.  Static guard so a
+    * subsequent create/destroy/create cycle doesn't double-subscribe. */
+   static int s_pipeline_sub = -1;
+   if (s_pipeline_sub < 0) {
+      s_pipeline_sub = voice_dictation_subscribe_lvgl(orb_pipeline_cb, NULL);
+      ESP_LOGI(TAG, "pipeline subscriber registered handle=%d", s_pipeline_sub);
+   }
+
    ESP_LOGI(TAG, "orb created at (%d, %d), size %d", cx, cy, ORB_SIZE);
 }
 
@@ -600,7 +614,7 @@ void ui_orb_destroy(void) {
    if (s_halo) {
       lv_anim_delete(s_halo, halo_opa_anim_cb);
    }
-   /* PR 2: tear down caption + saved-fade timer + record-elapsed timer. */
+   /* PR 2: tear down caption + saved-fade timer. */
    if (s_orb_caption) {
       lv_obj_del(s_orb_caption);
       s_orb_caption = NULL;
@@ -608,10 +622,6 @@ void ui_orb_destroy(void) {
    if (s_saved_fade_timer) {
       lv_timer_del(s_saved_fade_timer);
       s_saved_fade_timer = NULL;
-   }
-   if (s_rec_timer_label) {
-      lv_timer_del(s_rec_timer_label);
-      s_rec_timer_label = NULL;
    }
    /* The body's parent (the home screen) owns the actual delete via its
     * own destroy path; here we only clear our handles + reset state so
@@ -828,6 +838,14 @@ static void rec_timer_label_cb(lv_timer_t *t) {
    snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
             (unsigned long)(s / 60), (unsigned long)(s % 60));
    if (s_orb_caption) lv_label_set_text(s_orb_caption, buf);
+}
+
+/* Subscriber bridge: voice_dictation fires this on the LVGL thread
+ * (because we subscribe via voice_dictation_subscribe_lvgl).  Just
+ * forward to the public state-driver. */
+static void orb_pipeline_cb(const dict_event_t *event, void *user_data) {
+   (void)user_data;
+   ui_orb_set_pipeline_state(event);
 }
 
 void ui_orb_set_pipeline_state(const dict_event_t *event) {

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -18,7 +18,8 @@
 #include <stdlib.h> /* malloc/free for presence-call marshalling */
 #include <time.h>
 
-#include "config.h" /* FONT_CAPTION for pipeline-state caption (PR 2) */
+#include "config.h"    /* FONT_CAPTION for pipeline-state caption (PR 2) */
+#include "debug_obs.h" /* tab5_debug_obs_event for pipeline-cb tracing (PR 2) */
 #include "esp_log.h"
 #include "esp_timer.h" /* esp_timer_get_time for RECORDING caption timer (PR 2) */
 #include "imu.h"       /* tab5_imu_read for tilt-driven specular drift */
@@ -591,6 +592,14 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
       s_pipeline_sub = voice_dictation_subscribe_lvgl(orb_pipeline_cb, NULL);
       ESP_LOGI(TAG, "pipeline subscriber registered handle=%d", s_pipeline_sub);
    }
+   /* Rehydrate from current pipeline state — the subscriber only fires on
+    * future transitions, so a re-created orb stays at IDLE visuals even
+    * when the pipeline is mid-cycle.  Read current state and drive paint
+    * immediately. */
+   {
+      dict_event_t cur = voice_dictation_get();
+      ui_orb_set_pipeline_state(&cur);
+   }
 
    ESP_LOGI(TAG, "orb created at (%d, %d), size %d", cx, cy, ORB_SIZE);
 }
@@ -781,14 +790,25 @@ lv_obj_t *ui_orb_get_body(void) { return s_body; }
 /* Paint the orb body in the pipeline-state tint.  Caller is responsible
  * for setting the caption text + showing the caption label.
  *
- * Uses the same body widget that the voice-state painter paints into.
- * The previous body styling (circadian gradient, etc.) is shadowed by
- * the solid tint until pipeline returns to IDLE. */
+ * s_body is a vertical linear gradient (paint_body_for_hour /
+ * paint_for_tone write both bg_color = top stop and bg_grad_color =
+ * bottom stop).  Writing only bg_color leaves the bottom stop at the
+ * previous state's edge color, which produces a muddy mix instead of
+ * a clean state indicator.  Darken the requested hue ~45% for the
+ * bottom stop to keep the lit-sphere luster instead of going flat;
+ * stamp s_last_painted_hour = -1 so a clock-driven hour-repaint can't
+ * immediately revert the tint. */
 static void paint_pipeline_body(uint32_t color_hex) {
    if (!s_body) return;
+   uint8_t r = (color_hex >> 16) & 0xFF;
+   uint8_t g = (color_hex >> 8) & 0xFF;
+   uint8_t b = color_hex & 0xFF;
+   uint32_t bot = ((uint32_t)((r * 45) / 100) << 16) | ((uint32_t)((g * 45) / 100) << 8) | (uint32_t)((b * 45) / 100);
    lv_obj_set_style_bg_color(s_body, lv_color_hex(color_hex), LV_PART_MAIN);
-   /* Keep the radial-gradient luster for depth — only tint, don't go
-    * flat.  The existing body uses LV_GRAD_DIR_VER; preserve. */
+   lv_obj_set_style_bg_grad_color(s_body, lv_color_hex(bot), LV_PART_MAIN);
+   lv_obj_set_style_bg_grad_dir(s_body, LV_GRAD_DIR_VER, LV_PART_MAIN);
+   lv_obj_set_style_bg_opa(s_body, LV_OPA_COVER, LV_PART_MAIN);
+   s_last_painted_hour = -1;
 }
 
 static const char *fail_reason_caption(dict_fail_t r) {
@@ -852,6 +872,12 @@ static void rec_timer_label_cb(lv_timer_t *t) {
  * forward to the public state-driver. */
 static void orb_pipeline_cb(const dict_event_t *event, void *user_data) {
    (void)user_data;
+   if (event) {
+      char detail[48];
+      snprintf(detail, sizeof(detail), "%s/%s", voice_dictation_state_name(event->state),
+               voice_dictation_fail_name(event->fail_reason));
+      tab5_debug_obs_event("pipeline.orb_cb", detail);
+   }
    ui_orb_set_pipeline_state(event);
 }
 

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -577,17 +577,20 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_set_style_bg_opa(s_comet, 0, 0);
    lv_obj_clear_flag(s_comet, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
 
-   /* PR 2: caption label below the orb for pipeline state text
-    * ("● RECORDING 0:23", "UPLOADING…", "TRANSCRIBING…", "✓ Saved").
-    * Sits 24 px below the orb body, transparent background, caption
-    * font.  Hidden by default — paint_pipeline_state shows it. */
+   /* PR 2: hero caption below the orb for pipeline state — sized to read
+    * as a primary status indicator (Montserrat Bold 22 px), not a
+    * footnote.  Pure text, no unicode bullets — those rendered as
+    * missing-glyph rectangles in the 16 px caption font and made the
+    * label feel fragile.  Hidden by default; paint_pipeline_state shows
+    * + colors the text per state. */
    s_orb_caption = lv_label_create(parent);
    if (s_orb_caption) {
       lv_label_set_text(s_orb_caption, "");
-      lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xE8E8EF), 0);
-      lv_obj_set_style_text_font(s_orb_caption, FONT_CAPTION, 0);
-      lv_obj_set_style_text_letter_space(s_orb_caption, 2, 0);
-      lv_obj_align_to(s_orb_caption, s_body, LV_ALIGN_OUT_BOTTOM_MID, 0, 24);
+      lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xF8F8FB), 0);
+      lv_obj_set_style_text_font(s_orb_caption, FONT_HEADING, 0);
+      lv_obj_set_style_text_letter_space(s_orb_caption, 1, 0);
+      lv_obj_align_to(s_orb_caption, s_body, LV_ALIGN_OUT_BOTTOM_MID, 0, 22);
+      lv_obj_move_foreground(s_orb_caption);
       lv_obj_add_flag(s_orb_caption, LV_OBJ_FLAG_HIDDEN);
    }
 
@@ -873,7 +876,7 @@ static void rec_timer_label_cb(lv_timer_t *t) {
    uint32_t dur_ms = (s_pipeline.started_ms && now_ms >= s_pipeline.started_ms) ? (now_ms - s_pipeline.started_ms) : 0;
    uint32_t s = dur_ms / 1000;
    char buf[40];
-   snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
+   snprintf(buf, sizeof(buf), "RECORDING  %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
    if (s_orb_caption) lv_label_set_text(s_orb_caption, buf);
 }
 
@@ -928,7 +931,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
          uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
          uint32_t s = dur_ms / 1000;
-         snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
+         snprintf(buf, sizeof(buf), "RECORDING  %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
+         lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFD2CC), 0);
          set_caption_text(buf);
          /* Spawn the 200 ms tick that keeps the M:SS caption live. */
          if (!s_rec_timer_label) {
@@ -939,12 +943,14 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_UPLOADING:
          paint_pipeline_body(0xF59E0B);
-         set_caption_text("UPLOADING…");
+         lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
+         set_caption_text("UPLOADING");
          break;
 
       case DICT_TRANSCRIBING:
          paint_pipeline_body(0xF59E0B);
-         set_caption_text("TRANSCRIBING…");
+         lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
+         set_caption_text("TRANSCRIBING");
          /* Reuse the existing PROCESSING comet animation for visual
           * continuity. */
          ui_orb_set_state(ORB_STATE_PROCESSING);
@@ -952,7 +958,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_SAVED:
          paint_pipeline_body(0x22C55E);
-         set_caption_text("✓ Saved");
+         lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xCFFFE0), 0);
+         set_caption_text("SAVED");
          /* Schedule auto-fade back to IDLE after 2 s.  Idempotent — if
           * one already exists (rapid SAVED re-entry), don't stack. */
          if (!s_saved_fade_timer) {
@@ -963,7 +970,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_FAILED:
          paint_pipeline_body(0xE74C3C);
-         snprintf(buf, sizeof(buf), "● %s — tap to retry", fail_reason_caption(event->fail_reason));
+         snprintf(buf, sizeof(buf), "%s  ·  TAP TO RETRY", fail_reason_caption(event->fail_reason));
+         lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFD2CC), 0);
          set_caption_text(buf);
          break;
    }

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -614,7 +614,7 @@ void ui_orb_destroy(void) {
    if (s_halo) {
       lv_anim_delete(s_halo, halo_opa_anim_cb);
    }
-   /* PR 2: tear down caption + saved-fade timer. */
+   /* PR 2: tear down caption + saved-fade timer + record-elapsed timer. */
    if (s_orb_caption) {
       lv_obj_del(s_orb_caption);
       s_orb_caption = NULL;
@@ -622,6 +622,10 @@ void ui_orb_destroy(void) {
    if (s_saved_fade_timer) {
       lv_timer_del(s_saved_fade_timer);
       s_saved_fade_timer = NULL;
+   }
+   if (s_rec_timer_label) {
+      lv_timer_del(s_rec_timer_label);
+      s_rec_timer_label = NULL;
    }
    /* The body's parent (the home screen) owns the actual delete via its
     * own destroy path; here we only clear our handles + reset state so

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -123,6 +123,12 @@ static const char *TAG = "ui_orb";
 #define ORB_PRESENCE_ASLEEP_OPA 85 /* ≈33 % */
 #define ORB_PRESENCE_FADE_MS 600   /* gentle eyelid close/open */
 
+/* PR 2 polish: TRANSCRIBING rotating-arc sizing — used both at widget
+ * creation and inside the tick driver, so the defines live up here. */
+#define THINKING_ARC_DIAM (ORB_SIZE + 28)
+#define THINKING_ARC_PERIOD_MS 1800
+#define THINKING_ARC_SWEEP 90
+
 /* ── Module state ────────────────────────────────────────────────────── */
 
 static lv_obj_t *s_root = NULL;  /* parent container (= the home screen) */
@@ -132,6 +138,12 @@ static lv_obj_t *s_halo = NULL;  /* voice-bloom halo (sibling-BEHIND s_body) */
 static lv_obj_t *s_ripple_a = NULL;   /* PR 2 polish: sonar ripple A — outermost-expanding ring during RECORDING */
 static lv_obj_t *s_ripple_b = NULL;   /* PR 2 polish: sonar ripple B — phase-offset by 50% so a new ripple is always rising as the prior fades */
 static lv_timer_t *s_ripple_timer = NULL; /* 16 ms tick for ripple geometry */
+static lv_obj_t *s_thinking_arc = NULL;   /* PR 2 polish: rotating arc segment around body during TRANSCRIBING */
+static lv_timer_t *s_thinking_arc_timer = NULL; /* drives the arc's rotation */
+static lv_obj_t *s_saved_burst = NULL;     /* PR 2 polish: one-shot green ring on SAVED entry */
+static lv_timer_t *s_saved_burst_timer = NULL;
+static uint32_t s_saved_burst_t0 = 0;      /* ms uptime when burst started, for elapsed-frac math */
+static lv_timer_t *s_body_pulse_timer = NULL; /* PR 2 polish: body heartbeat scale during RECORDING */
 static lv_obj_t *s_comet = NULL; /* skill-rim comet (sibling-AFTER s_body so it draws on top) */
 static lv_timer_t *s_tilt_timer = NULL;
 static lv_timer_t *s_bloom_timer = NULL;
@@ -576,6 +588,21 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_clear_flag(s_ripple_b, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_add_flag(s_ripple_b, LV_OBJ_FLAG_HIDDEN);
 
+   /* PR 2 polish: SAVED burst — one-shot expanding green ring on
+    * DICT_SAVED entry.  Created behind everything; only visible during
+    * the 700 ms burst.  Same border-only outline style as the ripples. */
+   s_saved_burst = lv_obj_create(parent);
+   lv_obj_remove_style_all(s_saved_burst);
+   lv_obj_set_size(s_saved_burst, ORB_SIZE, ORB_SIZE);
+   lv_obj_set_pos(s_saved_burst, cx - (ORB_SIZE / 2), cy - (ORB_SIZE / 2));
+   lv_obj_set_style_radius(s_saved_burst, LV_RADIUS_CIRCLE, 0);
+   lv_obj_set_style_bg_opa(s_saved_burst, 0, 0);
+   lv_obj_set_style_border_width(s_saved_burst, 4, 0);
+   lv_obj_set_style_border_color(s_saved_burst, lv_color_hex(0x4ADE80), 0);
+   lv_obj_set_style_border_opa(s_saved_burst, 0, 0);
+   lv_obj_clear_flag(s_saved_burst, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(s_saved_burst, LV_OBJ_FLAG_HIDDEN);
+
    /* Halo FIRST so it sits BEHIND s_body in z-order (LVGL draws siblings
     * in creation order).  s_body's opa-cover gradient masks the part of
     * the halo overlapping the orb; only the outer "bloom" ring shows. */
@@ -626,6 +653,29 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_set_style_bg_color(s_comet, lv_color_hex(0xFFE0A0), 0);
    lv_obj_set_style_bg_opa(s_comet, 0, 0);
    lv_obj_clear_flag(s_comet, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+
+   /* PR 2 polish: rotating arc for TRANSCRIBING — sibling AFTER s_body
+    * so the arc draws ON TOP of the body's edge.  Created with the
+    * main/knob/indicator parts neutralised, indicator carries the
+    * visible sweep that the tick callback rotates. */
+   s_thinking_arc = lv_arc_create(parent);
+   if (s_thinking_arc) {
+      lv_obj_remove_style(s_thinking_arc, NULL, LV_PART_KNOB);
+      lv_obj_set_size(s_thinking_arc, THINKING_ARC_DIAM, THINKING_ARC_DIAM);
+      lv_obj_set_pos(s_thinking_arc, cx - THINKING_ARC_DIAM / 2, cy - THINKING_ARC_DIAM / 2);
+      lv_arc_set_bg_angles(s_thinking_arc, 0, 360);
+      lv_arc_set_angles(s_thinking_arc, 0, THINKING_ARC_SWEEP);
+      lv_arc_set_value(s_thinking_arc, 0);
+      lv_obj_set_style_arc_width(s_thinking_arc, 4, LV_PART_INDICATOR);
+      lv_obj_set_style_arc_color(s_thinking_arc, lv_color_hex(0xFCD34D), LV_PART_INDICATOR);
+      lv_obj_set_style_arc_opa(s_thinking_arc, LV_OPA_COVER, LV_PART_INDICATOR);
+      lv_obj_set_style_arc_width(s_thinking_arc, 0, LV_PART_MAIN);
+      lv_obj_set_style_arc_opa(s_thinking_arc, 0, LV_PART_MAIN);
+      lv_obj_set_style_bg_opa(s_thinking_arc, 0, LV_PART_MAIN);
+      lv_obj_remove_flag(s_thinking_arc, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_clear_flag(s_thinking_arc, LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_add_flag(s_thinking_arc, LV_OBJ_FLAG_HIDDEN);
+   }
 
    /* PR 2: hero caption below the orb for pipeline state — sized to read
     * as a primary status indicator (Montserrat Bold 22 px), not a
@@ -924,6 +974,121 @@ static void ripple_stop(void) {
    if (s_ripple_b) lv_obj_add_flag(s_ripple_b, LV_OBJ_FLAG_HIDDEN);
 }
 
+/* ── TRANSCRIBING rotating arc ───────────────────────────────────────── */
+
+/* A 90°-sweep amber arc orbits around the body.  Reads as a "loading
+ * spinner" — clearer "I'm thinking" than the existing comet's tiny dot.
+ * Geometry defines hoisted to the top of the file. */
+
+static void thinking_arc_tick_cb(lv_timer_t *t) {
+   (void)t;
+   if (!s_thinking_arc) return;
+   uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   int rotation = (int)((t_ms * 360 / THINKING_ARC_PERIOD_MS) % 360);
+   lv_arc_set_angles(s_thinking_arc, rotation, (rotation + THINKING_ARC_SWEEP) % 360);
+}
+
+static void thinking_arc_start(uint32_t color_hex) {
+   if (!s_thinking_arc) return;
+   lv_obj_set_style_arc_color(s_thinking_arc, lv_color_hex(color_hex), LV_PART_INDICATOR);
+   lv_obj_clear_flag(s_thinking_arc, LV_OBJ_FLAG_HIDDEN);
+   if (!s_thinking_arc_timer) {
+      s_thinking_arc_timer = lv_timer_create(thinking_arc_tick_cb, 16, NULL);
+   }
+}
+
+static void thinking_arc_stop(void) {
+   if (s_thinking_arc_timer) {
+      lv_timer_del(s_thinking_arc_timer);
+      s_thinking_arc_timer = NULL;
+   }
+   if (s_thinking_arc) lv_obj_add_flag(s_thinking_arc, LV_OBJ_FLAG_HIDDEN);
+}
+
+/* ── SAVED celebratory burst ─────────────────────────────────────────── */
+
+/* On DICT_SAVED entry, a single green ring flies outward + fades in
+ * ~700 ms.  Self-stops once the cycle completes. */
+#define SAVED_BURST_DURATION_MS 700
+#define SAVED_BURST_MIN_PX ORB_SIZE
+#define SAVED_BURST_MAX_PX (ORB_HALO_DIAM + 80)
+#define SAVED_BURST_PEAK_OPA 230
+
+static void saved_burst_tick_cb(lv_timer_t *t) {
+   (void)t;
+   if (!s_saved_burst) return;
+   uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   uint32_t elapsed = (now_ms >= s_saved_burst_t0) ? (now_ms - s_saved_burst_t0) : 0;
+   if (elapsed >= SAVED_BURST_DURATION_MS) {
+      if (s_saved_burst_timer) {
+         lv_timer_del(s_saved_burst_timer);
+         s_saved_burst_timer = NULL;
+      }
+      lv_obj_add_flag(s_saved_burst, LV_OBJ_FLAG_HIDDEN);
+      return;
+   }
+   float frac = (float)elapsed / (float)SAVED_BURST_DURATION_MS;
+   /* Cubic ease-out so the burst flies out fast then settles. */
+   float inv = 1.0f - frac;
+   float eased = 1.0f - inv * inv * inv;
+   int span = SAVED_BURST_MAX_PX - SAVED_BURST_MIN_PX;
+   int size = SAVED_BURST_MIN_PX + (int)(eased * (float)span);
+   lv_obj_set_size(s_saved_burst, size, size);
+   lv_obj_set_pos(s_saved_burst, s_orb_cx - size / 2, s_orb_cy - size / 2);
+   int opa = (int)((1.0f - frac) * SAVED_BURST_PEAK_OPA);
+   lv_obj_set_style_border_opa(s_saved_burst, (lv_opa_t)opa, LV_PART_MAIN);
+}
+
+static void saved_burst_fire(void) {
+   if (!s_saved_burst) return;
+   s_saved_burst_t0 = (uint32_t)(esp_timer_get_time() / 1000);
+   lv_obj_set_size(s_saved_burst, SAVED_BURST_MIN_PX, SAVED_BURST_MIN_PX);
+   lv_obj_set_pos(s_saved_burst, s_orb_cx - SAVED_BURST_MIN_PX / 2, s_orb_cy - SAVED_BURST_MIN_PX / 2);
+   lv_obj_set_style_border_opa(s_saved_burst, SAVED_BURST_PEAK_OPA, LV_PART_MAIN);
+   lv_obj_clear_flag(s_saved_burst, LV_OBJ_FLAG_HIDDEN);
+   if (!s_saved_burst_timer) {
+      s_saved_burst_timer = lv_timer_create(saved_burst_tick_cb, 16, NULL);
+   }
+}
+
+/* ── Body heartbeat during RECORDING ─────────────────────────────────── */
+
+/* Subtle ±2.3% scale pulse on s_body, 1.2 s cycle.  Adds a literal
+ * heartbeat feel on top of sonar ripples + halo breath.  LVGL 9's
+ * transform_scale uses 256 = 1.0×; pivot snapped to body centre. */
+#define BODY_PULSE_PERIOD_MS 1200
+#define BODY_PULSE_AMPLITUDE 6
+
+static void body_pulse_tick_cb(lv_timer_t *t) {
+   (void)t;
+   if (!s_body) return;
+   uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   uint32_t phase = t_ms % BODY_PULSE_PERIOD_MS;
+   float half = BODY_PULSE_PERIOD_MS / 2.0f;
+   float tri = (phase < half) ? ((float)phase / half) : (1.0f - ((float)phase - half) / half);
+   int scale = 256 + (int)((tri * 2.0f - 1.0f) * (float)BODY_PULSE_AMPLITUDE);
+   lv_obj_set_style_transform_scale_x(s_body, scale, LV_PART_MAIN);
+   lv_obj_set_style_transform_scale_y(s_body, scale, LV_PART_MAIN);
+}
+
+static void body_pulse_start(void) {
+   if (!s_body || s_body_pulse_timer) return;
+   lv_obj_set_style_transform_pivot_x(s_body, ORB_SIZE / 2, LV_PART_MAIN);
+   lv_obj_set_style_transform_pivot_y(s_body, ORB_SIZE / 2, LV_PART_MAIN);
+   s_body_pulse_timer = lv_timer_create(body_pulse_tick_cb, 16, NULL);
+}
+
+static void body_pulse_stop(void) {
+   if (s_body_pulse_timer) {
+      lv_timer_del(s_body_pulse_timer);
+      s_body_pulse_timer = NULL;
+   }
+   if (s_body) {
+      lv_obj_set_style_transform_scale_x(s_body, 256, LV_PART_MAIN);
+      lv_obj_set_style_transform_scale_y(s_body, 256, LV_PART_MAIN);
+   }
+}
+
 /* Paint the orb body in the pipeline-state tint.  Caller is responsible
  * for setting the caption text + showing the caption label.
  *
@@ -1051,6 +1216,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          hide_caption();
          reset_pipeline_halo();
          ripple_stop();
+         thinking_arc_stop();
+         body_pulse_stop();
          /* Repaint via the voice-state painter so the orb returns to its
           * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals.  Re-paint
           * body for current hour too — paint_pipeline_body() shadowed it. */
@@ -1067,6 +1234,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          paint_pipeline_body(0xE74C3C);
          paint_pipeline_halo(0xFF5C50); /* warm red halo glow */
          ripple_start(0xFF7A6F);        /* sonar rings expanding outward */
+         thinking_arc_stop();
+         body_pulse_start();            /* heartbeat pulse on body scale */
          uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
          uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
          uint32_t s = dur_ms / 1000;
@@ -1082,6 +1251,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_UPLOADING:
          ripple_stop();
+         body_pulse_stop();
+         thinking_arc_start(0xFCD34D); /* amber spinner */
          paint_pipeline_body(0xF59E0B);
          paint_pipeline_halo(0xFFB347); /* amber glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
@@ -1090,6 +1261,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_TRANSCRIBING:
          ripple_stop();
+         body_pulse_stop();
+         thinking_arc_start(0xFCD34D); /* amber spinner */
          paint_pipeline_body(0xF59E0B);
          paint_pipeline_halo(0xFFB347); /* amber glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
@@ -1101,6 +1274,9 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_SAVED:
          ripple_stop();
+         body_pulse_stop();
+         thinking_arc_stop();
+         saved_burst_fire();             /* one-shot expanding green ring */
          paint_pipeline_body(0x22C55E);
          paint_pipeline_halo(0x4ADE80); /* mint glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xCFFFE0), 0);
@@ -1115,6 +1291,8 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
       case DICT_FAILED:
          ripple_stop();
+         body_pulse_stop();
+         thinking_arc_stop();
          paint_pipeline_body(0xE74C3C);
          paint_pipeline_halo(0xFF5C50);
          /* Drop the unicode mid-dot — FONT_HEADING (montserrat bold 22)

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -20,14 +20,14 @@
 
 #include "config.h" /* FONT_CAPTION for pipeline-state caption (PR 2) */
 #include "esp_log.h"
-#include "esp_timer.h"        /* esp_timer_get_time for RECORDING caption timer (PR 2) */
-#include "imu.h"              /* tab5_imu_read for tilt-driven specular drift */
+#include "esp_timer.h" /* esp_timer_get_time for RECORDING caption timer (PR 2) */
+#include "imu.h"       /* tab5_imu_read for tilt-driven specular drift */
 #include "lvgl.h"
-#include "ui_core.h"          /* tab5_lv_async_call for cross-thread repaints */
-#include "voice.h"            /* voice_get_current_rms for the LISTENING bloom */
-#include "voice_dictation.h"       /* pipeline-state types (PR 2) */
-#include "voice_dictation_lvgl.h"  /* LVGL-marshalled subscriber (PR 2) */
-#include "widget.h"                /* widget_tone_t for paint_for_tone */
+#include "ui_core.h"              /* tab5_lv_async_call for cross-thread repaints */
+#include "voice.h"                /* voice_get_current_rms for the LISTENING bloom */
+#include "voice_dictation.h"      /* pipeline-state types (PR 2) */
+#include "voice_dictation_lvgl.h" /* LVGL-marshalled subscriber (PR 2) */
+#include "widget.h"               /* widget_tone_t for paint_for_tone */
 
 static const char *TAG = "ui_orb";
 
@@ -152,15 +152,15 @@ static uint8_t s_last_painted_mode = 0;
  * route through the pipeline-state painter and the voice-state painter
  * is suppressed.  IDLE → revert to voice-state painting. */
 static dict_event_t s_pipeline = {
-   .state = DICT_IDLE,
-   .fail_reason = DICT_FAIL_NONE,
-   .started_ms = 0,
-   .stopped_ms = 0,
-   .last_change_ms = 0,
-   .note_slot = -1,
+    .state = DICT_IDLE,
+    .fail_reason = DICT_FAIL_NONE,
+    .started_ms = 0,
+    .stopped_ms = 0,
+    .last_change_ms = 0,
+    .note_slot = -1,
 };
-static lv_obj_t *s_orb_caption = NULL;  /* Label below the orb body */
-static lv_timer_t *s_saved_fade_timer = NULL;  /* SAVED → IDLE 2s timer */
+static lv_obj_t *s_orb_caption = NULL;        /* Label below the orb body */
+static lv_timer_t *s_saved_fade_timer = NULL; /* SAVED → IDLE 2s timer */
 static lv_timer_t *s_rec_timer_label = NULL;  /* updates RECORDING caption every 200 ms */
 
 /* ── Circadian palette ───────────────────────────────────────────────── */
@@ -793,13 +793,20 @@ static void paint_pipeline_body(uint32_t color_hex) {
 
 static const char *fail_reason_caption(dict_fail_t r) {
    switch (r) {
-   case DICT_FAIL_AUTH:      return "AUTH";
-   case DICT_FAIL_NETWORK:   return "NETWORK";
-   case DICT_FAIL_EMPTY:     return "EMPTY — got silence";
-   case DICT_FAIL_NO_AUDIO:  return "NO AUDIO";
-   case DICT_FAIL_TOO_LONG:  return "TOO LONG (5 min cap)";
-   case DICT_FAIL_CANCELLED: return "CANCELLED";
-   default:                  return "FAIL";
+      case DICT_FAIL_AUTH:
+         return "AUTH";
+      case DICT_FAIL_NETWORK:
+         return "NETWORK";
+      case DICT_FAIL_EMPTY:
+         return "EMPTY — got silence";
+      case DICT_FAIL_NO_AUDIO:
+         return "NO AUDIO";
+      case DICT_FAIL_TOO_LONG:
+         return "TOO LONG (5 min cap)";
+      case DICT_FAIL_CANCELLED:
+         return "CANCELLED";
+      default:
+         return "FAIL";
    }
 }
 
@@ -817,8 +824,7 @@ static void hide_caption(void) {
 static void saved_fade_to_idle_cb(lv_timer_t *t) {
    (void)t;
    s_saved_fade_timer = NULL;
-   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE,
-                             (uint32_t)(esp_timer_get_time() / 1000));
+   voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
 }
 
 /* Update the RECORDING caption with live elapsed time.  Stops itself
@@ -834,13 +840,10 @@ static void rec_timer_label_cb(lv_timer_t *t) {
       return;
    }
    uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
-   uint32_t dur_ms = (s_pipeline.started_ms && now_ms >= s_pipeline.started_ms)
-                       ? (now_ms - s_pipeline.started_ms)
-                       : 0;
+   uint32_t dur_ms = (s_pipeline.started_ms && now_ms >= s_pipeline.started_ms) ? (now_ms - s_pipeline.started_ms) : 0;
    uint32_t s = dur_ms / 1000;
    char buf[40];
-   snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
-            (unsigned long)(s / 60), (unsigned long)(s % 60));
+   snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
    if (s_orb_caption) lv_label_set_text(s_orb_caption, buf);
 }
 
@@ -870,70 +873,64 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
 
    char buf[64];
    switch (event->state) {
-   case DICT_IDLE:
-      hide_caption();
-      /* Repaint via the voice-state painter so the orb returns to its
-       * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals.  Re-paint
-       * body for current hour too — paint_pipeline_body() shadowed it. */
-      paint_body_for_hour(orb_effective_hour());
-      ui_orb_set_state(s_state);
-      return;
+      case DICT_IDLE:
+         hide_caption();
+         /* Repaint via the voice-state painter so the orb returns to its
+          * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals.  Re-paint
+          * body for current hour too — paint_pipeline_body() shadowed it. */
+         paint_body_for_hour(orb_effective_hour());
+         ui_orb_set_state(s_state);
+         return;
 
-   case DICT_RECORDING: {
-      /* Engage the existing LISTENING state machine so the mic-RMS-driven
-       * halo bloom fires.  Our pipeline body tint overrides the body
-       * colour, but the bloom mechanic (halo opacity from mic RMS) still
-       * runs because it manipulates s_halo, not s_body. */
-      ui_orb_set_state(ORB_STATE_LISTENING);
-      paint_pipeline_body(0xE74C3C);
-      uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
-      uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms)
-                          ? (now_ms - event->started_ms)
-                          : 0;
-      uint32_t s = dur_ms / 1000;
-      snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu",
-               (unsigned long)(s / 60), (unsigned long)(s % 60));
-      set_caption_text(buf);
-      /* Spawn the 200 ms tick that keeps the M:SS caption live. */
-      if (!s_rec_timer_label) {
-         s_rec_timer_label = lv_timer_create(rec_timer_label_cb, 200, NULL);
+      case DICT_RECORDING: {
+         /* Engage the existing LISTENING state machine so the mic-RMS-driven
+          * halo bloom fires.  Our pipeline body tint overrides the body
+          * colour, but the bloom mechanic (halo opacity from mic RMS) still
+          * runs because it manipulates s_halo, not s_body. */
+         ui_orb_set_state(ORB_STATE_LISTENING);
+         paint_pipeline_body(0xE74C3C);
+         uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+         uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
+         uint32_t s = dur_ms / 1000;
+         snprintf(buf, sizeof(buf), "● RECORDING %lu:%02lu", (unsigned long)(s / 60), (unsigned long)(s % 60));
+         set_caption_text(buf);
+         /* Spawn the 200 ms tick that keeps the M:SS caption live. */
+         if (!s_rec_timer_label) {
+            s_rec_timer_label = lv_timer_create(rec_timer_label_cb, 200, NULL);
+         }
+         break;
       }
-      break;
-   }
 
-   case DICT_UPLOADING:
-      paint_pipeline_body(0xF59E0B);
-      set_caption_text("UPLOADING…");
-      break;
+      case DICT_UPLOADING:
+         paint_pipeline_body(0xF59E0B);
+         set_caption_text("UPLOADING…");
+         break;
 
-   case DICT_TRANSCRIBING:
-      paint_pipeline_body(0xF59E0B);
-      set_caption_text("TRANSCRIBING…");
-      /* Reuse the existing PROCESSING comet animation for visual
-       * continuity. */
-      ui_orb_set_state(ORB_STATE_PROCESSING);
-      break;
+      case DICT_TRANSCRIBING:
+         paint_pipeline_body(0xF59E0B);
+         set_caption_text("TRANSCRIBING…");
+         /* Reuse the existing PROCESSING comet animation for visual
+          * continuity. */
+         ui_orb_set_state(ORB_STATE_PROCESSING);
+         break;
 
-   case DICT_SAVED:
-      paint_pipeline_body(0x22C55E);
-      set_caption_text("✓ Saved");
-      /* Schedule auto-fade back to IDLE after 2 s.  Idempotent — if
-       * one already exists (rapid SAVED re-entry), don't stack. */
-      if (!s_saved_fade_timer) {
-         s_saved_fade_timer = lv_timer_create(saved_fade_to_idle_cb, 2000, NULL);
-         if (s_saved_fade_timer) lv_timer_set_repeat_count(s_saved_fade_timer, 1);
-      }
-      break;
+      case DICT_SAVED:
+         paint_pipeline_body(0x22C55E);
+         set_caption_text("✓ Saved");
+         /* Schedule auto-fade back to IDLE after 2 s.  Idempotent — if
+          * one already exists (rapid SAVED re-entry), don't stack. */
+         if (!s_saved_fade_timer) {
+            s_saved_fade_timer = lv_timer_create(saved_fade_to_idle_cb, 2000, NULL);
+            if (s_saved_fade_timer) lv_timer_set_repeat_count(s_saved_fade_timer, 1);
+         }
+         break;
 
-   case DICT_FAILED:
-      paint_pipeline_body(0xE74C3C);
-      snprintf(buf, sizeof(buf), "● %s — tap to retry",
-               fail_reason_caption(event->fail_reason));
-      set_caption_text(buf);
-      break;
+      case DICT_FAILED:
+         paint_pipeline_body(0xE74C3C);
+         snprintf(buf, sizeof(buf), "● %s — tap to retry", fail_reason_caption(event->fail_reason));
+         set_caption_text(buf);
+         break;
    }
 }
 
-bool ui_orb_pipeline_active(void) {
-   return s_pipeline.state != DICT_IDLE;
-}
+bool ui_orb_pipeline_active(void) { return s_pipeline.state != DICT_IDLE; }

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -129,6 +129,9 @@ static lv_obj_t *s_root = NULL;  /* parent container (= the home screen) */
 static lv_obj_t *s_body = NULL;  /* the lit sphere itself */
 static lv_obj_t *s_spec = NULL;  /* tilt-driven specular highlight (child of s_body) */
 static lv_obj_t *s_halo = NULL;  /* voice-bloom halo (sibling-BEHIND s_body) */
+static lv_obj_t *s_ripple_a = NULL;   /* PR 2 polish: sonar ripple A — outermost-expanding ring during RECORDING */
+static lv_obj_t *s_ripple_b = NULL;   /* PR 2 polish: sonar ripple B — phase-offset by 50% so a new ripple is always rising as the prior fades */
+static lv_timer_t *s_ripple_timer = NULL; /* 16 ms tick for ripple geometry */
 static lv_obj_t *s_comet = NULL; /* skill-rim comet (sibling-AFTER s_body so it draws on top) */
 static lv_timer_t *s_tilt_timer = NULL;
 static lv_timer_t *s_bloom_timer = NULL;
@@ -542,6 +545,37 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    s_orb_cx = cx;
    s_orb_cy = cy;
 
+   /* PR 2 polish: sonar ripple rings — two phase-offset transparent
+    * circles that grow outward from the orb body and fade.  Hidden by
+    * default; shown only during DICT_RECORDING.  Created BEFORE s_halo
+    * so their z-order is behind everything (the body fully masks the
+    * inner portion; only the outer expanding ring is visible).  Two
+    * rings 50% out of phase so the ripple cadence feels continuous
+    * instead of pulsing once a cycle. */
+   s_ripple_a = lv_obj_create(parent);
+   lv_obj_remove_style_all(s_ripple_a);
+   lv_obj_set_size(s_ripple_a, ORB_SIZE, ORB_SIZE);
+   lv_obj_set_pos(s_ripple_a, cx - (ORB_SIZE / 2), cy - (ORB_SIZE / 2));
+   lv_obj_set_style_radius(s_ripple_a, LV_RADIUS_CIRCLE, 0);
+   lv_obj_set_style_bg_opa(s_ripple_a, 0, 0); /* outline only */
+   lv_obj_set_style_border_width(s_ripple_a, 3, 0);
+   lv_obj_set_style_border_color(s_ripple_a, lv_color_hex(0xFF5C50), 0);
+   lv_obj_set_style_border_opa(s_ripple_a, 0, 0); /* invisible at rest */
+   lv_obj_clear_flag(s_ripple_a, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(s_ripple_a, LV_OBJ_FLAG_HIDDEN);
+
+   s_ripple_b = lv_obj_create(parent);
+   lv_obj_remove_style_all(s_ripple_b);
+   lv_obj_set_size(s_ripple_b, ORB_SIZE, ORB_SIZE);
+   lv_obj_set_pos(s_ripple_b, cx - (ORB_SIZE / 2), cy - (ORB_SIZE / 2));
+   lv_obj_set_style_radius(s_ripple_b, LV_RADIUS_CIRCLE, 0);
+   lv_obj_set_style_bg_opa(s_ripple_b, 0, 0);
+   lv_obj_set_style_border_width(s_ripple_b, 3, 0);
+   lv_obj_set_style_border_color(s_ripple_b, lv_color_hex(0xFF5C50), 0);
+   lv_obj_set_style_border_opa(s_ripple_b, 0, 0);
+   lv_obj_clear_flag(s_ripple_b, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(s_ripple_b, LV_OBJ_FLAG_HIDDEN);
+
    /* Halo FIRST so it sits BEHIND s_body in z-order (LVGL draws siblings
     * in creation order).  s_body's opa-cover gradient masks the part of
     * the halo overlapping the orb; only the outer "bloom" ring shows. */
@@ -834,6 +868,62 @@ static void reset_pipeline_halo(void) {
    lv_obj_set_style_bg_color(s_halo, lv_color_hex(0xFFB870), LV_PART_MAIN);
 }
 
+/* PR 2 polish: sonar ripple drive.  Each ring grows from the body's
+ * diameter out to a comfortable margin past the halo, fading its
+ * border opacity from a confident peak to invisible over the cycle.
+ * Two rings 50% out of phase keep the cadence continuous.  Tick at
+ * ~60 Hz for smooth interpolation. */
+#define RIPPLE_CYCLE_MS 1800
+#define RIPPLE_MIN_PX ORB_SIZE
+#define RIPPLE_MAX_PX (ORB_HALO_DIAM + 60)
+#define RIPPLE_PEAK_OPA 180
+
+static void ripple_paint_one(lv_obj_t *o, float frac) {
+   if (!o) return;
+   /* Ease-out for the geometry growth so the ring decelerates as it
+    * expands — feels like a real ripple slowing as it propagates. */
+   float eased = 1.0f - (1.0f - frac) * (1.0f - frac);
+   int span = RIPPLE_MAX_PX - RIPPLE_MIN_PX;
+   int size = RIPPLE_MIN_PX + (int)(eased * (float)span);
+   lv_obj_set_size(o, size, size);
+   lv_obj_set_pos(o, s_orb_cx - size / 2, s_orb_cy - size / 2);
+   /* Opacity falls linearly from peak to 0 over the cycle. */
+   int opa = (int)((1.0f - frac) * RIPPLE_PEAK_OPA);
+   if (opa < 0) opa = 0;
+   if (opa > 255) opa = 255;
+   lv_obj_set_style_border_opa(o, (lv_opa_t)opa, LV_PART_MAIN);
+}
+
+static void ripple_tick_cb(lv_timer_t *t) {
+   (void)t;
+   if (!s_ripple_a || !s_ripple_b) return;
+   uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   uint32_t phase_a = t_ms % RIPPLE_CYCLE_MS;
+   uint32_t phase_b = (t_ms + RIPPLE_CYCLE_MS / 2) % RIPPLE_CYCLE_MS;
+   ripple_paint_one(s_ripple_a, (float)phase_a / (float)RIPPLE_CYCLE_MS);
+   ripple_paint_one(s_ripple_b, (float)phase_b / (float)RIPPLE_CYCLE_MS);
+}
+
+static void ripple_start(uint32_t color_hex) {
+   if (!s_ripple_a || !s_ripple_b) return;
+   lv_obj_set_style_border_color(s_ripple_a, lv_color_hex(color_hex), LV_PART_MAIN);
+   lv_obj_set_style_border_color(s_ripple_b, lv_color_hex(color_hex), LV_PART_MAIN);
+   lv_obj_clear_flag(s_ripple_a, LV_OBJ_FLAG_HIDDEN);
+   lv_obj_clear_flag(s_ripple_b, LV_OBJ_FLAG_HIDDEN);
+   if (!s_ripple_timer) {
+      s_ripple_timer = lv_timer_create(ripple_tick_cb, 16, NULL);
+   }
+}
+
+static void ripple_stop(void) {
+   if (s_ripple_timer) {
+      lv_timer_del(s_ripple_timer);
+      s_ripple_timer = NULL;
+   }
+   if (s_ripple_a) lv_obj_add_flag(s_ripple_a, LV_OBJ_FLAG_HIDDEN);
+   if (s_ripple_b) lv_obj_add_flag(s_ripple_b, LV_OBJ_FLAG_HIDDEN);
+}
+
 /* Paint the orb body in the pipeline-state tint.  Caller is responsible
  * for setting the caption text + showing the caption label.
  *
@@ -960,6 +1050,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
       case DICT_IDLE:
          hide_caption();
          reset_pipeline_halo();
+         ripple_stop();
          /* Repaint via the voice-state painter so the orb returns to its
           * normal IDLE/LISTENING/PROCESSING/SPEAKING visuals.  Re-paint
           * body for current hour too — paint_pipeline_body() shadowed it. */
@@ -975,6 +1066,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          ui_orb_set_state(ORB_STATE_LISTENING);
          paint_pipeline_body(0xE74C3C);
          paint_pipeline_halo(0xFF5C50); /* warm red halo glow */
+         ripple_start(0xFF7A6F);        /* sonar rings expanding outward */
          uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
          uint32_t dur_ms = (event->started_ms && now_ms >= event->started_ms) ? (now_ms - event->started_ms) : 0;
          uint32_t s = dur_ms / 1000;
@@ -989,6 +1081,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
       }
 
       case DICT_UPLOADING:
+         ripple_stop();
          paint_pipeline_body(0xF59E0B);
          paint_pipeline_halo(0xFFB347); /* amber glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
@@ -996,6 +1089,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          break;
 
       case DICT_TRANSCRIBING:
+         ripple_stop();
          paint_pipeline_body(0xF59E0B);
          paint_pipeline_halo(0xFFB347); /* amber glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xFFE4B5), 0);
@@ -1006,6 +1100,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          break;
 
       case DICT_SAVED:
+         ripple_stop();
          paint_pipeline_body(0x22C55E);
          paint_pipeline_halo(0x4ADE80); /* mint glow */
          lv_obj_set_style_text_color(s_orb_caption, lv_color_hex(0xCFFFE0), 0);
@@ -1019,6 +1114,7 @@ void ui_orb_set_pipeline_state(const dict_event_t *event) {
          break;
 
       case DICT_FAILED:
+         ripple_stop();
          paint_pipeline_body(0xE74C3C);
          paint_pipeline_halo(0xFF5C50);
          /* Drop the unicode mid-dot — FONT_HEADING (montserrat bold 22)

--- a/main/ui_orb.h
+++ b/main/ui_orb.h
@@ -26,7 +26,8 @@
 #include <stdint.h>
 
 #include "lvgl.h"
-#include "widget.h" /* widget_tone_t */
+#include "voice_dictation.h" /* dict_event_t, dict_state_t (PR 2) */
+#include "widget.h"          /* widget_tone_t */
 
 #ifdef __cplusplus
 extern "C" {
@@ -114,6 +115,25 @@ lv_obj_t *ui_orb_get_root(void);
  *  that needs to attach children (e.g. status pip).  Discouraged for new
  *  code; prefer adding behaviors inside ui_orb itself. */
 lv_obj_t *ui_orb_get_body(void);
+
+/* ── Pipeline state (PR 2) ──────────────────────────────────────────── */
+
+/* Drive the orb's pipeline-state painting.  Takes precedence over the
+ * voice-state machine (IDLE/LISTENING/PROCESSING/SPEAKING) when pipeline
+ * state is anything except DICT_IDLE.  On DICT_IDLE, orb returns to the
+ * voice-state-driven visuals it had before.
+ *
+ * Safe to call only on the LVGL thread — callers using the dictation
+ * pipeline subscriber API should subscribe via voice_dictation_subscribe_lvgl
+ * to get automatic marshalling.
+ *
+ * The `event` is taken by value (caller may pass a stack copy). */
+void ui_orb_set_pipeline_state(const dict_event_t *event);
+
+/* Returns true if the orb is currently in a non-IDLE pipeline state and
+ * thus the voice-state painting is suppressed.  Used by ui_home's
+ * voice-state callback to know whether to skip orb repaints. */
+bool ui_orb_pipeline_active(void);
 
 #ifdef __cplusplus
 }

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -31,6 +31,7 @@
 #include "task_worker.h"
 #include "ui_core.h" /* tab5_lv_async_call (#258) */
 #include "ui_notes.h"
+#include "ui_orb.h" /* PR 2 polish: ui_orb_pipeline_active() for overlay suppression */
 #include "ui_theme.h" /* TT #328 Wave 4: TH_MODE_*/ TH_STATUS_ *tokens for state - icon hues * /
 #include "voice.h" /* W7-E.4c: voice_is_channel_reply_armed + getters */
 
@@ -1212,6 +1213,23 @@ static void show_state_listening(void)
      * amber-family PROCESSING / SPEAKING. */
     set_state_icon(LV_SYMBOL_AUDIO, TH_MODE_LOCAL);
 
+    /* PR 2 polish: when the dictation pipeline is on-flight, the orb is
+     * already painted with pipeline visuals (red body, hero caption,
+     * Dictate chip-as-cancel).  Suppress the voice overlay's "I'm here.
+     * Go." status text + LISTENING sub-caption + red stop button — they
+     * overlap the home-resident Dictate chip and double up the messaging.
+     * The pipeline + chip own this surface during dictation. */
+    if (ui_orb_pipeline_active()) {
+       if (s_lbl_status) lv_obj_add_flag(s_lbl_status, LV_OBJ_FLAG_HIDDEN);
+       if (s_lbl_sub) lv_obj_add_flag(s_lbl_sub, LV_OBJ_FLAG_HIDDEN);
+       if (s_send_btn) lv_obj_add_flag(s_send_btn, LV_OBJ_FLAG_HIDDEN);
+       if (s_lbl_transcript) lv_obj_add_flag(s_lbl_transcript, LV_OBJ_FLAG_HIDDEN);
+       if (s_lbl_dots) lv_obj_add_flag(s_lbl_dots, LV_OBJ_FLAG_HIDDEN);
+       if (s_wave_cont) lv_obj_add_flag(s_wave_cont, LV_OBJ_FLAG_HIDDEN);
+       if (s_lbl_rec_time) lv_obj_add_flag(s_lbl_rec_time, LV_OBJ_FLAG_HIDDEN);
+       return;
+    }
+
     /* Clean up READY-state orb click handler if still attached */
     lv_obj_clear_flag(s_orb_container, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_remove_event_cb(s_orb_container, orb_ready_click_cb);
@@ -1325,6 +1343,20 @@ static void show_state_processing(const char *detail)
     * speaking (blue). */
    set_state_icon(LV_SYMBOL_REFRESH, 0xA78BFA);
    render_queue_badge();
+
+   /* PR 2 polish: pipeline UPLOADING / TRANSCRIBING own the surface.
+    * Suppress overlay chrome so the hero caption + Dictate chip read
+    * cleanly without overlap. */
+   if (ui_orb_pipeline_active()) {
+      if (s_lbl_status) lv_obj_add_flag(s_lbl_status, LV_OBJ_FLAG_HIDDEN);
+      if (s_lbl_sub) lv_obj_add_flag(s_lbl_sub, LV_OBJ_FLAG_HIDDEN);
+      if (s_send_btn) lv_obj_add_flag(s_send_btn, LV_OBJ_FLAG_HIDDEN);
+      if (s_lbl_transcript) lv_obj_add_flag(s_lbl_transcript, LV_OBJ_FLAG_HIDDEN);
+      if (s_lbl_dots) lv_obj_add_flag(s_lbl_dots, LV_OBJ_FLAG_HIDDEN);
+      if (s_lbl_rec_time) lv_obj_add_flag(s_lbl_rec_time, LV_OBJ_FLAG_HIDDEN);
+      if (s_response_label) lv_obj_add_flag(s_response_label, LV_OBJ_FLAG_HIDDEN);
+      return;
+   }
    /* Note: this is called repeatedly as LLM tokens arrive.
     * detail = STT text (first call), then LLM text (subsequent calls).
     * We use voice_get_stt_text() and voice_get_llm_text() to distinguish. */

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -52,17 +52,35 @@ void voice_dictation_init(void) {
    /* Lazily create the mutex on first call.  Subsequent calls reuse the
     * existing handle so init remains idempotent.  We deliberately do NOT
     * destroy + recreate because callers in other tasks may already be
-    * spinning on a take. */
+    * spinning on a take.
+    *
+    * IMPORTANT: We do NOT clear s_subs here.  In TinkerTab boot order
+    * `ui_home_create` runs on the main task BEFORE the deferred LVGL-
+    * timer init callback fires `voice_dictation_init`.  ui_orb_create's
+    * pipeline subscription registers via voice_dictation_subscribe()
+    * during ui_home_create — wiping s_subs at init time would silently
+    * kill any already-registered subscriber and leave pipeline state
+    * machine fires unobserved at the UI.  BSS zero-init already gives
+    * us an empty subscriber table at first boot; nothing more is needed.
+    *
+    * s_event is BSS-zero-initialised too, but we leave the explicit
+    * field initialisers here (still idempotent — equivalent of a no-op
+    * after the first call) so the contract "init starts at DICT_IDLE
+    * with note_slot=-1" remains visible at the init site. */
    if (s_lock == NULL) {
       s_lock = xSemaphoreCreateRecursiveMutex();
    }
 
    dict_lock();
-   memset(&s_event, 0, sizeof(s_event));
-   s_event.state = DICT_IDLE;
-   s_event.fail_reason = DICT_FAIL_NONE;
-   s_event.note_slot = -1;
-   memset(s_subs, 0, sizeof(s_subs));
+   if (s_event.state == 0 && s_event.note_slot == 0) {
+      /* First-init path — BSS-zero state has note_slot=0 which is a
+       * valid slot id; fix it to the sentinel.  Re-entry path leaves
+       * the existing s_event alone (a dictation might already be in
+       * flight if another module called set_state before init). */
+      s_event.state = DICT_IDLE;
+      s_event.fail_reason = DICT_FAIL_NONE;
+      s_event.note_slot = -1;
+   }
    dict_unlock();
 }
 

--- a/main/voice_dictation.c
+++ b/main/voice_dictation.c
@@ -52,35 +52,17 @@ void voice_dictation_init(void) {
    /* Lazily create the mutex on first call.  Subsequent calls reuse the
     * existing handle so init remains idempotent.  We deliberately do NOT
     * destroy + recreate because callers in other tasks may already be
-    * spinning on a take.
-    *
-    * IMPORTANT: We do NOT clear s_subs here.  In TinkerTab boot order
-    * `ui_home_create` runs on the main task BEFORE the deferred LVGL-
-    * timer init callback fires `voice_dictation_init`.  ui_orb_create's
-    * pipeline subscription registers via voice_dictation_subscribe()
-    * during ui_home_create — wiping s_subs at init time would silently
-    * kill any already-registered subscriber and leave pipeline state
-    * machine fires unobserved at the UI.  BSS zero-init already gives
-    * us an empty subscriber table at first boot; nothing more is needed.
-    *
-    * s_event is BSS-zero-initialised too, but we leave the explicit
-    * field initialisers here (still idempotent — equivalent of a no-op
-    * after the first call) so the contract "init starts at DICT_IDLE
-    * with note_slot=-1" remains visible at the init site. */
+    * spinning on a take. */
    if (s_lock == NULL) {
       s_lock = xSemaphoreCreateRecursiveMutex();
    }
 
    dict_lock();
-   if (s_event.state == 0 && s_event.note_slot == 0) {
-      /* First-init path — BSS-zero state has note_slot=0 which is a
-       * valid slot id; fix it to the sentinel.  Re-entry path leaves
-       * the existing s_event alone (a dictation might already be in
-       * flight if another module called set_state before init). */
-      s_event.state = DICT_IDLE;
-      s_event.fail_reason = DICT_FAIL_NONE;
-      s_event.note_slot = -1;
-   }
+   memset(&s_event, 0, sizeof(s_event));
+   s_event.state = DICT_IDLE;
+   s_event.fail_reason = DICT_FAIL_NONE;
+   s_event.note_slot = -1;
+   memset(s_subs, 0, sizeof(s_subs));
    dict_unlock();
 }
 

--- a/main/voice_dictation_lvgl.c
+++ b/main/voice_dictation_lvgl.c
@@ -6,8 +6,8 @@
 
 typedef struct {
    dict_subscriber_t cb;
-   void             *user_data;
-   dict_event_t      event;
+   void *user_data;
+   dict_event_t event;
 } dict_marshal_t;
 
 static void dict_marshal_lvgl_cb(void *arg) {
@@ -18,7 +18,7 @@ static void dict_marshal_lvgl_cb(void *arg) {
 
 static void dict_marshal_dispatch(const dict_event_t *e, void *user_data) {
    dict_subscriber_t real_cb = ((void **)user_data)[0];
-   void *real_user_data      = ((void **)user_data)[1];
+   void *real_user_data = ((void **)user_data)[1];
    dict_marshal_t *m = malloc(sizeof(*m));
    if (!m) return;
    m->cb = real_cb;

--- a/main/voice_dictation_lvgl.c
+++ b/main/voice_dictation_lvgl.c
@@ -1,0 +1,42 @@
+#include "voice_dictation_lvgl.h"
+
+#include <stdlib.h>
+
+#include "ui_core.h" /* tab5_lv_async_call */
+
+typedef struct {
+   dict_subscriber_t cb;
+   void             *user_data;
+   dict_event_t      event;
+} dict_marshal_t;
+
+static void dict_marshal_lvgl_cb(void *arg) {
+   dict_marshal_t *m = (dict_marshal_t *)arg;
+   m->cb(&m->event, m->user_data);
+   free(m);
+}
+
+static void dict_marshal_dispatch(const dict_event_t *e, void *user_data) {
+   dict_subscriber_t real_cb = ((void **)user_data)[0];
+   void *real_user_data      = ((void **)user_data)[1];
+   dict_marshal_t *m = malloc(sizeof(*m));
+   if (!m) return;
+   m->cb = real_cb;
+   m->user_data = real_user_data;
+   m->event = *e;
+   tab5_lv_async_call(dict_marshal_lvgl_cb, m);
+}
+
+int voice_dictation_subscribe_lvgl(dict_subscriber_t cb, void *user_data) {
+   if (!cb) return -1;
+   void **tuple = malloc(sizeof(void *) * 2);
+   if (!tuple) return -1;
+   tuple[0] = (void *)cb;
+   tuple[1] = user_data;
+   int h = voice_dictation_subscribe(dict_marshal_dispatch, tuple);
+   if (h < 0) {
+      free(tuple);
+      return -1;
+   }
+   return h;
+}

--- a/main/voice_dictation_lvgl.h
+++ b/main/voice_dictation_lvgl.h
@@ -1,0 +1,17 @@
+/* main/voice_dictation_lvgl.h — LVGL-thread-marshalling wrapper around
+ * voice_dictation_subscribe().  Lives in its own file because pulling
+ * tab5_lv_async_call into voice_dictation.c would break the host test
+ * build (host shims don't cover ui_core.h). */
+#pragma once
+
+#include "voice_dictation.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int voice_dictation_subscribe_lvgl(dict_subscriber_t cb, void *user_data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -50,6 +50,46 @@ static const char *TAG = "tab5_voice_ws";
  * in voice.c.  No external readers — kept here so the dropped-frame
  * accounting stays colocated with the sender that increments it. */
 static int s_audio_drop_count = 0;
+/* PR 2 polish: grace-period timer for TRANSCRIBING WS drops.  Armed when
+ * the WS disconnects mid-transcription, fires after ~45 s, only flips
+ * the pipeline to FAILED if it's still stuck at TRANSCRIBING.  Cancelled
+ * by a fresh DICT_SAVED / DICT_FAILED transition from the summary
+ * handlers, which leave the pipeline in a terminal state the timer's
+ * check skips. */
+static esp_timer_handle_t s_tx_grace_timer = NULL;
+
+static void tx_grace_timer_fired(void *arg) {
+   (void)arg;
+   dict_event_t e = voice_dictation_get();
+   if (e.state == DICT_TRANSCRIBING) {
+      ESP_LOGW(TAG, "TRANSCRIBING grace window expired — flipping pipeline to FAILED/NETWORK");
+      voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
+   } else {
+      ESP_LOGI(TAG, "TRANSCRIBING grace timer fired but pipeline already resolved (state=%s) — no-op",
+               voice_dictation_state_name(e.state));
+   }
+}
+
+void voice_ws_arm_transcribe_grace_timer(uint32_t timeout_ms) {
+   if (s_tx_grace_timer == NULL) {
+      const esp_timer_create_args_t args = {
+          .callback = tx_grace_timer_fired,
+          .arg = NULL,
+          .dispatch_method = ESP_TIMER_TASK,
+          .name = "tx_grace",
+      };
+      if (esp_timer_create(&args, &s_tx_grace_timer) != ESP_OK) {
+         ESP_LOGE(TAG, "Failed to create TRANSCRIBING grace timer; falling back to immediate FAIL");
+         voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
+         return;
+      }
+   }
+   /* Stop any prior arming so we always have a full fresh window from
+    * the latest disconnect. */
+   esp_timer_stop(s_tx_grace_timer);
+   esp_timer_start_once(s_tx_grace_timer, (uint64_t)timeout_ms * 1000);
+   ESP_LOGI(TAG, "TRANSCRIBING grace timer armed: %u ms before pipeline flips to FAILED", (unsigned)timeout_ms);
+}
 
 /* SemaphoreHandle_t externs — defined in voice.c, used by the JSON RX
  * dispatcher + UI-async helpers below.  Declared here (not in voice.h)
@@ -822,6 +862,21 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       cJSON *ntitle = cJSON_GetObjectItem(root, "title");
       ESP_LOGI(TAG, "Dragon auto-created note: id=%s title=\"%s\"", cJSON_IsString(nid) ? nid->valuestring : "?",
                cJSON_IsString(ntitle) ? ntitle->valuestring : "?");
+   } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
+      /* PR 2 polish: Dragon's STT + auto-note-create completed but the
+       * LLM summary step failed (no_llm_available, generation error,
+       * etc.).  The note IS saved on Dragon (it was created from the
+       * STT transcript before the LLM step), so transition the pipeline
+       * to SAVED rather than leaving it stuck at TRANSCRIBING.  We use
+       * SAVED here even though there's no title/summary because the
+       * user's intent was captured — the note exists, just without an
+       * auto-generated heading.  Tab5's Notes screen will pick it up
+       * on next sync with a fallback title from the transcript. */
+      cJSON *err = cJSON_GetObjectItem(root, "error");
+      const char *err_str = (cJSON_IsString(err) && err->valuestring) ? err->valuestring : "unknown";
+      ESP_LOGW(TAG, "Dictation post-processing failed: %s — pipeline → SAVED (note already exists)", err_str);
+      voice_set_state(VOICE_STATE_READY, "dictation_postprocessing_error");
+      voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
    } else if (strcmp(type_str, "llm_done") == 0) {
       cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
       ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,
@@ -1410,13 +1465,28 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t even
          /* Flush playback so we don't keep speaking into a dead pipe. */
          voice_playback_buf_reset();
          tab5_audio_speaker_enable(false);
-         /* PR 1: if a dictation was mid-pipeline, fail it with NETWORK
-          * so the UI surfaces the disconnect.  No-op when pipeline is
-          * already IDLE/SAVED/FAILED. */
+         /* PR 2 polish: WS drop during dictation pipeline.
+          *
+          * RECORDING / UPLOADING — the audio frames we were streaming
+          * went into a dead pipe, no recovery is possible.  Fail
+          * immediately so the user can retry.
+          *
+          * TRANSCRIBING — Dragon's blocking LLM summary call may have
+          * starved the WS for >60 s and triggered an ngrok idle-close.
+          * The WS auto-reconnects within ~600 ms (esp_websocket_client
+          * built-in).  Don't flip the pipeline to FAILED right away —
+          * instead arm a 45 s grace timer.  If `dictation_summary` or
+          * `dictation_postprocessing_error` arrives on the reconnected
+          * WS during that window, the pipeline reaches SAVED naturally
+          * and the timer's pipeline-state check will skip the FAIL.
+          * If the window expires with no resolution, then FAIL. */
          {
             dict_state_t cur_dict = voice_dictation_get().state;
-            if (cur_dict == DICT_RECORDING || cur_dict == DICT_UPLOADING || cur_dict == DICT_TRANSCRIBING) {
+            if (cur_dict == DICT_RECORDING || cur_dict == DICT_UPLOADING) {
                voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
+            } else if (cur_dict == DICT_TRANSCRIBING) {
+               extern void voice_ws_arm_transcribe_grace_timer(uint32_t timeout_ms);
+               voice_ws_arm_transcribe_grace_timer(45000);
             }
          }
          /* Tab5 audit F5 (2026-04-20): if the drop landed MID-TURN (voice


### PR DESCRIPTION
## Summary

First **visible-on-home** PR in the dictation pipeline series.  Builds on PR #519's state machine.

- Orb body tints + caption text mirror pipeline state on home (RECORDING red, UPLOADING / TRANSCRIBING amber, SAVED green, FAILED red)
- New **Dictate chip** below the existing mode chip — mode-chip language, tap-to-start
- Chip mirrors orb state (label + caption + affordance) and acts as retry/cancel where applicable
- 1 Hz tick keeps the M:SS recording duration fresh on both orb caption + chip
- Boot-order fix: \`voice_dictation_init\` no longer wipes the subscriber table

Closes #520.

Plan: \`docs/superpowers/plans/2026-05-14-dictation-pipeline-pr2.md\`

## Test plan

- [x] \`idf.py build\` clean, no new warnings
- [x] \`git-clang-format --diff origin/main\` clean
- [x] Live on Tab5 192.168.1.90:
  - Home renders with mode chip + new Dictate chip stacked
  - Tap Dictate chip → orb goes red, chip "● RECORDING M:SS" with live counter
  - After stop → orb amber, chip "● TRANSCRIBING" with retry icon
  - After Dragon's dictation_summary → orb green for 2 s, chip "✓ Saved"
  - After SAVED → orb returns to circadian, chip returns to "Dictate · TAP TO START"
- [x] No PANIC across cycles
- [x] Heap stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)