### PR TITLE
fix(notes): pipeline dictations surface on Tab5 timeline

### DIFF
--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -758,6 +758,57 @@ static void __attribute__((unused)) voice_state_cb(voice_state_t state, const ch
     }
 }
 
+/* Forward decl — s_rec_note_slot is defined further down with the
+ * recording-flow statics but the dictated-async helper below uses it
+ * to skip duplicate creation when the local "+ NEW VOICE NOTE" flow
+ * already owns a slot. */
+static int s_rec_note_slot;
+
+/* PR 3 follow-up: deferred WS-thread → LVGL-thread dictated-note add.
+ * The dictation_summary handler in voice_ws_proto.c calls
+ * ui_notes_add_dictated_async with a transcript; we copy the bytes
+ * into PSRAM (s_notes touches PSRAM but refresh_list touches LVGL,
+ * so this MUST run on the LVGL thread) and dispatch via
+ * tab5_lv_async_call.  The callback runs ui_notes_add directly and
+ * frees the heap buffer. */
+static void notes_add_dictated_async_cb(void *arg) {
+   char *text = (char *)arg;
+   if (!text) return;
+   /* Skip if the local-recording flow already owns a slot (the
+    * "+ NEW VOICE NOTE" path on Notes — ui_notes_start_recording
+    * sets s_rec_note_slot >= 0 until ui_notes_stop_recording
+    * finalises it).  Without this guard a single dictation would
+    * land twice on the timeline. */
+   if (s_rec_note_slot >= 0) {
+      ESP_LOGI(TAG, "Skipping pipeline-add — local recording slot %d already active", s_rec_note_slot);
+      free(text);
+      return;
+   }
+   if (text[0]) {
+      int idx = ui_notes_add(text, true);
+      if (idx >= 0 && s_notes && idx >= 0 && idx < MAX_NOTES) {
+         /* Tag the new note as a voice dictation explicitly so the
+          * Notes filter pill 'Voice' picks it up without relying on
+          * legacy is_voice (which is also set above). */
+         s_notes[idx].type = NOTE_TYPE_VOICE;
+         /* notes_save will see the dirty type field on next sync;
+          * ui_notes_add already triggered a save, so re-save here. */
+         notes_save();
+      }
+   }
+   free(text);
+}
+
+void ui_notes_add_dictated_async(const char *transcript) {
+   if (!transcript || !transcript[0]) return;
+   size_t n = strnlen(transcript, MAX_NOTE_LEN - 1);
+   char *copy = (char *)malloc(n + 1);
+   if (!copy) return;
+   memcpy(copy, transcript, n);
+   copy[n] = '\0';
+   tab5_lv_async_call(notes_add_dictated_async_cb, copy);
+}
+
 /* ── Note storage API ──────────────────────────────────── */
 int ui_notes_add(const char *text, bool is_voice)
 {

--- a/main/ui_notes.h
+++ b/main/ui_notes.h
@@ -60,3 +60,12 @@ int ui_notes_clear_failed(void);
 
 /** S6: Sync all pending (needs_sync) notes to Dragon. Call on reconnect. */
 void ui_notes_sync_pending(void);
+
+/** PR 3 follow-up: add a dictated note from the WS pipeline path (FAB
+ *  or home Dictate chip) — Dragon's `dictation_summary` doesn't create
+ *  a Tab5-local slot otherwise.  Marshals to the LVGL thread via
+ *  tab5_lv_async_call so it's safe to call from the WS event task.
+ *  No-op if a local-recording slot is already active (the
+ *  "+ NEW VOICE NOTE" button path owns that slot via
+ *  ui_notes_start_recording).  Caller owns the string; we copy. */
+void ui_notes_add_dictated_async(const char *transcript);

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -854,6 +854,21 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       const uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
       if (s_dictation_title[0] || s_dictation_summary[0]) {
          voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, now);
+         /* PR 3 follow-up: surface the dictation as a local Tab5 note
+          * so it appears on the Notes timeline.  Path A (local
+          * "+ NEW VOICE NOTE" → ui_notes_start_recording) already owns
+          * its slot; this handler only fires for Path B (FAB / home
+          * Dictate chip via voice_start_dictation with no local slot).
+          * The async helper marshals to LVGL thread + no-ops if a
+          * local slot is already active so we don't duplicate. */
+         const char *transcript = voice_get_dictation_text();
+         if (transcript && transcript[0]) {
+            ui_notes_add_dictated_async(transcript);
+         } else if (s_dictation_summary[0]) {
+            ui_notes_add_dictated_async(s_dictation_summary);
+         } else {
+            ui_notes_add_dictated_async(s_dictation_title);
+         }
       } else {
          voice_dictation_set_state(DICT_FAILED, DICT_FAIL_EMPTY, now);
       }
@@ -877,6 +892,15 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       ESP_LOGW(TAG, "Dictation post-processing failed: %s — pipeline → SAVED (note already exists)", err_str);
       voice_set_state(VOICE_STATE_READY, "dictation_postprocessing_error");
       voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
+      /* PR 3 follow-up: same local-note creation path as
+       * dictation_summary above.  Dragon auto-created its own note
+       * before the LLM step failed, so the transcript is the user's
+       * captured content even though we don't have a title/summary.
+       * Surface it on Tab5's Notes timeline. */
+      const char *transcript = voice_get_dictation_text();
+      if (transcript && transcript[0]) {
+         ui_notes_add_dictated_async(transcript);
+      }
    } else if (strcmp(type_str, "llm_done") == 0) {
       cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
       ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,


### PR DESCRIPTION
## Summary
Closes #525.  PR #524 introduced the Notes timeline + FAB but dictations triggered via FAB or home chip never showed up on the Tab5 list (pipeline visuals worked, local ring didn't).  This patch adds the missing \`ui_notes_add\` call to the WS pipeline path.

## Verified live
- Notes count **6 → 7** after one FAB dictation
- New row appeared under fresh **TODAY** section
- Body: *"The accomplishments of his talented friends. Get up and stop"* (real STT capture)
- \`VOICE\` type chip; filter pill 'Voice' picks it up

## Test plan
- [x] idf.py build clean
- [x] git-clang-format --diff origin/main clean
- [x] Live FAB → record → stop → row appears
- [x] No duplication when Path A ('+ NEW VOICE NOTE') is in flight (no-op guard on s_rec_note_slot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)