### PR TITLE
feat(notes): SD WAV capture for pipeline-dictated voice notes

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -2017,12 +2017,20 @@ static void dictate_chip_tap_cb(lv_event_t *e) {
    (void)e;
    dict_event_t dp = voice_dictation_get();
    if (dp.state == DICT_IDLE || dp.state == DICT_FAILED) {
+      /* #537: arm a SD WAV before starting the pipeline so the mic
+       * capture task's ui_notes_write_audio() hook actually has a
+       * file to write to.  On dictation_summary the slot is finalised
+       * with the transcript + audio_path; on cancel/error we discard
+       * the WAV via ui_notes_pipeline_cancel_recording. */
+      bool armed = ui_notes_pipeline_arm_recording();
       esp_err_t err = voice_start_dictation();
       if (err != ESP_OK) {
          ESP_LOGW(TAG, "voice_start_dictation failed: %s", esp_err_to_name(err));
+         if (armed) ui_notes_pipeline_cancel_recording();
       }
    } else if (dp.state == DICT_RECORDING) {
       voice_cancel();
+      ui_notes_pipeline_cancel_recording();
       voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED, (uint32_t)(esp_timer_get_time() / 1000));
    }
 }

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -776,8 +776,11 @@ static void __attribute__((unused)) voice_state_cb(voice_state_t state, const ch
 /* Forward decl — s_rec_note_slot is defined further down with the
  * recording-flow statics but the dictated-async helper below uses it
  * to skip duplicate creation when the local "+ NEW VOICE NOTE" flow
- * already owns a slot. */
+ * already owns a slot.  #537 adds s_pipeline_armed_slot + s_rec_file
+ * to distinguish the home Dictate chip's pre-armed WAV path. */
 static int s_rec_note_slot;
+static bool s_pipeline_armed_slot;
+static FILE *s_rec_file;
 
 /* PR 3 follow-up: deferred WS-thread → LVGL-thread dictated-note add.
  * The dictation_summary handler in voice_ws_proto.c calls
@@ -789,6 +792,25 @@ static int s_rec_note_slot;
 static void notes_add_dictated_async_cb(void *arg) {
    char *text = (char *)arg;
    if (!text) return;
+   /* #537: if the pipeline-arm path (home Dictate chip / chat mic) opened
+    * a WAV file ahead of this dictation, finalise it now — write the
+    * transcript into the reserved slot, close the WAV, attach audio_path.
+    * This is the path that gives Dragon-routed voice notes a playable
+    * SD recording. */
+   if (s_pipeline_armed_slot && s_rec_note_slot >= 0 && s_rec_file != NULL) {
+      ESP_LOGI(TAG, "Pipeline-armed slot %d → finalising with transcript", s_rec_note_slot);
+      s_pipeline_armed_slot = false;
+      /* The arm path hides the slot (used=false) so a placeholder row
+       * doesn't render in-flight; flip it back before finalisation so
+       * the new transcribed note actually appears on the timeline. */
+      if (s_rec_note_slot < MAX_NOTES && !s_notes[s_rec_note_slot].used) {
+         s_notes[s_rec_note_slot].used = true;
+         if (s_note_count < MAX_NOTES) s_note_count++;
+      }
+      ui_notes_stop_recording(text[0] ? text : NULL);
+      free(text);
+      return;
+   }
    /* Skip if the local-recording flow already owns a slot (the
     * "+ NEW VOICE NOTE" path on Notes — ui_notes_start_recording
     * sets s_rec_note_slot >= 0 until ui_notes_stop_recording
@@ -973,6 +995,13 @@ static uint32_t s_rec_samples = 0;
 static SemaphoreHandle_t s_rec_mutex = NULL;
 static int s_rec_note_slot = -1;
 
+/* #537: pipeline-armed recording flag.  Distinguishes a slot opened by
+ * ui_notes_pipeline_arm_recording (home Dictate chip path) from one
+ * opened by ui_notes_start_recording via the FAB.  The FAB owns its own
+ * stop-via-tap teardown; the pipeline-armed slot is finalised when
+ * dictation_summary arrives or discarded on cancel. */
+static bool s_pipeline_armed_slot = false;
+
 /* WAV header for PCM 16-bit mono */
 static void wav_write_header(FILE *f, uint32_t data_bytes, uint16_t sample_rate)
 {
@@ -1062,6 +1091,60 @@ const char *ui_notes_start_recording(void)
 
     ESP_LOGI(TAG, "Recording started: %s (slot %d)", s_rec_path, s_rec_note_slot);
     return s_rec_path;
+}
+
+/* #537: arm a SD WAV recording for an incoming pipeline-path dictation.
+ * The reserved slot is left with `used = false` until dictation_summary
+ * arrives — the processing row at the top of Notes (and the home Dictate
+ * chip M:SS hint) communicate state during the in-flight phase, so a
+ * placeholder row in the list would be redundant + visually noisy with
+ * an inert play button. */
+bool ui_notes_pipeline_arm_recording(void) {
+   if (s_rec_file != NULL || s_rec_note_slot >= 0) {
+      ESP_LOGI(TAG, "Pipeline arm rejected — recording already in flight (slot %d)", s_rec_note_slot);
+      return false;
+   }
+   const char *wav = ui_notes_start_recording();
+   if (!wav) return false;
+   s_pipeline_armed_slot = true;
+   if (s_rec_note_slot >= 0 && s_rec_note_slot < MAX_NOTES) {
+      /* Hide the row until summary lands.  notes_add_dictated_async_cb
+       * flips used back to true via ui_notes_stop_recording(transcript). */
+      s_notes[s_rec_note_slot].used = false;
+      if (s_note_count > 0) s_note_count--;
+      s_notes[s_rec_note_slot].text[0] = '\0';
+      s_notes[s_rec_note_slot].type = NOTE_TYPE_VOICE;
+   }
+   refresh_list();
+   return true;
+}
+
+/* #537: cancel a pipeline-armed recording.  Closes the WAV, removes the
+ * file, releases the slot. */
+void ui_notes_pipeline_cancel_recording(void) {
+   if (!s_pipeline_armed_slot) return;
+   ESP_LOGI(TAG, "Pipeline-armed slot %d → discarding", s_rec_note_slot);
+   s_pipeline_armed_slot = false;
+
+   if (s_rec_mutex) xSemaphoreTake(s_rec_mutex, portMAX_DELAY);
+   if (s_rec_file) {
+      fclose(s_rec_file);
+      s_rec_file = NULL;
+   }
+   if (s_rec_mutex) xSemaphoreGive(s_rec_mutex);
+
+   if (s_rec_path[0]) {
+      remove(s_rec_path);
+      s_rec_path[0] = '\0';
+   }
+   if (s_rec_note_slot >= 0 && s_rec_note_slot < MAX_NOTES) {
+      s_notes[s_rec_note_slot].used = false;
+      if (s_note_count > 0) s_note_count--;
+   }
+   s_rec_note_slot = -1;
+   s_rec_samples = 0;
+   notes_save();
+   refresh_list();
 }
 
 void ui_notes_write_audio(const int16_t *samples, size_t count)

--- a/main/ui_notes.h
+++ b/main/ui_notes.h
@@ -69,3 +69,19 @@ void ui_notes_sync_pending(void);
  *  "+ NEW VOICE NOTE" button path owns that slot via
  *  ui_notes_start_recording).  Caller owns the string; we copy. */
 void ui_notes_add_dictated_async(const char *transcript);
+
+/** #537: arm a SD WAV recording for an incoming pipeline-path dictation
+ *  (Home Dictate chip / chat overlay mic).  Opens a new WAV file +
+ *  reserves a note slot in NOTE_STATE_RECORDED state — the existing
+ *  ui_notes_write_audio() hook in voice.c's mic capture task will
+ *  populate the file frame-by-frame.  Returns true if the slot was
+ *  armed, false if SD isn't mounted or another recording is already
+ *  in flight (FAB or prior arm).  Called from the LVGL thread. */
+bool ui_notes_pipeline_arm_recording(void);
+
+/** #537: cancel a pipeline-armed recording.  Closes the WAV, deletes
+ *  the half-written file from SD, and removes the dangling note slot
+ *  from the timeline.  No-op if no pipeline-armed recording exists
+ *  (FAB-armed slots are untouched).  Idempotent.  Called on user-
+ *  initiated cancel + on dictation_postprocessing_cancelled WS frames. */
+void ui_notes_pipeline_cancel_recording(void);

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -835,6 +835,8 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       voice_set_state(VOICE_STATE_READY, "dictation_cancelled");
       /* PR 1: pipeline transition for the cancelled path. */
       voice_dictation_set_state(DICT_FAILED, DICT_FAIL_CANCELLED, (uint32_t)(esp_timer_get_time() / 1000));
+      /* #537: discard the pipeline-armed WAV — no transcript is coming. */
+      tab5_lv_async_call((lv_async_cb_t)ui_notes_pipeline_cancel_recording, NULL);
    } else if (strcmp(type_str, "dictation_summary") == 0) {
       cJSON *title = cJSON_GetObjectItem(root, "title");
       cJSON *summary = cJSON_GetObjectItem(root, "summary");


### PR DESCRIPTION
## Summary
Home Dictate chip / chat mic dictations now have local audio playback. Previously these notes landed on the Notes timeline without a green play button because the audio was only streamed to Dragon, never saved to SD.

- New \`ui_notes_pipeline_arm_recording()\` / \`ui_notes_pipeline_cancel_recording()\` APIs pre-open a WAV file + reserve a hidden slot ahead of \`voice_start_dictation\`.
- mic_capture_task's existing \`ui_notes_write_audio()\` hook populates the WAV frame-by-frame.
- On \`dictation_summary\`, \`notes_add_dictated_async_cb\` finalises the armed slot via \`ui_notes_stop_recording(transcript)\` which attaches the audio_path. Conditional play button now renders.
- Slot starts with \`used=false\` so no placeholder row leaks during recording (the processing row + home chip M:SS hint already communicate state). Finalize flips \`used=true\`.
- Cancel paths (chip tap during RECORDING, \`dictation_postprocessing_cancelled\` WS frame) close the WAV, delete the file, release the slot.

Closes #537. Builds on #534.

## Test plan
- [x] Tap Home Dictate chip → spoke a sentence → released → row appeared on Notes timeline with full transcript AND green play button
- [x] Tap Dictate chip during RECORDING → row never appears + WAV file deleted from SD
- [x] FAB recording path unchanged (existing guard preserves the legacy ui_notes_start_recording flow)
- [x] Build clean + format gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)