### PR TITLE
feat(orb): hero-scale + louder voice bloom

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -79,13 +79,15 @@ static const char *TAG = "ui_home";
  * went too sparse — orb-in-center left too much empty bottom-half).
  * Greeting + mode chip sit below in the rich middle band. */
 #define ORB_CX            (SW / 2)
-#define ORB_CY            320
-#define ORB_SIZE          180
+#define ORB_CY 340
+#define ORB_SIZE 280 /* TT #541 — must match ui_orb.c ORB_SIZE */
 #define HALO_OUTER        520
 #define HALO_INNER        340
-#define RING_OUTER        310
-#define RING_MID          240
-#define RING_INNER        196
+/* TT #541 — rings scaled with the bigger orb so the inner ring sits
+ * just outside the body (was 310/240/196 around a 180 px orb). */
+#define RING_OUTER 480
+#define RING_MID 380
+#define RING_INNER 320
 
 /* v4·D Sovereign Halo live-line — replaces the 240 px NOW card.
  * Kicker + lede + optional right meta, top + bottom hairline borders,

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -34,7 +34,7 @@ static const char *TAG = "ui_orb";
 
 /* ── Sizing / layout constants ──────────────────────────────────────── */
 
-#define ORB_SIZE 180 /* body diameter — matches v4·C Ambient Canvas */
+#define ORB_SIZE 280 /* body diameter — TT #541 hero scale (was 180) */
 
 /* ── Specular highlight (tilt-driven) ───────────────────────────────── */
 
@@ -99,10 +99,10 @@ static const char *TAG = "ui_orb";
  * at opa 0.  Color tracks circadian "top" stop so dawn-bloom looks
  * different from night-bloom; intensity is per-state. */
 #define ORB_HALO_DIAM 260
-#define ORB_HALO_OPA_FLOOR 24   /* always-on minimum during LISTENING */
-#define ORB_HALO_OPA_CEILING 90 /* peak at full RMS */
-#define ORB_BLOOM_PERIOD_MS 100 /* 10 Hz */
-#define ORB_BLOOM_ALPHA 0.30f   /* EMA smoothing for RMS */
+#define ORB_HALO_OPA_FLOOR 40    /* TT #541: was 24 — visible at rest during LISTENING */
+#define ORB_HALO_OPA_CEILING 160 /* TT #541: was 90 — louder peak when user speaks */
+#define ORB_BLOOM_PERIOD_MS 100  /* 10 Hz */
+#define ORB_BLOOM_ALPHA 0.50f    /* TT #541: was 0.30 — faster reaction to speech onset */
 
 /* ── Speaking halo (SPEAKING state) ──────────────────────────────────── */
 
@@ -404,8 +404,12 @@ static void bloom_tick_cb(lv_timer_t *t) {
    int floor_v = ORB_HALO_OPA_FLOOR;
    int ceil_v = ORB_HALO_OPA_CEILING;
    if (s_pipeline.state == DICT_RECORDING) {
-      floor_v = 110;
-      ceil_v = 180;
+      /* TT #541: louder bloom envelope for a hero-scale orb.  Floor is
+       * a confident "I'm listening" glow even when the user is silent;
+       * ceiling is roomy enough to read voice peaks against the bigger
+       * body without saturating. */
+      floor_v = 150;
+      ceil_v = 220;
       /* Slow breath: 0.5 Hz triangle wave on the floor itself, ±20 opa. */
       uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
       uint32_t phase = t_ms % 2000;


### PR DESCRIPTION
## Summary
The 180 px orb felt small against 720x1280 and the voice-bloom halo barely registered. Three tightly-scoped knobs:

1. **Bigger** — `ORB_SIZE` 180 → 280 (both ui_home.c rings + ui_orb.c body). `ORB_CY` 320 → 340 for breathing room above. Rings scaled proportionally (310/240/196 → 480/380/320).
2. **Louder bloom** — Halo floor 24 → 40, ceiling 90 → 160 (ambient LISTENING). DICT_RECORDING floor 110 → 150, ceiling 180 → 220.
3. **Faster EMA** — `ORB_BLOOM_ALPHA` 0.30 → 0.50 so the halo reacts to speech onset promptly.

**Out of scope**: always-on ambient morph. TT #501→#508 already proved adding more layers makes it worse — subtraction-over-addition holds. Time-of-day variation is already covered by `pick_circadian_palette` (7 dawn→night buckets).

Closes #541.

## Test plan
- [x] Build clean
- [x] Home idle: orb visibly larger, centred, gradient reads as 3D sphere
- [x] Home → Dictate tap → RECORDING: red orb with visible halo glow extending past the body edge
- [x] Format gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)