### PR TITLE
feat(orb): lean into the sphere — kill 2D chrome, sphere-native motion

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -596,42 +596,15 @@ lv_obj_t *ui_home_create(void)
     s_halo_outer = NULL;
     s_halo_inner = NULL;
 
-    /* Rings: border-only circles for a "composed" orb. */
-    s_ring_outer = lv_obj_create(s_screen);
-    lv_obj_remove_style_all(s_ring_outer);
-    pos_centered(s_ring_outer, ORB_CY - RING_OUTER / 2, RING_OUTER, RING_OUTER);
-    lv_obj_set_style_radius(s_ring_outer, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_opa(s_ring_outer, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(s_ring_outer, 1, 0);
-    lv_obj_set_style_border_color(s_ring_outer, lv_color_hex(TH_AMBER), 0);
-    /* TT #507 — dim the outer ring; was 60 → 25 so it reads as soft
-     * atmospheric glow instead of a hard tree-ring. */
-    lv_obj_set_style_border_opa(s_ring_outer, 25, 0);
-    lv_obj_clear_flag(s_ring_outer, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
-
-    s_ring_mid = lv_obj_create(s_screen);
-    lv_obj_remove_style_all(s_ring_mid);
-    pos_centered(s_ring_mid, ORB_CY - RING_MID / 2, RING_MID, RING_MID);
-    lv_obj_set_style_radius(s_ring_mid, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_opa(s_ring_mid, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(s_ring_mid, 1, 0);
-    lv_obj_set_style_border_color(s_ring_mid, lv_color_hex(TH_AMBER), 0);
-    /* TT #507 — was 90 → 40. */
-    lv_obj_set_style_border_opa(s_ring_mid, 40, 0);
-    lv_obj_clear_flag(s_ring_mid, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
-
-    s_ring_inner = lv_obj_create(s_screen);
-    lv_obj_remove_style_all(s_ring_inner);
-    pos_centered(s_ring_inner, ORB_CY - RING_INNER / 2, RING_INNER, RING_INNER);
-    lv_obj_set_style_radius(s_ring_inner, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_opa(s_ring_inner, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(s_ring_inner, 1, 0);
-    lv_obj_set_style_border_color(s_ring_inner, lv_color_hex(TH_AMBER), 0);
-    /* TT #507 — was 140 → 60.  Inner ring stays the most visible of
-     * the three (it sits closest to the orb body) but no longer
-     * dominates as a stark concentric outline. */
-    lv_obj_set_style_border_opa(s_ring_inner, 60, 0);
-    lv_obj_clear_flag(s_ring_inner, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+    /* TT #547: three concentric rings (s_ring_outer / _mid / _inner)
+     * killed — they were 1 px amber border circles at opa 25 / 40 / 60
+     * that reinforced the orb as a 2D composition.  Sphere-native
+     * motion (corona halo, fill-from-bottom glow during SPEAKING) does
+     * the atmospheric job better.  Pointers stay declared NULL so the
+     * tear-down path's null guards stay valid without a refactor. */
+    s_ring_outer = NULL;
+    s_ring_mid = NULL;
+    s_ring_inner = NULL;
 
     /* TT #511 wave-1: the orb body itself + its circadian paint +
      * initial sizing live in ui_orb.  Click + long-press handlers

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -43,8 +43,12 @@ static const char *TAG = "ui_orb";
  * orb to suggest a lit surface.  Clipped by s_body's radius-full corner.
  * Larger than #511's attempt (which was too small + had no working IMU
  * behind it) so the drift is unambiguously visible. */
-#define ORB_SPEC_W 70
-#define ORB_SPEC_H 44
+/* TT #547: specular highlight beefed up for the sphere-native pass —
+ * bigger ellipse + brighter peak opa + soft outer shadow that bleeds
+ * a small glow into the body's lit side.  Reads like wet-sphere sun-
+ * glint instead of a stamped oval. */
+#define ORB_SPEC_W 96
+#define ORB_SPEC_H 56
 
 /* Resting position: upper-left quadrant.  cx-shift = -18 px, cy-shift =
  * 16 px from top.  These should mirror the eye's expectation of "lit
@@ -142,7 +146,11 @@ static lv_obj_t *s_ripple_b =
 static lv_timer_t *s_ripple_timer = NULL;       /* 16 ms tick for ripple geometry */
 static lv_obj_t *s_thinking_arc = NULL;         /* PR 2 polish: rotating arc segment around body during TRANSCRIBING */
 static lv_timer_t *s_thinking_arc_timer = NULL; /* drives the arc's rotation */
-static lv_obj_t *s_tts_arc = NULL;              /* TT #545: TTS scrubber arc — fills clockwise during SPEAKING */
+/* TT #547: replaced the 2D scrubber arc with a sphere-native warm
+ * overlay — a circular sibling of s_body sized identically; bg_opa
+ * animated from 0 to peak over the SPEAKING duration so the sphere
+ * visibly brightens + warms as TTS plays. */
+static lv_obj_t *s_speak_fill = NULL;
 #define TTS_SCRUBBER_DEFAULT_MS 6000
 static lv_obj_t *s_saved_burst = NULL;          /* PR 2 polish: one-shot green ring on SAVED entry */
 static lv_timer_t *s_saved_burst_timer = NULL;
@@ -477,7 +485,9 @@ static void bloom_stop(void) {
       lv_timer_delete(s_bloom_timer);
       s_bloom_timer = NULL;
    }
-   if (s_halo) lv_obj_set_style_bg_opa(s_halo, 0, LV_PART_MAIN);
+   if (s_halo) {
+      lv_obj_set_style_bg_opa(s_halo, 0, LV_PART_MAIN);
+   }
    s_bloom_rms_ema = 0.0f;
 }
 
@@ -661,6 +671,10 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_set_style_radius(s_halo, LV_RADIUS_CIRCLE, 0);
    lv_obj_set_style_bg_color(s_halo, lv_color_hex(0xFFB870), 0);
    lv_obj_set_style_bg_opa(s_halo, 0, 0); /* invisible at rest */
+   /* TT #547 attempted halo corona via outer shadow but even 24 px
+    * blur on a 380 px halo at 5 Hz invalidation crushed the UI task
+    * mutex budget.  Reverted — sticking with the breath/bloom bg_opa
+    * animation that already gives a soft halo-to-bg transition. */
    lv_obj_clear_flag(s_halo, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
 
    s_body = lv_obj_create(parent);
@@ -684,8 +698,13 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_set_size(s_spec, ORB_SPEC_W, ORB_SPEC_H);
    lv_obj_set_pos(s_spec, ORB_SPEC_REST_X, ORB_SPEC_REST_Y);
    lv_obj_set_style_radius(s_spec, LV_RADIUS_CIRCLE, 0);
-   lv_obj_set_style_bg_color(s_spec, lv_color_hex(0xFFF5E0), 0);
-   lv_obj_set_style_bg_opa(s_spec, 110, 0);
+   lv_obj_set_style_bg_color(s_spec, lv_color_hex(0xFFF8E8), 0);
+   /* TT #547: bigger ellipse + brighter peak.  Tried adding a shadow
+    * for sun-glint glow but the per-tilt-tick (20 Hz) re-render of a
+    * blurred shadow blew the LVGL render budget — reverted to flat
+    * fill.  The 96×56 size + 140 opa peak alone gives a brighter,
+    * wetter highlight than the 70×44 / 110 baseline. */
+   lv_obj_set_style_bg_opa(s_spec, 140, 0);
    lv_obj_clear_flag(s_spec, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
    s_tilt_dx_ema = 0.0f;
    s_tilt_dy_ema = 0.0f;
@@ -725,42 +744,29 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
       lv_obj_add_flag(s_thinking_arc, LV_OBJ_FLAG_HIDDEN);
    }
 
-   /* TT #545: TTS scrubber arc — sibling AFTER s_body, same shape as
-    * the thinking arc but with a different motion model.  bg_angles
-    * 270..630 starts the indicator at 12 o'clock and wraps clockwise.
-    * value 0..100 animates from 0 to full ring over the SPEAKING
-    * state, with a 6 s default duration if TTS metadata isn't
-    * available.  Hidden by default. */
-   s_tts_arc = lv_arc_create(parent);
-   if (s_tts_arc) {
-      lv_obj_remove_style(s_tts_arc, NULL, LV_PART_KNOB);
-      lv_obj_set_size(s_tts_arc, THINKING_ARC_DIAM, THINKING_ARC_DIAM);
-      lv_obj_set_pos(s_tts_arc, cx - THINKING_ARC_DIAM / 2, cy - THINKING_ARC_DIAM / 2);
-      /* Full ring, then rotate so the start is at 12 o'clock.  LVGL 9
-       * bg_angles > 360 wraps strangely with set_value; the
-       * bg_angles(0, 360) + rotation(270) pattern is the canonical one
-       * used by the existing thinking arc and lights-up reliably. */
-      lv_arc_set_bg_angles(s_tts_arc, 0, 360);
-      lv_arc_set_rotation(s_tts_arc, 270);
-      lv_arc_set_mode(s_tts_arc, LV_ARC_MODE_NORMAL);
-      lv_arc_set_range(s_tts_arc, 0, 100);
-      lv_arc_set_value(s_tts_arc, 0);
-      /* Indicator: 6 px amber stroke — wider than the thinking arc's 4 px
-       * since the scrubber sits further from the body edge and needs to
-       * read as a progress indicator, not a decorative sweep. */
-      lv_obj_set_style_arc_width(s_tts_arc, 6, LV_PART_INDICATOR);
-      lv_obj_set_style_arc_color(s_tts_arc, lv_color_hex(0xFCD34D), LV_PART_INDICATOR);
-      lv_obj_set_style_arc_opa(s_tts_arc, LV_OPA_COVER, LV_PART_INDICATOR);
-      /* MAIN part = the un-filled portion of the track.  Soft amber at
-       * low opa so the user sees the full ring as a "track" while the
-       * indicator fills clockwise — reads as progress, not a streak. */
-      lv_obj_set_style_arc_width(s_tts_arc, 6, LV_PART_MAIN);
-      lv_obj_set_style_arc_color(s_tts_arc, lv_color_hex(0xFCD34D), LV_PART_MAIN);
-      lv_obj_set_style_arc_opa(s_tts_arc, 40, LV_PART_MAIN);
-      lv_obj_set_style_bg_opa(s_tts_arc, 0, LV_PART_MAIN);
-      lv_obj_remove_flag(s_tts_arc, LV_OBJ_FLAG_CLICKABLE);
-      lv_obj_clear_flag(s_tts_arc, LV_OBJ_FLAG_SCROLLABLE);
-      lv_obj_add_flag(s_tts_arc, LV_OBJ_FLAG_HIDDEN);
+   /* TT #547: sphere-native SPEAKING overlay.  A circular sibling that
+    * sits exactly on top of s_body, animated bg_opa 0 → ~140 over the
+    * SPEAKING duration.  Vertical bg_grad runs from cream-amber top to
+    * brighter cream-amber bottom — combined with the body's existing
+    * lit-sphere gradient underneath, the whole sphere appears to
+    * brighten + warm uniformly as TTS plays.  Reads as the sphere
+    * absorbing sound, no 2D chrome around it.  Same circle shape as
+    * s_body so no clipping or bleed.  Drawing s_speak_fill BEFORE
+    * s_spec ensures the specular highlight stays on top. */
+   s_speak_fill = lv_obj_create(parent);
+   if (s_speak_fill) {
+      lv_obj_remove_style_all(s_speak_fill);
+      lv_obj_set_size(s_speak_fill, ORB_SIZE, ORB_SIZE);
+      lv_obj_set_pos(s_speak_fill, cx - ORB_SIZE / 2, cy - ORB_SIZE / 2);
+      lv_obj_set_style_radius(s_speak_fill, LV_RADIUS_CIRCLE, 0);
+      lv_obj_set_style_bg_color(s_speak_fill, lv_color_hex(0xFFD68A), 0);
+      lv_obj_set_style_bg_grad_color(s_speak_fill, lv_color_hex(0xFFF0C8), 0);
+      lv_obj_set_style_bg_grad_dir(s_speak_fill, LV_GRAD_DIR_VER, 0);
+      lv_obj_set_style_bg_opa(s_speak_fill, 0, 0);
+      lv_obj_set_style_border_width(s_speak_fill, 0, 0);
+      lv_obj_remove_flag(s_speak_fill, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_clear_flag(s_speak_fill, LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_add_flag(s_speak_fill, LV_OBJ_FLAG_HIDDEN);
    }
 
    /* PR 2: hero caption below the orb for pipeline state — sized to read
@@ -1122,37 +1128,53 @@ void ui_orb_wake(void) {
    }
 }
 
-/* ── TTS scrubber arc (TT #545) ──────────────────────────────────────── */
+/* ── SPEAKING fill — sphere-native progress (TT #547) ────────────────── */
 
-static void tts_arc_value_anim_cb(void *obj, int32_t v) {
+/* Opa animation drives the bright cream-amber overlay fading in over
+ * the SPEAKING duration.  The orb visibly warms + brightens as TTS
+ * plays.  Plateaus at peak opa if SPEAKING runs past the estimate;
+ * tts_scrubber_stop fades it out + hides. */
+static void speak_fill_anim_cb(void *obj, int32_t v) {
    if (!obj) return;
-   lv_arc_set_value((lv_obj_t *)obj, v);
+   lv_obj_set_style_bg_opa((lv_obj_t *)obj, (lv_opa_t)v, LV_PART_MAIN);
 }
 
+#define SPEAK_FILL_PEAK_OPA 140
+
 static void tts_scrubber_start(uint32_t duration_ms) {
-   if (!s_tts_arc) return;
+   if (!s_speak_fill) return;
    if (duration_ms == 0) duration_ms = TTS_SCRUBBER_DEFAULT_MS;
-   lv_anim_delete(s_tts_arc, tts_arc_value_anim_cb);
-   lv_arc_set_value(s_tts_arc, 0);
-   lv_obj_clear_flag(s_tts_arc, LV_OBJ_FLAG_HIDDEN);
+   lv_anim_delete(s_speak_fill, speak_fill_anim_cb);
+   lv_obj_set_style_bg_opa(s_speak_fill, 0, LV_PART_MAIN);
+   lv_obj_clear_flag(s_speak_fill, LV_OBJ_FLAG_HIDDEN);
    lv_anim_t a;
    lv_anim_init(&a);
-   lv_anim_set_var(&a, s_tts_arc);
-   lv_anim_set_exec_cb(&a, tts_arc_value_anim_cb);
-   lv_anim_set_values(&a, 0, 100);
+   lv_anim_set_var(&a, s_speak_fill);
+   lv_anim_set_exec_cb(&a, speak_fill_anim_cb);
+   lv_anim_set_values(&a, 0, SPEAK_FILL_PEAK_OPA);
    lv_anim_set_time(&a, duration_ms);
-   lv_anim_set_path_cb(&a, lv_anim_path_linear);
-   /* Plateaus at 100 if SPEAKING runs longer than the estimate — the
-    * stuck-at-full state still reads as "still talking, just past my
-    * guess" without needing a loop. */
+   lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
    lv_anim_start(&a);
 }
 
 static void tts_scrubber_stop(void) {
-   if (!s_tts_arc) return;
-   lv_anim_delete(s_tts_arc, tts_arc_value_anim_cb);
-   lv_obj_add_flag(s_tts_arc, LV_OBJ_FLAG_HIDDEN);
-   lv_arc_set_value(s_tts_arc, 0);
+   if (!s_speak_fill) return;
+   lv_anim_delete(s_speak_fill, speak_fill_anim_cb);
+   /* Quick fade-out instead of instant cut so the brightness doesn't
+    * pop off the moment SPEAKING ends. */
+   int cur = lv_obj_get_style_bg_opa(s_speak_fill, LV_PART_MAIN);
+   if (cur > 0) {
+      lv_anim_t a;
+      lv_anim_init(&a);
+      lv_anim_set_var(&a, s_speak_fill);
+      lv_anim_set_exec_cb(&a, speak_fill_anim_cb);
+      lv_anim_set_values(&a, cur, 0);
+      lv_anim_set_time(&a, 300);
+      lv_anim_set_path_cb(&a, lv_anim_path_ease_in);
+      lv_anim_start(&a);
+   } else {
+      lv_obj_add_flag(s_speak_fill, LV_OBJ_FLAG_HIDDEN);
+   }
 }
 
 static void orb_body_press_cb(lv_event_t *e) {


### PR DESCRIPTION
## Summary
Moving orb activity ONTO and INTO the sphere instead of around it. Three of four targets landed; corona halo via shadow hit a render-budget ceiling and was reverted.

### Shipped
- **Killed the three concentric rings.** `s_ring_outer / _mid / _inner` were 1 px amber outlines at low opa — pure 2D reinforcement of flatness.
- **Beefier specular highlight.** 70×44 px / 110 opa → 96×56 px / 140 opa. Reads like wet-sphere sun-glint, not a stamped oval. Compatible with the existing IMU tilt + lissajous drift.
- **SPEAKING fill — warm sphere overlay.** Replaces the TT #545 2D scrubber arc. Circular sibling overlay sized identically to s_body, bg_opa 0 → 140 over the SPEAKING duration with ease_out path. Vertical bg_grad warmer-at-bottom so the sphere appears to absorb sound. 300 ms fade-out on exit so brightness doesn't pop.

### Reverted (documented for future)
- **Corona halo via outer shadow.** Even 24 px blur on a 380 px halo at 5 Hz invalidation crushed the UI-task mutex budget — continuous `UI task: mutex timeout` reboot loop. The corona effect needs a different rendering path (canvas / pre-blurred sprite) to be feasible on Tab5; bg_opa on the existing halo gives enough soft-glow signal for now.

### Also explored
- speak_fill as child of s_body with clip_corner: same mutex-timeout symptom. clip_corner on a gradient-bg parent forces per-pixel masking on every descendant draw; combined with 20 Hz spec-tilt re-renders it exceeds budget.
- Rectangular fill growing upward: bleeds outside the sphere shape. Circular-sibling overlay is sphere-native without any clipping mess.

Closes #547.

## Test plan
- [x] Build clean
- [x] Home idle: bigger spec visible, no rings, sphere reads as a real lit ball
- [x] SPEAKING (via `/debug/inject_ws tts_start`): sphere visibly brightens + warms uniformly mid-fade
- [x] UI task stable (fps=4, no mutex timeouts) after 60s with sphere-native overlay active

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)