### PR TITLE
fix(orb): yield mic when voice is capturing

### DIFF
--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -1649,7 +1649,11 @@ static void ambient_apply(void) {
 
 static void ambient_smooth_tick_cb(lv_timer_t *t) {
    (void)t;
-   if (s_state != ORB_STATE_IDLE || ui_orb_pipeline_active()) return;
+   /* TT #563: yield when voice is actively reading the mic.  Two
+    * readers on the same I2S channel corrupt the audio + Dragon's
+    * STT prematurely declares the utterance over → orb jumps
+    * LISTENING → PROCESSING before the user finishes speaking. */
+   if (s_state != ORB_STATE_IDLE || ui_orb_pipeline_active() || voice_mic_is_active()) return;
    /* Approach target each tick — 30 Hz × alpha 0.18 ≈ ~5 frames to
     * cover 60 % of any gap.  Buttery, not lurchy. */
    s_ambient_rms += (s_ambient_rms_target - s_ambient_rms) * AMBIENT_SMOOTH_ALPHA;
@@ -1669,7 +1673,11 @@ static void ambient_smooth_tick_cb(lv_timer_t *t) {
 
 static void ambient_mic_tick_cb(lv_timer_t *t) {
    (void)t;
-   if (s_state != ORB_STATE_IDLE || ui_orb_pipeline_active()) return;
+   /* TT #563: yield when voice is actively reading the mic.  Two
+    * readers on the same I2S channel corrupt the audio + Dragon's
+    * STT prematurely declares the utterance over → orb jumps
+    * LISTENING → PROCESSING before the user finishes speaking. */
+   if (s_state != ORB_STATE_IDLE || ui_orb_pipeline_active() || voice_mic_is_active()) return;
 
    static int16_t buf[AMBIENT_FRAMES * AMBIENT_MIC_TDM_CHANNELS];
    if (tab5_mic_read(buf, AMBIENT_FRAMES, 20) != ESP_OK) {

--- a/main/voice.c
+++ b/main/voice.c
@@ -242,6 +242,8 @@ volatile bool s_using_ngrok = false; /* true once we've switched to the ngrok UR
 static TaskHandle_t  s_mic_task    = NULL;
 static volatile bool s_mic_running = false;
 
+bool voice_mic_is_active(void) { return s_mic_running; }
+
 /* W4-B (TT #375): SOLO mic-capture buffer.  In vmode=5 the mic loop
  * appends downsampled 16 kHz mono PCM here instead of sending over WS
  * to Dragon; on stop, voice_stop_listening hands it to

--- a/main/voice.h
+++ b/main/voice.h
@@ -175,6 +175,13 @@ esp_err_t voice_start_dictation(void);
 /** Return the current voice mode (ASK or DICTATE). */
 voice_mode_t voice_get_mode(void);
 
+/** TT #563: true while the mic capture task is actively streaming
+ *  PCM frames (LISTENING, dictating, or in-call).  Used by other
+ *  consumers (e.g. ui_orb's ambient sampler) to YIELD the mic so
+ *  two readers don't race on the same I2S channel — otherwise the
+ *  voice STT would receive partial / corrupted frames. */
+bool voice_mic_is_active(void);
+
 /** Return the accumulated dictation transcript from stt_partial results (PSRAM-backed, up to 64KB). */
 const char *voice_get_dictation_text(void);
 


### PR DESCRIPTION
Defensive correctness alongside the Dragon-side VAD fix (TinkerBox PR #333).

Tab5's ambient mic sampler (TT #552) and the voice mic_capture_task both call `tab5_mic_read` on the same I2S channel. The ambient sampler already yielded on `s_state != IDLE`, but the orb's `s_state` lags voice state changes by an lv_async_call queue tick — leaving a race window where both could read the channel during the transition.

Adds public `voice_mic_is_active()` + gates the ambient sampler on it. Closes the race window cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)