### PR TITLE
fix(voice): emit ready_ack to Dragon after playback drain

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -904,6 +904,10 @@ static void playback_drain_task(void *arg)
                     ESP_LOGI(TAG, "Playback drain complete — transitioning to READY");
                     tab5_audio_speaker_enable(false);
                     voice_set_state(VOICE_STATE_READY, NULL);
+                    /* TT #564: tell Dragon the turn is fully done.
+                     * Best-effort — drain task continues regardless. */
+                    voice_ws_send_ready_ack();
+                    tab5_debug_obs_event("voice.state", "ready_ack");
                 }
                 break;
             }

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -267,6 +267,24 @@ esp_err_t voice_ws_send_register(void) {
 }
 
 // ---------------------------------------------------------------------------
+// End-of-turn ready_ack (Tab5 → Dragon).  TT #564.  Pure observability:
+// emitted by the playback drain task after the SPEAKING → READY
+// transition so Dragon knows the device has fully drained.  Best-effort
+// — WS-closed / send-failure no-ops, the next config_update / register
+// will re-sync state.  Matched on the Dragon side by the new
+// `cmd_type == "ready_ack"` branch shipped in TinkerBox PR #335.
+// ---------------------------------------------------------------------------
+esp_err_t voice_ws_send_ready_ack(void) {
+   if (!g_voice_ws || !esp_websocket_client_is_connected(g_voice_ws)) {
+      return ESP_ERR_INVALID_STATE;
+   }
+   char json[64];
+   int n = snprintf(json, sizeof(json), "{\"type\":\"ready_ack\",\"mode\":%d}", (int)voice_get_mode());
+   if (n < 0 || n >= (int)sizeof(json)) return ESP_ERR_INVALID_SIZE;
+   return voice_ws_send_text(json);
+}
+
+// ---------------------------------------------------------------------------
 // Outbound widget_action (Tab5 → Dragon).  Pure WS-proto concern: builds a
 // JSON frame, rate-limits, sends via voice_ws_send_text.  Pre-extract this
 // lived inline in voice.c at the bottom of the public-API section.

--- a/main/voice_ws_proto.h
+++ b/main/voice_ws_proto.h
@@ -30,6 +30,14 @@ esp_err_t voice_ws_send_text(const char *msg);
 esp_err_t voice_ws_send_binary(const void *data, size_t len);
 esp_err_t voice_ws_send_register(void);
 
+/* End-of-turn observability (TT #564).  Sends {"type":"ready_ack",
+ * "mode":<voice_mode>} so Dragon can observe that Tab5 has finished
+ * playback and the orb has returned to READY.  Called by the playback
+ * drain task in voice.c right after the SPEAKING → READY transition.
+ * Best-effort: a closed WS or send failure just no-ops (the next
+ * config_update / register will re-synchronize state). */
+esp_err_t voice_ws_send_ready_ack(void);
+
 /* RX dispatchers — invoked by voice_ws_proto_event_handler. */
 void voice_ws_proto_handle_text(const char *data, int len);
 void voice_ws_proto_handle_binary(const char *data, int len);


### PR DESCRIPTION
## Summary

- Closes #564.  After the playback drain task transitions SPEAKING → READY, emit `{"type":"ready_ack","mode":<voice_mode>}` over the existing voice WS so Dragon can observe end-of-turn completion deterministically.
- Pairs with TinkerBox PR lorcan35/TinkerBox#335 which adds the matching `cmd_type == "ready_ack"` WS dispatcher branch (pure logging, no state change).
- The 50 ms semaphore-wakeup lag I initially suspected on `tts_end` turned out to be already fixed at `voice_ws_proto.c:629` (xSemaphoreGive fires on `tts_end` RX) — this PR is purely additive observability, no audio-path behavior change.

## What changed

| File | Change |
|------|--------|
| `main/voice_ws_proto.h` | New `voice_ws_send_ready_ack()` prototype + doc comment. |
| `main/voice_ws_proto.c` | New `voice_ws_send_ready_ack()` (builds 64-byte JSON, sends via existing `voice_ws_send_text`). |
| `main/voice.c` | After `voice_set_state(VOICE_STATE_READY, NULL)` in the playback drain task, call `voice_ws_send_ready_ack()` + emit `voice.state ready_ack` obs event. |

## Test plan

- [x] `idf.py build` clean
- [x] `git-clang-format --diff origin/main main/*.c main/*.h` clean
- [x] Tab5 boots, voice connects, vmode=3 set OK
- [x] Live: vmode=3 weather query → Dragon's `/api/v1/agent_log` shows inferred `weather` entry (cross-PR verification with TinkerBox#335)
- [ ] Live: audio TTS turn → `ready_ack` reaches Dragon (skipped — text-input path doesn't trigger TTS playback drain; mic-input path will be exercised in the next user-driven session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)