### PR TITLE
fix(voice): scrim card behind reply label so text doesn't clash with home

### DIFF
--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -907,7 +907,13 @@ static void build_overlay(void)
 
     /* closes #115: response text label below the orb.  Simple absolute-
      * positioned label so it's always visible during SPEAKING and for
-     * the auto-hide window afterward. */
+     * the auto-hide window afterward.
+     *
+     * TT #566: the voice-overlay parent is fully transparent (TT #511/#514)
+     * so the home screen's busy ambient layer leaks through behind this
+     * label.  Give the label its own soft dark backdrop card so the
+     * reply text stays readable without bringing back the full opaque
+     * overlay regression. */
     s_response_label = lv_label_create(s_overlay);
     if (s_response_label) {
         lv_label_set_text(s_response_label, "");
@@ -917,6 +923,15 @@ static void build_overlay(void)
         lv_obj_set_style_text_align(s_response_label, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_set_style_text_line_space(s_response_label, 4, 0);
         lv_obj_set_width(s_response_label, SW - 80);
+        /* Soft scrim card behind the text — TT #566.  bg_opa ~210/255
+         * keeps the home orb halo bleed visible at the edges without
+         * the reply text colors competing with whatever home is
+         * rendering at y≈600. */
+        lv_obj_set_style_bg_color(s_response_label, lv_color_hex(0x0a0a0a), 0);
+        lv_obj_set_style_bg_opa(s_response_label, 210, 0);
+        lv_obj_set_style_pad_all(s_response_label, 12, 0);
+        lv_obj_set_style_radius(s_response_label, 14, 0);
+        lv_obj_set_style_border_width(s_response_label, 0, 0);
         /* Centered below the orb (orb y-center ~360 with halo out to ~515).
          * Place the label at y=580 to clear the orb on all sizes. */
         lv_obj_align(s_response_label, LV_ALIGN_TOP_MID, 0, 600);


### PR DESCRIPTION
## Summary

- Closes #566.  The voice overlay's `s_response_label` lives on a fully-transparent parent (TT #511/#514), so the reply text was painting directly over the home screen's ambient content at y≈600.  Adds a soft dark backdrop *on the label itself* (`bg_opa 210` over `0x0a0a0a`, `pad_all 12`, `radius 14`) so the text reads cleanly.
- Does NOT bring back the full opaque-overlay regression TT #514 fixed — only the label's own rect gets the card, the rest of the voice overlay stays transparent and the home orb still shows through.

## What changed

| File | Change |
|------|--------|
| `main/ui_voice.c:911-924` | 4 new `lv_obj_set_style_*` calls on `s_response_label` to add the scrim card.  No new objects, no lifecycle changes. |

## Test plan

- [x] `idf.py build` clean
- [x] `git-clang-format --diff origin/main` clean
- [x] Tab5 boots, voice connects, home renders normally
- [ ] **Visual verify** needs a real mic-driven turn (tap orb → speak → hear reply) since `/chat` doesn't open the voice overlay.  Once user does a mic turn, the reply label should appear as a dark rounded card below the orb instead of bare bright text fighting the home background.

## Cross-PR pairing

Bundles with TinkerBox#337 (TC mode context restore) — together they close the "TC mode feels half-baked at the end of a turn" complaint thread: the agent now remembers you across turns AND the reply text is readable when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)