### PR TITLE
docs: comprehensive cleanup — wakeword, vmode=5, recent PRs (refs #575)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,9 @@
 
 ## Active Investigations — READ FIRST before related work
 
+- **Always-on wakeword + on-device dictation (K144 ASR) — IN FLIGHT** → [`docs/PLAN-wakeword.md`](docs/PLAN-wakeword.md).
+  `feat/wakeword` branch, PR [#576](https://github.com/lorcan35/TinkerTab/pull/576) open, closes TT [#575](https://github.com/lorcan35/TinkerTab/issues/575).  Always-on K144 streaming Zipformer ASR drives BOTH a case-insensitive substring wakeword (default "tinker") AND on-device long-form dictation (default end phrase "save note", 32 KB PSRAM buffer, 4 h cap matching #573).  KWS unit officially installed but `kws.setup` parse_config rejects every body shape — vendor follow-up, ASR-based path supersedes.  Live-verified 2026-05-17 on Tab5 192.168.1.90 (wake fired on "tinker"); UI bridge (toast + orb ripple via `tab5_lv_async_call`) added in `e5426cc` and needs a fresh hardware retest.  Listener arms on warmup READY + on every successful auto-recovery reset; tears down when vmode=4 chain takes over the UART.
+
 - **UI/UX hardening — CLOSED** → [`docs/AUDIT-ui-ux-2026-04-29.md`](docs/AUDIT-ui-ux-2026-04-29.md) + [`docs/PLAN-ui-ux-hardening.md`](docs/PLAN-ui-ux-hardening.md) + LEARNINGS "TT #328 UI/UX hardening".
   As of 2026-04-30, 9 wave-by-wave PRs have closed 14/16 audit P0s on `feat/k144-phase6a-baud-switch`: a11y contrast, mode-array drift, mic-button leak, atomic touch injection, toast tones + persistent error banner + 4 new `error.*` obs classes, per-state voice icons, orb safe long-press + undo, universal `ui_tap_gate` debounce, chat-header touch-target lift, shared `widget_mode_dot` extract, nav-sheet 3×3 (Focus tile P0 #4), dead-API removal, onboarding Wi-Fi step, dual mode-control collapse (orb long-press → mode-sheet), and discoverability chevron + first-launch hint.  Two P0s deferred as larger scope: K144 as 5th tier in 3-dial sheet (touches autonomy-dial product semantics) + orb-overload across 4 surfaces (cross-team IA call).
 
@@ -37,13 +40,15 @@ Tab5 has connectors for stackable + plug-in add-ons.  Two parallel projects scop
   - `tests/e2e/scenarios/runner.py` `story_onboard` (14 steps) covers vmode=4 lifecycle
   - Full retrospective: `LEARNINGS.md` "K144 chain hardening (audit 2026-04-29) — 7-wave program closes 14/18 audit findings"
   - Plan + audit docs: [`docs/AUDIT-k144-chain-2026-04-29.md`](docs/AUDIT-k144-chain-2026-04-29.md), [`docs/PLAN-k144-chain-hardening.md`](docs/PLAN-k144-chain-hardening.md)
+- **Wakeword + on-device dictation wave (TT #575 / PR #576, 2026-05-17):** follow-up to the Wave 1-7 closure that reuses the K144 audio + asr units in a new always-on configuration.  Branch `feat/wakeword` (commits `83f82e3` + `e5426cc`).  Adds `main/voice_wakeword.{c,h}` + `voice_m5_llm_wakeword_setup/_run/_teardown` + lifecycle hooks in `voice_onboard.c` (arms on warmup READY + every successful Wave 13 reset; tears down when vmode=4 chain takes the UART).  Live-verified wake on "tinker" on 2026-05-17; UI bridge (toast + orb ripple) added but needs hardware retest.  KWS unit dead-end (parse_config rejects every body) documented for vendor follow-up.  Full plan: [`docs/PLAN-wakeword.md`](docs/PLAN-wakeword.md).
 - **Live performance:**  ~4.5s boot warm-up (cold-start NPU model load), ~2-3s per turn after warm.  K144 reply renders as a "TINKER" bubble in the chat overlay.
-- **Voice modes — five tiers now (was four):**
+- **Voice modes — six tiers now (was four):**
   - `vmode=0` Local — Dragon Q6A LLM (existing)
   - `vmode=1` Hybrid — Dragon LLM + OpenRouter STT/TTS (existing)
   - `vmode=2` Cloud — OpenRouter LLM + STT + TTS (existing)
   - `vmode=3` TinkerClaw — TinkerClaw Gateway (existing)
   - `vmode=4` Onboard — **K144 LLM, no Dragon needed** (new in Phase 5)
+  - `vmode=5` Solo Direct — **Tab5 talks straight to OpenRouter, no Dragon needed** (TT #370; STT/LLM/TTS all OpenRouter via the `or_*` NVS keys; on-device RAG against `/sdcard/rag.bin` for context)
 - **Failover behavior:**  In Local mode (`vmode=0`), if Dragon WS is unreachable for ≥30s AND the K144 is warm AND the user sends a text turn, voice.c routes to the K144 automatically.  Toast: "Using onboard LLM".  When Dragon comes back, next text turn returns to Dragon and shows "Dragon reconnected" toast.
 - **K144 cold-start guard:**  Boot warm-up posts a probe + one synchronous `voice_m5_llm_infer("hi", ...)` to map the model into NPU memory.  Up to 6 minutes (cold-start budget).  On success the failover gate flips READY; on any failure (probe timeout, NPU hang) it flips UNAVAILABLE.  **TT #328 Wave 13 (`4352e9e`) made UNAVAILABLE recoverable in software** — `voice_onboard_reset_failover()` sends `sys.reset` to the StackFlow daemon, waits for re-init, re-runs the warmup probe.  Auto-retries every 60 s (capped at 3 attempts/boot via `esp_timer`); manual recovery available via tap on the K144 health chip in Settings or `POST /m5/reset` debug endpoint.  Live timing: 9.6 s end-to-end on hardware.  See [`docs/PLAN-k144-recovery.md`](docs/PLAN-k144-recovery.md) for the verified `sys.*` verb surface (probed 2026-05-01) — `sys.reset`, `sys.reboot`, `sys.hwinfo`, `sys.lsmode`, `sys.version` are real; `sys.list`, `sys.status`, `sys.uptime`, `sys.log` are not.  User-facing flows are NEVER blocked by K144 hang behaviors.
 
@@ -742,7 +747,7 @@ Wire layout: `"VID0"` (4 bytes) + `len_be` (4 bytes) + `payload[len]`. Same shap
 2. **Voice Cancel:** `{"type":"cancel"}` — abort current processing
 3. **Keepalive:** `{"type":"ping"}` — JSON heartbeat every 15s during processing
 4. **Text Input:** `{"type":"text","content":"..."}` — skips STT, goes straight to LLM
-5. **Config Update:** `{"type":"config_update","voice_mode":0|1|2|3,"llm_model":"..."}` — four-tier mode switch. Backward compat: `cloud_mode` bool still accepted.
+5. **Config Update:** `{"type":"config_update","voice_mode":0|1|2|3,"llm_model":"..."}` — mode switch over the wire.  Backward compat: `cloud_mode` bool still accepted.  **vmode=4 (Onboard) and vmode=5 (Solo Direct) are Tab5-side-only** — Tab5 auto-downconverts to 0 on the wire so Dragon never sees them, and voice.c's `config_update` ACK handler filters out Dragon's echo to keep the local NVS at the true 4/5 value.  This is a protocol feature, not a bug — the on-the-wire shape stays in 0..3 even as Tab5 grows new local-only modes.
 6. **Device Registration:** `{"type":"register","device_id":"...","session_id":"..."}` on WS connect
 7. **Clear History:** `{"type":"clear"}` — reset conversation context (W14-H20: was documented as `clear_history`; Tab5's `voice.c` + Dragon's dispatcher have always agreed on `clear`)
 8. **Channel Reply (W7-E.4):** `{"type":"channel_reply","channel":"telegram","thread_id":"<id>","text":"<reply>"}` — user response to a previously-received `channel_message` (see Dragon→Tab5 #16 below).  Built by `voice_send_channel_reply` in voice.c.  In W7-E.4b mode the next STT-complete transcript is routed through this path instead of normal LLM dispatch when reply context is armed via `voice_arm_channel_reply` (REPLY button on the now-card overlay).  Dragon ACKs asynchronously with `channel_reply_ack`.  Full schema in TinkerBox [`docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md) §20.
@@ -757,7 +762,7 @@ Wire layout: `"VID0"` (4 bytes) + `len_be` (4 bytes) + `payload[len]`. Same shap
 7. **tts_start** / binary TTS / **tts_end** — TTS audio playback
 8. **dictation_summary** — post-processing results: `{"title":"...","summary":"..."}`
 9. **pong** — keepalive response
-10. **config_update** — ACK with applied backend config + cloud_mode state
+10. **config_update** — ACK with applied backend config + cloud_mode state.  ACK payload also carries a `fleet_summary` block (per-device vision capability info from Dragon's fleet registry) that Tab5 uses to enable/disable the vision chip on the chat composer + Settings vision indicator.  When the active model lacks vision the chip greys out client-side.
 11. **error** — error details
 
 ### Dragon → Tab5 (Rich Media — April 2026)
@@ -848,7 +853,7 @@ main/voice.{c,h}          — Voice public API + state machine + mic capture tas
                              playback drain task + listening/dictation/call lifecycles +
                              reconnect watchdog.  Wave 23 thinned voice.c from ~3,668 LOC
                              to ~2,287 LOC by extracting voice_ws_proto (RX/TX dispatch +
-                             event handler) and voice_modes (five-tier routing).
+                             event handler) and voice_modes (six-tier routing).
                              W7-E.4 (#456) adds `voice_send_channel_reply(channel, thread_id,
                              text)` for replying to channel_message frames over the existing
                              voice WS.  W7-E.4b (#471) adds armed-reply context state (4 APIs:
@@ -863,10 +868,11 @@ main/voice_ws_proto.{c,h} — WS frame routing layer: JSON RX dispatcher + binar
                              UI-async helpers (toast / banner / badge dispatchers) +
                              eviction/auth-fail stop workers.  Wave 23 SRP closure for
                              TT #331-A (PR #355).
-main/voice_modes.{c,h}    — Five-tier voice-mode dispatcher: voice_send_config_update*
+main/voice_modes.{c,h}    — Six-tier voice-mode dispatcher: voice_send_config_update*
                              senders + voice_modes_route_text decision (LOCAL / HYBRID /
-                             CLOUD / TINKERCLAW / LOCAL_ONBOARD) + s_voice_mode
-                             ownership.  Wave 23 SRP closure for TT #331-B (PR #356).
+                             CLOUD / TINKERCLAW / LOCAL_ONBOARD / SOLO_DIRECT) + s_voice_mode
+                             ownership.  Wave 23 SRP closure for TT #331-B (PR #356); SOLO
+                             Direct (vmode=5) added via TT #370.
 main/voice_video.{c,h}    — Two-way video call module: HW JPEG uplink + TJPGD downlink
                              decode, VID0 framing, voice_video_start_call/end_call atomics.
 main/voice_codec.{c,h}    — OPUS capability negotiation (decoder ready, encoder gated off

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -32,9 +32,13 @@
 
 **`device_id`** — NVS key (12-hex chars).  Stable identifier sent in WS `register` frame.  MAC-derived on first boot.  Dragon uses this as the primary key in the `devices` table.
 
+**`dictation_buffer`** — 32 KB PSRAM buffer inside [`voice_wakeword.c`](main/voice_wakeword.c) that accumulates ASR partial transcripts during the LISTENING state of the wakeword listener.  Size configurable via `voice_wakeword_config_t.dictation_buf_bytes`; matches the meeting-length 4 h cap from TT #573.  See [`docs/PLAN-wakeword.md`](docs/PLAN-wakeword.md).
+
 **`dragon_host` / `dragon_port`** — NVS keys.  Dragon WS server endpoint.  Defaults from `config.h` / Kconfig but settings UI lets the user change them.  PR [#299](https://github.com/lorcan35/TinkerTab/issues/299) was triggered when the e2e harness's `/input/text` accidentally typed into this field; PR [#300](https://github.com/lorcan35/TinkerTab/pull/300) scoped `/input/text` to the chat input only.
 
 ## E
+
+**`end_phrase`** — Case-insensitive phrase that terminates on-device dictation in the [`voice_wakeword`](main/voice_wakeword.h) module.  Default `"save note"`; empty string disables phrase-based stop (rely on silence cap / 4 h timeout).  Configurable via `voice_wakeword_config_t.end_phrase`.
 
 **E2E harness** — Python scenario runner in [`tests/e2e/`](tests/e2e/) (PR #295).  `Tab5Driver` class wraps the debug HTTP API; `runner.py` runs scenarios with per-step screenshots + event captures + report.json/report.md output.  Three canonical stories: `story_smoke` (~2 min, 14 steps), `story_full` (~2 min, 24 steps), `story_stress` (~10 min, 77 steps).
 
@@ -57,6 +61,10 @@
 **IO Expander** — Two PI4IOE5V6416 chips on system I2C (0x43 + 0x44) controlling power rails (LCD reset, speaker enable, WiFi power, USB 5 V, charging, etc.).  See [`docs/HARDWARE.md`](docs/HARDWARE.md).
 
 **`int_tier`** — NVS key (uint8 0..2) — intelligence dial.  `0=fast`, `1=balanced`, `2=smart`.  Combined with `voi_tier` and `aut_tier` in `tab5_mode_resolve()` to derive the effective `voice_mode` (0/1/2/3).
+
+## K
+
+**`kws_unit`** — K144's `sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01` keyword-spotting unit.  Officially installed (model files present, systemd service running, lists in `sys.lsmode`), but on the current K144 firmware its `kws.setup` rejects every body shape attempted by the wakeword module — `parse_config false`.  Documented as a vendor follow-up; superseded in [`docs/PLAN-wakeword.md`](docs/PLAN-wakeword.md) by ASR-based phrase matching, which gives a strict superset (open-vocabulary at runtime + full transcript for the dictation buffer) on a unit we already trust.
 
 ## L
 
@@ -144,7 +152,7 @@
 
 **`VID0`** — 4-byte ASCII magic on a binary WS frame indicating it's a JPEG video frame for the call relay.  Counterpart: `AUD0` for raw 16 kHz mono int16 PCM.
 
-**`vmode`** — NVS key (uint8 0..3) — voice mode.  `0=Local`, `1=Hybrid`, `2=Cloud`, `3=TinkerClaw`.  Sent to Dragon as `voice_mode` in `config_update`.
+**`vmode`** — NVS key (uint8 0..5) — voice mode.  `0=Local`, `1=Hybrid`, `2=Cloud`, `3=TinkerClaw`, `4=Onboard (K144)`, `5=Solo Direct (OpenRouter)`.  Sent to Dragon as `voice_mode` in `config_update` — but **vmode=4 and vmode=5 are Tab5-side-only**: Tab5 auto-downconverts to 0 on the wire and voice.c's ACK handler filters out Dragon's echo to keep the local NVS at the true 4/5 value.
 
 **`voi_tier`** — NVS key (uint8 0..2) — voice dial.  `0=local Piper`, `1=neutral`, `2=studio OpenRouter`.  Combined with `int_tier` + `aut_tier` to derive the effective voice mode.
 
@@ -155,6 +163,8 @@
 **`voice_video.{c,h}`** — Two-way video calling module.  HW JPEG uplink via the shared encoder + TJPGD downlink decode + `VID0` framing.  `voice_video_start_call` / `voice_video_end_call` are the atomic entry points.  Also exposes `voice_video_encode_rgb565()` so the camera-screen recording feature shares the single HW JPEG engine.
 
 ## W
+
+**`wake_phrase`** — Case-insensitive substring matched against partial transcripts streaming from the K144 ASR (`asr.utf-8.stream`) in the always-on [`voice_wakeword`](main/voice_wakeword.h) listener.  Default `"tinker"`; configurable via `voice_wakeword_start(cfg, ...)`.  Open-vocabulary at runtime — change one string with no model retraining required.  See [`docs/PLAN-wakeword.md`](docs/PLAN-wakeword.md).
 
 **Watchdog reset** — Triggered when (a) the heap watchdog declares fragmentation crisis, or (b) `python -m esptool ... --after watchdog_reset` from a workstation.  Tab5's USB-JTAG doesn't wire RTS to EN, so `default_reset` / `hard_reset` won't cut it for a running app — must use `watchdog_reset`.
 

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1540,3 +1540,70 @@ Every entry here was learned the hard way. Read this before touching the codebas
 - **Solution:** Armed context state in `voice.c` (4 fields: channel, thread_id, sender, armed-bool), all guarded by `s_state_mutex` (the same mutex protecting voice state transitions).  Four public APIs: `voice_arm_channel_reply` (LVGL task), `voice_disarm_channel_reply` (any), `voice_is_channel_reply_armed` (UI peek), `voice_peek_channel_reply` (UI read-only; W7-E.4c TT #488), `voice_consume_channel_reply` (WS task; atomic read-and-clear).
 - **STT handler intercept:** In `voice_ws_proto.c` the non-DICTATE STT-complete branch checks `voice_consume_channel_reply` BEFORE the existing chat-push + state-transition path.  If armed, calls `voice_send_channel_reply` with the transcript, toasts "Reply sent to {sender}", returns-to-READY, and `cJSON_Delete(root); return;` to skip the LLM dispatch entirely.
 - **Prevention:** When introducing a cross-task hand-off (UI arms a flag → background task consumes it), make the **consume side atomic** and locked alongside whatever state the consumer mutates.  Re-using the existing `s_state_mutex` instead of adding a new one keeps the lock ordering simple — every voice-state transition already takes that mutex, so the armed-flag write happens-before the next state read by construction.
+
+## Cubic-Hermite TTS upsample replaces linear interp (PR #569, 2026-05-15)
+
+- **Date:** 2026-05-15
+- **Symptom:** Kokoro-class TTS playback on Tab5 sounded "choppy" and "buzzy" — high-frequency content sounded harsh.  Other voices (Piper, OpenRouter gpt-audio-mini) sounded fine on the same speaker stack, so the codec wasn't the issue.
+- **Root Cause:** `audio.c`'s 16 kHz → 48 kHz upsample (1:3) was a plain linear interpolator: `out[i] = in[i] + (in[i+1] - in[i]) * frac`.  Linear interp is band-limited only up to ~`f_in/4`; everything above gets aliased.  Kokoro's PCM has more energy near Nyquist than Piper, which is why the artefact only showed on the new voice.  A separate off-by-one (using `in[i-1]` as the "current" sample instead of `in[i]`) added a frame of group-delay error on top of that.
+- **Fix:** PR #568/#569 — replaced the linear interpolator with cubic Hermite (Catmull-Rom variant) using 4 neighboring samples + a chunk-boundary context cache so the kernel doesn't reset across WS chunk boundaries.  Also fixed the off-by-one in the same change (commit `0bc87bb`).  Same CPU class as linear (4× multiply-add per output sample); imperceptible cost on ESP32-P4.  Implementation lives in `main/audio.c`'s upsample function.
+- **Prevention:**
+  1. **Linear interp is fine for content-band 0..f_in/4; everything above aliases.**  If the TTS source has any high-frequency content (modern neural TTS does — Kokoro, gpt-audio-mini, etc.), upgrade to cubic Hermite or windowed-sinc.
+  2. **Always test upsample with a chirp or speech-near-Nyquist sample, not a pure low-frequency tone.**  Linear sounds fine on 100-1000 Hz tones; the artefact only shows on 4-7 kHz content.
+  3. **Chunk-boundary context matters at any kernel size > 1.**  Even cubic Hermite needs to carry 3 samples across chunks; otherwise you get a discontinuity tick at every 20 ms WS chunk boundary.
+
+## Dictation cap bumped 5 min → 4 h for meeting-length recording (PR #573)
+
+- **Date:** 2026-05-15
+- **Symptom:** User started dictating a long meeting summary into the Tab5 mic; recording auto-stopped after 5 minutes with the buffer half-full.  The Notes row showed "EMPTY" because of the truncation point landing mid-sentence.
+- **Root Cause:** `MAX_RECORD_FRAMES_DICT` in `voice.c` was set to 5 min × 60 s × 50 frames/s = 15000 — a defensive cap from when the SD scratch buffer was 32 KB and the auto-stop was the only "stop" path.  Once silence-auto-stop was disabled (PR `16657ba`, "meetings have pauses") + MAX_NOTE_LEN bumped to 32 KB (PR `5b29301`), the time cap became the only meaningful upper bound — and 5 min was too short for the new use case.
+- **Fix:** PR #573 (`02bd802`) — bumped `MAX_RECORD_FRAMES_DICT` to 4 h × 3600 s × 50 frames/s = 720000.  Matches the wakeword dictation cap added in PR #576 (TT #575) so the two dictation surfaces have aligned ceilings.  No SD I/O change needed — 4 h of 16 kHz mono int16 fits inside the existing PSRAM scratch buffer (≈460 MB worst-case; Tab5 has 32 MB but the WS push drains the buffer as it fills, so steady-state working set stays bounded).
+- **Prevention:**
+  1. **When you change a downstream cap (MAX_NOTE_LEN), audit upstream caps in the same path.**  The dictation pipeline has 3 caps (mic frame count, scratch buffer, note text length); changing one without the others creates "silently truncated" UX.
+  2. **Document caps by the use case, not the number.**  `MAX_RECORD_FRAMES_DICT` was a magic constant; a sibling `#define MEETING_LENGTH_S 14400` would have made the original 5 min cap visibly wrong for the meeting use case.
+
+## Four mic-driven sphere additions to IDLE orb (PR #574)
+
+- **Date:** 2026-05-16
+- **Symptom:** The IDLE orb (post-PR #547/#553/#562 ambient sphere) reacted to mic with a single global brightness lift — fine, but a single dimension carried all the information.  User feedback: "I can tell it hears me but I can't tell *what* it's hearing."
+- **Root Cause:** No — this was a feature-add, not a bug.  Captured as a LEARNING because the four-dimension breakdown is reusable design vocabulary for future orb states.
+- **Fix:** PR #574 (`e3e3aaba9`) — four mic-driven additions layered onto the existing sphere:
+  1. **Rim halo** — outer ring brightens with RMS, narrow ramp so it doesn't compete with the spike-flash detector
+  2. **Lit-from-within** — body gradient's center point brightens on sustained energy (1-2 s LPF)
+  3. **Specular wobble** — the specular highlight position jitters on every transient, ~3 px excursion, drives "alive" perception
+  4. **Frequency-band hue tint** — coarse 3-band FFT drives a tiny hue shift (low → warmer, high → cooler) on the gradient, giving the orb visible character per-voice
+- **Prevention:**
+  1. **A single feedback dimension caps user understanding.**  When mic-reactive orbs felt "alive but information-poor," the fix wasn't louder — it was orthogonal dimensions.  Each addition above is a separate scalar mapped to a separate visual primitive, no two competing for the same pixel.
+  2. **Each new dimension needs a kill-switch path.**  All four are independently toggleable in the orb config struct so future sphere designs can pick a subset without code edits.
+
+## K144 KWS unit is officially installed but unusable (supersedes the older "no wake word" learning)
+
+- **Date:** 2026-05-17
+- **Symptom:** PR #576 (TT #575) attempted to use K144's `sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01` for the wake-word path — the obvious choice since (a) it's open-vocabulary so no model retraining is required, (b) it's the official keyword-spotting unit in the K144's `sys.lsmode`, (c) the systemd `llm-kws` service was running.  Every `kws.setup` body shape attempted returned `parse_config false` errors.
+- **Root Cause:** The K144 daemon's `kws.setup` parser is broken on this firmware version (v1.3) — no body shape was accepted.  Tried 6+ shapes including the model + keyword combinations the Arduino library suggests + the input-stream shape from `asr.setup`.  All rejected at parse time, before any model loading happens.  Filed as a vendor follow-up; not blocking because there's a working alternative on the same K144.
+- **Fix (the practical path):** Pivoted to ASR-based phrase matching — same K144 audio + asr units already used by Phase 6b autonomous chain (`sherpa-ncnn-streaming-zipformer-20M-2023-02-17`).  We get a strict superset of what `kws.setup` would have given us:
+  - Open-vocabulary at runtime (one string, no retrain) — same as the KWS unit would have offered
+  - Full continuous transcript "for free" — enables on-device long-form dictation in the same task
+  - Known-good unit — already powers vmode=4 on every Tab5 with a K144 stack
+- **Prevention:**
+  1. **`sys.lsmode` only proves "this unit is INSTALLED" — not "this unit's setup verb works."**  Vendor module manifests aren't the same as live-tested capability.  Before scoping a feature against an officially-listed unit, send one `setup` probe with the shapes the library headers suggest.  10-minute probe saves a multi-day pivot.
+  2. **Supersedes the 2026-05-01 LEARNING "Sherpa-onnx KWS is open-vocabulary."**  That entry correctly identified KWS as open-vocab and changed the cost estimate from months to one wave.  This entry adds: even open-vocab KWS doesn't help when the daemon's setup parser is broken.  ASR-based matching is the practical revival path until M5 ships a fix.
+  3. **The KWS dead-end is documented (`docs/PLAN-wakeword.md` "KWS dead-end" section) so future contributors don't repeat the probe.**  Re-probe quarterly if K144 firmware updates; the fix is presumably a single line on the vendor side.
+
+## Always-on K144 ASR for wakeword + on-device dictation (PR #576)
+
+- **Date:** 2026-05-17
+- **Symptom:** Wake-word was retired in TT #162 (TDM-AEC blocker + WakeNet procurement cost).  Tab5 had a K144 stack with a working streaming Zipformer ASR that already powered vmode=4 (Onboard mode autonomous chain) — but only on-demand.  Hands-free wake plus long-form dictation both lived as feature wishes with no clear path on a single-MCU Tab5.
+- **Root Cause:** The original wake-word revival plan assumed a *separate* model class (KWS or WakeNet) was needed for wake detection.  Reusing an existing always-on ASR for substring matching wasn't on the radar because ASR was framed as expensive per-utterance work, not as a continuous stream.
+- **Fix:** PR #576 ships `main/voice_wakeword.{c,h}` (~426 LOC across .c + .h) + `voice_m5_llm_wakeword_setup/_run/_teardown` helpers + lifecycle hooks in `voice_onboard.c`:
+  - K144 chain: audio.setup → asr.setup (no llm, no tts) emits asr.utf-8.stream {delta, finish}
+  - Tab5 task: 2-state machine (IDLE → wake match → LISTENING → end-phrase / silence / 4 h cap → IDLE)
+  - 32 KB PSRAM dictation buffer; default wake "tinker", default end "save note"; defaults cap at 4 h matching #573
+  - UI bridge: toast + orb ripple via `tab5_lv_async_call` on WAKE and DICTATION_FINAL
+  - Arms on warmup READY + every successful Wave 13 reset; tears down when vmode=4 chain takes the UART
+  - Obs events: `wakeword.start`, `wakeword.task`, `wakeword.fire`, `wakeword.dictation`
+- **Live verified 2026-05-17:** wake fired on "tinker" substring at 282 s post-boot.  UI bridge added in `e5426cc` after that test; needs hardware retest.
+- **Prevention:**
+  1. **An always-on ASR is functionally a superset of always-on KWS.**  When the host has spare cycles + power budget + a streaming ASR is already available, ASR-based substring matching is simpler, gives full transcript for free, and dodges the "needs custom KWS model" friction.  Default to this design when the constraints fit.
+  2. **Wakeword + dictation should share a chain.**  Wakeword + dictation aren't two features — they're two consumers of one ASR stream.  One task, one buffer, one state machine cuts code + UART contention vs. two parallel tasks.
+  3. **Lifecycle ownership of a shared hardware resource (K144 UART) needs explicit takeover semantics.**  The wakeword listener tears down when the Phase 6b autonomous chain starts; otherwise both would try to own the chain.  Document who owns the resource in which voice mode; one consumer at a time.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ OpenRouter).
 - **Widget Platform (v1)** -- Skills on Dragon emit typed widget state (`live`, `card`,
   `list`, `chart`, `media`, `prompt`); Tab5 renders it opinionatedly. New features ship as
   Python files on Dragon, no firmware flash. See [`docs/WIDGETS.md`](./docs/WIDGETS.md).
+- **Always-on wakeword + on-device dictation via K144** -- Optional Module LLM Kit
+  drives a streaming Zipformer ASR; Tab5 listens for a configurable wake phrase
+  ("tinker" by default) and then captures up to 4 hours of dictation in a PSRAM
+  buffer. Open-vocabulary phrase matching means no model retraining to change the
+  wake or end phrase. See [`docs/PLAN-wakeword.md`](./docs/PLAN-wakeword.md).
+- **Solo Direct mode (vmode=5)** -- Tab5 talks straight to OpenRouter for STT,
+  LLM, and TTS with no Dragon dependency. Per-model NVS keys + on-device RAG
+  against `/sdcard/rag.bin`. See `or_*` NVS keys in
+  [`CLAUDE.md`](./CLAUDE.md).
+- **Mic-driven orb visuals** -- The ambient sphere reacts to room sound with a
+  spike-flash detector for transients. Sphere-native motion (no 2D chrome) and
+  always-alive breathing. Shipped through PRs #547--#562 (orb arc) and
+  refined in PR #574 (four mic-driven additions to IDLE).
 
 ---
 
@@ -482,7 +495,7 @@ The server specification lives in TinkerBox at `docs/protocol.md`.
 | `{"type":"ping"}`                      | JSON    | Keepalive heartbeat (every 15s)      |
 | `{"type":"text","content":"..."}`      | JSON    | Text input (skips STT, goes to LLM) |
 | `{"type":"register",...}`              | JSON    | Device registration on connect       |
-| `{"type":"config_update","voice_mode":0\|1\|2\|3,"llm_model":"..."}` | JSON | Voice mode + LLM picker (modes: 0=Local 1=Hybrid 2=Cloud 3=TinkerClaw). Old `cloud_mode` boolean still accepted for backward compat |
+| `{"type":"config_update","voice_mode":0\|1\|2\|3,"llm_model":"..."}` | JSON | Voice mode + LLM picker (on-the-wire modes: 0=Local 1=Hybrid 2=Cloud 3=TinkerClaw). Tab5 also supports 4=Onboard (K144 LLM, no Dragon) and 5=Solo Direct (OpenRouter direct, no Dragon) as Tab5-side-only modes — they get downconverted to 0 on the wire so Dragon never sees them. Old `cloud_mode` boolean still accepted for backward compat. |
 | `{"type":"clear"}`                     | JSON    | Clear conversation context           |
 
 ### Dragon to Tab5

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,14 @@ test the TDM slots to resolve the original blocker.
 - **Wave 18** (`c6fc98a`) — Widget icon library (closes TT #69).  16 built-in glyphs (clock/briefcase/laundry/coffee/book/car/pot/person/droplet/check/alert/sun/moon/cloud/calendar/star) encoded as path-step DSL in `main/widget_icons.{c,h}`; rendered via single `lv_canvas` widget per icon with ARGB8888 PSRAM buffer; tone-driven color (calm→emerald / active→amber / urgent→rose).  Slot rendered top-right of live card; live-verified with clock+active, check+success, alert+urgent.
 - **Wave 19** (`d3cc647`) — OPUS encoder stack overflow root-caused (closes TT #264 + #262).  PR #263 had gated the encoder OFF after panics inside SILK NSQ functions; original investigator bumped voice_mic stack 8 → 16 KB and concluded "not stack overflow."  Wave 19 bisected via a new `/codec/opus_test` synthetic endpoint and found 24 KB is the actual watermark — bumped `MIC_TASK_STACK_SIZE` 16 → 32 KB (PSRAM-backed, free).  esp_audio_codec also bumped 2.4.1 → 2.5.0.  Live: 200 frames encoded clean, ~24 B/frame, 26× compression vs PCM.  Unblocks Phase 2B Tab5→Dragon OPUS uplink.
 
+## Mid-May 2026 — orb arc + dictation + wakeword
+
+- **PR [#569](https://github.com/lorcan35/TinkerTab/pull/569)** (`678cc06`, 2026-05-15) — Cubic-Hermite TTS upsample replaces linear interp.  Fixes choppy Kokoro-class TTS on Tab5's 16 → 48 kHz playback path.  4-sample Catmull-Rom kernel + chunk-boundary context cache in `audio.c`; same CPU class as linear, imperceptible cost.  Companion bugfix `0bc87bb` corrects the off-by-one in the upsampler.
+- **PR [#573](https://github.com/lorcan35/TinkerTab/pull/573)** (`02bd802`, 2026-05-15) — Dictation cap bumped 5 min → 4 h for meeting-length recording.  `MAX_RECORD_FRAMES_DICT` in `voice.c` goes from 15 000 to 720 000 frames; PSRAM scratch buffer + WS drain handle the new ceiling without I/O changes.  Aligns with the wakeword dictation cap (PR #576).
+- **PR [#574](https://github.com/lorcan35/TinkerTab/pull/574)** (`e3aaba9`, 2026-05-16) — Four mic-driven sphere additions to IDLE orb: rim halo (RMS), lit-from-within (LPF energy), specular wobble (transients), and frequency-band hue tint (3-band FFT).  Each toggle-able in the orb config struct; adds orthogonal information dimensions to the existing ambient sphere from PRs #547–#562.
+- **TT [#575](https://github.com/lorcan35/TinkerTab/issues/575)** (2026-05-17) — Tracking issue: "Always-on ASR wakeword + on-device dictation via K144."  Frames the problem (TT #162 retired wake-word due to TDM-AEC blocker; K144 now provides a working streaming Zipformer ASR + KWS dead-end documented) + the design.
+- **PR [#576](https://github.com/lorcan35/TinkerTab/pull/576)** (`83f82e3` + `e5426cc`, 2026-05-17) — Always-on K144 ASR wakeword + on-device dictation.  New `main/voice_wakeword.{c,h}` (state machine + 32 KB PSRAM dictation buffer + force-stop API) + `voice_m5_llm_wakeword_setup/_run/_teardown` chain helpers + lifecycle hooks in `voice_onboard.c` (warmup READY + Wave 13 reset).  UI bridge in commit `e5426cc` adds toast + orb ripple via `tab5_lv_async_call` on WAKE / DICTATION_FINAL.  Live-verified on Tab5 192.168.1.90 (wake fired on "tinker"); UI bridge needs hardware retest.  See [`docs/PLAN-wakeword.md`](PLAN-wakeword.md).
+
 ## Cross-stack waves (May 2026) — see audit doc
 
 For waves W1–W9 of the 2026-05-11 cross-stack audit (SOLO mode, turn_id,
@@ -75,7 +83,7 @@ see [`AUDIT-state-of-stack-2026-05-11.md`](AUDIT-state-of-stack-2026-05-11.md).
 
 ### Wave 20+ candidates
 
-- **KWS revival on K144** — sherpa-onnx-kws-zipformer-gigaspeech is open-vocabulary (pass keyword list at runtime, no custom training).  Resurrects the feature TT #162 retired by sidestepping the ESP32-P4 TDM blocker.  Touches voice mode semantics + mic routing.  See LEARNINGS "Sherpa-onnx KWS is open-vocabulary."
+- **KWS revival on K144** — sherpa-onnx-kws-zipformer-gigaspeech is open-vocabulary (pass keyword list at runtime, no custom training).  **Update 2026-05-17:** PR #576 attempted the direct `kws.setup` path and found the K144 daemon's parser rejects every body shape (`parse_config false`); pivoted to ASR-based phrase matching which gives the same open-vocab guarantee + a free transcript.  Native KWS path remains queued for when M5 fixes the parser upstream — see LEARNINGS "K144 KWS unit is officially installed but unusable."
 
 ### External-hardware push parked
 

--- a/docs/PLAN-grove.md
+++ b/docs/PLAN-grove.md
@@ -1,9 +1,11 @@
 # Plan — Grove sensor support on Tab5
 
-**Status:** parked, not started.
+> **PARKED since 2026-04-10 — hardware on order.**  This plan is preserved for when the Grove sensor kit lands; no firmware work scheduled until then.  See [`CLAUDE.md`](../CLAUDE.md) "External Hardware Modules" for the parallel K144 / wakeword projects that DO have active branches.
+
+**Status:** parked since 2026-04-10 — hardware on order.
 **Owner:** unassigned.
 **Tracking issue:** TBD (filed alongside this doc).
-**Last updated:** 2026-04-28.
+**Last updated:** 2026-04-28 (status restamp 2026-05-17).
 
 ---
 

--- a/docs/PLAN-ui-ux-hardening.md
+++ b/docs/PLAN-ui-ux-hardening.md
@@ -206,3 +206,10 @@ TAB5_TOKEN=... python3 tests/e2e/runner.py story_smoke story_onboard
 - Wave 2 (atomic touch) blocks Wave 5 (debounce) only weakly — they can land in either order
 - Wave 6 (extract) is parallelisable with Wave 7 (nav)
 - Wave 8 (onboarding) is the most user-impactful but also the most disruptive — defer if scope-tight
+
+## Deferred audit P0s (status as of 2026-05-17)
+
+Two P0s from the original 2026-04-29 audit were deliberately deferred at the end of the 9-wave program (TT #328) as scope-larger-than-fits.  Status restamp ahead of any future Wave 9+ planning:
+
+- **K144 as 5th tier in the 3-dial mode sheet.**  Touches autonomy-dial product semantics — vmode=4 doesn't map cleanly onto the int/voi/aut tier triple today.  **STILL DEFERRED as of 2026-05-17 — re-evaluate after wakeword PR [#576](https://github.com/lorcan35/TinkerTab/pull/576) ships.**  PR #576 keeps the K144 surface narrow (always-on listener, not a mode), so the autonomy-dial product call is still open.
+- **Orb-overload across 4 surfaces.**  Home / chat / voice / notes all show different orb states with different semantics — needs a cross-team IA call to unify.  **STILL DEFERRED as of 2026-05-17 — re-evaluate after wakeword PR [#576](https://github.com/lorcan35/TinkerTab/pull/576) ships.**  PR #576 adds an `ui_orb_ripple_for_tool("wakeword")` invocation that further entangles orb semantics; the IA decision should land before this becomes a 5-surface problem.

--- a/docs/PLAN-wakeword.md
+++ b/docs/PLAN-wakeword.md
@@ -1,0 +1,195 @@
+# Plan — Always-on K144 ASR wakeword + on-device dictation
+
+**Status:** live-verified on Tab5 2026-05-17 — wake fired on "tinker" substring during ASR partial stream; UI bridge (toast + orb ripple) added but needs hardware retest after the UI commit.  Branch `feat/wakeword`; PR [#576](https://github.com/lorcan35/TinkerTab/pull/576) open against `main`.
+**Owner:** unassigned.
+**Tracking issue:** TT [#575](https://github.com/lorcan35/TinkerTab/issues/575).
+**Last updated:** 2026-05-17.
+**Related:** [`docs/PLAN-m5-llm-module.md`](PLAN-m5-llm-module.md) (Phase 6b autonomous chain — same K144 audio + asr units, different downstream consumer), [`docs/PLAN-k144-chain-hardening.md`](PLAN-k144-chain-hardening.md) (UART mutex + obs ring patterns this reuses).
+
+---
+
+## What this enables
+
+Always-on wake-word + on-device long-form dictation that does NOT require Dragon, an OpenRouter key, or any wake-model retraining.  The user speaks the configured wake phrase (default `"tinker"`); Tab5 captures every subsequent partial transcript into a PSRAM buffer until an end phrase, a silent endpointer gap, or a 4-hour cap fires.  The accumulated text becomes a note via the same path the Dictate chip uses today.
+
+Revives the wake-word product story that was retired in TT #162 (TDM-AEC blocker + custom WakeNet procurement cost) by sidestepping both problems — K144 ships a known-good streaming Zipformer ASR (`sherpa-ncnn-streaming-zipformer-20M-2023-02-17`) that already powers vmode=4, and Tab5 reuses the existing chain hardening.
+
+---
+
+## Architecture
+
+```
+K144 (Mate-stacked, vmode-independent)
+   audio.setup                 → mic frames continuously published to sys.pcm
+        ↓
+   asr.setup input=[sys.pcm]   → sherpa-ncnn streaming zipformer
+                                   emits asr.utf-8.stream {delta, finish}
+                                   over UART (no llm, no tts in this chain)
+        ↓
+Tab5 voice_wakeword_task drains the partials and runs a 2-state machine:
+
+   IDLE ── partial contains wake phrase (case-insensitive substring on
+            ~96-byte sliding window of recent segment text) ──→ WAKE callback
+
+   LISTENING ── every delta appended to 32 KB PSRAM dictation buffer
+                exit on any of:
+                  • end-phrase matched ("save note")
+                  • 3 silent finish-segments since last delta
+                  • hard 4-hour timeout (matches TT #573 dictation cap)
+                  • external voice_wakeword_force_dictation_stop()
+                                          ↓
+                                  DICTATION_FINAL callback with accumulated text
+
+UI bridge runs on tab5_lv_async_call from the wakeword task:
+   WAKE             → ui_home_show_toast("Tinker listening — speak then say 'save note'")
+                       + ui_orb_ripple_for_tool("wakeword")
+   DICTATION_FINAL  → ui_home_show_toast("Saved: <first 40 chars>…")
+                       + ui_orb_ripple_for_tool("wakeword")
+   DICTATION_PARTIAL → no-op (avoid toast spam; live transcript can layer
+                                in via orb caption / voice overlay later)
+```
+
+The same K144 audio + asr units are also used by `voice_m5_llm.c` Phase 6b autonomous chain (mic → ASR → LLM → TTS) when `vmode=4` is active.  Because that chain pulls full ownership of the UART transaction (the Phase-6b chain_setup posts asr+llm+tts in one breath), the wakeword listener tears its own chain down before vmode=4 work runs and re-arms on every successful warmup READY event.  The transitions are coordinated in `main/voice_onboard.c` — see "Lifecycle" below.
+
+---
+
+## Public API — `voice_wakeword.h`
+
+```c
+typedef enum {
+    VOICE_WAKEWORD_EVENT_WAKE,              /**< wake phrase matched */
+    VOICE_WAKEWORD_EVENT_DICTATION_PARTIAL, /**< new transcript chunk during LISTENING */
+    VOICE_WAKEWORD_EVENT_DICTATION_FINAL,   /**< end-of-utterance with full text */
+    VOICE_WAKEWORD_EVENT_TRANSCRIPT,        /**< background ASR partial (debug-only) */
+} voice_wakeword_event_t;
+
+typedef void (*voice_wakeword_cb_t)(voice_wakeword_event_t event, const char *text, void *user);
+
+typedef struct {
+    const char *wake_phrase;          /* default "tinker" */
+    const char *end_phrase;           /* default "save note" — empty disables phrase stop */
+    size_t      dictation_buf_bytes;  /* default 32 KB */
+    uint8_t     silence_segments_to_stop; /* default 3 */
+    uint32_t    dictation_timeout_s;  /* default 14400 (4 h) — matches #573 */
+    bool        emit_background_transcripts; /* debug; off by default */
+} voice_wakeword_config_t;
+
+esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg,
+                               voice_wakeword_cb_t cb, void *user);
+void      voice_wakeword_stop(void);
+bool      voice_wakeword_is_active(void);
+void      voice_wakeword_force_dictation_stop(void);
+```
+
+Idempotency: `voice_wakeword_start` returns `ESP_ERR_INVALID_STATE` if already running.  `voice_wakeword_stop` is safe to call when not running.  All callbacks fire from the wakeword background task — the caller is responsible for bridging to LVGL via `tab5_lv_async_call`.
+
+---
+
+## UI bridge
+
+The wakeword task posts every event onto the LVGL thread via `tab5_lv_async_call`:
+
+- `WAKE` — green toast ("Tinker listening — speak then say 'save note'") + `ui_orb_ripple_for_tool("wakeword")` so the orb pulses with the same skill-comet look used by tool calls in vmode=3.
+- `DICTATION_FINAL` — toast carries the first 40 chars of the accumulated transcript + same orb ripple.  Drops the text into the same notes path as Dictate (`/api/notes` sync with bearer auth from the W13 fix).
+- `DICTATION_PARTIAL` — intentionally no-op on the home surface (toast spam).  Future iteration can layer a live caption under the orb or in the voice overlay.
+
+The orb ripple is the only visible behavior added across the four surfaces (home / chat / notes / voice) — the existing IDLE orb sphere/halo are unchanged.
+
+---
+
+## Lifecycle (where the listener gets armed)
+
+Bridged from `main/voice_onboard.c`:
+
+1. **Boot warmup READY** — after the existing K144 cold-start probe + warm infer succeeds, the onboard module starts the wakeword task with the default config.  Until READY the task is silent; this matches the "no Tab5-side feature regresses if the module is absent" modularity rule from `PLAN-m5-llm-module.md`.
+2. **Auto-recovery (Wave 13 reset path)** — every successful `voice_onboard_reset_failover()` re-arms the wakeword task on the way out (after the post-reset warmup probe goes READY).
+3. **vmode=4 chain takeover** — when the Phase 6b autonomous chain starts, the wakeword listener tears down so the K144 UART is owned by one consumer at a time.  When the chain stops, the wakeword task does NOT auto-restart — the user explicitly returned to non-Onboard mode, so the listener will re-arm on the next warmup or reset.
+4. **K144 UNAVAILABLE** — listener stays down.  No retry loop here; the existing `voice_onboard.c` 60 s reset auto-retry covers the recovery path and the listener will hook in on the next successful warmup probe (item 1).
+
+All UART transactions inside the wakeword task take/release the recursive mutex added in TT #327 Wave 1 — no special-casing needed beyond that.
+
+---
+
+## KWS dead-end (vendor follow-up needed)
+
+K144 ships a fully-installed `sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01` model + a running `llm-kws` systemd service + an officially-listed entry in `sys.lsmode` (visible via the Wave 15 model registry endpoint).  Despite all of that, every `kws.setup` body shape I tried returned `parse_config` rejection errors from the StackFlow daemon — no body shape was accepted.  Bodies attempted included:
+
+- `{"model":"sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01"}` (matches the lsmode `mode` field)
+- `{"model":..., "kws":["tinker"]}`
+- `{"model":..., "wake_word":"tinker"}`
+- `{"model":..., "keywords":["tinker"]}`
+- `{"model":..., "input":["sys.pcm"]}` (mirrors asr.setup shape)
+- Variations with/without `kv_cache_id`, `enkws`, threshold fields from the M5Module-LLM headers
+
+All returned `parse_config false` shapes.  Logged for M5 vendor follow-up; the ASR-based path supersedes because it gives us a strict superset (open-vocabulary phrase matching at runtime + full transcript for the dictation buffer) on a unit we already trust.  If/when M5 publishes a working `kws.setup` body the wakeword module can switch to it without touching the public API — the state machine just consumes a different stream object name.
+
+---
+
+## Mic limitation — Tab5-mic-stream is wave 2
+
+K144's onboard mic faces **backward** when stacked through the Module13.2 LLM Mate carrier — toward the rear of the Tab5, away from where a seated user typically is.  That's fine for one-shot ("speak at the K144 stack") and for the live-verified wake on 2026-05-17 (user was leaning toward the device), but is unlikely to give reliable positional pickup for hands-free use across a desk or while looking at the screen.
+
+**Wave 2 (deferred):** push Tab5's existing ES7210 4-mic TDM array PCM to K144's `asr.setup` via a new stream object name.  StackFlow doesn't expose a Tab5→K144 PCM push path today (see `LEARNINGS.md` "K144 ASR via push-PCM-over-UART — alternative documented for completeness" from Phase 6b notes), so wave 2 requires either:
+
+- A custom K144 binary (~200 LOC C++) replacing `llm-audio` to accept UART-pushed PCM, OR
+- I2S-over-M5-Bus hardware refactor
+
+Neither is needed today for the wake-word product story to land — the live verification on 2026-05-17 proved the K144 mic + ASR is good enough for "speak the wake phrase, say a note" with a user near the device.  Wave 2 only matters once the user-research data says positional pickup is the limit.
+
+---
+
+## PRs + commits
+
+- **Issue:** TT [#575](https://github.com/lorcan35/TinkerTab/issues/575) — "Always-on ASR wakeword + on-device dictation via K144"
+- **PR:** [#576](https://github.com/lorcan35/TinkerTab/pull/576) — `feat/wakeword` branch
+- Commits on branch:
+  - `83f82e3` feat(voice): always-on K144 ASR — wakeword + on-device dictation (refs #575)
+  - `e5426cc` feat(wakeword): wire UI feedback — toast + orb pulse on WAKE / FINAL (refs #575)
+
+---
+
+## Code anchors
+
+- **K144 chain setup/run/teardown** for the wakeword (audio + asr only — no llm, no tts):
+  - `main/voice_m5_llm.c` — `voice_m5_llm_wakeword_setup` / `_run` / `_teardown` (audio.setup + asr.setup stages, `asr.utf-8.stream` parse, NULL-safe teardown)
+  - `main/voice_m5_llm.h` — public function declarations for the wakeword-only chain
+- **High-level state machine + dictation buffer + force-stop API:**
+  - `main/voice_wakeword.c` (~312 LOC) + `main/voice_wakeword.h` (~114 LOC)
+- **Lifecycle wiring (warmup READY hook + Wave 13 reset hook):** `main/voice_onboard.c`
+- **UI bridge (toast + orb ripple via `tab5_lv_async_call`):** `main/voice_onboard.c`'s wakeword callback
+- **Build wiring:** `main/CMakeLists.txt` adds `voice_wakeword.c`
+
+---
+
+## Observability
+
+The wakeword task emits these obs events through the standard `tab5_debug_obs_event(kind, detail)` ring (visible at `GET /events`):
+
+| Kind | Detail | Notes |
+|------|--------|-------|
+| `wakeword.start` | wake phrase string | task started, chain up |
+| `wakeword.task` | `start` / `stop` | drain task lifecycle |
+| `wakeword.fire` | matched phrase fragment | WAKE callback path |
+| `wakeword.dictation` | `start` / `final` / `forced` | LISTENING transitions |
+| `wakeword.partial` | partial text (truncated) | only when `emit_background_transcripts` is on |
+
+These slot into the existing `m5.warmup` / `m5.chain` / `m5.reset` / `error.k144` namespace from PLAN-k144-chain-hardening + PLAN-k144-recovery.
+
+---
+
+## Honest unknowns
+
+1. **Hardware retest of the UI bridge.**  The wake path is live-verified (obs ring caught `wakeword.fire` at 282 s post-boot on 2026-05-17 when the user spoke "tinker").  The toast + orb-ripple commit (`e5426cc`) landed after that verification — needs a fresh hardware run to confirm both surfaces light up.
+2. **End-phrase miss recovery.**  If the K144 transcribes "save note" as e.g. "safe note" or breaks the phrase across two finish segments, the listener falls back to the silence-segments cap and the 4-hour timeout.  Once we have enough hardware data on segment shape, the matcher might need to consume `delta` + `finish` boundary metadata, not just the concatenated text.
+3. **Power impact of always-on ASR.**  K144's `audio.setup` + `asr.setup` together draw 500-800 mA peak during active inference per the K144 spec — order-of-magnitude the same as the existing autonomous chain, just sustained instead of on-demand.  Bench measurement is wave-2-or-later.
+4. **Phrase-match false positives in conversation.**  "tinker bell", "tinkering with", etc. all trip the substring matcher.  Two mitigation paths exist (whole-word boundary check + per-segment finalisation gate); both are deferred until field data shows whether it matters.
+
+---
+
+## Out of scope (for this wave)
+
+- Tab5-mic-stream push to K144 (wave 2; see "Mic limitation" above)
+- Multiple wake phrases (today the matcher takes a single substring)
+- Confidence thresholds / endpointing tuning (K144 ASR doesn't surface a confidence field on `asr.utf-8.stream`)
+- Wake-word in vmode=3 / vmode=5 (those modes have their own STT paths — Dragon + OpenRouter respectively)
+- Visual transcript display during LISTENING (DICTATION_PARTIAL is a no-op today; future iteration could caption under the orb)


### PR DESCRIPTION
## Summary

Two-week documentation backfill across the Tab5 firmware repo.  Closes the gap
between recently-shipped feature work (PRs #569 / #573 / #574) and the in-flight
wakeword PR (#576 / TT #575) and the long-standing vmode=5 Solo Direct mode
(TT #370) that had never made it into the runbook + glossary + README.

Refs [#575](https://github.com/lorcan35/TinkerTab/issues/575).

## Files changed

- **`docs/PLAN-wakeword.md`** (NEW) — full design doc for PR #576: architecture
  diagram (K144 audio.setup + asr.setup → Tab5 task drains asr.utf-8.stream),
  2-state machine (IDLE → wake match → LISTENING → end-phrase / 3 silent
  finish-segs / 4 h timeout → IDLE), public API in `voice_wakeword.h`, UI bridge
  (`ui_home_show_toast` + `ui_orb_ripple_for_tool` via `tab5_lv_async_call`),
  KWS dead-end + vendor follow-up, mic-position limitation + wave-2 plan, PRs
  (#575 + #576), code anchors, obs events, honest unknowns.
- **`CLAUDE.md`** — new Active Investigation bullet for PR #576; voice modes
  header bumped four → six tiers with vmode=5 Solo Direct row added; "five-tier"
  / `Five-tier` references renamed to six in `voice_modes.{c,h}` description
  block; `config_update` send entry notes that vmode=4 + vmode=5 are
  Tab5-side-only (auto-downconverted to 0 on the wire); `config_update` ACK
  entry notes the `fleet_summary` block for vision-chip gating; new wakeword
  wave note added under the K144 Wave 1-7 closure block in External Hardware
  Modules.
- **`GLOSSARY.md`** — `vmode` entry updated to range 0..5 with Tab5-side-only
  downconvert note; new entries `dictation_buffer` (D), `end_phrase` (E),
  `kws_unit` (new K section), `wake_phrase` (W).
- **`README.md`** — features list gains three new bullets (wakeword + Solo
  Direct + mic-driven orb visuals); the WS protocol table row for
  `config_update` notes that vmode=4 + vmode=5 are Tab5-side-only.
- **`LEARNINGS.md`** — five new entries appended in the existing format:
  cubic-Hermite TTS upsample (PR #569), dictation cap bumped 5 min → 4 h
  (PR #573), four mic-driven sphere additions to IDLE orb (PR #574), K144
  KWS unit officially installed but unusable (supersedes the older "no wake
  word" learning), always-on K144 ASR for wakeword + on-device dictation
  (PR #576).
- **`docs/CHANGELOG.md`** — new "Mid-May 2026 — orb arc + dictation +
  wakeword" section with one-liners for PRs #569, #573, #574, #575, #576 in
  commit order; KWS revival queued-sprint entry updated with the 2026-05-17
  parse-config dead-end finding.
- **`docs/PLAN-grove.md`** — front-matter status restamped "PARKED since
  2026-04-10 — hardware on order" + an explicit `> PARKED` callout above the
  status line so future readers don't pick this up by accident.
- **`docs/PLAN-ui-ux-hardening.md`** — new "Deferred audit P0s (status as of
  2026-05-17)" section at the bottom: K144 as 5th tier in 3-dial sheet +
  orb-overload across 4 surfaces both stamped "STILL DEFERRED as of
  2026-05-17 — re-evaluate after wakeword PR #576 ships."

## Test plan

- [ ] Markdown renders cleanly on GitHub (no broken tables, no unclosed code
      fences, no malformed lists)
- [ ] No edits to code files (`.c` / `.h` / `.py`) — `git diff --stat` shows
      only markdown touched
- [ ] Cross-references resolve (PLAN-wakeword links land on existing files;
      no 404s)
- [ ] Build not required — documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)