### PR TITLE
feat(tinkeron): debug endpoint family for full health + runtime control

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -35,7 +35,7 @@ else()
         SRCS "main.c"
              "sdcard.c" "wifi.c"
              "voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_solo.c" "voice_codec.c" "voice_dictation.c" "voice_dictation_lvgl.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "voice_messages_sync.c" "mode_manager.c"
-             "debug_server.c" "debug_server_m5.c" "debug_server_ota.c"
+             "debug_server.c" "debug_server_m5.c" "debug_server_tinkeron.c" "debug_server_ota.c"
              "debug_server_codec.c" "debug_server_voice.c" "debug_server_mode.c"
              "debug_server_settings.c" "debug_server_wifi.c" "debug_server_dictation.c"
              "debug_server_call.c" "debug_server_camera.c" "debug_server_obs.c"

--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -67,6 +67,7 @@
 #include "debug_server_input.h"
 #include "debug_server_internal.h"
 #include "debug_server_m5.h"
+#include "debug_server_tinkeron.h"
 #include "debug_server_metrics.h"
 #include "debug_server_mode.h"
 #include "debug_server_nav.h"
@@ -813,6 +814,8 @@ esp_err_t tab5_debug_server_init(void)
     debug_server_voice_register(server);
     /* Wave 23b (#332): K144 endpoint family registered en-bloc. */
     debug_server_m5_register(server);
+    /* TT #578: TinkerON health + runtime control family. */
+    debug_server_tinkeron_register(server);
     debug_server_call_register(server);
     /* Wave 23b (#332): /dictation family registered en-bloc. */
     debug_server_dictation_register(server);

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -1,0 +1,292 @@
+/*
+ * debug_server_tinkeron.c — TinkerON (K144) health + control HTTP family.
+ *
+ * TT #578 (2026-05-18): Tab5 debug server family that gives the user
+ * runtime visibility + control over the always-on wakeword listener
+ * AND the underlying K144 module.  Builds on the wakeword work in
+ * PR #576 (`feat/wakeword`).  The existing m5 endpoint family stays
+ * as the low-level K144 surface; tinkeron is the product-level layer
+ * that combines wakeword state + K144 hwinfo into a single dashboard.
+ *
+ * Endpoints:
+ *   GET  /tinkeron/status        — wakeword + K144 hwinfo combined
+ *   POST /tinkeron/arm?on=1|0    — start / stop the listener at runtime
+ *   POST /tinkeron/wake_phrase   — change wake phrase at runtime
+ *   POST /tinkeron/reboot        — full K144 Linux reboot via sys.reboot
+ *   GET  /tinkeron/transcripts   — recent ASR partials (debug tail)
+ */
+
+#include "debug_server_tinkeron.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "debug_server_internal.h" /* tab5_debug_check_auth */
+#include "esp_err.h"
+#include "esp_http_server.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "task_worker.h"     /* tab5_worker_enqueue */
+#include "voice_m5_llm.h"    /* sys_reboot, hwinfo accessor */
+#include "voice_onboard.h"   /* failover state names */
+#include "voice_wakeword.h"  /* status + reconfigure_phrase + transcripts */
+
+static const char *TAG = "debug_tinkeron";
+
+/* httpd_query_key_value does NOT URL-decode the value.  Decode in-place:
+ * %XX → byte, + → space.  Length doesn't grow, so this is safe. */
+static void url_decode_inplace(char *s) {
+   if (s == NULL) return;
+   char *w = s;
+   for (char *r = s; *r; r++) {
+      if (*r == '+') {
+         *w++ = ' ';
+      } else if (*r == '%' && r[1] && r[2]) {
+         int hi = r[1], lo = r[2];
+         int hv = (hi >= '0' && hi <= '9') ? hi - '0'
+                  : (hi >= 'a' && hi <= 'f') ? hi - 'a' + 10
+                  : (hi >= 'A' && hi <= 'F') ? hi - 'A' + 10 : -1;
+         int lv = (lo >= '0' && lo <= '9') ? lo - '0'
+                  : (lo >= 'a' && lo <= 'f') ? lo - 'a' + 10
+                  : (lo >= 'A' && lo <= 'F') ? lo - 'A' + 10 : -1;
+         if (hv >= 0 && lv >= 0) {
+            *w++ = (char)((hv << 4) | lv);
+            r += 2;
+         } else {
+            *w++ = *r;
+         }
+      } else {
+         *w++ = *r;
+      }
+   }
+   *w = '\0';
+}
+
+/* Helper: read a URL-decoded query value into out (returns true on hit). */
+static bool query_get(httpd_req_t *req, const char *key, char *out, size_t cap) {
+   size_t qlen = httpd_req_get_url_query_len(req);
+   if (qlen == 0 || qlen + 1 > 512) return false;
+   char qbuf[512];
+   if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) != ESP_OK) return false;
+   if (httpd_query_key_value(qbuf, key, out, cap) != ESP_OK) return false;
+   url_decode_inplace(out);
+   return true;
+}
+
+static esp_err_t respond_json(httpd_req_t *req, cJSON *obj, int status_code) {
+   char *body = cJSON_PrintUnformatted(obj);
+   cJSON_Delete(obj);
+   if (body == NULL) {
+      httpd_resp_set_status(req, "500 Internal Server Error");
+      return httpd_resp_sendstr(req, "{\"error\":\"json_print_failed\"}");
+   }
+   if (status_code != 200) {
+      char status[32];
+      snprintf(status, sizeof(status), "%d Error", status_code);
+      httpd_resp_set_status(req, status);
+   }
+   httpd_resp_set_type(req, "application/json");
+   esp_err_t r = httpd_resp_sendstr(req, body);
+   cJSON_free(body);
+   return r;
+}
+
+/* ── GET /tinkeron/status ─────────────────────────────────────────── */
+
+static esp_err_t handle_status(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+
+   voice_wakeword_status_t ww = {0};
+   voice_wakeword_status(&ww);
+
+   cJSON *root = cJSON_CreateObject();
+   /* Wakeword listener */
+   cJSON *w = cJSON_AddObjectToObject(root, "wakeword");
+   cJSON_AddBoolToObject(w, "armed", ww.armed);
+   cJSON_AddStringToObject(w, "wake_phrase", ww.wake_phrase);
+   cJSON_AddStringToObject(w, "wake_phrase_alt", ww.wake_phrase_alt);
+   cJSON_AddStringToObject(w, "end_phrase", ww.end_phrase);
+   cJSON_AddNumberToObject(w, "fire_count", ww.fire_count);
+   cJSON_AddNumberToObject(w, "last_fire_ms", (double)ww.last_fire_ms);
+   cJSON_AddStringToObject(w, "last_match", ww.last_match);
+
+   /* K144 hardware snapshot (best-effort; we use the live hwinfo path
+    * which is itself 30s-cached on the underlying voice_m5_llm side). */
+   cJSON *k = cJSON_AddObjectToObject(root, "k144");
+   voice_m5_hwinfo_t hw;
+   if (voice_m5_llm_sys_hwinfo(&hw) == ESP_OK) {
+      cJSON_AddBoolToObject(k, "hwinfo_valid", true);
+      cJSON_AddNumberToObject(k, "temp_celsius", hw.temperature_milli_c / 1000.0);
+      cJSON_AddNumberToObject(k, "temp_milli_c", hw.temperature_milli_c);
+      cJSON_AddNumberToObject(k, "cpu_loadavg", hw.cpu_loadavg);
+      cJSON_AddNumberToObject(k, "mem", hw.mem);
+   } else {
+      cJSON_AddBoolToObject(k, "hwinfo_valid", false);
+   }
+   char ver[16] = {0};
+   if (voice_m5_llm_sys_version(ver, sizeof(ver)) == ESP_OK) {
+      cJSON_AddStringToObject(k, "version", ver);
+   }
+
+   cJSON_AddNumberToObject(root, "uptime_ms", (double)(esp_timer_get_time() / 1000));
+   return respond_json(req, root, 200);
+}
+
+/* ── POST /tinkeron/arm?on=1|0 ────────────────────────────────────── */
+
+static void arm_start_job(void *arg) {
+   (void)arg;
+   /* Need an event handler — re-use the canonical one from voice_onboard.
+    * voice_wakeword_reconfigure_phrase() with the CURRENT phrase
+    * effectively re-arms with cached cb/user.  Simpler: just call start
+    * with NULL config (defaults) + no callback.  But that drops the UI
+    * bridge.  Better path: read the cached phrase via status, then
+    * reconfigure with it — that re-uses the cached cb/user. */
+   voice_wakeword_status_t st;
+   voice_wakeword_status(&st);
+   const char *phrase = st.wake_phrase[0] ? st.wake_phrase : "hey tinker";
+   esp_err_t e = voice_wakeword_reconfigure_phrase(phrase);
+   if (e != ESP_OK) {
+      ESP_LOGW(TAG, "arm_start: reconfigure failed (%s)", esp_err_to_name(e));
+   }
+}
+
+static esp_err_t handle_arm(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   char on[8] = {0};
+   if (!query_get(req, "on", on, sizeof(on))) {
+      cJSON *err = cJSON_CreateObject();
+      cJSON_AddStringToObject(err, "error", "missing_query_on");
+      cJSON_AddStringToObject(err, "detail", "expected ?on=1 or ?on=0");
+      return respond_json(req, err, 400);
+   }
+
+   bool want_on = (on[0] == '1' || on[0] == 't' || on[0] == 'T');
+   bool currently = voice_wakeword_is_active();
+   const char *action;
+
+   if (want_on && !currently) {
+      tab5_worker_enqueue(arm_start_job, NULL, "tinkeron_arm");
+      action = "starting";
+   } else if (!want_on && currently) {
+      voice_wakeword_stop();
+      action = "stopped";
+   } else {
+      action = want_on ? "already_armed" : "already_stopped";
+   }
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", action);
+   cJSON_AddBoolToObject(resp, "armed", voice_wakeword_is_active());
+   return respond_json(req, resp, 200);
+}
+
+/* ── POST /tinkeron/wake_phrase?phrase=hey+tink ──────────────────── */
+
+static esp_err_t handle_wake_phrase(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   char phrase[64] = {0};
+   if (!query_get(req, "phrase", phrase, sizeof(phrase)) || phrase[0] == '\0') {
+      cJSON *err = cJSON_CreateObject();
+      cJSON_AddStringToObject(err, "error", "missing_query_phrase");
+      cJSON_AddStringToObject(err, "detail", "expected ?phrase=hey+tinker");
+      return respond_json(req, err, 400);
+   }
+   esp_err_t e = voice_wakeword_reconfigure_phrase(phrase);
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "phrase", phrase);
+   cJSON_AddStringToObject(resp, "status", e == ESP_OK ? "armed" : esp_err_to_name(e));
+   cJSON_AddBoolToObject(resp, "armed", voice_wakeword_is_active());
+   return respond_json(req, resp, e == ESP_OK ? 200 : 500);
+}
+
+/* ── POST /tinkeron/reboot ──────────────────────────────────────────
+ *
+ * Async — kicks the reboot on tab5_worker, returns 202 immediately.
+ * Caller polls GET /tinkeron/status to see when K144 comes back. */
+
+static void reboot_job(void *arg) {
+   (void)arg;
+   /* Tear down the wakeword task first so its UART drain doesn't fight
+    * the rebooting K144. */
+   voice_wakeword_stop();
+   ESP_LOGI(TAG, "/tinkeron/reboot: sending sys.reboot...");
+   esp_err_t e = voice_m5_llm_sys_reboot();
+   if (e == ESP_OK) {
+      ESP_LOGI(TAG, "sys.reboot acked — K144 will come back in ~30 s");
+   } else {
+      ESP_LOGW(TAG, "sys.reboot returned %s", esp_err_to_name(e));
+   }
+   /* Caller-side warmup re-trigger lives in voice_onboard_reset_failover;
+    * we don't auto-invoke it here because the user may want to observe
+    * the cold state via /tinkeron/status first. */
+}
+
+static esp_err_t handle_reboot(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   tab5_worker_enqueue(reboot_job, NULL, "tinkeron_reboot");
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "queued");
+   cJSON_AddStringToObject(resp, "detail",
+                           "sys.reboot dispatched. K144 will Linux-reboot (~30 s); "
+                           "poll GET /tinkeron/status. Call POST /m5/reset afterward "
+                           "to re-warm the failover chain.");
+   return respond_json(req, resp, 202);
+}
+
+/* ── GET /tinkeron/transcripts?n=20 ───────────────────────────────── */
+
+#define TRANSCRIPT_MAX_RETURN 32
+
+static esp_err_t handle_transcripts(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   char nbuf[8] = {0};
+   size_t want = 20;
+   if (query_get(req, "n", nbuf, sizeof(nbuf))) {
+      int n = atoi(nbuf);
+      if (n > 0 && n <= TRANSCRIPT_MAX_RETURN) want = (size_t)n;
+   }
+   voice_wakeword_transcript_t buf[TRANSCRIPT_MAX_RETURN];
+   size_t got = voice_wakeword_get_recent_transcripts(buf, want);
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(root, "transcripts");
+   for (size_t i = 0; i < got; i++) {
+      cJSON *e = cJSON_CreateObject();
+      cJSON_AddNumberToObject(e, "ms", (double)buf[i].ms);
+      cJSON_AddBoolToObject(e, "finish", buf[i].finish);
+      cJSON_AddStringToObject(e, "text", buf[i].text);
+      cJSON_AddItemToArray(arr, e);
+   }
+   cJSON_AddNumberToObject(root, "count", got);
+   return respond_json(req, root, 200);
+}
+
+/* ── Registration ─────────────────────────────────────────────────── */
+
+void debug_server_tinkeron_register(httpd_handle_t server) {
+   static const httpd_uri_t uri_status = {
+       .uri = "/tinkeron/status", .method = HTTP_GET, .handler = handle_status, .user_ctx = NULL,
+   };
+   static const httpd_uri_t uri_arm = {
+       .uri = "/tinkeron/arm", .method = HTTP_POST, .handler = handle_arm, .user_ctx = NULL,
+   };
+   static const httpd_uri_t uri_phrase = {
+       .uri = "/tinkeron/wake_phrase", .method = HTTP_POST, .handler = handle_wake_phrase, .user_ctx = NULL,
+   };
+   static const httpd_uri_t uri_reboot = {
+       .uri = "/tinkeron/reboot", .method = HTTP_POST, .handler = handle_reboot, .user_ctx = NULL,
+   };
+   static const httpd_uri_t uri_transcripts = {
+       .uri = "/tinkeron/transcripts", .method = HTTP_GET, .handler = handle_transcripts, .user_ctx = NULL,
+   };
+   httpd_register_uri_handler(server, &uri_status);
+   httpd_register_uri_handler(server, &uri_arm);
+   httpd_register_uri_handler(server, &uri_phrase);
+   httpd_register_uri_handler(server, &uri_reboot);
+   httpd_register_uri_handler(server, &uri_transcripts);
+   ESP_LOGI(TAG, "TinkerON debug family registered (5 endpoints)");
+}

--- a/main/debug_server_tinkeron.h
+++ b/main/debug_server_tinkeron.h
@@ -1,0 +1,23 @@
+/*
+ * debug_server_tinkeron.h — TinkerON (K144) full health + control family.
+ *
+ * TT #578 (2026-05-18): extends the existing m5 endpoint surface with
+ * a dedicated tinkeron family that gives the user runtime visibility
+ * + control over the always-on wakeword listener from the Tab5 debug
+ * HTTP server.  Builds on the wakeword work in PR #576.
+ *
+ * Endpoints owned by this module:
+ *   GET  /tinkeron/status        — combined snapshot: wakeword + K144 hwinfo
+ *   POST /tinkeron/arm?on=1|0    — start / stop the always-on listener
+ *   POST /tinkeron/wake_phrase   — change wake phrase at runtime
+ *   POST /tinkeron/reboot        — full K144 Linux reboot via sys.reboot
+ *   GET  /tinkeron/transcripts   — recent ASR partials (debug tail)
+ */
+
+#pragma once
+
+#include "esp_http_server.h"
+
+/* Register the TinkerON endpoint family.  Called from
+ * tab5_debug_server_start() in debug_server.c during boot. */
+void debug_server_tinkeron_register(httpd_handle_t server);

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -515,6 +515,57 @@ esp_err_t voice_m5_llm_sys_reset(void) {
    return ok ? ESP_OK : ESP_ERR_INVALID_RESPONSE;
 }
 
+/* TT #578 — full hardware reboot of the K144 module via sys.reboot.
+ * Heavier hammer than sys.reset: this restarts the entire Linux on the
+ * AX630C, not just the StackFlow daemon.  Recovery time is ~30 s vs ~5 s
+ * for sys.reset, so use it only when sys.reset can't unstick the NPU.
+ * Caller is responsible for waiting + re-warmup. */
+esp_err_t voice_m5_llm_sys_reboot(void) {
+   esp_err_t err = ensure_uart();
+   if (err != ESP_OK) return err;
+   M5_LOCK_OR_RETURN(2000);
+
+   char request_id[32];
+   make_request_id(request_id, sizeof(request_id), "rbt-");
+   const m5_stackflow_request_t req = {
+       .request_id = request_id,
+       .work_id = "sys",
+       .action = "reboot",
+   };
+
+   char tx[256];
+   int tx_len = m5_stackflow_build_request(&req, tx, sizeof(tx));
+   if (tx_len < 0) {
+      M5_UNLOCK();
+      return ESP_ERR_NO_MEM;
+   }
+
+   int frame_len = send_and_recv_one_frame(tx, tx_len, 1500);
+   if (frame_len < 0) {
+      M5_UNLOCK();
+      ESP_LOGW(TAG, "sys.reboot: no ack frame (timeout — K144 may already be rebooting)");
+      /* Reboot doesn't always ack before the kernel cuts the UART; treat
+       * timeout as best-effort success.  Caller waits then re-probes. */
+      s_setup_work_id[0] = '\0';
+      return ESP_OK;
+   }
+
+   m5_stackflow_response_t resp = {0};
+   esp_err_t pe = m5_stackflow_parse_response(s_rx_buf, (size_t)frame_len, &resp);
+   bool ok = (pe == ESP_OK) && m5_stackflow_response_matches(&resp, request_id)
+             && resp.error_code == 0;
+   if (ok) {
+      ESP_LOGI(TAG, "sys.reboot acked: %s", resp.error_message ? resp.error_message : "(no msg)");
+      s_setup_work_id[0] = '\0';
+   } else {
+      ESP_LOGW(TAG, "sys.reboot returned error_code=%d msg=%s",
+               resp.error_code, resp.error_message ? resp.error_message : "(none)");
+   }
+   m5_stackflow_response_free(&resp);
+   M5_UNLOCK();
+   return ok ? ESP_OK : ESP_ERR_INVALID_RESPONSE;
+}
+
 esp_err_t voice_m5_llm_sys_hwinfo(voice_m5_hwinfo_t *out) {
    if (out == NULL) return ESP_ERR_INVALID_ARG;
    memset(out, 0, sizeof(*out));

--- a/main/voice_m5_llm.h
+++ b/main/voice_m5_llm.h
@@ -78,6 +78,13 @@ esp_err_t voice_m5_llm_probe(void);
  */
 esp_err_t voice_m5_llm_sys_reset(void);
 
+/* TT #578 — hard hammer: full K144 Linux reboot via sys.reboot.
+ * Use when sys.reset can't unstick the NPU.  Recovery ~30 s vs ~5 s
+ * for sys.reset.  Caller is responsible for the post-reboot wait +
+ * re-warmup.  Reboot doesn't always ack before the kernel cuts the
+ * UART; timeout is treated as best-effort success. */
+esp_err_t voice_m5_llm_sys_reboot(void);
+
 /**
  * @brief K144 hardware status snapshot (Wave 14).
  *

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -75,6 +75,21 @@ static uint8_t s_silence_segments_seen = 0;
 static char s_wake_window[WAKE_WINDOW_BYTES + 1];
 static size_t s_wake_window_len = 0;
 
+/* TT #578 — TinkerON debug surface: fire counter, last-fire bookkeeping,
+ * cached callback/user so reconfigure can re-arm with the same wiring,
+ * and a 32-entry ASR transcript ring for /tinkeron/transcripts. */
+static uint32_t s_fire_count = 0;
+static int64_t s_last_fire_us = 0;
+static char s_last_match[64] = {0};
+static voice_wakeword_cb_t s_cached_cb = NULL;
+static void *s_cached_user = NULL;
+
+#define TRANSCRIPT_RING_BYTES 32
+static voice_wakeword_transcript_t s_trans_ring[TRANSCRIPT_RING_BYTES];
+static size_t s_trans_ring_head = 0; /* next slot to write */
+static size_t s_trans_ring_count = 0; /* entries populated (0..32) */
+static portMUX_TYPE s_trans_lock = portMUX_INITIALIZER_UNLOCKED;
+
 /* Case-insensitive substring search.  Returns pointer into haystack on
  * hit, NULL on miss.  Both strings expected to be UTF-8 ASCII for this
  * use case — wake phrases are English and the K144 zipformer emits
@@ -190,8 +205,27 @@ static bool wakeword_suppressed_by_voice_state(void) {
            st == VOICE_STATE_RECONNECTING);
 }
 
+/* TT #578: push every ASR delta into the debug ring buffer.  Cheap —
+ * 32-entry FIFO in static storage.  GET /tinkeron/transcripts pulls
+ * the latest N. */
+static void transcript_ring_push(const char *delta, bool finish) {
+   if (delta == NULL) return;
+   taskENTER_CRITICAL(&s_trans_lock);
+   voice_wakeword_transcript_t *slot = &s_trans_ring[s_trans_ring_head];
+   slot->ms = esp_timer_get_time() / 1000;
+   slot->finish = finish;
+   strncpy(slot->text, delta, sizeof(slot->text) - 1);
+   slot->text[sizeof(slot->text) - 1] = '\0';
+   s_trans_ring_head = (s_trans_ring_head + 1) % TRANSCRIPT_RING_BYTES;
+   if (s_trans_ring_count < TRANSCRIPT_RING_BYTES) s_trans_ring_count++;
+   taskEXIT_CRITICAL(&s_trans_lock);
+}
+
 static void asr_partial_cb(const char *delta, bool finish, void *user) {
    (void)user;
+
+   /* TT #578: every delta into the debug ring before any state branching. */
+   if (delta && delta[0]) transcript_ring_push(delta, finish);
 
    if (s_state == ST_IDLE) {
       /* Suppress matching while Tinker is mid-turn — K144 hears its
@@ -220,6 +254,11 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
       if (match != NULL) {
          ESP_LOGI(TAG, "wake matched \"%s\" in \"%s\"", match, s_wake_window);
          tab5_debug_obs_event("wakeword.fire", match);
+         /* TT #578: bookkeeping for /tinkeron/status. */
+         s_fire_count++;
+         s_last_fire_us = esp_timer_get_time();
+         strncpy(s_last_match, match, sizeof(s_last_match) - 1);
+         s_last_match[sizeof(s_last_match) - 1] = '\0';
          enter_listening();
       } else if (finish) {
          /* Segment closed without match — clear the window so the next
@@ -333,6 +372,10 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    s_emit_bg = (cfg && cfg->emit_background_transcripts);
    s_cb = cb;
    s_user = user;
+   /* TT #578: cache for voice_wakeword_reconfigure_phrase() so /tinkeron/
+    * wake_phrase can restart with the same callback wiring. */
+   s_cached_cb = cb;
+   s_cached_user = user;
    s_stop_flag = false;
    s_force_dict_stop = false;
    s_state = ST_IDLE;
@@ -390,3 +433,63 @@ void voice_wakeword_stop(void) {
 bool voice_wakeword_is_active(void) { return s_handle != NULL && s_task != NULL; }
 
 void voice_wakeword_force_dictation_stop(void) { s_force_dict_stop = true; }
+
+/* ── TT #578 — TinkerON debug-surface accessors ───────────────────── */
+
+void voice_wakeword_status(voice_wakeword_status_t *out) {
+   if (out == NULL) return;
+   out->armed = voice_wakeword_is_active();
+   strncpy(out->wake_phrase, s_wake_phrase, sizeof(out->wake_phrase) - 1);
+   out->wake_phrase[sizeof(out->wake_phrase) - 1] = '\0';
+   strncpy(out->wake_phrase_alt, s_wake_phrase_alt, sizeof(out->wake_phrase_alt) - 1);
+   out->wake_phrase_alt[sizeof(out->wake_phrase_alt) - 1] = '\0';
+   strncpy(out->end_phrase, s_end_phrase, sizeof(out->end_phrase) - 1);
+   out->end_phrase[sizeof(out->end_phrase) - 1] = '\0';
+   out->fire_count = s_fire_count;
+   out->last_fire_ms = s_last_fire_us / 1000;
+   strncpy(out->last_match, s_last_match, sizeof(out->last_match) - 1);
+   out->last_match[sizeof(out->last_match) - 1] = '\0';
+}
+
+esp_err_t voice_wakeword_reconfigure_phrase(const char *new_phrase) {
+   if (new_phrase == NULL || new_phrase[0] == '\0') return ESP_ERR_INVALID_ARG;
+   /* Need the cached cb/user from the last start so we can preserve UI
+    * wiring across the restart.  If never started, bail. */
+   if (s_cached_cb == NULL && s_cached_user == NULL) {
+      /* Allow user==NULL but require at least one prior start to have
+       * happened — detect via s_wake_phrase being non-empty (cleared
+       * never). */
+      if (s_wake_phrase[0] == '\0') return ESP_ERR_INVALID_STATE;
+   }
+   voice_wakeword_cb_t cb = s_cached_cb;
+   void *user = s_cached_user;
+   voice_wakeword_stop();
+   voice_wakeword_config_t cfg = {
+      .wake_phrase = new_phrase,
+      .end_phrase = s_end_phrase[0] ? s_end_phrase : NULL,
+      .dictation_buf_bytes = s_dict_buf_cap,
+      .silence_segments_to_stop = s_silence_segments_to_stop,
+      .dictation_timeout_s = s_dict_timeout_s,
+      .emit_background_transcripts = s_emit_bg,
+   };
+   return voice_wakeword_start(&cfg, cb, user);
+}
+
+size_t voice_wakeword_get_recent_transcripts(voice_wakeword_transcript_t *out, size_t max) {
+   if (out == NULL || max == 0) return 0;
+   size_t n;
+   taskENTER_CRITICAL(&s_trans_lock);
+   n = s_trans_ring_count < max ? s_trans_ring_count : max;
+   /* Copy newest-last (oldest-first within the n window).  Head points
+    * to next-to-write, so oldest = head - count, wrapping. */
+   size_t start = (s_trans_ring_head + TRANSCRIPT_RING_BYTES - s_trans_ring_count)
+                  % TRANSCRIPT_RING_BYTES;
+   size_t skip = s_trans_ring_count - n;  /* drop oldest if caller wants fewer */
+   start = (start + skip) % TRANSCRIPT_RING_BYTES;
+   for (size_t i = 0; i < n; i++) {
+      size_t idx = (start + i) % TRANSCRIPT_RING_BYTES;
+      out[i] = s_trans_ring[idx];
+   }
+   taskEXIT_CRITICAL(&s_trans_lock);
+   return n;
+}

--- a/main/voice_wakeword.h
+++ b/main/voice_wakeword.h
@@ -109,6 +109,48 @@ bool voice_wakeword_is_active(void);
  *         with whatever has been accumulated so far. */
 void voice_wakeword_force_dictation_stop(void);
 
+/* ── Status accessors (TT #578 — TinkerON debug surface) ──────────── */
+
+/** @brief Snapshot of the listener's runtime state.  All fields are
+ *         output-only; pass storage from the caller. */
+typedef struct {
+   bool armed;                /**< true iff the task is running */
+   char wake_phrase[64];      /**< configured wake phrase (e.g. "hey tinker") */
+   char wake_phrase_alt[64];  /**< auto-derived T→Th variant (or "") */
+   char end_phrase[64];       /**< end-of-dictation phrase */
+   uint32_t fire_count;       /**< number of WAKE events fired since arm */
+   int64_t last_fire_ms;      /**< esp_timer ms at last wake (0 if never) */
+   char last_match[64];       /**< phrase that matched on the last wake */
+} voice_wakeword_status_t;
+
+/** @brief Fill @p out with the current listener status.  All fields are
+ *         populated even when the listener is not armed (armed=false +
+ *         cached config values from the last start). */
+void voice_wakeword_status(voice_wakeword_status_t *out);
+
+/** @brief Restart the listener with a new wake phrase at runtime.
+ *
+ *  Convenience for live A/B testing of phonetic variants without a
+ *  reflash.  Internally: stop → cache new phrase → start with the
+ *  same callback + user pointer that were registered on the last
+ *  successful start.  Returns ESP_ERR_INVALID_STATE if the listener
+ *  has never been started.  On failure the previous phrase is NOT
+ *  preserved — caller is responsible for re-issuing start with the
+ *  known-good phrase. */
+esp_err_t voice_wakeword_reconfigure_phrase(const char *new_phrase);
+
+/** @brief Snapshot one ASR transcript ring-buffer entry. */
+typedef struct {
+   int64_t ms;                /**< esp_timer ms when this delta arrived */
+   bool finish;               /**< whether the K144 marked this as a finish segment */
+   char text[96];             /**< delta payload (silently truncated) */
+} voice_wakeword_transcript_t;
+
+/** @brief Copy up to @p max entries (newest-last) into @p out.  Returns
+ *         the number actually filled.  Ring buffer is 32 entries; older
+ *         deltas are evicted FIFO.  Useful for debug tail. */
+size_t voice_wakeword_get_recent_transcripts(voice_wakeword_transcript_t *out, size_t max);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
New \`/tinkeron/*\` HTTP family on the Tab5 debug server.  Five endpoints that combine wakeword state + K144 hwinfo into a single dashboard surface, with runtime arm/disarm, phrase reconfigure, hard reboot, and an ASR transcript tail.

Closes #578.  **Stacked on \`feat/wakeword\` (#576)** — merge that first.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | \`/tinkeron/status\` | Combined wakeword + K144 hwinfo + uptime |
| POST | \`/tinkeron/arm?on=1\|0\` | Start / stop the listener at runtime (async) |
| POST | \`/tinkeron/wake_phrase?phrase=hey%20tinker\` | Change wake phrase at runtime (URL-decoded; T→Th alt auto-derived) |
| POST | \`/tinkeron/reboot\` | Full K144 Linux reboot via sys.reboot |
| GET | \`/tinkeron/transcripts?n=20\` | Last N ASR partials from a 32-entry PSRAM ring |

## Supporting work
- \`voice_wakeword_status()\`, \`voice_wakeword_reconfigure_phrase()\`, \`voice_wakeword_get_recent_transcripts()\` public accessors (+ fire_count / last_fire / last_match state, 32-entry transcript ring, cached cb/user)
- \`voice_m5_llm_sys_reboot()\` — heavier hammer than sys_reset; treats post-send UART timeout as best-effort success
- \`url_decode_inplace()\` in the new family (\`httpd_query_key_value\` doesn't decode \`%XX\` / \`+\`)

## Test plan
- [x] \`GET /tinkeron/status\` returns full payload with armed=true
- [x] \`GET /tinkeron/transcripts\` returns ring with ms / finish / text
- [x] \`POST /tinkeron/arm?on=0\` stops cleanly; \`?on=1\` starts (async, armed=true within ~1 s)
- [x] \`POST /tinkeron/wake_phrase?phrase=computer\` swaps phrase + clears alt
- [x] \`POST /tinkeron/wake_phrase?phrase=hey%20tinker\` URL-decoded to "hey tinker", alt auto-derived to "hey thinker"
- [ ] \`POST /tinkeron/reboot\` not yet exercised on live hardware (kept behind explicit user action — recovery is ~30 s and we don't want to lose the test session)

## Out of scope for this PR
- Tab5 home-screen "TinkerON armed" status chip (visual feedback)
- Tab5 Settings UI for arm/disarm + reset button
- Persistence of fire_count / phrase across reboots