### PR TITLE
feat(tinkeron): crack K144 KWS unit — purpose-built keyword spotter

### DIFF
--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1613,6 +1613,91 @@ fail:
    return err;
 }
 
+/* TT #593 — KWS-backed alternative.  Same envelope as
+ * voice_m5_llm_wakeword_setup but stage 2 is kws.setup instead of
+ * asr.setup.  See header for the schema source (M5Module-LLM
+ * api_kws.cpp + StackFlow main_kws/main.cpp). */
+esp_err_t voice_m5_llm_kws_wakeword_setup(voice_m5_wakeword_handle_t **out_handle,
+                                          const char *const *keywords,
+                                          volatile bool *stop_flag) {
+   if (out_handle == NULL || keywords == NULL || keywords[0] == NULL) {
+      return ESP_ERR_INVALID_ARG;
+   }
+   *out_handle = NULL;
+
+   esp_err_t err = ensure_uart();
+   if (err != ESP_OK) return err;
+
+   M5_LOCK_OR_RETURN(60000);
+
+   voice_m5_wakeword_handle_t *h = heap_caps_calloc(1, sizeof(*h), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (h == NULL) {
+      M5_UNLOCK();
+      return ESP_ERR_NO_MEM;
+   }
+
+   /* 1) audio.setup — identical to the ASR path. */
+   {
+      cJSON *d = cJSON_CreateObject();
+      cJSON_AddNumberToObject(d, "capcard", 0);
+      cJSON_AddNumberToObject(d, "capdevice", 0);
+      cJSON_AddNumberToObject(d, "capVolume", 0.5);
+      cJSON_AddNumberToObject(d, "playcard", 0);
+      cJSON_AddNumberToObject(d, "playdevice", 1);
+      cJSON_AddNumberToObject(d, "playVolume", 0.15);
+      err = chain_setup_unit("audio", "audio.setup", d, h->audio_id, sizeof(h->audio_id),
+                             M5_SETUP_TIMEOUT_MS, stop_flag);
+      if (err != ESP_OK) goto fail;
+   }
+
+   /* 2) kws.setup — purpose-built keyword spotter.
+    *   - model: REQUIRED, must include the -2024-01-01 date suffix
+    *     (bare "...-3.3M" fails parse_config — empirically confirmed
+    *      by M5Module-LLM api_kws.cpp + StackFlow mode_*.json files).
+    *   - response_format: "kws.bool" → daemon emits one frame per hit
+    *     with object="kws.bool", data="", finish=true.  No transcript
+    *     content — caller just gets a binary "wake fired" signal.
+    *   - input: sys.pcm from the audio.setup stage above.
+    *   - enoutput: true (required by parse_config .at() lookup).
+    *   - kws: array of UPPERCASE keyword strings.  text2token.py
+    *     compiles them against the model's tokens.txt at setup time;
+    *     lowercase tokens won't compile.  Per-keyword threshold via
+    *     "PHRASE @0.20" suffix syntax. */
+   {
+      cJSON *d = cJSON_CreateObject();
+      cJSON_AddStringToObject(d, "model",
+                              "sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01");
+      cJSON_AddStringToObject(d, "response_format", "kws.bool");
+      cJSON *inp = cJSON_CreateArray();
+      cJSON_AddItemToArray(inp, cJSON_CreateString("sys.pcm"));
+      cJSON_AddItemToObject(d, "input", inp);
+      cJSON_AddBoolToObject(d, "enoutput", true);
+      /* M5Stack's own KWS_ASR.ino example passes a SINGLE keyword string
+       * (not an array).  The daemon's parse_config accepts string OR
+       * array, but the live model_loading path may have a narrower
+       * sweet-spot.  Send just the first (primary) keyword as a string
+       * to mirror the known-working example exactly. */
+      cJSON_AddStringToObject(d, "kws", keywords[0]);
+      /* First-time keyword compile shells out to text2token.py — give
+       * it 30 s like the M5Module-LLM Arduino library does. */
+      err = chain_setup_unit("kws", "kws.setup", d, h->asr_id, sizeof(h->asr_id),
+                             30000, stop_flag);
+      if (err != ESP_OK) goto fail;
+   }
+
+   M5_UNLOCK();
+   *out_handle = h;
+   ESP_LOGI(TAG, "KWS chain up: audio=%s kws=%s", h->audio_id, h->asr_id);
+   return ESP_OK;
+
+fail:
+   if (h->asr_id[0]) chain_exit_unit(h->asr_id);
+   if (h->audio_id[0]) chain_exit_unit(h->audio_id);
+   heap_caps_free(h);
+   M5_UNLOCK();
+   return err;
+}
+
 esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5_wakeword_cb cb, void *user,
                                     volatile bool *stop_flag, uint32_t timeout_s) {
    if (handle == NULL) return ESP_ERR_INVALID_ARG;
@@ -1679,6 +1764,16 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
          }
          ESP_LOGI(TAG, "asr delta: finish=%d text=\"%.80s\"", finished, delta_str);
          if (cb != NULL) cb(delta_str, finished, user);
+      }
+      /* TT #593 — kws.bool frame: K144's purpose-built keyword spotter
+       * fires one frame per hit with object="kws.bool" and an empty
+       * data payload (per StackFlow main_kws/main.cpp task_output).
+       * We synthesize a non-empty delta ("WAKE") so the upstream
+       * matcher in voice_wakeword.c can use the same substring path
+       * — saves a separate "KWS hit" code path. */
+      else if (resp.object != NULL && strcmp(resp.object, "kws.bool") == 0) {
+         ESP_LOGI(TAG, "kws hit: work_id=%s", resp.work_id);
+         if (cb != NULL) cb("WAKE", true, user);
       }
       m5_stackflow_response_free(&resp);
    }

--- a/main/voice_m5_llm.h
+++ b/main/voice_m5_llm.h
@@ -487,6 +487,32 @@ typedef void (*voice_m5_wakeword_cb)(const char *delta, bool finish, void *user)
 esp_err_t voice_m5_llm_wakeword_setup(voice_m5_wakeword_handle_t **out_handle, volatile bool *stop_flag);
 
 /**
+ * @brief TT #593 — alternative chain backed by K144's PURPOSE-BUILT
+ *        KWS unit (`sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01`)
+ *        instead of the full streaming ASR.
+ *
+ * Same envelope as @ref voice_m5_llm_wakeword_setup but the asr.setup
+ * stage is replaced with `kws.setup` carrying the runtime keyword
+ * list.  The keyword detector emits `kws.bool` frames on hit, which
+ * @ref voice_m5_llm_wakeword_run translates into a synthetic delta
+ * call with the matched keyword text + finish=true.
+ *
+ * Keyword strings must be UPPERCASE ASCII (the daemon's text2token.py
+ * compiles them against the model's tokens.txt; lowercase tokens
+ * won't compile).  Per-keyword threshold via the `@<float>` suffix:
+ *   "HEY TINKER @0.20"
+ *
+ * @param keywords  NULL-terminated array of keyword strings.  Pointer
+ *                  must remain valid until setup completes (helper
+ *                  builds + sends a JSON array immediately).
+ * @return ESP_OK on success; falls through to caller's ASR-path
+ *         fallback on ESP_ERR_INVALID_RESPONSE (K144 firmware too old).
+ */
+esp_err_t voice_m5_llm_kws_wakeword_setup(voice_m5_wakeword_handle_t **out_handle,
+                                          const char *const *keywords,
+                                          volatile bool *stop_flag);
+
+/**
  * @brief Drain asr.utf-8.stream frames, invoking cb on every partial.
  *
  * Blocking — runs until @p stop_flag transitions to true OR

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -243,7 +243,15 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
          emit_event(VOICE_WAKEWORD_EVENT_TRANSCRIPT, delta);
       }
       const char *match = NULL;
-      if (s_wake_window_len > 0) {
+      /* TT #593 — KWS unit emits a sentinel "WAKE" delta on each
+       * keyword hit (synthesized in voice_m5_llm_wakeword_run when
+       * a kws.bool frame arrives).  The K144 daemon has already
+       * confirmed the match against the compiled keyword list, so
+       * we fire wake immediately without sliding-window substring
+       * checks.  ASR fallback path continues to use substring. */
+      if (delta && strcmp(delta, "WAKE") == 0) {
+         match = s_wake_phrase;
+      } else if (s_wake_window_len > 0) {
          if (istrstr(s_wake_window, s_wake_phrase) != NULL) {
             match = s_wake_phrase;
          } else if (s_wake_phrase_alt[0] &&
@@ -392,12 +400,44 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    s_dict_buf[0] = '\0';
    s_dict_buf_len = 0;
 
-   ESP_LOGI(TAG, "starting K144 always-on ASR: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
+   ESP_LOGI(TAG, "starting K144 always-on listener: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
    tab5_debug_obs_event("wakeword.start", s_wake_phrase);
 
-   esp_err_t err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
+   /* TT #593 — try the purpose-built KWS unit first.  Convert the
+    * wake phrase + alt to UPPERCASE (text2token.py requires it).
+    * If kws.setup fails (older K144 firmware), fall back to the
+    * full ASR + substring-match path which is the proven baseline. */
+   char kws_main[64], kws_alt[64];
+   for (size_t i = 0; i < sizeof(kws_main) - 1 && s_wake_phrase[i]; i++) {
+      kws_main[i] = toupper((unsigned char)s_wake_phrase[i]);
+      kws_main[i + 1] = '\0';
+   }
+   kws_main[sizeof(kws_main) - 1] = '\0';
+   if (s_wake_phrase_alt[0]) {
+      for (size_t i = 0; i < sizeof(kws_alt) - 1 && s_wake_phrase_alt[i]; i++) {
+         kws_alt[i] = toupper((unsigned char)s_wake_phrase_alt[i]);
+         kws_alt[i + 1] = '\0';
+      }
+      kws_alt[sizeof(kws_alt) - 1] = '\0';
+   } else {
+      kws_alt[0] = '\0';
+   }
+   const char *kws_list[3] = { kws_main, kws_alt[0] ? kws_alt : NULL, NULL };
+   esp_err_t err = voice_m5_llm_kws_wakeword_setup(&s_handle, kws_list, &s_stop_flag);
+   if (err == ESP_OK) {
+      ESP_LOGI(TAG, "using KWS unit (purpose-built keyword spotter)");
+      tab5_debug_obs_event("wakeword.start", "kws_unit");
+   } else {
+      ESP_LOGW(TAG, "kws.setup failed (%s) — falling back to ASR substring match",
+               esp_err_to_name(err));
+      err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
+      if (err == ESP_OK) {
+         ESP_LOGI(TAG, "using ASR substring fallback");
+         tab5_debug_obs_event("wakeword.start", "asr_fallback");
+      }
+   }
    if (err != ESP_OK) {
-      ESP_LOGE(TAG, "ASR chain setup failed: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "wakeword chain setup failed: %s", esp_err_to_name(err));
       char detail[48];
       snprintf(detail, sizeof(detail), "fail %s", esp_err_to_name(err));
       tab5_debug_obs_event("wakeword.start", detail);


### PR DESCRIPTION
Closes #593.  Cracks the K144 \`kws.setup\` schema:
- Model name needs the \`-2024-01-01\` date suffix
- Keywords must be UPPERCASE ASCII
- Use single-string \`kws\` field (per M5Stack's own example)
- First-time keyword compile takes ~22s

Result: KWS unit loads cleanly; NPU load drops 55% → 17%.  ASR substring fallback retained for older K144 firmware.

**Open follow-up:** \"TINKER\" may not be in the gigaspeech training vocab — clean setup but no hits on live speech tests.  Try "HELLO" first to confirm the path is live, then explore wenetspeech model or custom training.