### PR TITLE
feat(wakeword): barge-in — interrupt Tinker mid-TTS

### DIFF
--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -129,6 +129,18 @@ static void wakeword_toast_async(void *user) {
  * next wake. */
 static void wakeword_trigger_voice_turn(void *user) {
    (void)user;
+   /* TT #597 — Barge-in: if wake fires while Tinker is mid-TTS, cancel
+    * the current voice turn first.  voice_cancel() stops in-flight TTS
+    * playback + sends the cancel frame to Dragon so the LLM doesn't
+    * keep streaming.  Then start a fresh listening session.  Small
+    * grace period after cancel so the state machine settles to READY
+    * before we try to open the mic. */
+   if (voice_get_state() == VOICE_STATE_SPEAKING) {
+      ESP_LOGI(TAG, "barge-in: wake during SPEAKING — cancelling current turn");
+      tab5_debug_obs_event("wakeword.fire", "barge_in");
+      voice_cancel();
+      vTaskDelay(pdMS_TO_TICKS(150));
+   }
    esp_err_t err = voice_start_listening();
    if (err != ESP_OK) {
       ESP_LOGW(TAG, "voice_start_listening on wake failed: %s",

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -209,9 +209,7 @@ static bool wakeword_suppressed_by_voice_state(void) {
     * ("hey tinker", not bare "tinker") + the VAD pre-gate's 8-char
     * window floor.  Tinker's TTS would have to coincidentally say
     * the full "hey tinker" phrase to false-trigger, which is rare. */
-   return (st == VOICE_STATE_LISTENING ||
-           st == VOICE_STATE_PROCESSING ||
-           st == VOICE_STATE_RECONNECTING);
+   return (st == VOICE_STATE_LISTENING || st == VOICE_STATE_PROCESSING || st == VOICE_STATE_RECONNECTING);
 }
 
 /* TT #578: push every ASR delta into the debug ring buffer.  Cheap —

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -199,9 +199,18 @@ static void finish_dictation(const char *reason) {
  * coordination; not in this fix. */
 static bool wakeword_suppressed_by_voice_state(void) {
    voice_state_t st = voice_get_state();
+   /* TT #597 — Barge-in: SPEAKING is NO LONGER suppressed.  The user
+    * may say "Hey Tinker" mid-TTS to interrupt + start a new turn.
+    * The WAKE handler in voice_onboard.c::wakeword_event_handler is
+    * responsible for calling voice_cancel() before voice_start_
+    * listening() when the wake fires during SPEAKING.
+    *
+    * Self-wake risk mitigated by the wake_phrase being multi-word
+    * ("hey tinker", not bare "tinker") + the VAD pre-gate's 8-char
+    * window floor.  Tinker's TTS would have to coincidentally say
+    * the full "hey tinker" phrase to false-trigger, which is rare. */
    return (st == VOICE_STATE_LISTENING ||
            st == VOICE_STATE_PROCESSING ||
-           st == VOICE_STATE_SPEAKING ||
            st == VOICE_STATE_RECONNECTING);
 }
 


### PR DESCRIPTION
Closes #597.  Allow 'Hey Tinker' mid-TTS to cancel + start a new turn.  Self-wake risk gated by multi-word phrase + VAD pre-gate.