### PR TITLE
feat(wakeword): rolling-text fast path — skip STT when K144 already heard it (closes #599)

### DIFF
--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -150,9 +150,8 @@ static int find_phrase_offset(const char *haystack, const char *needle) {
  * remainder via @p out (NUL-terminated, possibly empty).  We grab the
  * last 6 entries (~last 3-6 seconds of speech) and search for the wake
  * phrase or its T→Th alt — first hit wins, take everything after it. */
-static void extract_post_wake_remainder(const char *wake_phrase,
-                                        const char *wake_phrase_alt,
-                                        char *out, size_t out_cap) {
+static void extract_post_wake_remainder(const char *wake_phrase, const char *wake_phrase_alt, char *out,
+                                        size_t out_cap) {
    if (out == NULL || out_cap == 0) return;
    out[0] = '\0';
 
@@ -209,8 +208,7 @@ static void wakeword_trigger_voice_turn(void *user) {
    voice_wakeword_status_t ww;
    voice_wakeword_status(&ww);
    char remainder[256];
-   extract_post_wake_remainder(ww.wake_phrase, ww.wake_phrase_alt,
-                               remainder, sizeof(remainder));
+   extract_post_wake_remainder(ww.wake_phrase, ww.wake_phrase_alt, remainder, sizeof(remainder));
    /* Heuristic floor — need at least 5 chars + 1 space (a real word
     * boundary).  Empty / single-token remainders fall through to the
     * mic path so a "Hey Tinker" with pause still works. */
@@ -219,8 +217,7 @@ static void wakeword_trigger_voice_turn(void *user) {
       tab5_debug_obs_event("wakeword.fire", "text_path");
       esp_err_t e = voice_send_text(remainder);
       if (e == ESP_OK) return;
-      ESP_LOGW(TAG, "voice_send_text failed (%s) — falling back to mic",
-               esp_err_to_name(e));
+      ESP_LOGW(TAG, "voice_send_text failed (%s) — falling back to mic", esp_err_to_name(e));
    }
 
    esp_err_t err = voice_start_listening();

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -127,6 +127,65 @@ static void wakeword_toast_async(void *user) {
  * so we don't get a stray "Saved: …" toast at the end of every voice
  * turn.  The matcher returns to IDLE and continues listening for the
  * next wake. */
+/* TT #599 — case-insensitive substring locate, returns offset OR -1. */
+static int find_phrase_offset(const char *haystack, const char *needle) {
+   if (haystack == NULL || needle == NULL || needle[0] == '\0') return -1;
+   size_t nlen = strlen(needle);
+   for (const char *p = haystack; *p; ++p) {
+      size_t i;
+      for (i = 0; i < nlen; i++) {
+         if (p[i] == 0) return -1;
+         char a = p[i], b = needle[i];
+         if (a >= 'A' && a <= 'Z') a += 32;
+         if (b >= 'A' && b <= 'Z') b += 32;
+         if (a != b) break;
+      }
+      if (i == nlen) return (int)(p - haystack) + (int)nlen;
+   }
+   return -1;
+}
+
+/* TT #599 — Build a "rolling text buffer" from the K144 transcript ring
+ * by concatenating the last few entries.  Returns the post-wake-phrase
+ * remainder via @p out (NUL-terminated, possibly empty).  We grab the
+ * last 6 entries (~last 3-6 seconds of speech) and search for the wake
+ * phrase or its T→Th alt — first hit wins, take everything after it. */
+static void extract_post_wake_remainder(const char *wake_phrase,
+                                        const char *wake_phrase_alt,
+                                        char *out, size_t out_cap) {
+   if (out == NULL || out_cap == 0) return;
+   out[0] = '\0';
+
+   voice_wakeword_transcript_t buf[8];
+   size_t n = voice_wakeword_get_recent_transcripts(buf, 8);
+   if (n == 0) return;
+
+   /* Concatenate newest 6 entries with spaces. */
+   char joined[512] = {0};
+   size_t joined_len = 0;
+   size_t start = (n > 6) ? n - 6 : 0;
+   for (size_t i = start; i < n; i++) {
+      size_t add = strlen(buf[i].text);
+      if (joined_len + add + 2 >= sizeof(joined)) break;
+      if (joined_len > 0) joined[joined_len++] = ' ';
+      memcpy(joined + joined_len, buf[i].text, add);
+      joined_len += add;
+   }
+   joined[joined_len] = '\0';
+
+   int off = find_phrase_offset(joined, wake_phrase);
+   if (off < 0 && wake_phrase_alt && wake_phrase_alt[0]) {
+      off = find_phrase_offset(joined, wake_phrase_alt);
+   }
+   if (off < 0) return;
+
+   /* Skip trailing whitespace + punctuation after the phrase. */
+   const char *rest = joined + off;
+   while (*rest == ' ' || *rest == ',' || *rest == '.' || *rest == '?') rest++;
+   strncpy(out, rest, out_cap - 1);
+   out[out_cap - 1] = '\0';
+}
+
 static void wakeword_trigger_voice_turn(void *user) {
    (void)user;
    /* TT #597 — Barge-in: if wake fires while Tinker is mid-TTS, cancel
@@ -141,6 +200,29 @@ static void wakeword_trigger_voice_turn(void *user) {
       voice_cancel();
       vTaskDelay(pdMS_TO_TICKS(150));
    }
+
+   /* TT #599 — Rolling-text fast path: if the K144 has already
+    * transcribed text AFTER the wake phrase (user said it all in one
+    * breath), send that text directly to Dragon and skip the entire
+    * Tab5 mic → audio upload → STT round-trip.  Saves ~2-3 s.
+    * Falls through to voice_start_listening when no remainder. */
+   voice_wakeword_status_t ww;
+   voice_wakeword_status(&ww);
+   char remainder[256];
+   extract_post_wake_remainder(ww.wake_phrase, ww.wake_phrase_alt,
+                               remainder, sizeof(remainder));
+   /* Heuristic floor — need at least 5 chars + 1 space (a real word
+    * boundary).  Empty / single-token remainders fall through to the
+    * mic path so a "Hey Tinker" with pause still works. */
+   if (strlen(remainder) >= 5 && strchr(remainder, ' ') != NULL) {
+      ESP_LOGI(TAG, "rolling-text fast path: %.80s", remainder);
+      tab5_debug_obs_event("wakeword.fire", "text_path");
+      esp_err_t e = voice_send_text(remainder);
+      if (e == ESP_OK) return;
+      ESP_LOGW(TAG, "voice_send_text failed (%s) — falling back to mic",
+               esp_err_to_name(e));
+   }
+
    esp_err_t err = voice_start_listening();
    if (err != ESP_OK) {
       ESP_LOGW(TAG, "voice_start_listening on wake failed: %s",


### PR DESCRIPTION
## Summary
- Re-cut of #600 onto fresh main after the Tier-1 cascade landed (#596 VAD pre-gate + #598 barge-in).  Same logic; format-clean.
- Adds `extract_post_wake_remainder()` in `voice_onboard.c` that pulls the last 6 ASR transcripts via `voice_wakeword_get_recent_transcripts()`, concatenates them, finds the wake-phrase offset (with T→Th alt fallback), and returns whatever was said *after* the wake phrase.
- `wakeword_trigger_voice_turn()` now:
  1. Cancels TTS if SPEAKING (barge-in carry-over from #598)
  2. Extracts remainder
  3. If ≥5 chars + has a word boundary → `voice_send_text(remainder)` and emits `wakeword.fire: text_path` obs event
  4. Else falls through to `voice_start_listening()` (existing mic path) — preserves "Hey Tinker… [pause] …what time is it?" UX.

## Test plan
- [ ] Flash to Tab5 192.168.1.90
- [ ] Say "Hey Tinker what time is it?" in one breath — verify `wakeword.fire: text_path` event + response arrives without mic ramp-up
- [ ] Say "Hey Tinker" + pause + "what time is it?" — verify falls through to mic path (existing UX)
- [ ] Verify `/events?since=...` shows `wakeword.fire` events distinguishing `text_path` vs the existing default

Closes #599