### PR TITLE
fix(wakeword): wake_window_push BSS overflow (closes #606)

### DIFF
--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -122,20 +122,35 @@ static void emit_event(voice_wakeword_event_t ev, const char *text) {
 static void wake_window_push(const char *chunk) {
    if (chunk == NULL || chunk[0] == '\0') return;
    size_t add = strlen(chunk);
+   /* TT #606: clamp add up front so the rest of the function never
+    * exceeds WAKE_WINDOW_BYTES.  Old code only handled add > BYTES;
+    * add == BYTES underflowed (WAKE_WINDOW_BYTES - add - 1) to
+    * SIZE_MAX and overran into adjacent BSS, corrupting
+    * s_wake_phrase_alt / s_end_phrase with TV transcript text. */
+   if (add > WAKE_WINDOW_BYTES) add = WAKE_WINDOW_BYTES;
+
    /* Truncate from the left when we'd overflow — keep the most recent
-    * WAKE_WINDOW_BYTES.  Cheaper than ring-buffer math for this size. */
+    * WAKE_WINDOW_BYTES.  Cheaper than ring-buffer math for this size.
+    * Uses (>=) so add == WAKE_WINDOW_BYTES forces a clean reset rather
+    * than the underflow path. */
    if (s_wake_window_len + 1 + add > WAKE_WINDOW_BYTES) {
-      size_t keep = (add > WAKE_WINDOW_BYTES) ? 0 : (WAKE_WINDOW_BYTES - add - 1);
+      size_t keep = (add + 1 >= WAKE_WINDOW_BYTES) ? 0 : (WAKE_WINDOW_BYTES - add - 1);
       if (keep > s_wake_window_len) keep = s_wake_window_len;
       if (keep > 0) memmove(s_wake_window, s_wake_window + s_wake_window_len - keep, keep);
       s_wake_window_len = keep;
    }
-   if (s_wake_window_len > 0) {
+   if (s_wake_window_len > 0 && s_wake_window_len < WAKE_WINDOW_BYTES) {
       s_wake_window[s_wake_window_len++] = ' ';
    }
-   if (add > WAKE_WINDOW_BYTES) add = WAKE_WINDOW_BYTES;
-   memcpy(s_wake_window + s_wake_window_len, chunk, add);
-   s_wake_window_len += add;
+   /* Final defensive clamp — never write past s_wake_window[WAKE_WINDOW_BYTES]
+    * regardless of how we got here. */
+   if (s_wake_window_len + add > WAKE_WINDOW_BYTES) {
+      add = WAKE_WINDOW_BYTES - s_wake_window_len;
+   }
+   if (add > 0) {
+      memcpy(s_wake_window + s_wake_window_len, chunk, add);
+      s_wake_window_len += add;
+   }
    s_wake_window[s_wake_window_len] = '\0';
 }
 


### PR DESCRIPTION
## Summary
**Critical memory-corruption fix.**  Unsigned-underflow in \`wake_window_push\` was overrunning \`s_wake_window\` into adjacent BSS, clobbering \`s_wake_phrase_alt\` + \`s_end_phrase\` with TV transcript text.  Once \`wake_phrase_alt\` held arbitrary TV phrases, every TV utterance containing that substring \"matched\" via \`istrstr()\` — root cause of the fuzzy-matcher false-fires we mis-attributed to the matcher itself.

## Trigger
K144 ASR delta with strlen exactly \`WAKE_WINDOW_BYTES (96)\`:

\`\`\`c
size_t keep = (add > WAKE_WINDOW_BYTES) ? 0 : (WAKE_WINDOW_BYTES - add - 1);
\`\`\`

For \`add == 96\`: \`96 > 96\` false → else branch → \`96 - 96 - 1 = -1\` as \`size_t\` = \`SIZE_MAX\`.  Subsequent memcpy wrote 96 bytes past \`s_wake_window[97]\`.

## Fix
- Clamp \`add\` at function entry
- \`(>=)\` instead of \`(>)\` for the boundary check
- Gate the separator-space write on \`< WAKE_WINDOW_BYTES\`
- Defensive memcpy-length clamp before write

## Live verification
| State           | Before fix              | After fix             |
|-----------------|-------------------------|-----------------------|
| \`wake_phrase_alt\` after 3 min K144 audio | \`\" neatly hold while israel has\"\` | \`\"hey thinker\"\` ✓ |
| \`end_phrase\` after 3 min | \`\"rgin so manipulation ah ol...\"\` | \`\"save note\"\` ✓ |
| False fires on TV background | 1-2 per few minutes | 0 across 5 min ✓ |

Closes #606