### PR TITLE
docs: Path A blocked — pivot wake architecture to Dragon-side (refs #608)

### DIFF
--- a/docs/PLAN-tab5-mic-to-k144-asr.md
+++ b/docs/PLAN-tab5-mic-to-k144-asr.md
@@ -7,92 +7,96 @@ Wakeword today runs on the K144's onboard mic, which is physically buried inside
 
 Tab5's ES7210 quad-mic array sits on the front face of the device, much closer to the user. We already stream this mic cleanly to Dragon during voice turns. **The wakeword path should use Tab5's mic, not K144's.**
 
-## Architecture decision: Path A (UART PCM injection)
+## Architecture decision: Path A (UART PCM injection) — BLOCKED
 
-Confirmed feasible via K144 ADB probe 2026-05-18:
+ADB-probed K144 2026-05-18. The asr subscription side works — `asr.setup` with `input: ["sys.pcm"]` is accepted and produces an `asr.utf-8.stream` work_id, exactly as the wakeword listener already uses. **But there is no JSON-RPC verb to publish PCM onto the `sys.pcm` bus from outside.**
 
-1. K144's `llm_asr` binary publishes config schema with `"input_type": ["sys.pcm", "sys.cap.0_0"]`. `sys.pcm` is **raw host-injected PCM**, separate from `sys.cap.0_0` (K144's hardware mic chained via `audio.setup`).
-2. Each asr work_id exposes per-instance ZMQ sockets: `inference_url` (push PCM frames in) + `output_url` (read transcripts out).
-3. The existing UART bridge `llm_sys` already converts UART JSON ↔ ZMQ — no firmware-side changes needed on K144. Same mechanism we use today for setup messages.
-4. UART runs at 1.5 Mbps (verified Phase 6a). 16 kHz × 16-bit mono = 256 kbps audio bandwidth — fits with ~6× headroom for JSON+base64 framing overhead.
+Probe-confirmed negatives:
 
-### Why not Path B (Dragon-side wake)
-Considered. Rejected for this iteration:
-- Requires Tab5 to stream audio continuously to Dragon over WiFi → battery + privacy concern (continuous over-air audio when device is idle)
-- Adds Dragon as a hard dependency for the wakeword path. Current K144 setup keeps wake fully on-device — works even when Dragon is offline.
-- Dragon-side wake model would need to be picked + benchmarked (more research).
+| Attempt | K144 response |
+|---|---|
+| `action: inference` on `asr.NNNN`, `object: audio.pcm/asr.pcm/sys.pcm/audio.raw/audio.cap.0_0`, base64 PCM | `-4 "inference data push false"` for every shape |
+| `action: sys.push` on `work_id: sys.pcm` | `-3 "action match false"` |
 
-Could revisit Path B as a Tier-3 follow-up if Tab5→K144 latency proves too high.
+`sys.push` is an internal C++ function (`zmq_bus_publisher_push`) called from inside the audio unit's hardware-capture loop — it isn't registered as a callable RPC action.  The `audio.cap` action group on `llm_audio` is `cap_param / cap_config / cap_stop / cap_stop_all` only — no `cap_raw` symmetric to the documented `play_raw` for speaker.
+
+**Conclusion:** without modifying K144's `llm_audio` binary or deploying a custom audio-source daemon to the K144 filesystem (binary deploy via ADB), there is no public StackFlow API to publish host PCM onto the `sys.pcm` bus. Path A as originally designed cannot be implemented purely from Tab5.
+
+### Path B (Dragon-side wake) — now the active path
+
+Original plan deferred this, but Path A's K144 protocol blocker makes B the only realistic implementation route without K144 firmware modification:
+
+- Tab5 streams 16 kHz mono PCM to Dragon continuously when idle (existing voice WS, new "always-listening" mode flag)
+- Dragon runs a lightweight wake detector on the stream — options:
+  - Whisper.cpp `tiny.en` in streaming mode (already on disk, used by dictation path)
+  - openWakeWord with a fine-tuned "hey tinker" model (custom training needed, several days)
+  - Moonshine streaming partials matched against `hey tinker` substring (already configured, just route to a new wake-detector instead of full STT path)
+- Dragon sends a `wake` WS frame to Tab5 when fired; Tab5 then opens a real voice turn (mic stays open, just transitions from continuous-tap-to-Dragon mode → in-turn mode)
+
+Trade-offs accepted: Dragon becomes a hard dependency for wake (was acceptable for everything else already in vmode=0). Continuous WiFi audio is local LAN only, ~256 kbps, no battery concern (Tab5 is wired). Privacy: same trust boundary as today's voice turns — user owns Dragon.
+
+Could still revisit Path A in a follow-up by writing + deploying a custom `llm_audio_external` daemon to the K144 that accepts PCM via a /tmp/pipe and publishes to `sys.pcm`. That's a multi-day effort (cross-compile ARM64 binary, ADB push to K144 `/opt/m5stack/bin/`, register as a StackFlow unit, wire up). Worth doing if Path B latency proves unworkable, otherwise leave for later.
 
 ### Why not Path C (physical fix)
 Repositioning the K144 doesn't unlock Tab5's better mic. The whole device topology is fixed by the M5-Bus stacking spec.
 
-## Implementation phases
+## Implementation phases — REVISED to Path B
 
-### Phase 1 — Manual probe (1 hour, no code)
-Validate Path A works end-to-end with hand-crafted JSON before writing C code.
+### Phase 1 — Manual probe (DONE 2026-05-18)
+Probed K144 via ADB.  Findings:
+- `asr.setup` with `input: [sys.pcm]` is accepted and allocates a work_id ✅
+- `asr.utf-8.stream` deltas flow back over the existing TCP/UART bridge ✅
+- No JSON-RPC verb exists to publish PCM onto `sys.pcm` — Path A blocked, see "Architecture decision" section above ❌
 
-- ADB into K144, manually setup an ASR work_id with `input_type=sys.pcm`
-- Hand-stream a known WAV (e.g. "hey tinker" recorded on a phone) via ZMQ PUSH to the inference_url
-- Confirm asr.utf-8.stream output frames return with the expected transcript
+Conclusion: pivot to Path B.
 
-Exit criteria: known-good audio in → known-good transcript out.
+### Phase 2 — Tab5 always-listening mic mode (3-4 hours)
+New Tab5-side flag: `voice_set_wake_streaming(true/false)`. When on, the existing mic capture path runs in IDLE state too, not just during voice turns. PCM frames go to Dragon over the existing voice WS as `{"type":"wake_audio"}` framed binary (new type, parallel to the existing untagged-PCM-during-turn).
 
-### Phase 2 — Tab5 mic-tap task (4-6 hours)
-New module `main/voice_wakeword_mic_tap.{c,h}` — a low-priority background task that captures Tab5 mic audio continuously while the wakeword listener is armed, and ships it over UART to K144.
+- Reuse existing `voice.c` mic task — just open earlier (on wake-streaming arm) and keep running through state transitions
+- No new audio capture code needed
+- Lifecycle: pauseable when SPEAKING (so Tab5 doesn't hear its own TTS — barge-in stays as a separate feature)
 
-- Reuse the existing `mic.c` API (ES7210 quad-mic, TDM slot 0 extraction)
-- Downsample 48 kHz → 16 kHz (3:1 same as voice path)
-- Frame at 20-50 ms cadence (320-800 samples per frame at 16 kHz)
-- JSON-encode with `{action: "inference", work_id: "asr.NNNN", object: "audio.raw", data: "<base64>"}` per frame
-- Write to UART through the existing `bsp/tab5/uart_port_c` mutex-guarded sender
+### Phase 3 — Dragon-side wake detector (4-5 hours)
+New `dragon_voice/wake/` module on Dragon. Subscribes to a new WS frame type:
+- Tab5 → Dragon: `wake_audio` binary frame (16 kHz mono int16)
+- Dragon runs a sliding-window detector on the stream
+- v1 detector: feed audio into the existing `whisper_cpp small.en` backend (already on disk) with a short window (~1.5 s), match output text against `hey tinker` substring (case-insensitive, with the fuzzy phonetic matcher logic ported from Tab5's `voice_wakeword.c`)
+- v2 (follow-up): openWakeWord with a custom-trained "hey tinker" model
 
-Bandwidth budget: 30 fps × ~1.5 KB/frame (incl. base64 1.33× overhead + JSON wrap) = 45 KB/s. UART at 1.5 Mbps = 187 KB/s capacity. ~25% utilization. Headroom for control traffic.
+On match: Dragon sends `{"type": "wake"}` WS frame back to Tab5. Tab5 transitions to LISTENING + pauses wake-streaming for the duration of the turn.
 
-Concerns:
-- **Mic contention with the voice WS path** during real voice turns. Two options:
-  - Stop the K144 tap when voice state enters LISTENING (single mic consumer at a time, simple lifecycle)
-  - Tee the PCM stream to both consumers (cleaner UX — wake fires during TTS still work, barge-in stays smooth)
-- Go with **stop-on-LISTENING for v1**, tee in a follow-up. Less risk.
-
-### Phase 3 — K144 setup wiring change (2 hours)
-Modify `main/voice_m5_llm.c::voice_m5_llm_wakeword_setup`:
-
-- Drop the `audio.setup` chain step
-- Setup ASR directly with `"input_type": "sys.pcm"`
-- Cache the returned `asr.work_id` so the mic-tap task knows where to push
-- Teardown: stop mic tap → ASR exit (no audio unit to release)
-
-Existing wakeword task drains transcripts unchanged — the asr output_url protocol is identical.
-
-### Phase 4 — Lifecycle coordination (2 hours)
-- Mic-tap task starts when wakeword arms (warmup READY)
-- Mic-tap task stops when wakeword stops OR voice enters LISTENING
-- On LISTENING → READY transition, mic-tap resumes
-- Wake-during-SPEAKING (barge-in #598) still works because the mic-tap was paused before TTS started, so K144 doesn't hear its own response
+### Phase 4 — Lifecycle + state machine (2 hours)
+- New Tab5 voice substate or NVS key: `wake_streaming_armed` (default true when Dragon connected + vmode=0/1/2/3)
+- When armed: mic capture loop runs continuously, ships frames to Dragon
+- On `wake` frame from Dragon: transition to LISTENING (existing path), stop wake-streaming
+- On voice turn end (state → READY): re-arm wake-streaming
+- K144 wakeword path stays as a fallback when Dragon is offline (current behavior unchanged in failover scenarios)
 
 ### Phase 5 — Live verify (1 hour)
 - Flash to Tab5 192.168.1.90
-- Say "Hey Tinker" from 1 m, 2 m, 3 m positions → confirm fire_count increments cleanly
-- Background TV/podcast playing → confirm fire_count does NOT spuriously increment
+- Say "Hey Tinker" from 1 m, 2 m, 3 m positions → confirm wake fires
+- Background TV/podcast playing → confirm wake does NOT spuriously fire
 - Mid-TTS barge-in: speak "Hey Tinker" while Tinker is replying → confirm cancel + new turn opens
+- Network drop: Dragon disconnect → confirm fallback to K144 wakeword path (no regression)
 
-## Code anchors
+## Code anchors (revised for Path B)
 
 | Phase | File | What |
 |-------|------|------|
-| 2 | `main/voice_wakeword_mic_tap.{c,h}` | new module, background mic+UART task |
-| 2 | `main/voice_wakeword.c` | call into mic_tap start/stop in lifecycle hooks |
-| 2 | `main/voice.c` | hook mic-tap pause/resume on voice state changes |
-| 3 | `main/voice_m5_llm.c` | swap audio.setup chain → sys.pcm input |
-| 3 | `main/voice_m5_llm.h` | API exposes inference_url / work_id for mic-tap |
+| 2 | `main/voice.c` | extend mic capture lifecycle, new `voice_set_wake_streaming()` API + WAKE_AUDIO binary magic tag for the WS frame |
+| 2 | `main/voice_ws_proto.{c,h}` | new `WAK0` 4-byte magic for `wake_audio` frames (parallel to `VID0` / `AUD0`) |
+| 3 | `dragon_voice/wake/__init__.py` (Dragon) | new module — sliding-window wake detector consuming `wake_audio` WS frames |
+| 3 | `dragon_voice/server.py` (Dragon) | wire wake module into the per-connection pipeline |
+| 4 | `main/voice.c` | state machine — wake-streaming pauses during LISTENING/SPEAKING |
+| 4 | `main/settings.{c,h}` | new NVS key `wake_stream` (default 1 when Dragon connected) |
 
 ## Risks + unknowns
 
-1. **UART contention during a voice turn**: voice WS path sends PCM directly to Dragon over WiFi — it doesn't touch K144 UART. So no contention. But control messages (setup/teardown) might compete. Mutex on uart_port_c already exists (TT #327 Wave 1).
-2. **PCM framing overhead**: base64 vs binary. Probe Phase 1 will reveal whether the asr inference accepts binary `data` field. If yes, drop the 1.33× base64 multiplier.
-3. **Latency budget**: each PCM frame = JSON parse + ZMQ hop + ASR feature extract. Need to measure end-to-end wake latency vs current. Target: ≤ 500 ms from spoken "tinker" to wake fire.
-4. **K144 daemon crash on sustained PCM stream**: unknown reliability. The KWS unit was rejected by vendor firmware (parse_config fails); ASR might have similar surprises with sys.pcm input. Phase 1 probe gates this.
+1. **Continuous WiFi audio bandwidth**: 256 kbps continuous. Tab5 wired, local LAN, fine.
+2. **Dragon-side detector accuracy**: whisper-tiny.en in sliding-window mode is a v1 detector — not purpose-built for wake detection. False-fire rate vs miss rate need measurement. Fallback option: train openWakeWord "hey tinker" model.
+3. **Wake latency**: 1.5 s sliding window + WiFi roundtrip + Dragon CPU = expect ~1-2 s wake latency. Compare to current K144 wake (~500 ms). Acceptable if accuracy is dramatically better; not acceptable if comparable.
+4. **K144 wakeword fallback path**: must stay working when Dragon is offline. Don't remove the K144 code — gate it behind a `wake_source` setting (auto / k144 / dragon).
 
 ## Rollback plan
 If any phase fails: revert to current K144-mic-onboard wakeword path. The new mic-tap module is additive; old code stays in place until Phase 4 cuts it over via config. Worst case: comment out one function call and rebuild.


### PR DESCRIPTION
## Summary
Deeper ADB probe of K144 (Phase 1) found a hard blocker for Path A: there's no JSON-RPC verb to publish PCM onto K144's \`sys.pcm\` bus from outside.  Updates the plan doc with the probe findings and pivots to Path B (Dragon-side wake detector).

## Findings
| Probe | Result |
|---|---|
| \`asr.setup\` with \`input: [sys.pcm]\` | ✅ accepted, work_id allocated |
| \`asr.utf-8.stream\` output flow | ✅ deltas come back over TCP/UART |
| \`action: inference\` on \`asr.NNNN\` with PCM data (5 different shapes) | ❌ \`-4 \"inference data push false\"\` |
| \`action: sys.push\` on \`work_id: sys.pcm\` | ❌ \`-3 \"action match false\"\` |
| \`llm_audio\` action group | Only \`cap_param / cap_config / cap_stop\` — no \`cap_raw\` |

\`sys.push\` exists as an internal C++ function (\`zmq_bus_publisher_push\`) but is not registered as a callable RPC action.  Implementing Path A would require deploying a custom audio-source daemon to K144's filesystem — multi-day effort (ARM64 cross-compile + ADB deploy + StackFlow SDK research).

## Pivot
Path B: Tab5 streams 16 kHz PCM to Dragon continuously when idle (new \`WAK0\` binary frame type parallel to existing \`VID0\` / \`AUD0\`).  Dragon runs sliding-window wake detection via the existing whisper.cpp small.en backend.  K144 wakeword stays as offline fallback.

Estimated effort: ~10 hours across 4 phases (Tab5 mic lifecycle, Dragon wake module, state machine, live verify).

refs #608