### PR TITLE
fix(wake): unified ui_home_start_voice_turn() — true wake=tap parity (closes #611)

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1724,54 +1724,69 @@ static void refresh_timer_cb(lv_timer_t *t)
  * trailing CLICKED doesn't also open the listening overlay. */
 static bool s_orb_long_pressed = false;
 
-static void orb_click_cb(lv_event_t *e)
-{
-    (void)e;
-    if (any_overlay_visible()) return;
+/* TT #611 — Single entry point for "user wants to start an Ask voice
+ * turn".  See ui_home.h for the contract.  The orb tap handler and the
+ * K144 wakeword handler both call this so wake = tap, full stop. */
+esp_err_t ui_home_start_voice_turn(const char *source) {
+   const char *src = (source && source[0]) ? source : "unknown";
 
-    /* TT #328 Wave 4 — swallow the trailing CLICKED that LVGL emits after
-     * a LONG_PRESSED.  See s_orb_long_pressed above for full rationale. */
-    if (s_orb_long_pressed) {
-       s_orb_long_pressed = false;
-       return;
-    }
+   if (any_overlay_visible()) {
+      ESP_LOGI(TAG, "start_voice_turn(%s): overlay visible, bouncing", src);
+      return ESP_ERR_INVALID_STATE;
+   }
 
-    /* Tap debounce — prevents SDIO TX copy_buff exhaustion from repeat-taps.
-     * Same 500 ms window as v5. */
-    static uint32_t last_tap_ms = 0;
-    uint32_t now = lv_tick_get();
-    if (now - last_tap_ms < 500) {
-        ESP_LOGI(TAG, "orb/pill tap debounced (dt=%lums)",
-                 (unsigned long)(now - last_tap_ms));
-        return;
-    }
-    last_tap_ms = now;
+   /* Debounce — prevents SDIO TX copy_buff exhaustion from repeat
+    * triggers (rapid taps, multi-fire wake). */
+   static uint32_t last_start_ms = 0;
+   uint32_t now = lv_tick_get();
+   if (now - last_start_ms < 500) {
+      ESP_LOGI(TAG, "start_voice_turn(%s): debounced (dt=%lums)", src, (unsigned long)(now - last_start_ms));
+      return ESP_ERR_INVALID_STATE;
+   }
+   last_start_ms = now;
 
-    ESP_LOGI(TAG, "orb/pill tap -> open voice");
-    /* Wave 15 banner-UX: if the WS is currently disconnected we don't
-     * want to open the LISTENING overlay and then silently drop audio
-     * frames (they go to a closed socket).  Instead, kick off a
-     * reconnect + show a brief toast so the user knows why their tap
-     * didn't do anything yet, then return.  They can tap again when
-     * the top-left pill reads "ready". */
-    if (!voice_is_connected()) {
-        char dhost[64];
-        tab5_settings_get_dragon_host(dhost, sizeof(dhost));
-        if (dhost[0]) voice_connect_async(dhost, TAB5_VOICE_PORT, false);
-        ui_home_show_toast("Reconnecting to Dragon… try again in a moment.");
-        return;
-    }
-    /* PR 2 polish: tapping the orb to Ask should always start clean.
-     * If a previous dictation left the pipeline in a transient terminal
-     * state (FAILED/SAVED), reset it to IDLE so the orb's Ask visuals
-     * aren't shadowed by stale "CANCELLED · TAP TO RETRY" text. */
-    dict_event_t pe = voice_dictation_get();
-    if (pe.state == DICT_FAILED || pe.state == DICT_SAVED) {
-       voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
-    }
+   ESP_LOGI(TAG, "start_voice_turn(%s) -> open voice", src);
 
-    ui_voice_show();
-    voice_start_listening();
+   /* If WS is currently disconnected, kick off a reconnect + show a
+    * brief toast so the user knows why nothing happened.  Same UX as
+    * Wave-15 orb tap (don't silently open an overlay then drop the
+    * frames). */
+   if (!voice_is_connected()) {
+      char dhost[64];
+      tab5_settings_get_dragon_host(dhost, sizeof(dhost));
+      if (dhost[0]) voice_connect_async(dhost, TAB5_VOICE_PORT, false);
+      ui_home_show_toast("Reconnecting to Dragon… try again in a moment.");
+      return ESP_ERR_INVALID_STATE;
+   }
+
+   /* PR 2 polish: starting a fresh Ask turn should always start clean.
+    * If a previous dictation left the pipeline in a transient terminal
+    * state (FAILED/SAVED), reset it to IDLE so the orb's Ask visuals
+    * aren't shadowed by stale "CANCELLED · TAP TO RETRY" text. */
+   dict_event_t pe = voice_dictation_get();
+   if (pe.state == DICT_FAILED || pe.state == DICT_SAVED) {
+      voice_dictation_set_state(DICT_IDLE, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
+   }
+
+   ui_voice_show();
+   return voice_start_listening();
+}
+
+static void orb_click_cb(lv_event_t *e) {
+   (void)e;
+
+   /* TT #328 Wave 4 — swallow the trailing CLICKED that LVGL emits after
+    * a LONG_PRESSED.  See s_orb_long_pressed above for full rationale. */
+   if (s_orb_long_pressed) {
+      s_orb_long_pressed = false;
+      return;
+   }
+
+   /* TT #611 — all the entry-checks + voice overlay open + listen
+    * start moved into ui_home_start_voice_turn so the K144 wakeword
+    * handler can call the same code.  Return is informational; the
+    * helper already showed the relevant toast on rejection. */
+   (void)ui_home_start_voice_turn("orb_tap");
 }
 
 /* v4·D Sovereign Halo: 4-dot chip opens the nav sheet (menu hub) so the

--- a/main/ui_home.h
+++ b/main/ui_home.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "esp_err.h"
 #include "lvgl.h"
 
 /** Create and show the home screen. Returns the screen object. */
@@ -119,6 +120,21 @@ void ui_home_orb_aliveness_sync(void);
 void ui_home_orb_aliveness_pause(void);
 void ui_home_orb_aliveness_resume(void);
 void ui_home_orb_ripple_for_tool(const char *tool_name);
+
+/** TT #611 — Single entry point for "user wants to start an Ask voice
+ *  turn from this device".  Both the orb-tap handler and the K144
+ *  wakeword handler call this so the UX is identical regardless of
+ *  trigger: overlay-visibility check, 500 ms debounce, WS-connected
+ *  guard with reconnect/toast, dictation-pipeline reset, voice
+ *  overlay show, then voice_start_listening.
+ *
+ *  @param source  Diagnostic label for the obs/log trace
+ *                 (e.g. "orb_tap", "wakeword").  Must be valid for
+ *                 the duration of the call.
+ *  @return ESP_OK on successful entry into LISTENING; ESP_ERR_INVALID_STATE
+ *          if the call was bounced by an overlay/debounce/WS guard
+ *          (toast already shown to the user where applicable). */
+esp_err_t ui_home_start_voice_turn(const char *source);
 
 /** TT #503 orb circadian — gradient stops drift through 7 phases over
  *  24 hours (dawn/morning/midday/afternoon/sunset/dusk/night).

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -142,18 +142,17 @@ static void wakeword_trigger_voice_turn(void *user) {
       vTaskDelay(pdMS_TO_TICKS(150));
    }
 
-   /* TT #604 — Wake = orb-tap parity.  The rolling-text fast path
-    * (TT #599) was sending K144's sherpa-ncnn transcript directly to
-    * Dragon as a text turn, bypassing Tab5 mic + Dragon STT.  K144's
-    * transcripts of remainders are often garbled ("eight thinker what
-    * time is it"), producing different LLM inputs than orb-tap would.
-    * Per user 2026-05-18: wake should behave identically to tap.  Go
-    * straight to voice_start_listening — same code path as the orb
-    * handler. */
-   esp_err_t err = voice_start_listening();
+   /* TT #611 — Wake = orb-tap parity, properly.  Earlier attempt
+    * (TT #604) called voice_start_listening directly, which matched
+    * the audio path but skipped 5 UX wrapper steps (overlay-visibility
+    * check, debounce, WS-connected guard with reconnect/toast,
+    * dictation pipeline reset, ui_voice_show).  ui_home_start_voice_turn
+    * is the single source of truth for "start an Ask voice turn from
+    * this device" — same function the orb tap handler calls.  Wake
+    * now opens the voice overlay, runs the same guards, identical UX. */
+   esp_err_t err = ui_home_start_voice_turn("wakeword");
    if (err != ESP_OK) {
-      ESP_LOGW(TAG, "voice_start_listening on wake failed: %s",
-               esp_err_to_name(err));
+      ESP_LOGW(TAG, "ui_home_start_voice_turn on wake bounced: %s", esp_err_to_name(err));
    }
 }
 


### PR DESCRIPTION
## Summary
Macro audit caught that wake and orb-tap diverge in 5 places despite my earlier 'parity' fix (#604).  \`orb_click_cb\` is a 50-line UX wrapper; the wake handler did only the final \`voice_start_listening()\` call.

This PR extracts the wrapper into a single public function and routes both triggers through it.

## Side-by-side before / after

| Step | Tap (before) | Wake (before) | Both (after) |
|------|--------------|---------------|--------------|
| any_overlay_visible bounce | ✅ | ❌ | ✅ |
| 500 ms debounce | ✅ | ❌ | ✅ |
| voice_is_connected guard + reconnect + toast | ✅ | ❌ | ✅ |
| dictation FAILED/SAVED → IDLE reset | ✅ | ❌ | ✅ |
| \`ui_voice_show()\` — open voice overlay | ✅ | ❌ | ✅ |
| voice_start_listening | ✅ | ✅ | ✅ |
| Pre-step: TTS cancel during SPEAKING (barge-in) | ❌ | ✅ | ✅ wake only |

## Files
- \`main/ui_home.h\` — public API: \`esp_err_t ui_home_start_voice_turn(const char *source)\`
- \`main/ui_home.c\` — extracted body, \`orb_click_cb\` now a one-line wrapper
- \`main/voice_onboard.c\` — wake handler calls the new function

## Test plan
- [x] Build clean, format clean, flashed to Tab5 192.168.1.90
- [ ] Tap orb → voice overlay opens, mic listens — verify no regression
- [ ] Say 'Hey Tinker' → **same** voice overlay opens, **same** mic listening — verify parity
- [ ] WS disconnected: both paths toast 'Reconnecting…' and skip the mic
- [ ] Rapid wake-retriggers: second one debounced (500 ms window)

Closes #611