### PR TITLE
feat(wake): Tab5 mic → Dragon wake detector (Path B MVP, closes #615)

### DIFF
--- a/docs/AUDIT-solid-2026-05-03.md
+++ b/docs/AUDIT-solid-2026-05-03.md
@@ -1,0 +1,739 @@
+# TinkerTab SOLID Audit — 2026-05-03
+
+Fresh SOLID-principles pass over `main/` (138 files, ~46 KLOC).  Builds on the
+2026-05-01 architecture audit; only flags things that audit either missed,
+underweighted, or that May 2026 churn introduced.
+
+## Executive summary
+
+The codebase is in **noticeably better shape** than the prior audit found.  The
+debug_server god-file shrank 4520 → 3339 LOC across nine clean family extracts
+(#336/#340-#348), `ui_notes` BSS cache moved to PSRAM (#335), and the LVGL
+async wrapper rule is still 100% enforced (zero direct `lv_async_call`
+references outside `ui_core.c` itself).  Modularity-rule discipline around
+K144 holds.
+
+The dominant residual issue is **`voice.c` (4251 LOC, unchanged)**: its
+`handle_text_message()` dispatcher is 970 LOC of `if/else-if` chain across 25
+WS message types spanning chat, widgets, dictation, receipts, vision, and
+config — and ~270 LOC of that is widget handling that is a **clean, low-risk
+extract** today (already calls a stable widget_store.h surface).
+
+Two broader patterns deserve attention this round:
+1. **Persistent `extern` declarations at call sites** (203 occurrences across
+   18 files) — DIP smell, redundant noise, and a real refactor headwind.
+2. **Service registry ceremony** — the lifecycle scaffolding's `_stop()` API
+   is **never called anywhere**, three of five `_stop` impls are no-ops, and
+   the registry adds 187 LOC + 15 `extern` decls + boilerplate per service
+   that buys nothing main.c couldn't do with five direct init calls.
+
+P0 findings: **2** (one ISP/naming collision, one big-volume DIP smell).
+P1 findings: **9**.  P2 findings: **11**.  Anti-findings: **6**.
+
+---
+
+## SRP — Single Responsibility
+
+### SRP-1 [P1] — voice.c `handle_text_message()` dispatches 25 WS verb classes in one 970-LOC function
+
+**Where:** [main/voice.c:926-1890](main/voice.c#L926)
+
+**Smell:** A single static function owns the entire Dragon → Tab5 JSON message
+surface.  25 verb branches: `stt_partial`, `stt`, `tts_start`, `tts_end`,
+`llm`, `cancel_ack`, `error`, `session_start`, `session_messages`,
+`dictation_postprocessing`, `dictation_postprocessing_error`,
+`dictation_postprocessing_cancelled`, `dictation_summary`, `note_created`,
+`llm_done`, `receipt`, `text_update`, `vision_capability`, `pong`,
+`config_update`, `tool_call`, `tool_result`, `media`, `card`, `widget_card`,
+`audio_clip`, `widget_live*`, `widget_list`, `widget_chart`, `widget_media`,
+`widget_prompt`, `widget_dismiss`.
+
+**Why it's a violation:** Each verb class is its own concern (chat rendering,
+session lifecycle, dictation flow, billing, tool activity, widget store
+mutation) but they all share the same `cJSON *root` + `if/else-if` chain, so
+adding any new verb forces a touch in this exact function and makes the
+control flow nearly impossible to reason about locally.
+
+**Fix sketch:** Convert to a verb-table dispatch — `static const struct {const
+char *name; void (*fn)(cJSON*);} s_verbs[]` populated by per-verb static
+handlers.  The widget verbs (270 LOC, see SRP-2) split out first, dictation
+verbs (~80 LOC) second, receipt + budget (~120 LOC) third.
+
+**Risk:** Low.  Each branch is already self-contained — no shared locals
+across branches.  Receipt/config_update branches mutate `s_*` statics; those
+keep file scope.
+
+---
+
+### SRP-2 [P1] — voice.c widget WS handlers are a clean ~270 LOC extract
+
+**Where:** [main/voice.c:1596-1865](main/voice.c#L1596)
+
+**Smell:** Six `widget_*` JSON handlers (`widget_card`, `widget_live`,
+`widget_live_update`, `widget_list`, `widget_chart`, `widget_media`,
+`widget_prompt`, `widget_dismiss`) live inside `handle_text_message`.  Each
+re-declares `extern widget_store_upsert` / `extern widget_store_update` /
+`extern widget_tone_from_str` / `extern ui_home_update_status` — six identical
+extern blocks (lines 1638-1646, 1699-1701, 1743-1745, 1783-1785, 1815-1817,
+1856-1857) that should be a header include.
+
+**Why it's a violation:** SRP — voice.c's job is the WS protocol, not
+unmarshalling 7 widget JSON shapes.  Also DIP — the function reaches into the
+widget_store implementation through repeated extern decls instead of
+`#include "widget.h"`.
+
+**Fix sketch:** New `voice_widget_ws.{c,h}`:
+```c
+/* voice_widget_ws.h */
+bool voice_widget_ws_dispatch(const char *type_str, cJSON *root);
+```
+Returns `true` if the verb was handled, `false` otherwise; caller chains it
+before its remaining else-if cases.  voice.c includes `widget.h` exactly
+nowhere afterward.
+
+**Risk:** Very low.  All widget verbs are self-contained, write through the
+already-stable `widget_store_*` surface, and end with the same
+`tab5_lv_async_call(ui_home_update_status, NULL)` tail.
+
+**Estimated diff:** -270 LOC voice.c, +320 LOC voice_widget_ws.c.
+
+---
+
+### SRP-3 [P1] — voice.c receipt + budget + cap-downgrade is its own concern (~150 LOC)
+
+**Where:** [main/voice.c:1305-1410](main/voice.c#L1305)
+
+**Smell:** The `receipt` verb branch reads token counts, computes mils,
+calls `tab5_budget_accumulate`, `tab5_budget_get_today_mils`, refreshes the
+home + chat-header spend chips, AND auto-downgrades the voice mode when the
+daily cap is hit (all in ~110 LOC inside `handle_text_message`, plus another
+~40 LOC of `voice_defer_receipt_attach` machinery at line 391).  Mixes
+billing/policy with WS protocol.
+
+**Why it's a violation:** Billing policy (cap-triggered mode downgrade) is a
+different axis of change than "Dragon sent me a receipt frame".  Today the
+cap-downgrade rule is hardcoded ("Hybrid+Cloud → Local; Agent unchanged");
+extending to "warn at 80% before downgrade" or "different policy per user"
+forces an edit deep inside the WS dispatcher.
+
+**Fix sketch:** Move the receipt → spend → cap-policy chain to
+`voice_billing.{c,h}`:
+```c
+void voice_billing_record_receipt(const char *model, int ptok, int ctok,
+                                  int cost_mils);
+```
+The function owns the NVS write, UI refresh hops, and the cap-downgrade rule.
+`voice.c` becomes a 5-line caller.
+
+**Risk:** Low.  Only one caller; behaviour is a pure function of its inputs +
+NVS state.  Easy to unit-test offline.
+
+---
+
+### SRP-4 [P1] — main.c hosts a 430-LOC inline serial REPL with 40+ commands
+
+**Where:** [main/main.c:731-1167](main/main.c#L731)
+
+**Smell:** `app_main`'s "interactive console" path is one giant
+`while/getchar` loop with ~40 nested `if/else if (strcmp(cmd_buf, ...))`
+branches, including the entire K144 surface (`m5ping`, `m5lscmd`, `m5infer`,
+`m5release`, `m5tts`, `m5recover`, `m5baud`, `m5chain`).  This is the only
+caller of `voice_m5_llm_infer`, `voice_m5_llm_tts`, `voice_m5_llm_release`,
+`voice_m5_llm_recover_baud`, `voice_m5_llm_set_baud`, `voice_m5_llm_chain_*`
+outside of voice_onboard.c — meaning a "test bench surface" leaks
+implementation calls main.c shouldn't know about.
+
+**Why it's a violation:** SRP (boot-orchestration vs developer test bench),
+plus DIP (main.c bypasses voice_onboard's lifecycle to poke voice_m5_llm
+directly).
+
+**Fix sketch:** Extract `serial_repl.{c,h}`:
+```c
+void serial_repl_start(void);   /* spawns the task; no return */
+```
+Internal handler table (`{name, fn}` rows).  K144 commands become thin
+wrappers that go through `voice_onboard_*` so the policy gate (READY check,
+mutex) is honoured.
+
+**Risk:** Low if extraction is mechanical.  Only sensitive if any serial
+command currently relies on something `app_main` only initialised in its
+local stack (skim shows nothing).
+
+**Estimated diff:** -430 LOC main.c (1172→742), +500 LOC serial_repl.c.
+
+---
+
+### SRP-5 [P1] — debug_server.c `selftest_handler` has 12 inline subsystem probes
+
+**Where:** [main/debug_server.c:2094-2249](main/debug_server.c#L2094)
+
+**Smell:** 155 LOC, one cJSON struct, twelve copy-pasted `cJSON_CreateObject
++ AddString + AddBool + counter` blocks for {wifi, voice_ws, sd_card, psram,
+internal_sram, dma, lvgl_pool, audio, mic, camera, k144, etc}.  Each has
+slightly different probe shape.
+
+**Why it's a violation:** Adding a new subsystem means appending a 13th 13-line
+copy-paste in this exact function.  The list of "things tab5 self-tests" is a
+different concern from the HTTP handler that returns the JSON.
+
+**Fix sketch:** Add a `selftest.{c,h}` table:
+```c
+typedef struct {
+    const char *name;
+    bool (*probe)(void *out_extra);  /* extra fields glued in */
+    void (*augment_json)(cJSON *t);  /* optional, NULL ok */
+} selftest_t;
+```
+Modules register at boot via `selftest_register()`.  Handler iterates the
+table, dumps JSON.
+
+**Risk:** Low — selftest results are a debug-only surface.  Risk is
+underestimating what each existing probe needs to expose; first cut keep all
+12 probes in selftest.c verbatim, then iterate.
+
+---
+
+### SRP-6 [P2] — voice.c dictation state surface is half-extracted
+
+**Where:** [main/voice.c:326-329, 945-1245, 3323-3408, 4018-4030](main/voice.c#L326)
+
+**Smell:** Dictation owns three top-level statics (`s_dictation_text`,
+`s_dictation_title`, `s_dictation_summary`), four WS verb branches
+(`stt_partial` accumulation, `dictation_postprocessing*`,
+`dictation_summary`), `voice_start_dictation()`, `voice_get_dictation_*()` —
+all interleaved with Ask-mode and Call-mode logic.  ~250 LOC scattered.
+
+**Why it's a violation:** Dictation is a distinct user flow with its own state
+machine (accumulating partial → silence → post-process → summary) that's
+threaded through three different parts of voice.c.  Touching it always means
+greping the file.
+
+**Fix sketch:** `voice_dictation.{c,h}` owns the three buffers + `start`,
+`stop`, `get_text/title/summary`, and the four WS handlers (called via
+SRP-1's verb-table).  voice.c retains only the mic-task branch that consumes
+the dictation flag.
+
+**Risk:** Medium — the partial-text accumulation runs on the voice WS rx
+task and reads/writes statics that voice.c also reads from the mic task.
+Need careful audit of any cross-task reads (probably one volatile + the
+existing state mutex covers it).
+
+---
+
+### SRP-7 [P2] — service_registry.c is dead-weight ceremony around 5 init calls
+
+**Where:** [main/service_registry.c:1-187](main/service_registry.c#L1) +
+[main/service_dragon.c](main/service_dragon.c#L1) +
+[main/service_audio.c](main/service_audio.c#L1) etc.
+
+**Smell:** `tab5_services_stop()` is **never called anywhere** in the codebase
+(verified: `grep -rn 'tab5_services_stop' main/` returns only the definition
++ its prototype).  Three of five `_stop()` implementations are pure no-ops
+(`network_service_stop` says "WiFi disconnect not implemented yet — just
+log").  `service_dragon.c` is self-described as "nearly vestigial" with a
+3-line `init` and a `start` that just logs.
+
+**Why it's a violation:** SRP — the registry's stated job is "lifecycle
+management" but only the `init` half is real.  The `_start/_stop` slots are
+ceremony.  187 LOC + 15 `extern` decls + 5 boilerplate files implement what
+`audio_init(); display_init(); ...` would in 5 lines of `app_main`.
+
+**Fix sketch:** Two paths:
+- **Aggressive:** Delete `service_registry.{c,h}`, `service_dragon.c`
+  (mode-mutex init moves to main.c), shrink each `service_*` to a single
+  `init()` function.  Net: ~250 LOC deleted.
+- **Conservative:** Keep registry but delete `_start/_stop` slots until a real
+  caller emerges; preserves the pattern as scaffolding.  Net: ~80 LOC
+  deleted.
+
+**Risk:** Very low (aggressive) — there is no behavioural reliance on the
+state machine the registry tracks.  Only loss is `tab5_services_print_status()`
+in the serial REPL, replaceable in ~10 lines.
+
+---
+
+### SRP-8 [P2] — voice.c LAN+ngrok probe task is a separate concern
+
+**Where:** [main/voice.c:2881-3000](main/voice.c#L2881) +
+[main/voice.c:215-218](main/voice.c#L215)
+
+**Smell:** `voice_lan_probe_task` (130 LOC) implements a progressive WiFi
+zombie-detection escalation ladder (soft-kick → hard-kick → reboot) along
+with TCP probes for both LAN and ngrok endpoints.  Owns 4 file-static
+probe-result globals.  Has nothing to do with the WS protocol; it's a
+network-health watchdog that voice.c happens to host because it shares a few
+WiFi helpers.
+
+**Why it's a violation:** SRP — network watchdog logic is a peer of
+heap_watchdog.c, not part of the voice client.
+
+**Fix sketch:** Move to `network_watchdog.{c,h}` next to `heap_watchdog.{c,h}`.
+voice.c reads the probe results via getter calls; everything else stays.
+
+**Risk:** Low — the task already runs independently; only coupling is the
+4 file-statics that get pulled into the new module.
+
+---
+
+## OCP — Open/Closed
+
+### OCP-1 [P1] — debug_server.c URI registration is a 47-line `httpd_register_uri_handler` switchboard
+
+**Where:** [main/debug_server.c:3243-3316](main/debug_server.c#L3243)
+
+**Smell:** Adding a new endpoint means: (a) write the handler, (b) declare its
+`httpd_uri_t uri_*` struct, (c) call `httpd_register_uri_handler(server,
+&uri_*)`.  Step (c) is a single block of 47 nearly-identical lines that grows
+linearly with endpoints.  The Wave 23b family extracts have NOT migrated
+their registrations into the family files; instead each per-family `_register`
+function gets called from this same block.
+
+**Why it's a violation:** OCP — adding endpoints requires modifying a central
+list rather than just dropping a new file.
+
+**Fix sketch:** Convert each per-family registrar to a constructor-style hook:
+```c
+/* debug_server_internal.h */
+void tab5_debug_register_family(void (*reg_fn)(httpd_handle_t));
+
+/* In each debug_server_X.c */
+__attribute__((constructor)) static void _register_X(void) {
+    tab5_debug_register_family(register_X_handlers);
+}
+```
+debug_server.c then iterates the family list at boot.  Or simpler: an
+explicit `tab5_debug_server_families_init(server)` function that calls each
+`debug_server_X_register(server)` — still central, but the dispatcher is one
+line per family instead of one per endpoint.
+
+**Risk:** Low.  Constructor-style adds boot-order dependency; the explicit
+call path is safer.
+
+---
+
+### OCP-2 [P2] — `selftest` probe list (see SRP-5) — same fix-shape
+
+**Where:** [main/debug_server.c:2099-2245](main/debug_server.c#L2099)
+
+Same pattern as OCP-1 — the cJSON probe table grows by copy-paste.  The fix
+sketched in SRP-5 (registry table) is the OCP fix.
+
+---
+
+### OCP-3 [P2] — config_update voice-mode fields use ad-hoc enum reading
+
+**Where:** [main/voice.c:1438-1530](main/voice.c#L1438)
+
+**Smell:** Adding a new config_update field (e.g., `voice_codec`,
+`tts_voice_id`) means adding a new `cJSON_GetObjectItem` block + assignment
+inside the type=="config_update" branch.  Each field has its own special
+handling (cap-downgrade for vmode; codec name string for codec; etc.).
+
+**Why it's a violation:** OCP — a new field is a new edit to the central
+handler.
+
+**Fix sketch:** Field registry + per-field setter callbacks.  Lower priority
+than the others because this branch only grows occasionally.
+
+---
+
+## LSP — Liskov Substitution
+
+### LSP-1 [P0] — `voice_mode_t` enum + `VOICE_MODE_*` macro family share the same prefix but are unrelated
+
+**Where:** [main/voice.h:36-43](main/voice.h#L36) +
+[main/config.h:52-57](main/config.h#L52)
+
+**Smell:** Two completely different enumerations both named `VOICE_MODE_*`:
+```c
+/* voice.h */
+typedef enum { VOICE_MODE_ASK, VOICE_MODE_DICTATE, VOICE_MODE_CALL } voice_mode_t;
+
+/* config.h */
+#define VOICE_MODE_LOCAL       0
+#define VOICE_MODE_HYBRID      1
+#define VOICE_MODE_CLOUD       2
+#define VOICE_MODE_TINKERCLAW  3
+#define VOICE_MODE_ONBOARD     4
+```
+They mean different things at different layers (mic-task dispatch vs user-tier
+NVS pick) but a reader sees `VOICE_MODE_*` and can reasonably believe they're
+the same family.  ui_voice.c switches on numeric values 0-4 against
+`VOICE_MODE_LOCAL/HYBRID/CLOUD` macros even though `voice_mode_t` only
+defines symbolic constants for {0,1,2}.
+
+**Why it's a violation:** LSP — code that takes a `voice_mode_t` parameter
+might be passed a `VOICE_MODE_LOCAL` macro by an unaware caller, with no
+compiler warning (both are `int`-compatible) and silent semantic breakage
+(`VOICE_MODE_LOCAL == VOICE_MODE_ASK == 0`, but `VOICE_MODE_TINKERCLAW == 3`
+is undefined as a `voice_mode_t`).
+
+**Fix sketch:** Rename the macros.  The user-tier semantic is "voice
+**routing**", not "voice mode" — the enum is the real "mode" (mic-task
+dispatch).  Rename `VOICE_MODE_LOCAL` → `VROUTE_LOCAL`, etc.; keep
+`voice_mode_t` as-is.  ~50 sites; mechanical.  NVS key `vmode` stays
+unchanged (it's a u8, not a typed enum).
+
+**Risk:** Medium — a wide rename, but every site is greppable; CI catches
+typos.  Worth doing exactly because the pun has already misled readers.
+
+**Estimated diff:** ~50 file changes, +0 LOC net.
+
+---
+
+### LSP-2 [P2] — `voice_send_config_update` vs `voice_send_config_update_ex` aren't substitutable
+
+**Where:** [main/voice.c:3923-3962](main/voice.c#L3923)
+
+**Smell:** `voice_send_config_update(mode, model)` calls
+`voice_send_config_update_ex(mode, model, NULL)` — fine.  But the `_ex` variant
+adds a `reason` field to the JSON, and Dragon's behaviour differs based on
+whether `reason == "cap_downgrade"` (triggers a TTS alert).  A caller who
+only knows the public surface might assume the two are interchangeable when
+they're not.
+
+**Why it's a violation:** LSP — the "_ex" variant has side effects the base
+variant doesn't.
+
+**Fix sketch:** Either (a) make `_ex` the only public function and inline the
+2-line `_simple` wrapper at its 3 callers, or (b) document the
+"reason"-triggers-alert contract in voice.h.  (a) is cleaner.
+
+**Risk:** Trivial.
+
+---
+
+## ISP — Interface Segregation
+
+### ISP-1 [P2] — voice.h is 263 LOC exposing 60+ symbols; many consumers need only `voice_state_t`
+
+**Where:** [main/voice.h:1-263](main/voice.h#L1)
+
+**Smell:** voice.h exposes mic, TTS, dictation, call-audio, vision, billing,
+config_update, link-health, K144 chain, history, cancel, reconnect,
+deferred-receipt — every consumer of voice.h drags the whole protocol surface
+into its translation unit.  heap_watchdog.c only needs `voice_get_state` +
+`voice_state_t`; ui_chat.c needs maybe 8 functions; service_dragon.c needs 0.
+
+**Why it's a violation:** ISP — modules depend on a header much wider than
+their actual usage.
+
+**Fix sketch:** Split into voice_state.h (4 symbols), voice_send.h (8
+symbols), voice_health.h (4 symbols), keep voice.h as the umbrella.  Lower
+priority because header bloat in C doesn't have the runtime cost it does in
+C++; the refactor would be cosmetic.
+
+**Risk:** Low but high churn.
+
+---
+
+### ISP-2 [P2] — voice_m5_llm.h is 434 LOC exposing 18 functions; ui_settings + debug_server_m5 use 3
+
+**Where:** [main/voice_m5_llm.h:1-434](main/voice_m5_llm.h#L1)
+
+**Smell:** Same shape as ISP-1.  ui_settings only calls `_sys_hwinfo`,
+`_sys_version`, `_sys_lsmode`; debug_server_m5 the same plus `_get_baud`.
+Everyone else (main.c REPL aside) goes through voice_onboard.c.  The chain
+APIs (`_chain_setup`, `_chain_run`, `_chain_teardown`) and the streaming
+infer/tts surface should arguably be `voice_m5_llm_internal.h` only seen by
+voice_onboard.c.
+
+**Fix sketch:** Carve `voice_m5_llm_telemetry.h` for the read-only `sys_*`
++ `get_baud` getters; keep heavyweight inference + chain in voice_m5_llm.h
+seen only by main.c (REPL) and voice_onboard.c.
+
+**Risk:** Low (header split, no behavioural change).  Worth doing IF SRP-4
+(REPL extract) lands first, since the REPL is the only "innocent" consumer of
+the heavyweight surface.
+
+---
+
+## DIP — Dependency Inversion
+
+### DIP-1 [P0] — 203 `extern` declarations at call sites across 18 files
+
+**Where:** widespread; top offenders:
+- [main/debug_server.c:1129-3239](main/debug_server.c#L1129) — 47 occurrences
+- [main/voice.c:382-3577](main/voice.c#L382) — 40 occurrences (most repeated)
+- [main/ui_home.c:849-2160](main/ui_home.c#L849) — 17
+- [main/ui_settings.c:98-854](main/ui_settings.c#L98) — 16
+- [main/ui_camera.c:274-1002](main/ui_camera.c#L274) — 13
+
+**Smell:** Code uses `extern void some_func(void);` inline at the call site
+instead of `#include`-ing the header that already declares it.  Three
+sub-flavors:
+1. **Pure noise** — the header is already transitively included.  Example:
+   [main/heap_watchdog.c:174](main/heap_watchdog.c#L174) does `extern
+   voice_state_t voice_get_state(void);` THREE times even though
+   `voice.h` is included at line 17 and already declares it.
+2. **Bypassing missing headers** — `widget_store_*` is in `widget.h` but
+   voice.c has six clusters of `extern widget_store_upsert/...` instead of
+   `#include "widget.h"`.
+3. **Cross-module reach-through** — `chat_store_attach_receipt_ex` is
+   declared in `chat_msg_store.h` but voice.c + voice_onboard.c each carry
+   their own extern decl rather than including the header.
+
+**Why it's a violation:** DIP — high-level modules (voice.c, ui_*, debug_server.c)
+reach into low-level modules (widget_store, chat_store, ui_home) through
+ad-hoc declarations rather than depending on a stable abstraction (the
+header).  Refactoring widget_store's signature breaks N callers
+silently — the linker complains, but only after the build.  Also: every
+extern is a documentation lie about what voice.c "really" depends on.
+
+**Fix sketch:** Three mechanical sweeps:
+1. Delete redundant externs whose header is already included
+   (heap_watchdog.c × 3, ui_camera.c × ~6, ui_chat.c × ~3).  ~30 LOC.
+2. Replace voice.c widget extern clusters with `#include "widget.h"` (one
+   include, six 7-line blocks deleted).  ~40 LOC + cleaner.
+3. Promote `chat_store_*` cross-module externs to honest includes.  ~10 LOC.
+
+**Risk:** Trivial; pure code hygiene.  Total saving ~80 LOC + significant
+readability.
+
+---
+
+### DIP-2 [P1] — voice_onboard.c reaches into ui_home + chat_store via extern
+
+**Where:** [main/voice_onboard.c:96, 197, 284-286](main/voice_onboard.c#L96)
+
+**Smell:** voice_onboard.c — a clean extracted module — does
+```c
+extern void tab5_debug_obs_event(const char *kind, const char *detail);
+extern void ui_home_clear_error_banner(void);
+extern int chat_store_attach_receipt_ex(...);
+extern void ui_chat_refresh_receipts(void);
+```
+These are "I know voice_onboard works without this so I'd rather inline-extern
+than make myself depend on ui_home.h" reasoning — but the extern STILL makes
+voice_onboard depend on ui_home; it just hides the dependency from the
+include graph.
+
+**Why it's a violation:** DIP — module thinks it's free of UI deps because no
+`#include "ui_home.h"` is visible, but it can't link without ui_home.
+
+**Fix sketch:** Two options:
+- **Honest includes** — add `#include "ui_home.h"`, `#include "chat_msg_store.h"`,
+  `#include "ui_chat.h"`, `#include "debug_obs.h"`.  Same dependencies, no
+  surprises.
+- **Inversion** — voice_onboard publishes events; ui_home subscribes.  Adds a
+  `voice_onboard_register_state_cb()` API.  Cleaner but more code; only
+  worth it if there's a 2nd consumer.
+
+**Risk:** Trivial for the includes path.
+
+---
+
+### DIP-3 [P1] — voice.c statelessly reaches into 18 different ui_*/chat_*/widget_* helpers
+
+**Where:** [main/voice.c:382-4023](main/voice.c#L382) — 40 extern decls
+
+**Smell:** voice.c is "the WS client".  But its extern decls show it actually
+calls into: `ui_home_show_toast`, `ui_home_refresh_sys_label`,
+`ui_home_refresh_mode_badge`, `ui_home_pulse_orb_alert`,
+`ui_home_show_error_banner`, `ui_home_update_status`, `ui_chat_refresh_*`,
+`ui_chat_push_*`, `chat_store_*`, `widget_store_*`, `tool_log_push_*`,
+`ui_notes_*`, `tab5_debug_obs_event`, `voice_lan_probe_task`,
+`voice_defer_receipt_attach` — voice.c effectively orchestrates the entire
+device's response to a Dragon message.  This is the SRP-1 problem viewed
+through the DIP lens.
+
+**Why it's a violation:** DIP — voice.c is the highest-level WS protocol
+module but it's hardwired to ~18 low-level UI/storage modules.  An
+abstraction layer ("I just got a tool_call event" → published to N
+subscribers) would invert the dependency.
+
+**Fix sketch:** Long-term — events bus ("voice_event_emit") with pluggable
+subscribers (ui_chat subscribes, ui_home subscribes, chat_store subscribes).
+Short-term — see SRP-1/SRP-2/SRP-3, which constrain the blast radius.
+
+**Risk:** High at the bus-extraction level (touches every UI module).
+Pragmatic priority is the per-verb extracts first.
+
+---
+
+### DIP-4 [P2] — debug_server families reach back into debug_server.c via internal header
+
+**Where:** [main/debug_server_internal.h](main/debug_server_internal.h#L1) +
+all `debug_server_*.c`
+
+**Smell:** Per-family extracts call back into debug_server.c through a
+private "internal" header (`tab5_debug_check_auth`, `tab5_debug_send_json_resp`,
+`tab5_debug_check_factory_reset_confirm`).  This is fine in itself, but
+documents that the family files are NOT independent of the parent — they're
+sub-files sharing a private contract.  The auth-token state lives in
+debug_server.c; family files have no choice but to call back.
+
+**Why it's a violation:** DIP — the auth gate is a cross-cutting concern that
+should be a layered service, not a private back-channel.
+
+**Fix sketch:** Promote `debug_server_internal.h` symbols to a real
+`debug_auth.{c,h}` module with the auth-token statics.  All families depend on
+debug_auth.h instead of debug_server_internal.h.  debug_server.c becomes a
+pure URI dispatcher.
+
+**Risk:** Low; the internal header is already a stable shared contract,
+this is mostly a rename + relocate of state.
+
+---
+
+### DIP-5 [P2] — heap_watchdog.c declares `voice_get_state` extern despite including voice.h
+
+**Where:** [main/heap_watchdog.c:174, 230, 266](main/heap_watchdog.c#L174)
+
+**Smell:** Three-times-repeated `extern voice_state_t voice_get_state(void);`
+inside `static void` callbacks, even though line 17 says `#include "voice.h"`
+and voice.h:84 declares the same prototype.  Pure noise.
+
+**Why it's a violation:** Anti-DIP cosmetic — the inclusion is correct, the
+extern is wrong.  Misleads readers into thinking voice.h is missing this
+function.
+
+**Fix sketch:** Delete all 3.  ~3 LOC change.
+
+**Risk:** None.
+
+---
+
+## Cross-cutting
+
+### X-1 [P1] — Naming pun: `voice_mode_t` vs `vmode` vs `VOICE_MODE_*` macros — three terms, three meanings
+
+**Where:** voice.h, config.h, settings.h, NVS key `vmode`
+
+The same `VOICE_MODE_*` prefix names two enumerations (LSP-1).  Plus the NVS
+key is `vmode` (the user-tier).  Plus settings has both a numeric (0-4) and
+string ("VMODE_LOCAL_ONBOARD") form.  Reader confusion is constant — the prior
+audit's A1 finding even used "five voice modes" and "five tier modes"
+interchangeably without flagging that they're literally different enums.
+
+**Fix:** Adopt LSP-1's rename (`VROUTE_*` for the user-tier) and standardize
+the prose.
+
+---
+
+### X-2 [P2] — `tool_log_push_call`/`_result` are extern'd from debug_server.c instead of including tool_log.h
+
+**Where:** [main/debug_server.c:2637-2638](main/debug_server.c#L2637)
+
+Standalone DIP-1 instance worth its own line because tool_log.h is exactly 49
+LOC and would pull in nothing else.
+
+---
+
+## Anti-findings (patterns considered + rejected)
+
+### AF-1 — voice.c's 4 file-static mutexes are NOT a SRP violation
+Same conclusion as the prior audit (A13).  Module-scoped sync primitives are
+the right pattern; no refactoring needed.
+
+### AF-2 — chat_*.c family is genuinely well-factored, NOT a god-cluster
+Six files, max 920 LOC (chat_msg_view.c), clean single-direction includes
+(view → store, ui_chat → all six).  The prior audit's A11 holds.
+
+### AF-3 — service_audio.c's `extern i2c_master_bus_handle_t tab5_get_i2c_bus(void)` is justified
+The BSP intentionally hides the bus handle from a public header (concurrency
+discipline).  The extern is documented at the BSP boundary; main/ doesn't have
+a better path.
+
+### AF-4 — ui_chat.c's `extern lv_obj_t *ui_home_get_screen` calls are fine
+ui_home.h ALREADY exposes `ui_home_get_screen()`.  ui_chat.c could drop the
+`extern` and use the include — but it already includes ui_home.h transitively.
+File this under DIP-1 sweep #1 (low-priority cleanup) rather than its own
+finding.
+
+### AF-5 — voice_video.c's single extern (`voice_ws_send_binary_public`) is the cleanest possible
+voice_video.h would have to take a forward dependency on voice.h to expose
+this, which would create a circular include.  The deliberate `extern` at
+voice_video.c:53 with explanatory comment is the right tradeoff.
+
+### AF-6 — `mode_manager.c` thin mutex wrapper is justified (per prior audit A10)
+Confirmed unchanged.  4 concurrent caller tasks; mutex is necessary; not
+ceremony.
+
+---
+
+## Recommended next 3 PRs
+
+### PR-1: voice.c widget WS handlers → voice_widget_ws.{c,h}
+- **What:** Extract the 8 widget verb branches (lines 1596-1865) into a new
+  module with one entry point: `bool voice_widget_ws_dispatch(const char
+  *type, cJSON *root)`.
+- **Why:** Cleanest seam in voice.c.  All 8 verbs already use the stable
+  widget_store.h surface; six clusters of redundant `extern` decls disappear.
+- **Risk:** Very low — verbs are pure functions of their inputs + the
+  widget_store global.  No mutex, no tasks, no UI refresh more complex than
+  one `tab5_lv_async_call(ui_home_update_status, NULL)` tail.
+- **Diff estimate:** -270 LOC voice.c (4251→3981), +320 LOC voice_widget_ws.c.
+- **Closes findings:** SRP-2 + half of DIP-1 + half of DIP-3.
+
+### PR-2: serial REPL → serial_repl.{c,h}; main.c stops calling voice_m5_llm directly
+- **What:** Lift the `cmd_buf` switch (main.c:731-1167) into a dedicated
+  task.  Replace direct `voice_m5_llm_*` calls with `voice_onboard_*` so the
+  REPL goes through the same READY-gate the rest of the system uses.
+- **Why:** SRP-4 + ISP-2 setup.  main.c shrinks back to a pure boot
+  orchestrator (~740 LOC).
+- **Risk:** Medium — the REPL is a developer-only surface, but each command
+  needs verification it still works after the indirection.
+- **Diff estimate:** -430 LOC main.c, +500 LOC serial_repl.c.
+- **Closes findings:** SRP-4, sets up ISP-2.
+
+### PR-3: extern-cleanup sweep (DIP-1, DIP-5)
+- **What:** Three mechanical passes:
+  1. Delete redundant externs where header is already included
+     (heap_watchdog × 3, ui_camera × 6, ui_chat × 3).
+  2. Replace voice.c widget extern clusters with `#include "widget.h"`
+     (also closed by PR-1 if it lands first).
+  3. Promote cross-module externs (`chat_store_attach_receipt_ex`,
+     `tool_log_push_call/_result`) to honest header includes.
+- **Why:** Pure hygiene; ~80 LOC deleted; readability wins.  No behaviour
+  change.
+- **Risk:** Trivial — CI catches anything that breaks.  Recommended as a
+  weekend-throwaway PR; can land independent of PR-1/PR-2.
+- **Diff estimate:** -80 LOC across ~12 files.
+- **Closes findings:** DIP-1, DIP-5, X-2.
+
+---
+
+## Summary table
+
+| ID    | Sev | Principle | Where | Title |
+|-------|----|-----------|-------|-------|
+| SRP-1 | P1 | SRP | voice.c:926-1890 | `handle_text_message` dispatches 25 WS verbs in 970 LOC |
+| SRP-2 | P1 | SRP | voice.c:1596-1865 | Widget WS handlers — clean ~270 LOC extract candidate |
+| SRP-3 | P1 | SRP | voice.c:1305-1410 | Receipt + budget + cap-downgrade should be voice_billing.c |
+| SRP-4 | P1 | SRP | main.c:731-1167 | 430-LOC inline serial REPL with K144 reach-through |
+| SRP-5 | P1 | SRP | debug_server.c:2094-2249 | `selftest_handler` 12 inline subsystem probes |
+| SRP-6 | P2 | SRP | voice.c (4 regions) | Dictation half-extracted — 250 LOC scattered |
+| SRP-7 | P2 | SRP | service_registry.c | Lifecycle ceremony around 5 init calls; `_stop` never called |
+| SRP-8 | P2 | SRP | voice.c:2881-3000 | LAN+ngrok probe is its own watchdog, not WS-client business |
+| OCP-1 | P1 | OCP | debug_server.c:3243-3316 | 47-line URI registration switchboard |
+| OCP-2 | P2 | OCP | debug_server.c:2099-2245 | Selftest probe table grows by copy-paste |
+| OCP-3 | P2 | OCP | voice.c:1438-1530 | config_update fields are ad-hoc |
+| LSP-1 | **P0** | LSP | voice.h:36 + config.h:52 | `voice_mode_t` and `VOICE_MODE_*` macros are unrelated enums sharing a prefix |
+| LSP-2 | P2 | LSP | voice.c:3923-3962 | `_send_config_update` vs `_ex` — `_ex` has Dragon-side side effects |
+| ISP-1 | P2 | ISP | voice.h | 263 LOC / 60+ symbols; consumers use 4-8 |
+| ISP-2 | P2 | ISP | voice_m5_llm.h | 434 LOC / 18 symbols; UI/debug consumers use 3-4 |
+| DIP-1 | **P0** | DIP | 18 files, 203 occurrences | Persistent `extern` redeclarations at call sites |
+| DIP-2 | P1 | DIP | voice_onboard.c:96-286 | Extracted module hides UI deps via extern |
+| DIP-3 | P1 | DIP | voice.c (40 externs) | voice.c orchestrates 18 ui/chat/widget modules silently |
+| DIP-4 | P2 | DIP | debug_server_internal.h | Auth-token statics should be a real `debug_auth.c` module |
+| DIP-5 | P2 | DIP | heap_watchdog.c:174,230,266 | `extern voice_get_state` × 3 redundant w/ `#include "voice.h"` |
+| X-1   | P1 | naming | voice.h + config.h + NVS | Three "voice mode" terms, three meanings |
+| X-2   | P2 | DIP | debug_server.c:2637 | tool_log functions extern'd instead of including 49-LOC header |
+
+---
+
+## Methodology
+
+- LOC + structural counts via `wc`, `grep`, `awk` over `main/`
+- `extern` audit: `grep -rn '^[[:space:]]*extern [a-z]' main/*.c`
+- WS verb audit: `grep -nE '"type"|strcmp|cJSON_GetObjectItemCaseSensitive' main/voice.c`
+- Service registry callers: `grep -rn 'tab5_services_stop\|service_*_stop' main/`
+- LVGL async wrapper enforcement: `grep -nE 'lv_async_call\b' main/*.c | grep -v 'tab5_lv_async_call'` — confirmed clean
+- K144 modularity rules: re-verified per prior audit A6 — still locked
+- Cross-stack drift: not re-audited (prior audit's A9 stands; Tab5/Dragon
+  vmode 0-4 enumeration unchanged in May 2026)
+
+**Files NOT examined in depth:** `bsp/tab5/*` (out of scope per prior audit),
+`managed_components/*` (vendored), `dragon_voice/*` (separate repo mirror),
+`tests/e2e/*` (Python harness — peer agent owns).

--- a/docs/superpowers/plans/2026-05-03-voice-c-extraction.md
+++ b/docs/superpowers/plans/2026-05-03-voice-c-extraction.md
@@ -1,0 +1,1442 @@
+# voice.c Extraction Implementation Plan (Wave 23 · TT #331)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drop `main/voice.c` from 3,846 → ~2,470 LOC by extracting WS frame routing into `voice_ws_proto.{c,h}` and the five-tier voice-mode dispatch into `voice_modes.{c,h}`, with zero observable behavior change verified on physical Tab5 hardware via the e2e harness.
+
+**Architecture:** Two sibling C modules in `main/` (same shape as the prior `voice_billing` / `voice_widget_ws` / `voice_onboard` extracts). `voice_ws_proto.c` owns the WS event callback + JSON RX dispatcher + binary-magic dispatcher + send wrappers + REGISTER frame builder. `voice_modes.c` owns `voice_send_config_update*` + `voice_get_mode` + the five-tier text-routing decision (pure-K144 vs Local-mode-failover vs Dragon path). voice.c keeps the state machine, mic capture task, playback drain task, listening/dictation/call lifecycles, reconnect watchdog, and the public API surface.
+
+**Tech Stack:** ESP-IDF v5.5.2, C11, esp_websocket_client, cJSON, FreeRTOS, LVGL 9.x. No new dependencies.
+
+**Verification discipline:** No host-side C unit test framework exists. The two test loops are:
+1. **Build is the type-checker** — `idf.py build` fails on any missed call site or stale forward decl.
+2. **E2E user stories are the behavior spec** — `python3 tests/e2e/runner.py <story>` against a flashed Tab5 must match the pre-extract baseline pass count + heap profile.
+
+**Branching strategy:** One branch per PR (`refactor/voice-ws-proto-extract` then `refactor/voice-modes-extract`). Each PR is a SINGLE squash-merge to `main` per the workflow in `CLAUDE.md` ("Workflow" section). Inside the branch we do many small commits; squash on merge.
+
+---
+
+## Pre-flight context for the implementer
+
+### Environment
+
+```bash
+# IDF must be sourced once per shell:
+. /home/rebelforce/esp/esp-idf/export.sh   # IDF v5.5.2
+
+# Tab5 reachability:
+export TAB5_URL=http://192.168.1.90:8080
+export TAB5_TOKEN=05eed3b13bf62d92cfd8ac424438b9f2   # from CLAUDE.md
+ping -c 2 192.168.1.90                                # MUST respond
+curl -s "$TAB5_URL/info" | python3 -m json.tool       # device discovery
+```
+
+### Tab5 hardware
+
+- M5Stack Tab5 (ESP32-P4), wired via USB to `/dev/ttyACM0`, on LAN at 192.168.1.90.
+- Dragon at 192.168.1.91 must be reachable for any voice-path test (otherwise the WS sits in CONNECTING). Verify with `ssh radxa@192.168.1.91 sudo systemctl is-active tinkerclaw-voice` → `active`.
+- The Tab5 may need a watchdog reset after flashing if it sticks in ROM download mode:
+  ```bash
+  python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+      --before no_reset --after watchdog_reset read_mac
+  ```
+
+### Files this plan touches
+
+**Created:**
+- `main/voice_ws_proto.h` — public API for the WS proto module
+- `main/voice_ws_proto.c` — implementation
+- `main/voice_modes.h` — public API for the modes module
+- `main/voice_modes.c` — implementation
+
+**Modified:**
+- `main/voice.c` — symbol removal + new `#include`s + call-site updates
+- `main/voice.h` — minor: a few statics promoted to public for cross-module access
+- `main/CMakeLists.txt` (line 35) — add `voice_ws_proto.c` `voice_modes.c` to the `SRCS` list
+- `CLAUDE.md` "Key Files → Dragon voice link" subsection — add the two new modules
+- `~/.claude/projects/-home-rebelforce/memory/project_solid_audit_wave23.md` — append PR-merge entries
+- `docs/AUDIT-architecture-2026-05-01.md` (or whichever audit doc tracks #331) — flip A1 from "open" to "shipped via PR #N + #N+1"
+
+### Source map — what moves where
+
+The grep + section-header pass produced this canonical map. Line numbers are AS-OF the current `main` HEAD (`95d732f`); they will drift as commits land but the symbol names are stable.
+
+| voice.c lines | Symbol | Destination |
+|---------------|--------|-------------|
+| L525-543 | `voice_ws_send_text` (static) | voice_ws_proto.c (becomes non-static, declared in .h) |
+| L545-572 | `voice_ws_send_binary` (static) | voice_ws_proto.c (becomes non-static, declared in .h) |
+| L574-577 | `voice_ws_send_binary_public` | voice_ws_proto.c (already public; .h decl moves to voice_ws_proto.h via re-export, voice.h keeps the declaration too for source compat with existing callers) |
+| L587-672 | `voice_ws_send_register` (static) | voice_ws_proto.c (becomes non-static, declared in .h) |
+| L876-879 | `voice_debug_inject_text` | voice_ws_proto.c (it's the debug entry to handle_text_message) |
+| L881-1479 | `handle_text_message` (static) | voice_ws_proto.c (becomes non-static, declared in .h as `voice_ws_proto_handle_text`) |
+| L1486-1499 | `upsample_16k_to_48k` (static helper) | voice_ws_proto.c (stays static — only used by handle_binary_message) |
+| L1500-1582 | `handle_binary_message` (static) | voice_ws_proto.c (becomes non-static, declared in .h as `voice_ws_proto_handle_binary`) |
+| L1586-1940 | `voice_ws_event_handler` (static) | voice_ws_proto.c (becomes non-static, declared in .h as `voice_ws_proto_event_handler`) |
+| L1944-1948 | `voice_build_local_uri` (static) | voice_ws_proto.c (becomes non-static, declared in .h as `voice_ws_proto_build_local_uri`) |
+| L3019-3022 | `voice_get_mode` | voice_modes.c (already public; voice.h decl stays) |
+| L3478-3516 | `voice_send_widget_action` | voice_ws_proto.c (it builds a JSON frame and calls voice_ws_send_text — pure WS proto concern) |
+| L3518-3543 | `voice_send_config_update_ex` | voice_modes.c |
+| L3545-3548 | `voice_send_config_update` | voice_modes.c |
+| L3373-3471 (subset) | The five-tier mode-routing branches inside `voice_send_text`: `VMODE_LOCAL_ONBOARD` always-onboard branch + `VMODE_LOCAL` failover-grace branch | voice_modes.c (extracted as a pure helper `voice_modes_route_text(const char *text, voice_modes_route_result_t *out)` returning an enum: ROUTE_K144_CHAIN_BUSY / ROUTE_K144_OK / ROUTE_K144_FAILED / ROUTE_DRAGON_PATH; voice.c's `voice_send_text` just dispatches on the result) |
+
+### Statics that need promotion (cross-module access)
+
+These are currently `static` in voice.c but the extracted code reads/writes them. Two options: (a) promote to non-static + add to `voice.h` (preferred when the symbol is logically a voice-module-wide datum), or (b) add a getter/setter in voice.h.
+
+| Symbol | Read by | Write by | Approach |
+|--------|---------|----------|----------|
+| `s_ws` (WS handle) | voice_ws_proto.c (sends + event handler) | voice.c (connect/disconnect) + voice_ws_proto.c (event handler) | Promote to non-static, declare `extern esp_websocket_client_handle_t volatile g_voice_ws;` in voice.h. Rename for clarity in the same commit. |
+| `s_state_mutex` | voice_ws_proto.c (RX guard) | voice.c (init) | Promote to non-static, declare `extern SemaphoreHandle_t g_voice_state_mutex;` in voice.h. |
+| `s_session_gen` | voice_ws_proto.c (async-call guard) + voice_modes.c | voice.c (set on disconnect) | Add `voice_get_session_gen()` getter in voice.h (read-only access is enough). |
+| `s_voice_mode` | voice_modes.c (route decision; reads its own static directly) | voice.c (start_listening / call_audio_start / stop_listening) | Move the static itself into voice_modes.c. Add `voice_modes_set_internal(voice_mode_t)` setter in voice_modes.h for voice.c's lifecycle calls. The existing public `voice_get_mode()` moves into voice_modes.c too and becomes a one-line `return s_voice_mode;` (its declaration in voice.h stays — public API contract is unchanged). |
+| `s_send_lock`, `s_register_lock`, etc. | voice_ws_proto.c (every send) | voice.c (init only) | Promote to non-static. |
+| `s_dragon_host`, `s_dragon_port`, `s_session_id`, `s_device_id` | voice_ws_proto.c (REGISTER frame) | voice.c (connect) | Promote to non-static, declare extern. |
+| `s_last_ws_alive_ms` (failover gate) | voice_modes.c | voice.c (event handler stamps it) | Add `voice_get_last_ws_alive_ms()` getter in voice.h. |
+| `s_voice_mode_locked` etc. | voice_modes.c | voice.c | Promote per the same pattern. |
+
+> The implementer should grep for `static\s+\([a-zA-Z_]\+\s\+\)\+s_` in voice.c BEFORE moving any function, to build the exact list of statics each extracted function touches. Update the table above if anything was missed — the audit was pattern-matched, not line-by-line.
+
+### Story coverage matrix
+
+Map each extracted concern to the story that exercises it on hardware. Run these BEFORE any extract to capture a green baseline.
+
+| Concern | Story to run | Story duration |
+|---------|--------------|----------------|
+| WS event handler (CONNECTED → REGISTER → READY transition) | `story_smoke` | ~5 min |
+| JSON dispatcher: `stt`, `stt_partial`, `llm`, `llm_done`, `tts_*` | `story_smoke` (one Local turn) + `story_full` (4 modes) | ~15 min combined |
+| JSON dispatcher: `media`, `card`, `audio_clip`, `text_update` (rich media) | `story_full` (Cloud turn renders rich media) | (covered above) |
+| JSON dispatcher: `widget_*` (live, card, list, chart, prompt, dismiss) | No dedicated story today — use `story_wave10_ui_skills` (1738) which exercises widget surfaces | ~5 min |
+| Binary dispatcher: untagged PCM (TTS audio) | `story_smoke` (Local turn produces PCM TTS) | (covered above) |
+| Binary dispatcher: VID0 (downlink JPEG video) | `story_full` does a brief video pane probe; full call exercises this | (covered above) |
+| Binary dispatcher: AUD0 (in-call mic uplink + downlink) | Manual: `POST /call/start` + observe `/video` stats | ~30 sec |
+| Send wrappers (text + binary) | Implicit in every story — any text turn fires `voice_ws_send_text` | (covered above) |
+| REGISTER frame on reconnect | `story_stress` does a forced reconnect cycle | ~20 min |
+| Five-tier mode dispatch (config_update) | `story_full` rotates through all 4 modes, each fires a config_update | (covered above) |
+| Five-tier text routing: VMODE_LOCAL_ONBOARD always-K144 | `story_onboard` (K144 must be warm — skip otherwise) | ~30 sec |
+| Five-tier text routing: VMODE_LOCAL → K144 failover | `story_wave7_onboard_polish` (line 1253) | ~3 min |
+| Reconnect after WS drop | `story_stress` | (covered above) |
+
+**Minimum baseline run before any extract:** `story_smoke` + `story_full` + `story_onboard`. About 16 min total. Save the report directory paths for diff comparison after the extract.
+
+---
+
+## Phase 0 — Pre-flight baseline
+
+### Task 0.1: Confirm working tree + Dragon are healthy
+
+**Files:** none (read-only checks)
+
+- [ ] **Step 1: Check git working tree is clean**
+
+```bash
+cd ~/projects/TinkerTab
+git status --short
+```
+
+Expected: empty output OR only untracked files (`docs-site/`, `docs/AUDIT-solid-2026-05-03.md`). Any modified-tracked files → stop and reconcile with the user before proceeding.
+
+- [ ] **Step 2: Confirm we're on main**
+
+```bash
+git branch --show-current
+```
+
+Expected: `main`. If not → `git switch main`.
+
+- [ ] **Step 3: Pull latest main**
+
+```bash
+git fetch origin && git merge --ff-only origin/main
+```
+
+Expected: "Already up to date" or fast-forward. If a non-FF is reported, stop — the user has local main commits that need investigation.
+
+- [ ] **Step 4: Confirm Tab5 is reachable**
+
+```bash
+ping -c 2 192.168.1.90
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/voice | python3 -m json.tool
+```
+
+Expected: ping responds + `/voice` returns a JSON blob with `"connected": true` (or "false" with state=`CONNECTING` if Dragon is mid-restart).
+
+- [ ] **Step 5: Confirm Dragon is up**
+
+```bash
+sshpass -p 'thedragon' ssh -o StrictHostKeyChecking=no radxa@192.168.1.91 \
+    sudo systemctl is-active tinkerclaw-voice
+```
+
+Expected: `active`. If `inactive` or `failed` → restart with `sudo systemctl restart tinkerclaw-voice` and wait 60s for Moonshine/Piper/Ollama to load, then re-check.
+
+### Task 0.2: Capture green E2E baseline on the current `main` HEAD
+
+**Files:** none (produces baseline reports for diff)
+
+- [ ] **Step 1: Run `story_smoke`**
+
+```bash
+cd ~/projects/TinkerTab
+python3 tests/e2e/runner.py story_smoke 2>&1 | tee /tmp/baseline-smoke.log
+```
+
+Expected: trailing line says `PASS: N/N steps`. Note the run dir from the log (`tests/e2e/runs/story_smoke-<ts>/`). Save the path:
+
+```bash
+BASELINE_SMOKE=$(ls -td tests/e2e/runs/story_smoke-* | head -1)
+echo "BASELINE_SMOKE=$BASELINE_SMOKE"
+```
+
+- [ ] **Step 2: Run `story_full`**
+
+```bash
+python3 tests/e2e/runner.py story_full 2>&1 | tee /tmp/baseline-full.log
+BASELINE_FULL=$(ls -td tests/e2e/runs/story_full-* | head -1)
+echo "BASELINE_FULL=$BASELINE_FULL"
+```
+
+Expected: `PASS: N/N steps`. Document N — this is the bar that must hold post-extract.
+
+- [ ] **Step 3: Run `story_onboard` only if K144 is warm**
+
+```bash
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/m5 \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('failover_state_name'))"
+```
+
+If output is `ready` → run it. Otherwise skip (the story self-skips):
+
+```bash
+python3 tests/e2e/runner.py story_onboard 2>&1 | tee /tmp/baseline-onboard.log
+BASELINE_ONBOARD=$(ls -td tests/e2e/runs/story_onboard-* | head -1)
+```
+
+- [ ] **Step 4: Capture heap floor**
+
+```bash
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/heap \
+    | python3 -m json.tool > /tmp/baseline-heap.json
+cat /tmp/baseline-heap.json
+```
+
+Expected: a JSON blob with `internal_free`, `internal_largest_free_block`, `psram_free`. Anchor numbers — extracts must not introduce a >5% regression in `internal_largest_free_block` after a fresh boot + smoke run.
+
+- [ ] **Step 5: Record baseline expectations in a scratch file**
+
+```bash
+cat > /tmp/voice-extract-baseline.md << 'EOF'
+# Pre-extract baseline for #331 (capture date: $(date -u +%Y-%m-%dT%H:%M:%SZ))
+
+- story_smoke: <NN/NN> steps
+- story_full:  <NN/NN> steps
+- story_onboard: <NN/NN> steps (or SKIPPED — K144 not warm)
+- internal_free: <bytes>
+- internal_largest_free_block: <bytes>
+EOF
+${EDITOR:-vi} /tmp/voice-extract-baseline.md
+```
+
+Acceptance: baseline file exists with concrete numbers. This is the contract every subsequent extract must honor.
+
+---
+
+## Phase 1 — PR #1: Extract `voice_ws_proto.{c,h}`
+
+### Task 1.1: Create branch
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Branch off main**
+
+```bash
+git switch -c refactor/voice-ws-proto-extract
+```
+
+### Task 1.2: Open the tracking sub-issue
+
+**Files:** none (GitHub only)
+
+- [ ] **Step 1: Open issue**
+
+```bash
+gh issue create --title "refactor(voice): extract voice_ws_proto.{c,h} (refs #331)" \
+    --body "$(cat <<'EOF'
+## Scope
+
+Extract the WS frame routing layer out of `main/voice.c` into a new sibling module `main/voice_ws_proto.{c,h}`.  Same shape as the prior `voice_billing` / `voice_widget_ws` / `voice_onboard` extracts (see PRs #349 / #351 / #327).
+
+## What moves
+
+- `voice_ws_send_text`, `voice_ws_send_binary`, `voice_ws_send_binary_public` — send wrappers
+- `voice_ws_send_register` — REGISTER frame builder/sender
+- `voice_debug_inject_text` — debug entry to the JSON dispatcher
+- `handle_text_message` (599 LOC JSON RX dispatcher) — exposed as `voice_ws_proto_handle_text`
+- `handle_binary_message` (binary magic VID0/AUD0/untagged-PCM dispatcher) — exposed as `voice_ws_proto_handle_binary`
+- `voice_ws_event_handler` (esp_websocket_client callback) — exposed as `voice_ws_proto_event_handler`
+- `upsample_16k_to_48k` (helper used only by binary dispatcher — stays static in the new module)
+- `voice_build_local_uri` (URI helper) — exposed as `voice_ws_proto_build_local_uri`
+- `voice_send_widget_action` (builds JSON + calls send_text — pure WS-proto concern)
+
+## What stays in voice.c
+
+- State machine (`voice_set_state` etc.)
+- Mic capture task + playback drain task
+- Listening / dictation / call lifecycles
+- Reconnect watchdog
+- Public API surface (voice_init, voice_connect*, voice_start_listening, etc.)
+
+## Verification
+
+- Build is clean (`idf.py build`)
+- E2E baseline holds: story_smoke + story_full + story_onboard match pre-extract pass count
+- Heap floor (internal_largest_free_block after smoke) within 5% of baseline
+- No regression in CLAUDE.md "story coverage matrix" (see plan doc)
+
+## Plan doc
+
+`docs/superpowers/plans/2026-05-03-voice-c-extraction.md` — Phase 1 (Tasks 1.1 – 1.10)
+
+Refs #331.
+EOF
+)"
+```
+
+Expected: prints the new issue URL. Note the issue number (call it `$WSPROTO_ISSUE`).
+
+### Task 1.3: Carve the new header (no symbol moves yet)
+
+**Files:**
+- Create: `main/voice_ws_proto.h`
+
+- [ ] **Step 1: Write the header skeleton**
+
+```c
+/**
+ * Voice WebSocket protocol layer (Tab5 ↔ Dragon).
+ *
+ * Owns the on-the-wire dispatch:
+ *   - JSON RX (text frames) → handle_text routes to typed handlers in voice.c
+ *   - Binary RX (mag-tagged VID0/AUD0 + untagged PCM) → handle_binary
+ *   - WS event callback (CONNECTED / DISCONNECTED / DATA / ERROR)
+ *   - TX wrappers around esp_websocket_client_send_{text,bin}
+ *   - REGISTER frame builder
+ *
+ * Wave 23 SOLID-audit closure for TT #331 (extract A1).  Pre-extract
+ * this all lived inline in voice.c at L525-1948; voice.c is left with
+ * the state machine + mic capture + listening/dictation/call lifecycles.
+ */
+#pragma once
+
+#include "esp_err.h"
+#include "esp_websocket_client.h"
+#include "esp_event.h"
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* TX wrappers (formerly static helpers in voice.c) */
+esp_err_t voice_ws_send_text(const char *msg);
+esp_err_t voice_ws_send_binary(const void *data, size_t len);
+esp_err_t voice_ws_send_register(void);
+
+/* RX dispatchers — invoked by voice_ws_proto_event_handler. */
+void voice_ws_proto_handle_text(const char *data, int len);
+void voice_ws_proto_handle_binary(const char *data, int len);
+
+/* esp_websocket_client event callback — register with
+ * esp_websocket_register_events from voice_ws_start_client in voice.c. */
+void voice_ws_proto_event_handler(void *arg, esp_event_base_t base,
+                                  int32_t event_id, void *event_data);
+
+/* URI helper (LAN target builder).  out_cap must be at least 64. */
+void voice_ws_proto_build_local_uri(char *out, size_t out_cap,
+                                    const char *dragon_host, uint16_t dragon_port);
+
+#ifdef __cplusplus
+}
+#endif
+```
+
+- [ ] **Step 2: Verify it compiles standalone**
+
+```bash
+. /home/rebelforce/esp/esp-idf/export.sh
+cd ~/projects/TinkerTab
+idf.py build 2>&1 | tail -20
+```
+
+Expected: build still passes (the .h is unused so far). If it fails, the issue is in the existing tree, not the change — investigate before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add main/voice_ws_proto.h
+git commit -m "refactor(voice): carve voice_ws_proto.h skeleton (refs #$WSPROTO_ISSUE, refs #331)"
+```
+
+### Task 1.4: Move TX send wrappers (`voice_ws_send_text`, `_send_binary`, register)
+
+**Files:**
+- Create: `main/voice_ws_proto.c` (initial creation)
+- Modify: `main/voice.c` — delete L525-577 + L587-672 (send wrappers + register)
+- Modify: `main/CMakeLists.txt` line 35 — add `voice_ws_proto.c` to SRCS
+
+- [ ] **Step 1: Create voice_ws_proto.c with the moved TX wrappers**
+
+Copy verbatim out of voice.c:
+- `voice_ws_send_text` body (L525-543, current line numbers — re-grep before moving)
+- `voice_ws_send_binary` body (L545-572)
+- `voice_ws_send_register` body (L587-672)
+- All statics they touch: `s_send_lock`, `s_register_lock`, etc. (grep for `static\s.*\bs_send_lock\b` etc. in voice.c)
+
+Each function loses its `static` qualifier (now declared in the header). The `s_*` locks they use stay as file-statics IN voice_ws_proto.c — they're internal to the WS-proto layer. The WS handle `s_ws` and connection-context statics (`s_dragon_host`, `s_session_id`, `s_device_id`) remain in voice.c but are referenced via `extern` from voice_ws_proto.c (next step adds the externs to voice.h).
+
+Top-of-file includes for voice_ws_proto.c:
+
+```c
+#include "voice_ws_proto.h"
+#include "voice.h"             /* extern g_voice_ws + s_state_mutex etc. */
+#include "esp_log.h"
+#include "esp_websocket_client.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "cJSON.h"
+#include "settings.h"
+#include <string.h>
+#include <stdio.h>
+
+static const char *TAG = "tab5_voice_ws";
+```
+
+- [ ] **Step 2: Promote `s_ws` and shared statics to voice.h externs**
+
+In voice.c, find the line `static esp_websocket_client_handle_t volatile s_ws = NULL;` (around L199). Rename to `g_voice_ws` and remove `static`. In voice.h, add (in a new section near the bottom labeled `// Cross-module accessors (voice_ws_proto.c)`):
+
+```c
+/* Promoted from static in voice.c so voice_ws_proto.c can send / inspect.
+ * volatile because the WS event task (Core 1) writes it on connect/disconnect
+ * while the LVGL thread (Core 0) reads it for liveness checks. */
+extern esp_websocket_client_handle_t volatile g_voice_ws;
+
+/* Shared connection context — voice.c's voice_connect populates these,
+ * voice_ws_send_register reads them when stamping the REGISTER frame. */
+extern char g_voice_dragon_host[];
+extern uint16_t g_voice_dragon_port;
+extern char g_voice_session_id[];   /* persisted via NVS */
+extern char g_voice_device_id[];
+
+/* Read-only accessor for the session generation counter (voice_ws_proto.c
+ * uses it to guard async lv_async_call dispatches against stale RX). */
+uint32_t voice_get_session_gen(void);
+```
+
+In voice.c, rename `s_ws` → `g_voice_ws`, `s_dragon_host` → `g_voice_dragon_host`, etc. (use `replace_all` style).
+
+- [ ] **Step 3: Add voice_ws_proto.c to CMakeLists.txt**
+
+In `main/CMakeLists.txt` at line 35, change:
+
+```cmake
+"voice.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "mode_manager.c"
+```
+
+to:
+
+```cmake
+"voice.c" "voice_ws_proto.c" "voice_codec.c" "voice_video.c" "voice_widget_ws.c" "voice_billing.c" "mode_manager.c"
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+idf.py build 2>&1 | tail -30
+```
+
+Expected: clean build. If linker errors about undefined refs to `voice_ws_send_text` etc., the call sites in voice.c (mic_capture_task at L2089/L2095/L2173/L2201, voice_start_listening at L2902, voice_start_dictation at L3000, voice_clear_history at L3112, voice_stop_listening at L3180, voice_cancel at L3221, voice_send_text at L3469, voice_send_widget_action at L3510, voice_send_config_update_ex at L3540) need an `#include "voice_ws_proto.h"` at the top of voice.c. Add it next to the other voice_* includes.
+
+- [ ] **Step 5: Flash to Tab5**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -20
+```
+
+Expected: `Hash of data verified.` and `Leaving...` lines. If it sticks in ROM mode, run the watchdog reset (see "Pre-flight" section).
+
+- [ ] **Step 6: Wait for boot and confirm WS connects**
+
+```bash
+sleep 25
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/voice \
+    | python3 -m json.tool
+```
+
+Expected: `"connected": true`, `"state_name": "READY"` (or `"LISTENING"` if mid-test). If state is stuck in `CONNECTING` for >30s after boot, check serial output for stack/linker issues — a missed promotion of a static is the most common cause.
+
+- [ ] **Step 7: Smoke E2E**
+
+```bash
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -5
+```
+
+Expected: same pass count as baseline. Diff the report:
+
+```bash
+NEW_SMOKE=$(ls -td tests/e2e/runs/story_smoke-* | head -1)
+diff <(jq '.steps[].name' $BASELINE_SMOKE/report.json) \
+     <(jq '.steps[].name' $NEW_SMOKE/report.json)
+```
+
+Expected: empty diff (same step list). Pass counts in `report.json`'s `summary` field must match.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add main/voice.c main/voice.h main/voice_ws_proto.c main/CMakeLists.txt
+git commit -m "refactor(voice): move WS send wrappers + REGISTER to voice_ws_proto (refs #$WSPROTO_ISSUE)"
+```
+
+### Task 1.5: Move `voice_send_widget_action`
+
+**Files:**
+- Modify: `main/voice_ws_proto.c` — append the function
+- Modify: `main/voice.c` — delete L3478-3516
+- Modify: `main/voice.h` — no change (declaration already there as public API)
+
+- [ ] **Step 1: Move the function verbatim**
+
+Copy `voice_send_widget_action` (L3478-3516 in current main) from voice.c into voice_ws_proto.c. It uses cJSON to build the JSON payload then calls `voice_ws_send_text` — both are local to the new module so no external symbol resolution needed.
+
+- [ ] **Step 2: Build**
+
+```bash
+idf.py build 2>&1 | tail -10
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Flash + smoke**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+python3 tests/e2e/runner.py story_wave10_ui_skills 2>&1 | tail -3
+```
+
+Expected: both stories pass at baseline counts. story_wave10 exercises widget_action emission.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/voice.c main/voice_ws_proto.c
+git commit -m "refactor(voice): move voice_send_widget_action to voice_ws_proto (refs #$WSPROTO_ISSUE)"
+```
+
+### Task 1.6: Move `handle_text_message` (the 599-LOC giant)
+
+**Files:**
+- Modify: `main/voice_ws_proto.c` — append the function as `voice_ws_proto_handle_text`
+- Modify: `main/voice.c` — delete L876-1479 (`voice_debug_inject_text` + `handle_text_message` body)
+
+- [ ] **Step 1: Identify cross-module symbols the function touches**
+
+Before moving, grep the function body for symbols defined elsewhere in voice.c:
+
+```bash
+sed -n '881,1479p' main/voice.c \
+    | grep -oE '\bs_[a-z_][a-zA-Z0-9_]*\b' | sort -u
+```
+
+Expected output: a list like `s_dictation_text`, `s_dictation_text_len`, `s_dictation_partial_acc`, `s_llm_text`, `s_stt_text`, `s_last_transcript`, `s_state_mutex`, `s_voice_mode`, `s_session_gen`, `s_ws`, `s_link_health`, `s_vision_capable`, `s_vision_model`, `s_per_frame_mils`, `s_dictation_title`, `s_dictation_summary`, `s_queued_text_pending`, `s_queued_text_buf`, `s_call_audio_muted`, `s_last_ws_alive_ms`, etc. Each one is either:
+
+  - **Already promoted in Task 1.4** (e.g. `s_ws` → `g_voice_ws`)
+  - **A buffer that should stay private to voice.c** — wrap with a getter/setter in voice.h (e.g., `voice_set_stt_text(const char*)`, `voice_set_llm_text_partial(const char*)` already exists at L3361)
+  - **A flag that voice_ws_proto only needs read access to** — add a getter in voice.h
+
+For each unique symbol, make the call: promote-with-extern OR getter/setter. Update voice.h accordingly.
+
+- [ ] **Step 2: Move the function and `voice_debug_inject_text`**
+
+Cut L876-1479 from voice.c. Paste into voice_ws_proto.c. Rename `static void handle_text_message` to `void voice_ws_proto_handle_text`. Keep `voice_debug_inject_text` public (its name doesn't change — it's already in voice.h).
+
+Inside the moved body, replace direct `s_*` reads with the getters/extern names from Step 1. Rename `s_ws` references to `g_voice_ws`.
+
+- [ ] **Step 3: Update the WS event callback's call site**
+
+The remaining static `voice_ws_event_handler` in voice.c (still there until Task 1.8) currently calls `handle_text_message(...)`. Update to `voice_ws_proto_handle_text(...)`. (After Task 1.8 the event handler itself moves out, so this becomes an internal call.)
+
+- [ ] **Step 4: Build**
+
+```bash
+idf.py build 2>&1 | tail -30
+```
+
+Expected: clean. If you missed a static-promotion, the linker will tell you exactly which symbol — go back to Step 1, add it, rebuild.
+
+- [ ] **Step 5: Flash**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+```
+
+- [ ] **Step 6: Smoke + full E2E**
+
+```bash
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+python3 tests/e2e/runner.py story_full 2>&1 | tail -3
+```
+
+Expected: both at baseline pass count. **This is the high-risk extract — if anything regresses, this is where it shows.** Particularly watch for:
+
+- Rich-media bubbles missing (broken `media`/`card`/`audio_clip` JSON branches)
+- LLM streaming bubbles not updating (broken `llm` partial-token branch)
+- Tool-call indicators missing (broken `tool_call`/`tool_result` branches)
+- TTS playback stuck silent (broken `tts_start`/`tts_end` state transitions)
+
+If a regression appears, `git diff HEAD~1 -- main/voice_ws_proto.c` against the original L881-1479 in main — every JSON-type branch must be byte-equivalent except for the renamed `s_*` → getter/extern references.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add main/voice.c main/voice.h main/voice_ws_proto.c
+git commit -m "refactor(voice): move handle_text_message + voice_debug_inject_text (refs #$WSPROTO_ISSUE)"
+```
+
+### Task 1.7: Move `handle_binary_message` + `upsample_16k_to_48k`
+
+**Files:**
+- Modify: `main/voice_ws_proto.c` — append both functions
+- Modify: `main/voice.c` — delete L1486-1582
+
+- [ ] **Step 1: Move both functions**
+
+`upsample_16k_to_48k` (L1486-1499) is a tiny static helper used only by `handle_binary_message` — keep it `static` inside voice_ws_proto.c. `handle_binary_message` (L1500-1582) becomes `void voice_ws_proto_handle_binary(const char *data, int len)`.
+
+The function dispatches on the binary-frame magic prefix:
+- `"VID0"` → `voice_video_handle_downlink_frame(payload, len-8)` (already external)
+- `"AUD0"` → `voice_handle_call_audio_pcm(payload, len-8)` — currently a small static near the top of voice.c (around L800-820 — re-grep). For now, expose it as `void voice_handle_call_audio_pcm(const char *pcm, int bytes)` in voice.h (promote to non-static + add decl). It stays in voice.c (it touches the playback ring buffer).
+- Untagged → existing `playback_buf_write` path. `playback_buf_write` is also a static in voice.c — promote to non-static OR (cleaner) add a `voice_playback_write_pcm(const int16_t*, size_t)` wrapper in voice.h.
+
+- [ ] **Step 2: Update WS event handler call site (still in voice.c)**
+
+In `voice_ws_event_handler` (still at L1586+), change `handle_binary_message(...)` → `voice_ws_proto_handle_binary(...)`.
+
+- [ ] **Step 3: Build**
+
+```bash
+idf.py build 2>&1 | tail -20
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Flash + smoke + brief call test**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+
+# Quick call test — verifies AUD0 path
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" -X POST http://192.168.1.90:8080/call/start
+sleep 8
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/video | python3 -m json.tool
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" -X POST http://192.168.1.90:8080/call/end
+```
+
+Expected: smoke passes; `/video` shows non-zero `frames_sent` after the 8s call; voice state returns to READY after end.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice.c main/voice.h main/voice_ws_proto.c
+git commit -m "refactor(voice): move handle_binary_message + upsample helper (refs #$WSPROTO_ISSUE)"
+```
+
+### Task 1.8: Move `voice_ws_event_handler`
+
+**Files:**
+- Modify: `main/voice_ws_proto.c` — append as `voice_ws_proto_event_handler`
+- Modify: `main/voice.c` — delete L1586-1940
+- Modify: `main/voice.c` — update `voice_ws_start_client` (L2607+) to register `voice_ws_proto_event_handler` instead of `voice_ws_event_handler`
+
+- [ ] **Step 1: Move the function**
+
+Cut L1586-1940 from voice.c. Paste into voice_ws_proto.c. Rename `static void voice_ws_event_handler` to `void voice_ws_proto_event_handler`. The body calls `voice_ws_proto_handle_text` and `voice_ws_proto_handle_binary` (already in the same module — no externs needed) and `voice_ws_send_register` (already public via the header).
+
+Watch for these voice.c statics it touches and ensure each is reachable:
+- `g_voice_ws` (already extern)
+- `s_state_mutex` — promote OR add a setter `voice_set_state(VOICE_STATE_*, detail)` (already exists, public — use it)
+- `s_voice_mode` — read via `voice_get_mode()` (public)
+- `s_link_health` (link probe stats) — needs promotion. Add `extern voice_link_health_t g_voice_link_health;` to voice.h.
+- `s_last_ws_alive_ms` — add `voice_set_last_ws_alive_ms(uint32_t ms)` setter in voice.h.
+- `s_consec_lan_fail`, `s_consec_auth_fail` — connection-state counters. Promote to voice.h externs or wrap with setters.
+- `voice_async_toast`, `voice_async_error_banner_dyn`, `voice_async_refresh_badge` — these are statics in voice.c (around L749-866). They're UI helpers. Two options:
+  - (a) Promote to non-static + add to voice.h as `voice_show_toast(...)`, `voice_show_error_banner(...)` etc.
+  - (b) Move them to voice_ws_proto.c (they're only called from event_handler + handle_text_message — both now in voice_ws_proto.c).
+  - **Decision: (b)** — move them. Cleaner. They're UI-callback helpers, but the only callers are the WS-proto layer.
+
+- [ ] **Step 2: Update `voice_ws_start_client` registration call**
+
+Find this in voice.c (around L2700):
+
+```c
+esp_websocket_register_events(client, WEBSOCKET_EVENT_ANY,
+                              voice_ws_event_handler, NULL);
+```
+
+Change to:
+
+```c
+esp_websocket_register_events(client, WEBSOCKET_EVENT_ANY,
+                              voice_ws_proto_event_handler, NULL);
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+idf.py build 2>&1 | tail -30
+```
+
+Expected: clean. Linker errors here mean a static UI helper or a connection-state counter wasn't promoted — go back to Step 1.
+
+- [ ] **Step 4: Flash + run the FULL E2E suite**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+python3 tests/e2e/runner.py story_full  2>&1 | tail -3
+```
+
+Expected: both pass at baseline counts. The event handler IS the boot-time WS bring-up — if the boot READY transition is missing, the WS stayed in CONNECTING and the smoke story would fail at step 1 (await_voice_state READY).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice.c main/voice.h main/voice_ws_proto.c
+git commit -m "refactor(voice): move WS event handler + UI-callback helpers (refs #$WSPROTO_ISSUE)"
+```
+
+### Task 1.9: Move `voice_build_local_uri`
+
+**Files:**
+- Modify: `main/voice_ws_proto.c` — append as `voice_ws_proto_build_local_uri`
+- Modify: `main/voice.c` — delete L1944-1948
+- Modify: `main/voice.c` — update the single call site (in `voice_ws_start_client` around L2660) to use the new name
+
+- [ ] **Step 1: Move + rename**
+
+Cut L1944-1948 from voice.c, paste into voice_ws_proto.c. Rename `static void voice_build_local_uri` → `void voice_ws_proto_build_local_uri`.
+
+- [ ] **Step 2: Update the call site**
+
+In `voice_ws_start_client` find `voice_build_local_uri(uri, sizeof(uri), dragon_host, dragon_port);` → change to `voice_ws_proto_build_local_uri(...)`.
+
+- [ ] **Step 3: Build**
+
+```bash
+idf.py build 2>&1 | tail -10
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Flash + smoke**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice.c main/voice_ws_proto.c
+git commit -m "refactor(voice): move voice_build_local_uri to voice_ws_proto (refs #$WSPROTO_ISSUE)"
+```
+
+### Task 1.10: Final regression sweep + clang-format
+
+**Files:** all touched in Phase 1.
+
+- [ ] **Step 1: Run clang-format on the diff**
+
+```bash
+git fetch origin main:refs/remotes/origin/main
+git-clang-format --binary clang-format-18 --diff origin/main \
+    main/voice.c main/voice.h main/voice_ws_proto.c main/voice_ws_proto.h
+```
+
+Expected: empty output. If any files print, autofix:
+
+```bash
+git-clang-format --binary clang-format-18 origin/main main/voice.c main/voice.h main/voice_ws_proto.c main/voice_ws_proto.h
+git add -u
+git commit -m "chore(format): clang-format voice_ws_proto extract (refs #$WSPROTO_ISSUE)"
+```
+
+- [ ] **Step 2: Run the full E2E gauntlet**
+
+```bash
+python3 tests/e2e/runner.py story_smoke    2>&1 | tail -3
+python3 tests/e2e/runner.py story_full     2>&1 | tail -3
+[ "$(curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/m5 \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("failover_state_name"))')" = "ready" ] && \
+    python3 tests/e2e/runner.py story_onboard  2>&1 | tail -3
+python3 tests/e2e/runner.py story_wave10_ui_skills 2>&1 | tail -3
+```
+
+Expected: all match baseline pass counts.
+
+- [ ] **Step 3: Heap floor check**
+
+```bash
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/heap | python3 -m json.tool > /tmp/post-pr1-heap.json
+python3 -c "
+import json
+b = json.load(open('/tmp/baseline-heap.json'))
+n = json.load(open('/tmp/post-pr1-heap.json'))
+for k in ('internal_free', 'internal_largest_free_block', 'psram_free'):
+    delta_pct = (n[k] - b[k]) / b[k] * 100
+    print(f'{k}: baseline={b[k]} now={n[k]} delta={delta_pct:+.1f}%')
+"
+```
+
+Expected: each delta within ±5%. A regression >5% on `internal_largest_free_block` means we leaked an allocation site or duplicated buffer ownership — investigate via `git diff origin/main -- main/voice.c main/voice_ws_proto.c | grep -E 'malloc|heap_caps_alloc'`.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin refactor/voice-ws-proto-extract
+gh pr create --title "refactor(voice): extract voice_ws_proto.{c,h} (closes #$WSPROTO_ISSUE, refs #331)" \
+    --body "$(cat <<'EOF'
+## Summary
+
+- Extract WS frame routing out of `main/voice.c` into a new sibling module `main/voice_ws_proto.{c,h}`.
+- voice.c drops by ~1230 LOC (3,846 → ~2,616).
+- Same shape as the prior `voice_billing` / `voice_widget_ws` / `voice_onboard` extracts.
+
+## Symbols moved
+
+- TX wrappers: `voice_ws_send_text`, `voice_ws_send_binary`, `voice_ws_send_binary_public`, `voice_ws_send_register`
+- RX dispatchers: `voice_ws_proto_handle_text` (formerly `handle_text_message`), `voice_ws_proto_handle_binary` (formerly `handle_binary_message`)
+- Event callback: `voice_ws_proto_event_handler` (formerly `voice_ws_event_handler`)
+- Helpers: `upsample_16k_to_48k` (private), `voice_ws_proto_build_local_uri`
+- UI callback helpers: `voice_async_toast`, `voice_async_error_banner_dyn`, `voice_async_refresh_badge`
+- `voice_send_widget_action`, `voice_debug_inject_text`
+
+## Verification (on physical Tab5 192.168.1.90)
+
+- `idf.py build` clean
+- story_smoke:    NN/NN steps (matches baseline)
+- story_full:     NN/NN steps (matches baseline)
+- story_onboard:  NN/NN steps (matches baseline; or SKIPPED if K144 cold)
+- story_wave10_ui_skills: NN/NN steps (matches baseline)
+- Heap floor delta within ±5% of baseline
+- AUD0/VID0 call path verified via /call/start + /video stats
+
+Closes #$WSPROTO_ISSUE.
+Refs #331.
+EOF
+)"
+```
+
+**Acceptance:** PR is green on CI (`git-clang-format` diff is empty), every regression bullet is filled in with concrete numbers, and the linked issue auto-closes on squash-merge.
+
+---
+
+## Phase 2 — PR #2: Extract `voice_modes.{c,h}`
+
+This phase only starts after PR #1 is merged to main and the local working tree is rebased onto the new main. The PR-1 extraction promoted enough statics that PR-2's extracts compose cleanly.
+
+### Task 2.1: Branch + tracking issue
+
+**Files:** none (git + gh).
+
+- [ ] **Step 1: Branch**
+
+```bash
+git switch main && git pull --ff-only
+git switch -c refactor/voice-modes-extract
+```
+
+- [ ] **Step 2: Open issue**
+
+```bash
+gh issue create --title "refactor(voice): extract voice_modes.{c,h} (refs #331)" \
+    --body "$(cat <<'EOF'
+## Scope
+
+Extract the five-tier voice-mode dispatcher out of `main/voice.c` into a new sibling module `main/voice_modes.{c,h}`.  Closes the second extract from #331.  Builds on PR #$WSPROTO_ISSUE (voice_ws_proto extract) which must land first.
+
+## What moves
+
+- `voice_send_config_update_ex` + `voice_send_config_update` — config_update JSON sender (with optional reason for cap_downgrade)
+- `voice_get_mode` — public mode getter
+- The five-tier text-routing decision currently inline in `voice_send_text` — extracted as a pure helper `voice_modes_route_text(const char *text, voice_modes_route_result_t *out)` returning ROUTE_K144_CHAIN_BUSY / ROUTE_K144_OK / ROUTE_K144_FAILED / ROUTE_DRAGON_PATH
+
+## What stays in voice.c
+
+- `voice_send_text` itself (the public API) — becomes a thin dispatcher on the result of voice_modes_route_text
+- `voice_start_listening` / `voice_start_dictation` (they set s_voice_mode but the lifecycle is a voice.c concern)
+- The internal `s_voice_mode` static is moved into voice_modes.c with new getter/setter
+
+## Verification
+
+- Build clean
+- E2E baseline holds: story_full (4-mode rotation) + story_onboard (vmode=4) + story_wave7_onboard_polish (Local→K144 failover)
+
+## Plan doc
+
+`docs/superpowers/plans/2026-05-03-voice-c-extraction.md` — Phase 2 (Tasks 2.1 – 2.6)
+
+Refs #331.
+EOF
+)"
+```
+
+Note the new issue number as `$MODES_ISSUE`.
+
+### Task 2.2: Carve the new header
+
+**Files:**
+- Create: `main/voice_modes.h`
+
+- [ ] **Step 1: Write the header**
+
+```c
+/**
+ * Voice five-tier mode dispatcher (Tab5).
+ *
+ * Owns the {LOCAL, HYBRID, CLOUD, TINKERCLAW, LOCAL_ONBOARD} routing
+ * decision for outbound text turns + the config_update JSON frame
+ * that announces a mode/model change to Dragon.
+ *
+ * Wave 23 SOLID-audit closure for TT #331 (extract A2).  Pre-extract
+ * the routing decision was inline at voice.c:3373-3471 inside
+ * voice_send_text.  Pulling it out lets voice.c keep the public API
+ * (voice_send_text) thin while the mode-specific branches stay
+ * testable + extendable in voice_modes.c.
+ */
+#pragma once
+
+#include "esp_err.h"
+#include "voice.h"   /* voice_mode_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    /* VMODE_LOCAL_ONBOARD active + chain currently running — caller must
+     * surface a "Stop onboard chat first" toast and refuse the send. */
+    VOICE_MODES_ROUTE_K144_CHAIN_BUSY = 0,
+    /* Routed text to K144 successfully (vmode=4 OR Local-mode failover hit). */
+    VOICE_MODES_ROUTE_K144_OK,
+    /* Routed text to K144 but K144 returned an error — caller should
+     * surface a toast (failure detail in `err`). */
+    VOICE_MODES_ROUTE_K144_FAILED,
+    /* Default — caller should send the text via the Dragon WS path. */
+    VOICE_MODES_ROUTE_DRAGON_PATH,
+} voice_modes_route_kind_t;
+
+typedef struct {
+    voice_modes_route_kind_t kind;
+    esp_err_t err;       /* set when kind == K144_FAILED */
+} voice_modes_route_result_t;
+
+/* Pure routing decision.  Called by voice_send_text BEFORE building any
+ * Dragon-side JSON frame — caller dispatches based on result.kind.
+ *
+ *   - vmode=4 (LOCAL_ONBOARD) → always K144 (CHAIN_BUSY if chain active,
+ *     OK on send success, FAILED on send error)
+ *   - vmode=0 (LOCAL) AND Dragon WS down for >= M5_FAILOVER_GRACE_MS AND
+ *     K144 warm → K144 failover (OK or FAILED)
+ *   - Otherwise → DRAGON_PATH
+ */
+void voice_modes_route_text(const char *text, voice_modes_route_result_t *out);
+
+/* config_update frame senders (formerly voice_send_config_update*). */
+esp_err_t voice_send_config_update(int voice_mode, const char *llm_model);
+esp_err_t voice_send_config_update_ex(int voice_mode, const char *llm_model,
+                                      const char *reason);
+
+#ifdef __cplusplus
+}
+#endif
+```
+
+- [ ] **Step 2: Build to verify the header parses**
+
+```bash
+. /home/rebelforce/esp/esp-idf/export.sh
+idf.py build 2>&1 | tail -10
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add main/voice_modes.h
+git commit -m "refactor(voice): carve voice_modes.h skeleton (refs #$MODES_ISSUE, refs #331)"
+```
+
+### Task 2.3: Move `voice_send_config_update*`
+
+**Files:**
+- Create: `main/voice_modes.c`
+- Modify: `main/voice.c` — delete L3518-3548 (config_update_ex + config_update)
+- Modify: `main/CMakeLists.txt` line 35 — add `voice_modes.c`
+
+- [ ] **Step 1: Create voice_modes.c with the moved senders**
+
+Top-of-file:
+
+```c
+#include "voice_modes.h"
+#include "voice.h"
+#include "voice_ws_proto.h"     /* voice_ws_send_text */
+#include "voice_onboard.h"      /* failover state + chain helpers */
+#include "voice_m5_llm.h"       /* M5_FAILOVER_GRACE_MS + voice_m5_llm_send_text */
+#include "settings.h"           /* tab5_settings_get_voice_mode + VMODE_* */
+#include "ui_home.h"            /* ui_home_show_toast */
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "cJSON.h"
+#include <string.h>
+
+static const char *TAG = "tab5_voice_modes";
+```
+
+Body: paste `voice_send_config_update_ex` (L3518-3543 in main pre-Phase-1) and `voice_send_config_update` (L3545-3548) verbatim. The `voice_ws_send_text` call already resolves via the new include.
+
+- [ ] **Step 2: Update CMakeLists.txt**
+
+Append `voice_modes.c` to the `SRCS` list:
+
+```cmake
+"voice.c" "voice_ws_proto.c" "voice_modes.c" "voice_codec.c" ...
+```
+
+- [ ] **Step 3: Build + flash + smoke**
+
+```bash
+idf.py build 2>&1 | tail -15
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+```
+
+Expected: clean build + smoke matches baseline. config_update fires on every boot (during REGISTER → first mode-set).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main/voice.c main/voice_modes.c main/CMakeLists.txt
+git commit -m "refactor(voice): move config_update senders to voice_modes (refs #$MODES_ISSUE)"
+```
+
+### Task 2.4: Move `voice_get_mode` + extract `s_voice_mode` ownership
+
+**Files:**
+- Modify: `main/voice_modes.c` — add `s_voice_mode` static + `voice_get_mode` + accessors
+- Modify: `main/voice.c` — delete `s_voice_mode` static + delete `voice_get_mode` (L3019-3022)
+- Modify: `main/voice_modes.h` — declare the internal accessors
+
+- [ ] **Step 1: Add accessors to voice_modes.h**
+
+Append before the closing `#ifdef __cplusplus`:
+
+```c
+/* Internal mode setter — voice.c calls this from voice_start_listening
+ * (sets ASK), voice_start_dictation (sets DICTATE), voice_call_audio_start
+ * (sets CALL), voice_call_audio_stop (sets ASK).  Keeps s_voice_mode
+ * ownership inside voice_modes.c. */
+void voice_modes_set_internal(voice_mode_t mode);
+```
+
+- [ ] **Step 2: In voice_modes.c**
+
+Add the static at the top:
+
+```c
+static voice_mode_t s_voice_mode = VOICE_MODE_ASK;
+```
+
+Append at the bottom:
+
+```c
+voice_mode_t voice_get_mode(void) {
+    return s_voice_mode;
+}
+
+void voice_modes_set_internal(voice_mode_t mode) {
+    s_voice_mode = mode;
+}
+```
+
+- [ ] **Step 3: In voice.c**
+
+Delete the `static voice_mode_t s_voice_mode = VOICE_MODE_ASK;` line (around L324). Delete the `voice_get_mode` body (L3019-3022). Add `#include "voice_modes.h"` at the top (alongside the other voice_* includes).
+
+Find every `s_voice_mode = ...` assignment in voice.c (grep result earlier showed L2899, L2975, L3052, L3099, L3176) and rewrite as `voice_modes_set_internal(...)`. Find every `s_voice_mode` read (mic_capture_task: L1992, L2007, L2073, L2105, L2111, L2120, L2143, L2198) and rewrite as `voice_get_mode()`.
+
+- [ ] **Step 4: Build**
+
+```bash
+idf.py build 2>&1 | tail -20
+```
+
+Expected: clean. Linker errors here mean a `s_voice_mode` reference was missed — re-grep `git diff main/voice.c | grep s_voice_mode`.
+
+- [ ] **Step 5: Flash + run mode-rotation E2E**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_full 2>&1 | tail -3
+```
+
+Expected: story_full passes — it rotates through all 4 voice modes. If any mode-switch silently fails to take effect, this is where it shows up.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add main/voice.c main/voice_modes.c main/voice_modes.h
+git commit -m "refactor(voice): move s_voice_mode ownership + voice_get_mode (refs #$MODES_ISSUE)"
+```
+
+### Task 2.5: Extract the five-tier text-routing decision
+
+**Files:**
+- Modify: `main/voice_modes.c` — add `voice_modes_route_text` body
+- Modify: `main/voice.c` — gut the K144-routing branches in `voice_send_text` (L3373-L3441 approximately) and replace with a single `voice_modes_route_text(text, &result)` call + dispatch
+
+- [ ] **Step 1: Implement voice_modes_route_text**
+
+In voice_modes.c append:
+
+```c
+void voice_modes_route_text(const char *text, voice_modes_route_result_t *out)
+{
+    if (!out) return;
+    out->kind = VOICE_MODES_ROUTE_DRAGON_PATH;
+    out->err  = ESP_OK;
+
+    /* TT #317 Phase 5: VMODE_LOCAL_ONBOARD always routes to K144 regardless
+     * of Dragon WS state.  voice_onboard.c owns the actual chain transport. */
+    if (tab5_settings_get_voice_mode() == VMODE_LOCAL_ONBOARD) {
+        if (voice_onboard_chain_active()) {
+            ESP_LOGI(TAG, "VMODE_LOCAL_ONBOARD: chain active, refusing text turn");
+            out->kind = VOICE_MODES_ROUTE_K144_CHAIN_BUSY;
+            out->err  = ESP_ERR_INVALID_STATE;
+            return;
+        }
+        esp_err_t fe = voice_onboard_send_text(text);
+        if (fe == ESP_OK) {
+            ESP_LOGI(TAG, "VMODE_LOCAL_ONBOARD — routed to K144");
+            out->kind = VOICE_MODES_ROUTE_K144_OK;
+        } else {
+            ESP_LOGW(TAG, "VMODE_LOCAL_ONBOARD but K144 unavailable (%s) — refusing send",
+                     esp_err_to_name(fe));
+            out->kind = VOICE_MODES_ROUTE_K144_FAILED;
+            out->err  = fe;
+        }
+        return;
+    }
+
+    /* TT #317 Phase 4: WS unreachable in Local mode → try K144 failover after
+     * the M5_FAILOVER_GRACE_MS grace window. */
+    uint32_t down_ms = 0;
+    uint32_t last_alive = voice_get_last_ws_alive_ms();
+    if (last_alive) {
+        down_ms = (uint32_t)(esp_timer_get_time() / 1000) - last_alive;
+    }
+    if (down_ms >= M5_FAILOVER_GRACE_MS &&
+        tab5_settings_get_voice_mode() == VMODE_LOCAL) {
+        esp_err_t fe = voice_onboard_send_text(text);
+        if (fe == ESP_OK) {
+            ESP_LOGI(TAG, "Local-mode failover engaged — routed to K144 (down=%ums)", down_ms);
+            out->kind = VOICE_MODES_ROUTE_K144_OK;
+            return;
+        }
+        /* K144 also unreachable — fall through to DRAGON_PATH so the
+         * existing voice_ws_send_text error pathway can surface the
+         * connectivity error to the user uniformly. */
+        ESP_LOGW(TAG, "Local-mode failover attempted but K144 errored: %s",
+                 esp_err_to_name(fe));
+    }
+
+    /* Default — Dragon WS path. */
+    out->kind = VOICE_MODES_ROUTE_DRAGON_PATH;
+}
+```
+
+This requires `voice_get_last_ws_alive_ms()` in voice.h — add it as a getter in Phase 1 Task 1.8 (already in the static-promotion list above; if not added then, do it here).
+
+- [ ] **Step 2: Replace the inline branches in voice_send_text**
+
+In voice.c at the top of `voice_send_text` (L3369), replace the chunk from L3373 to wherever the `// TT #317 Phase 4` failover branch ends (approximately L3441 — re-read the exact range before editing) with:
+
+```c
+voice_modes_route_result_t route;
+voice_modes_route_text(text, &route);
+switch (route.kind) {
+case VOICE_MODES_ROUTE_K144_CHAIN_BUSY:
+    if (s_state_cb) {
+        ui_home_show_toast("Stop onboard chat first to send text");
+    }
+    return route.err;
+case VOICE_MODES_ROUTE_K144_OK:
+    return ESP_OK;
+case VOICE_MODES_ROUTE_K144_FAILED:
+    /* Toast already surfaced by the K144 path — fall through to a
+     * Dragon-side error return for the caller. */
+    return route.err;
+case VOICE_MODES_ROUTE_DRAGON_PATH:
+    /* Fall through to the existing Dragon-WS send below. */
+    break;
+}
+```
+
+Everything below (the existing `voice_ws_send_text(json)` + queue-busy branch) stays put.
+
+- [ ] **Step 3: Build**
+
+```bash
+idf.py build 2>&1 | tail -20
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Flash + run all three K144-relevant stories**
+
+```bash
+idf.py -p /dev/ttyACM0 flash 2>&1 | tail -5
+sleep 25
+python3 tests/e2e/runner.py story_smoke 2>&1 | tail -3
+python3 tests/e2e/runner.py story_wave7_onboard_polish 2>&1 | tail -3
+[ "$(curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/m5 \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("failover_state_name"))')" = "ready" ] && \
+    python3 tests/e2e/runner.py story_onboard 2>&1 | tail -3
+```
+
+Expected:
+- story_smoke matches baseline (Dragon path)
+- story_wave7 matches baseline (Local→K144 failover)
+- story_onboard matches baseline if K144 is warm (vmode=4 always-K144 path)
+
+The three together cover every `voice_modes_route_text` branch.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/voice.c main/voice_modes.c main/voice_modes.h
+git commit -m "refactor(voice): extract five-tier text-routing decision (refs #$MODES_ISSUE)"
+```
+
+### Task 2.6: Final regression sweep + clang-format
+
+- [ ] **Step 1: clang-format diff**
+
+```bash
+git fetch origin main:refs/remotes/origin/main
+git-clang-format --binary clang-format-18 --diff origin/main \
+    main/voice.c main/voice.h main/voice_modes.c main/voice_modes.h
+```
+
+Expected: empty. If not, autofix + re-commit.
+
+- [ ] **Step 2: Full E2E gauntlet**
+
+```bash
+python3 tests/e2e/runner.py story_smoke    2>&1 | tail -3
+python3 tests/e2e/runner.py story_full     2>&1 | tail -3
+python3 tests/e2e/runner.py story_wave7_onboard_polish  2>&1 | tail -3
+[ "$(curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/m5 \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("failover_state_name"))')" = "ready" ] && \
+    python3 tests/e2e/runner.py story_onboard  2>&1 | tail -3
+```
+
+Expected: all match baseline pass counts.
+
+- [ ] **Step 3: Heap floor check**
+
+```bash
+curl -sS -H "Authorization: Bearer $TAB5_TOKEN" http://192.168.1.90:8080/heap | python3 -m json.tool > /tmp/post-pr2-heap.json
+python3 -c "
+import json
+b = json.load(open('/tmp/baseline-heap.json'))
+n = json.load(open('/tmp/post-pr2-heap.json'))
+for k in ('internal_free', 'internal_largest_free_block', 'psram_free'):
+    print(f'{k}: baseline={b[k]} now={n[k]} delta={(n[k]-b[k])/b[k]*100:+.1f}%')
+"
+```
+
+Expected: each delta within ±5%.
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin refactor/voice-modes-extract
+gh pr create --title "refactor(voice): extract voice_modes.{c,h} (closes #$MODES_ISSUE, refs #331)" \
+    --body "$(cat <<'EOF'
+## Summary
+
+- Second of two extracts that close TT #331 (the first was voice_ws_proto in PR #$WSPROTO_ISSUE).
+- voice.c lands at ~2,470 LOC owning state machine + mic + playback + reconnect + listening/dictation/call.
+- Five-tier mode-routing decision is now a pure helper testable in isolation.
+
+## Symbols moved
+
+- `voice_send_config_update`, `voice_send_config_update_ex`
+- `voice_get_mode` + `s_voice_mode` ownership
+- New: `voice_modes_route_text` (extracted from inline branches in `voice_send_text`)
+
+## Verification (on physical Tab5 192.168.1.90)
+
+- `idf.py build` clean
+- story_smoke:                 NN/NN steps (matches baseline)
+- story_full:                  NN/NN steps (matches baseline) — 4-mode rotation green
+- story_wave7_onboard_polish:  NN/NN steps (matches baseline) — Local→K144 failover green
+- story_onboard:               NN/NN steps (matches baseline) — vmode=4 always-K144 green
+- Heap floor delta within ±5% of baseline
+
+Closes #$MODES_ISSUE.
+Closes #331.
+EOF
+)"
+```
+
+**Acceptance:** PR is green, both issues auto-close on squash-merge.
+
+---
+
+## Phase 3 — Wrap-up
+
+### Task 3.1: Update `CLAUDE.md` Key Files section
+
+**Files:**
+- Modify: `CLAUDE.md` — "Key Files → Dragon voice link" subsection (around the `voice.c` entry).
+
+- [ ] **Step 1: Edit the description block**
+
+Find:
+
+```markdown
+main/voice.{c,h}          — Voice WS client (port 3502), mic capture, TTS playback,
+                             dictation, reconnect watchdog, three-tier mode, tool events,
+                             rich-media handlers, VOICE_MODE_CALL (AUD0-tagged mic).
+                             Tab5 talks to Dragon only via this path.
+```
+
+Replace with:
+
+```markdown
+main/voice.{c,h}          — Voice public API + state machine + mic capture task +
+                             playback drain task + listening/dictation/call lifecycles +
+                             reconnect watchdog. Wave 23 thinned voice.c from ~3,846 LOC to
+                             ~2,470 LOC by extracting voice_ws_proto (RX/TX dispatch +
+                             event handler) and voice_modes (five-tier routing).
+main/voice_ws_proto.{c,h} — WS frame routing layer: JSON RX dispatcher + binary magic
+                             VID0/AUD0/untagged-PCM dispatcher + esp_websocket_client
+                             event callback + send wrappers + REGISTER frame builder.
+                             Wave 23 SRP closure for TT #331-A.
+main/voice_modes.{c,h}    — Five-tier voice-mode dispatcher: config_update sender +
+                             voice_modes_route_text decision (LOCAL / HYBRID / CLOUD /
+                             TINKERCLAW / LOCAL_ONBOARD).  Wave 23 SRP closure for
+                             TT #331-B.
+```
+
+- [ ] **Step 2: Commit on a docs branch**
+
+```bash
+git switch -c docs/wave-23-voice-c-keyfiles
+git add CLAUDE.md
+git commit -m "docs(claude): refresh voice.{c,h} Key Files block after #331 extracts"
+git push -u origin docs/wave-23-voice-c-keyfiles
+gh pr create --title "docs(claude): refresh voice.{c,h} Key Files after #331 extracts" \
+    --body "Updates the Key Files section to reflect Wave 23 voice.c thinning (PR #$WSPROTO_ISSUE + PR #$MODES_ISSUE, closes #331)."
+```
+
+### Task 3.2: Update memory + audit tracker
+
+**Files:**
+- Modify: `~/.claude/projects/-home-rebelforce/memory/project_solid_audit_wave23.md` — append PR-merge entries
+- Modify: `docs/AUDIT-architecture-2026-05-01.md` — flip A1 from "open" to "shipped"
+
+- [ ] **Step 1: Append to memory**
+
+In `~/.claude/projects/-home-rebelforce/memory/project_solid_audit_wave23.md`, find the "Closures" or "Status" section and append:
+
+```markdown
+- 2026-05-XX — TT #331 closed via PR #$WSPROTO_ISSUE (voice_ws_proto extract: WS event handler + JSON RX + binary RX + send wrappers + REGISTER, ~1230 LOC out of voice.c) + PR #$MODES_ISSUE (voice_modes extract: config_update senders + voice_modes_route_text + s_voice_mode ownership, ~150 LOC out + behavioral split).  voice.c lands at ~2,470 LOC.  E2E full + onboard + wave7 hold at baseline pass counts on physical Tab5 (192.168.1.90); heap floor delta within ±5%.
+```
+
+- [ ] **Step 2: Flip A1 in the audit doc**
+
+In `docs/AUDIT-architecture-2026-05-01.md`, find finding A1 (`voice.c god-file`) and change its status line to:
+
+```markdown
+**Status:** SHIPPED — closed by PR #$WSPROTO_ISSUE + PR #$MODES_ISSUE (Wave 23, 2026-05-XX).  voice.c thinned 3,846 → ~2,470 LOC.
+```
+
+- [ ] **Step 3: Commit on the same docs branch**
+
+```bash
+git add docs/AUDIT-architecture-2026-05-01.md
+git commit -m "docs(audit): mark A1 (voice.c god-file) shipped via #$WSPROTO_ISSUE + #$MODES_ISSUE"
+git push
+```
+
+(Memory file is outside the repo — no git step.)
+
+### Task 3.3: Run the long-form stress story
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: 20-minute stress sweep**
+
+```bash
+python3 tests/e2e/runner.py story_stress 2>&1 | tail -10
+```
+
+Expected: `PASS: 76/77` or better (the historic single LLM-timeout flake noted in CLAUDE.md is acceptable). Heap watchdog assertions inside the story must all hold — any "internal SRAM largest free block dropped below 30 KB" failure means the extract introduced fragmentation and we need to investigate before signing off.
+
+- [ ] **Step 2: Document the result**
+
+Append to the wrap-up issue or comment on #331:
+
+```bash
+gh issue comment 331 --body "Wave 23 extract complete. story_stress: NN/77 steps over ~20 min on physical Tab5 (192.168.1.90).  Heap floor stable.  Refs PRs #$WSPROTO_ISSUE + #$MODES_ISSUE."
+```
+
+---
+
+## Files to modify summary
+
+| Path | Phase | Change |
+|------|-------|--------|
+| `main/voice_ws_proto.h` | 1.3 | Create |
+| `main/voice_ws_proto.c` | 1.4 – 1.9 | Create + grow per task |
+| `main/voice_modes.h` | 2.2 | Create |
+| `main/voice_modes.c` | 2.3 – 2.5 | Create + grow per task |
+| `main/voice.c` | 1.4 – 2.5 | Symbol removal + getter wiring + new includes (see source map) |
+| `main/voice.h` | 1.4, 1.7, 1.8 | New extern declarations + getters/setters for promoted statics |
+| `main/CMakeLists.txt` | 1.4, 2.3 | Append `voice_ws_proto.c` then `voice_modes.c` to SRCS |
+| `CLAUDE.md` | 3.1 | Refresh Key Files block |
+| `docs/AUDIT-architecture-2026-05-01.md` | 3.2 | Mark A1 shipped |
+| `~/.claude/projects/-home-rebelforce/memory/project_solid_audit_wave23.md` | 3.2 | Append closure entry |
+
+## Risks + things to watch
+
+- **Static-promotion churn.** The biggest risk is missing a `static s_*` symbol that the extracted code reads. The grep step at the start of each task catches most of these but some macros expand to `s_*` references that grep misses — the linker error is the fallback.
+- **WS event handler is on the WS task (Core 1).** Anything that the moved event handler used to reach via voice.c statics now needs an explicit thread-safety guarantee. Use `g_voice_state_mutex` for shared mutable state (it was already taken by the original code). Sanity-check by re-reading the WS task's locking pattern around `voice_set_state` — the move shouldn't add any new lock dependencies.
+- **K144 path requires hardware that may be cold.** `story_onboard` self-skips if K144 isn't ready. If K144 IS warm but a regression breaks the chain, we'll see `voice_modes_route_text` returning `K144_FAILED` for every send — symptom is the `/voice` endpoint shows `last_llm_text` empty after a vmode=4 send.
+- **Heap regression.** The most likely fragmentation source is the moved cJSON parsing in `handle_text_message` allocating from a different file's static lock context. The `±5% on internal_largest_free_block` gate after each PR catches this; if breached, look for double-allocation or a missing `cJSON_Delete` in the moved branches.
+- **CI clang-format.** The Task 1.10 / 2.6 clang-format step is non-negotiable — CI will reject the PR otherwise. Run it BEFORE pushing.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -67,6 +67,7 @@ else()
              "voice_m5_llm.c"
              "voice_onboard.c"
              "voice_wakeword.c"
+             "voice_wake_stream.c"
         EMBED_TXTFILES "debug_ui.html"
         INCLUDE_DIRS "."
         REQUIRES tab5

--- a/main/voice.c
+++ b/main/voice.c
@@ -515,6 +515,23 @@ void voice_set_state(voice_state_t new_state, const char *detail) {
          s_conv_active = false;
       }
    }
+
+   /* TT #615 — Path B wake-stream: tell the wake-stream task about
+    * every state transition so it can gate I2S reads + WS sends to
+    * the quiescent states only.  Also arm on first transition to
+    * READY (Dragon WS handshake complete + initial register ack
+    * landed) and disarm on disconnect. */
+   {
+      extern void voice_wake_stream_on_state_change(int new_state);
+      extern void voice_wake_stream_arm(void);
+      extern void voice_wake_stream_disarm(void);
+      voice_wake_stream_on_state_change((int)new_state);
+      if (new_state == VOICE_STATE_READY && old != VOICE_STATE_READY) {
+         voice_wake_stream_arm();
+      } else if (new_state == VOICE_STATE_IDLE && old != VOICE_STATE_IDLE) {
+         voice_wake_stream_disarm();
+      }
+   }
 }
 
 /* closes #133: runs on the shared worker (16 KB PSRAM stack), safe for
@@ -1154,6 +1171,19 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
 
     s_initialized = true;
     voice_set_state(VOICE_STATE_IDLE, NULL);
+
+    /* TT #615 — Path B wake-stream: spawn the background task that
+     * ships Tab5 mic to Dragon as WAK0 frames during quiescent voice
+     * states.  Arm-on-connect happens in voice_ws_proto when the WS
+     * RX READY frame lands; the task itself idles until armed. */
+    {
+       extern esp_err_t voice_wake_stream_init(void);
+       esp_err_t we = voice_wake_stream_init();
+       if (we != ESP_OK) {
+          ESP_LOGW(TAG, "voice_wake_stream_init failed (%s) — wake-stream disabled", esp_err_to_name(we));
+       }
+    }
+
     ESP_LOGI(TAG, "Voice module initialized");
     return ESP_OK;
 }

--- a/main/voice_codec.c
+++ b/main/voice_codec.c
@@ -285,6 +285,21 @@ size_t voice_codec_pack_call_audio(uint8_t *out, size_t out_cap,
     return body_len + VOICE_CALL_AUDIO_HEADER_LEN;
 }
 
+/* TT #615 — see voice_codec.h for wire format.  Mirror of pack_call_audio
+ * with WAK0 magic. */
+size_t voice_codec_pack_wake_audio(uint8_t *out, size_t out_cap, const void *body, size_t body_len)
+{
+    if (!out || !body) return 0;
+    if (out_cap < body_len + VOICE_WAKE_AUDIO_HEADER_LEN) return 0;
+    out[0] = 'W'; out[1] = 'A'; out[2] = 'K'; out[3] = '0';
+    out[4] = (uint8_t)((body_len >> 24) & 0xff);
+    out[5] = (uint8_t)((body_len >> 16) & 0xff);
+    out[6] = (uint8_t)((body_len >>  8) & 0xff);
+    out[7] = (uint8_t)( body_len        & 0xff);
+    memcpy(out + VOICE_WAKE_AUDIO_HEADER_LEN, body, body_len);
+    return body_len + VOICE_WAKE_AUDIO_HEADER_LEN;
+}
+
 bool voice_codec_unpack_call_audio(const uint8_t *wire, size_t wire_len,
                                    const uint8_t **out_body, size_t *out_body_len)
 {

--- a/main/voice_codec.h
+++ b/main/voice_codec.h
@@ -144,3 +144,21 @@ bool voice_codec_peek_call_audio_magic(const void *data, size_t len);
  * via out_body / out_body_len.  Returns false on malformed input. */
 bool voice_codec_unpack_call_audio(const uint8_t *wire, size_t wire_len,
                                    const uint8_t **out_body, size_t *out_body_len);
+
+/* TT #615 — Path B wakeword audio framing.  When wake-streaming is
+ * armed (WS connected + voice state IDLE/READY), Tab5 mic frames are
+ * tagged with the "WAK0" magic + 4-byte BE length and shipped to
+ * Dragon.  Dragon accumulates a sliding window, runs whisper.cpp
+ * periodically, and on a 'hey tinker' substring match sends back
+ * {"type":"wake"} so Tab5 routes through ui_home_start_voice_turn —
+ * same UX as orb tap.
+ *
+ * Wire format mirrors AUD0 / VID0:
+ *   bytes 0..3 : magic "WAK0" (0x57 0x41 0x4B 0x30)
+ *   bytes 4..7 : payload length (uint32_t big-endian)
+ *   bytes 8..  : raw int16 LE PCM @ 16 kHz mono
+ */
+#define VOICE_WAKE_AUDIO_MAGIC      0x57414B30u   /* "WAK0" big-endian */
+#define VOICE_WAKE_AUDIO_HEADER_LEN 8
+
+size_t voice_codec_pack_wake_audio(uint8_t *out, size_t out_cap, const void *body, size_t body_len);

--- a/main/voice_wake_stream.c
+++ b/main/voice_wake_stream.c
@@ -1,0 +1,216 @@
+/**
+ * @file voice_wake_stream.c
+ * @brief Tab5 mic → Dragon wakeword streamer (TT #615 Path B).
+ *
+ * Background task that captures the same downsampled 16 kHz mono PCM
+ * stream the existing mic_task produces for voice turns, and ships it
+ * to Dragon as WAK0-tagged binary frames whenever:
+ *   - The task is armed (voice_wake_stream_arm)
+ *   - The Dragon WS is connected
+ *   - voice state is quiescent (IDLE or READY)
+ *
+ * Single I2S RX consumer at a time: when voice state transitions to
+ * LISTENING/PROCESSING/SPEAKING/RECONNECTING the in-turn mic_task is
+ * the owner; the wake-stream task is gated off via the state check
+ * (no I2S reads, no WS sends).  On SPEAKING→READY the in-turn mic
+ * task has already disabled itself, so wake-stream resumes naturally.
+ *
+ * Bandwidth: 16 kHz × 16-bit × continuous = 256 kbps over the existing
+ * voice WS.  Header overhead 8 B (WAK0 + BE length) per ~30 ms chunk.
+ *
+ * Dragon side handles WAK0 frames: sliding window into whisper.cpp,
+ * substring match against "hey tinker" / "hey thinker", then sends
+ * {"type":"wake"} back; the WS RX handler in voice_ws_proto routes
+ * to ui_home_start_voice_turn("dragon_wake").
+ */
+
+#include "voice_wake_stream.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "audio.h" /* tab5_mic_read, TAB5_AUDIO_SAMPLE_RATE */
+#include "config.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "esp_websocket_client.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "voice.h"
+#include "voice_codec.h"
+
+/* Mirror constants from voice.c.  Kept local; the canonical defs live
+ * with mic_task and aren't header-exposed.  If they drift, both sites
+ * need the same change. */
+#define WS_MIC_48K_FRAMES (TAB5_AUDIO_SAMPLE_RATE * TAB5_VOICE_CHUNK_MS / 1000)
+#define WS_MIC_TDM_CHANNELS 4
+#define WS_MIC_TDM_MIC1_OFF 0
+#define WS_MIC_TDM_SAMPLES (WS_MIC_48K_FRAMES * WS_MIC_TDM_CHANNELS)
+#define WS_DOWNSAMPLE_RATIO (TAB5_AUDIO_SAMPLE_RATE / TAB5_VOICE_SAMPLE_RATE)
+
+extern esp_websocket_client_handle_t volatile g_voice_ws;
+extern esp_err_t voice_ws_send_binary(const uint8_t *data, size_t len);
+extern void tab5_debug_obs_event(const char *kind, const char *detail);
+extern bool voice_mic_is_active(void);
+
+static const char *TAG = "voice_wake_stream";
+
+#define WAKE_STREAM_TASK_STACK 8192
+#define WAKE_STREAM_TASK_PRIO 4
+#define WAKE_STREAM_TASK_CORE 1
+
+/* Matches mic_task's downsample ratio (48 kHz TDM → 16 kHz mono).  Pull
+ * the same constants from config.h. */
+#define WS_CHUNK_SAMPLES (TAB5_VOICE_SAMPLE_RATE * TAB5_VOICE_CHUNK_MS / 1000)
+#define WS_CHUNK_BYTES (WS_CHUNK_SAMPLES * sizeof(int16_t))
+
+static TaskHandle_t s_task = NULL;
+static volatile bool s_armed = false;
+static volatile int s_voice_state = 0; /* mirror of voice_state_t — checked each iteration */
+static int64_t s_last_send_log_us = 0;
+
+static bool quiescent_state(int st) {
+   /* IDLE=0, CONNECTING=1, READY=2, LISTENING=3, PROCESSING=4, SPEAKING=5, RECONNECTING=6.
+    * Only stream when READY.  IDLE means voice WS isn't up; CONNECTING /
+    * RECONNECTING are transient — WS may flap, no point streaming.
+    * LISTENING/PROCESSING/SPEAKING: mic_task owns I2S. */
+   return (st == 2);
+}
+
+static void wake_stream_task(void *arg) {
+   (void)arg;
+
+   const int WS_MIC_TDM_SAMPLES_LOCAL = WS_MIC_48K_FRAMES * WS_MIC_TDM_CHANNELS;
+   int16_t *tdm_buf =
+       heap_caps_malloc(WS_MIC_TDM_SAMPLES_LOCAL * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   int16_t *mono_buf = heap_caps_malloc(WS_CHUNK_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   uint8_t *wire_buf = heap_caps_malloc(WS_CHUNK_BYTES + VOICE_WAKE_AUDIO_HEADER_LEN,
+                                        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!tdm_buf || !mono_buf || !wire_buf) {
+      ESP_LOGE(TAG, "buffer alloc failed; wake-stream disabled");
+      if (tdm_buf) heap_caps_free(tdm_buf);
+      if (mono_buf) heap_caps_free(mono_buf);
+      if (wire_buf) heap_caps_free(wire_buf);
+      s_task = NULL;
+      vTaskSuspend(NULL);
+      return;
+   }
+
+   ESP_LOGI(TAG, "wake-stream task started (chunk=%d samples)", WS_CHUNK_SAMPLES);
+
+   /* Boot grace — give voice_init + mic_task + audio HW a full second
+    * to settle before we even consider touching I2S.  Avoids racing the
+    * mic_task's I2S enable on the first voice turn after boot. */
+   vTaskDelay(pdMS_TO_TICKS(1500));
+
+   uint32_t frames_sent = 0;
+   while (1) {
+      bool ws_live = (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
+      bool can_pump = s_armed && ws_live && quiescent_state(s_voice_state);
+
+      /* CRITICAL — never touch I2S while mic_task is using it.  The
+       * I2S RX driver is not reentrant; two readers crash the kernel
+       * (Tab5 PANIC, reset_reason=PANIC). */
+      if (can_pump && voice_mic_is_active()) {
+         can_pump = false;
+      }
+
+      if (!can_pump) {
+         vTaskDelay(pdMS_TO_TICKS(100));
+         continue;
+      }
+
+      esp_err_t err = tab5_mic_read(tdm_buf, WS_MIC_TDM_SAMPLES_LOCAL, 100);
+      if (err != ESP_OK) {
+         /* I2S not enabled yet (boot order), or transient — back off. */
+         vTaskDelay(pdMS_TO_TICKS(100));
+         continue;
+      }
+
+      /* Downsample identical to mic_task: take MIC1 slot, average
+       * WS_DOWNSAMPLE_RATIO consecutive samples for the 16 kHz output. */
+      int out_idx = 0;
+      for (int i = 0; i + WS_DOWNSAMPLE_RATIO - 1 < WS_MIC_48K_FRAMES && out_idx < WS_CHUNK_SAMPLES;
+           i += WS_DOWNSAMPLE_RATIO) {
+         int32_t sum = 0;
+         for (int j = 0; j < WS_DOWNSAMPLE_RATIO; j++) {
+            sum += tdm_buf[(i + j) * WS_MIC_TDM_CHANNELS + WS_MIC_TDM_MIC1_OFF];
+         }
+         mono_buf[out_idx++] = (int16_t)(sum / WS_DOWNSAMPLE_RATIO);
+      }
+      if (out_idx == 0) {
+         vTaskDelay(pdMS_TO_TICKS(10));
+         continue;
+      }
+
+      /* Re-check state after the I2S read (which can block ~30 ms).  If
+       * voice transitioned into a turn in the meantime, drop the chunk
+       * — mic_task is now the owner.  Also re-check voice_mic_is_active
+       * to catch the race where mic_task spun up between our pre-check
+       * and the actual read. */
+      if (!quiescent_state(s_voice_state) || voice_mic_is_active()) {
+         continue;
+      }
+
+      size_t body_bytes = (size_t)out_idx * sizeof(int16_t);
+      size_t wire_len = voice_codec_pack_wake_audio(wire_buf, WS_CHUNK_BYTES + VOICE_WAKE_AUDIO_HEADER_LEN, mono_buf,
+                                                    body_bytes);
+      if (wire_len > 0) {
+         err = voice_ws_send_binary(wire_buf, wire_len);
+         if (err == ESP_OK) {
+            frames_sent++;
+            int64_t now = esp_timer_get_time();
+            if (now - s_last_send_log_us > 5 * 1000000) {
+               ESP_LOGI(TAG, "wake-stream pumped %lu frames (last chunk %d samples)", (unsigned long)frames_sent,
+                        out_idx);
+               s_last_send_log_us = now;
+            }
+         } else {
+            /* WS send failed — likely WS dropped between our ws_live
+             * check and now.  Back off a bit then loop, the gating
+             * will catch the disconnect on the next iteration. */
+            vTaskDelay(pdMS_TO_TICKS(100));
+         }
+      }
+   }
+   /* unreachable */
+}
+
+esp_err_t voice_wake_stream_init(void) {
+   if (s_task != NULL) return ESP_OK;
+   BaseType_t ok = xTaskCreatePinnedToCore(wake_stream_task, "voice_wake_stream", WAKE_STREAM_TASK_STACK, NULL,
+                                           WAKE_STREAM_TASK_PRIO, &s_task, WAKE_STREAM_TASK_CORE);
+   if (ok != pdPASS) {
+      ESP_LOGE(TAG, "wake_stream_task spawn failed");
+      s_task = NULL;
+      return ESP_ERR_NO_MEM;
+   }
+   ESP_LOGI(TAG, "init done (disarmed)");
+   return ESP_OK;
+}
+
+void voice_wake_stream_arm(void) {
+   if (s_armed) return;
+   s_armed = true;
+   tab5_debug_obs_event("wake_stream", "arm");
+   ESP_LOGI(TAG, "armed");
+}
+
+void voice_wake_stream_disarm(void) {
+   if (!s_armed) return;
+   s_armed = false;
+   tab5_debug_obs_event("wake_stream", "disarm");
+   ESP_LOGI(TAG, "disarmed");
+}
+
+bool voice_wake_stream_is_active(void) {
+   if (!s_armed || s_task == NULL) return false;
+   if (!quiescent_state(s_voice_state)) return false;
+   return (g_voice_ws != NULL) && esp_websocket_client_is_connected(g_voice_ws);
+}
+
+void voice_wake_stream_on_state_change(int new_state) {
+   s_voice_state = new_state;
+}

--- a/main/voice_wake_stream.h
+++ b/main/voice_wake_stream.h
@@ -1,0 +1,66 @@
+/**
+ * @file voice_wake_stream.h
+ * @brief Tab5 → Dragon mic streaming for wakeword detection (TT #615).
+ *
+ * Path B from PLAN-tab5-mic-to-k144-asr.md: Tab5's ES7210 quad-mic ships
+ * 16 kHz mono PCM continuously to Dragon as WAK0-tagged binary frames
+ * whenever voice WS is connected AND the voice state machine is in a
+ * quiescent state (IDLE/READY).  Dragon runs a sliding-window whisper.cpp
+ * pass on the stream and emits {"type":"wake"} back when it matches
+ * "hey tinker" / "hey thinker" — Tab5 routes that to
+ * ui_home_start_voice_turn() (same path as orb tap).
+ *
+ * Lifecycle:
+ *   - voice_wake_stream_init()    — called once from main.c after voice_init
+ *   - voice_wake_stream_arm()     — start the background task; called when
+ *                                   WS goes READY and the user wants
+ *                                   always-on wake (default on)
+ *   - voice_wake_stream_disarm()  — stop the background task
+ *   - voice_wake_stream_on_state_change() — informs the module of voice
+ *                                   state transitions so it can pause
+ *                                   sending during a real voice turn
+ *                                   (the existing mic_task owns the
+ *                                   mic during LISTENING)
+ *
+ * Mic ownership: only ONE consumer of the I2S RX channel at a time.
+ * When voice_state ∈ {LISTENING, PROCESSING, SPEAKING, RECONNECTING}
+ * the existing mic_task is the active consumer.  The wake-stream task
+ * is paused (no I2S reads).  On the SPEAKING→READY edge the wake-stream
+ * task resumes — though in practice conversation mode (TT #613) will
+ * usually re-listen first, so wake-stream resumes only at the end of
+ * the conversation.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Spawn the wake-stream background task in the suspended state.
+ *  Idempotent; safe to call from any task.  Returns ESP_OK on success. */
+esp_err_t voice_wake_stream_init(void);
+
+/** @brief Allow the wake-stream task to capture + transmit when the
+ *  voice state machine is quiescent.  Has no effect if the task isn't
+ *  initialized yet. */
+void voice_wake_stream_arm(void);
+
+/** @brief Disarm — the task stays alive but won't capture or transmit. */
+void voice_wake_stream_disarm(void);
+
+/** @brief Whether wake-stream is currently armed AND actively pumping
+ *  frames (i.e. armed && voice_state == IDLE/READY && WS connected). */
+bool voice_wake_stream_is_active(void);
+
+/** @brief Inform the module that voice_state has transitioned.  Wake-
+ *  stream needs to know this so it pauses while a real voice turn
+ *  consumes the mic.  Called from voice.c::voice_set_state. */
+void voice_wake_stream_on_state_change(int new_state);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -419,6 +419,19 @@ void voice_async_toast(char *text) {
    tab5_lv_async_call(async_show_toast_cb, t);
 }
 
+/* TT #615 — Dragon-side wake event arriving from voice WS RX (any task).
+ * Marshal onto LVGL so ui_home_start_voice_turn can touch overlay
+ * state safely. */
+static void dispatch_dragon_wake_async_cb(void *arg) {
+   (void)arg;
+   extern esp_err_t ui_home_start_voice_turn(const char *source);
+   (void)ui_home_start_voice_turn("dragon_wake");
+}
+
+void voice_ws_proto_dispatch_dragon_wake_async(void) {
+   tab5_lv_async_call(dispatch_dragon_wake_async_cb, NULL);
+}
+
 /* TT #328 Wave 3 — async fire of ui_home_show_error_banner from voice WS
  * task.  Persistent error banner survives across the 2-3 s toast lifetime
  * so the user can't miss a fatal-state notification (auth lockout, device
@@ -627,6 +640,15 @@ void voice_ws_proto_handle_text(const char *data, int len) {
             voice_set_state(VOICE_STATE_PROCESSING, s_stt_text);
          }
       }
+   } else if (strcmp(type_str, "wake") == 0) {
+      /* TT #615 — Path B wake: Dragon's wake detector matched on the
+       * WAK0-streamed audio and is telling Tab5 to open a real voice
+       * turn.  Route through ui_home_start_voice_turn so it goes
+       * through the same UX wrapper as orb-tap. */
+      ESP_LOGI(TAG, "WS wake frame from Dragon — routing through ui_home_start_voice_turn");
+      tab5_debug_obs_event("wake_stream", "wake_event");
+      extern void voice_ws_proto_dispatch_dragon_wake_async(void);
+      voice_ws_proto_dispatch_dragon_wake_async();
    } else if (strcmp(type_str, "tts_start") == 0) {
       /* Audit #80 DMA leak hunt (wave 9): log heap state at the 5
        * interesting boundaries of a chat turn (llm_done, tts_start,


### PR DESCRIPTION
Tab5 streams mic to Dragon as WAK0 frames; Dragon runs whisper.cpp tiny.en sliding-window wake detection; on `hey tinker` substring match Dragon sends `{"type":"wake"}`; Tab5 routes through `ui_home_start_voice_turn("dragon_wake")` (same UX as orb tap).

## Tab5 side
- new `voice_wake_stream.{c,h}` background task — gates on voice_state==READY AND !voice_mic_is_active() to never race mic_task on I2S
- 1.5 s boot grace before first I2S touch
- Hooked from voice_set_state: arm on first READY, disarm on IDLE/disconnect
- WAK0 wire framing in voice_codec (mirror of AUD0)
- Wake-event RX handler in voice_ws_proto routes through ui_home_start_voice_turn

## Dragon side
- new `dragon_voice/wake_detector.py` — per-connection sliding 1.6 s window + lazy whisper.cpp tiny.en + 3 s post-fire cooldown
- module-level detector cache keyed by `id(ws)` (typed ConnState dataclass rejects unknown keys — module dict avoids it)
- binary_frame_dispatch + server patched to route WAK0 → detector
- Sends `{"type":"wake", "matched":"...", "transcript":"..."}` back

## Known caveats
- Whisper tiny.en takes ~3 s per 1.6 s window on Dragon ARM CPU — detection lags by ~1-2 s.  Wake fires but not instantly.  Real-time would need: Vosk small, openWakeWord ONNX via Pulsar2, or FasterWhisper.
- K144 wake (#576) still running in parallel — disable when Path B is healthy

closes #615