### PR TITLE
feat(wake): wake_src NVS picker — k144/dragon/off runtime switch (closes #617)

### DIFF
--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include "cJSON.h"
+#include "debug_obs.h"             /* tab5_debug_obs_event */
 #include "debug_server_internal.h" /* tab5_debug_check_auth */
 #include "esp_err.h"
 #include "esp_http_server.h"
@@ -29,10 +30,11 @@
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "task_worker.h"     /* tab5_worker_enqueue */
-#include "voice_m5_llm.h"    /* sys_reboot, hwinfo accessor */
-#include "voice_onboard.h"   /* failover state names */
-#include "voice_wakeword.h"  /* status + reconfigure_phrase + transcripts */
+#include "settings.h"       /* TT #617 — wake_src */
+#include "task_worker.h"    /* tab5_worker_enqueue */
+#include "voice_m5_llm.h"   /* sys_reboot, hwinfo accessor */
+#include "voice_onboard.h"  /* failover state names */
+#include "voice_wakeword.h" /* status + reconfigure_phrase + transcripts */
 
 static const char *TAG = "debug_tinkeron";
 
@@ -74,6 +76,24 @@ static bool query_get(httpd_req_t *req, const char *key, char *out, size_t cap) 
    if (httpd_query_key_value(qbuf, key, out, cap) != ESP_OK) return false;
    url_decode_inplace(out);
    return true;
+}
+
+static esp_err_t respond_error(httpd_req_t *req, const char *msg, int status_code) {
+   cJSON *obj = cJSON_CreateObject();
+   cJSON_AddStringToObject(obj, "error", msg ? msg : "");
+   char *body = cJSON_PrintUnformatted(obj);
+   cJSON_Delete(obj);
+   if (body == NULL) {
+      httpd_resp_set_status(req, "500 Internal Server Error");
+      return httpd_resp_sendstr(req, "{\"error\":\"json_print_failed\"}");
+   }
+   char status[32];
+   snprintf(status, sizeof(status), "%d Error", status_code);
+   httpd_resp_set_status(req, status);
+   httpd_resp_set_type(req, "application/json");
+   esp_err_t r = httpd_resp_sendstr(req, body);
+   cJSON_free(body);
+   return r;
 }
 
 static esp_err_t respond_json(httpd_req_t *req, cJSON *obj, int status_code) {
@@ -133,6 +153,60 @@ static esp_err_t handle_status(httpd_req_t *req) {
    }
 
    cJSON_AddNumberToObject(root, "uptime_ms", (double)(esp_timer_get_time() / 1000));
+
+   /* TT #617 — surface current wake source */
+   {
+      char src[16] = {0};
+      tab5_settings_get_wake_src(src, sizeof(src));
+      cJSON_AddStringToObject(root, "wake_src", src);
+   }
+
+   return respond_json(req, root, 200);
+}
+
+/* ── POST /tinkeron/wake_src?src=k144|dragon|off ─────────────────── */
+
+static esp_err_t handle_wake_src(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   char qry[64] = {0};
+   if (httpd_req_get_url_query_str(req, qry, sizeof(qry)) != ESP_OK) {
+      return respond_error(req, "missing src query param", 400);
+   }
+   char src[16] = {0};
+   if (httpd_query_key_value(qry, "src", src, sizeof(src)) != ESP_OK) {
+      return respond_error(req, "missing src= param", 400);
+   }
+   /* Validate against the known set.  Future ext_pcm will land as a new
+    * branch + value here. */
+   if (strcmp(src, "k144") != 0 && strcmp(src, "dragon") != 0 && strcmp(src, "off") != 0) {
+      return respond_error(req, "src must be k144|dragon|off", 400);
+   }
+   esp_err_t e = tab5_settings_set_wake_src(src);
+   if (e != ESP_OK) {
+      return respond_error(req, esp_err_to_name(e), 500);
+   }
+   ESP_LOGI(TAG, "/tinkeron/wake_src: set to %s", src);
+   tab5_debug_obs_event("wake_src", src);
+
+   /* Apply immediately: disarm whatever is wrong, arm whatever is right. */
+   if (strcmp(src, "k144") == 0) {
+      extern void voice_wake_stream_disarm(void);
+      voice_wake_stream_disarm();
+      extern esp_err_t voice_onboard_arm_wakeword(void);
+      voice_onboard_arm_wakeword();
+   } else if (strcmp(src, "dragon") == 0) {
+      voice_wakeword_stop();
+      extern void voice_wake_stream_arm(void);
+      voice_wake_stream_arm();
+   } else { /* off */
+      voice_wakeword_stop();
+      extern void voice_wake_stream_disarm(void);
+      voice_wake_stream_disarm();
+   }
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "status", "applied");
+   cJSON_AddStringToObject(root, "wake_src", src);
    return respond_json(req, root, 200);
 }
 
@@ -284,10 +358,17 @@ void debug_server_tinkeron_register(httpd_handle_t server) {
    static const httpd_uri_t uri_transcripts = {
        .uri = "/tinkeron/transcripts", .method = HTTP_GET, .handler = handle_transcripts, .user_ctx = NULL,
    };
+   static const httpd_uri_t uri_wake_src = {
+       .uri = "/tinkeron/wake_src",
+       .method = HTTP_POST,
+       .handler = handle_wake_src,
+       .user_ctx = NULL,
+   };
    httpd_register_uri_handler(server, &uri_status);
    httpd_register_uri_handler(server, &uri_arm);
    httpd_register_uri_handler(server, &uri_phrase);
    httpd_register_uri_handler(server, &uri_reboot);
    httpd_register_uri_handler(server, &uri_transcripts);
-   ESP_LOGI(TAG, "TinkerON debug family registered (5 endpoints)");
+   httpd_register_uri_handler(server, &uri_wake_src);
+   ESP_LOGI(TAG, "TinkerON debug family registered (6 endpoints)");
 }

--- a/main/settings.c
+++ b/main/settings.c
@@ -486,6 +486,21 @@ esp_err_t tab5_settings_set_llm_model(const char *model)
     return set_str("llm_mdl", model);
 }
 
+/* ── Wake source picker (TT #617) ───────────────────────────────────── */
+
+esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {
+   /* Default "dragon" — Tab5 mic + Dragon whisper.cpp (PR #616).  K144's
+    * onboard mic position is unreliable for cross-room wake until the
+    * ext_pcm unit lands; until then Dragon is the better default.
+    * Override per-deployment via Settings UI or POST /tinkeron/wake_src. */
+   return get_str("wake_src", buf, len, "dragon");
+}
+
+esp_err_t tab5_settings_set_wake_src(const char *src) {
+   if (src == NULL || src[0] == '\0') return ESP_ERR_INVALID_ARG;
+   return set_str("wake_src", src);
+}
+
 /* ── Mic mute ───────────────────────────────────────────────────────── */
 
 uint8_t tab5_settings_get_mic_mute(void)

--- a/main/settings.h
+++ b/main/settings.h
@@ -8,10 +8,12 @@
  */
 #pragma once
 
-#include "esp_err.h"
-#include <stdint.h>
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "esp_err.h"
 
 /**
  * Open the "settings" NVS namespace.  Safe to call repeatedly — only
@@ -179,6 +181,21 @@ esp_err_t tab5_settings_set_voice_mode(uint8_t mode);
 /** Cloud LLM model ID (e.g. "anthropic/claude-3-haiku"). Empty = default. */
 esp_err_t tab5_settings_get_llm_model(char *buf, size_t len);
 esp_err_t tab5_settings_set_llm_model(const char *model);
+
+/** TT #617 — Wake source.  Picks which wakeword detection path runs.
+ *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
+ *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future
+ *  "ext_pcm" (custom K144 unit consuming Tab5 PCM over UART).  Empty
+ *  string → defaults to "dragon" (better mic, post-BSS-overflow-fix). */
+esp_err_t tab5_settings_get_wake_src(char *buf, size_t len);
+esp_err_t tab5_settings_set_wake_src(const char *src);
+
+/** Convenience helpers: parse wake_src and answer which paths should run. */
+static inline bool tab5_settings_wake_src_is(const char *target) {
+   char buf[16];
+   if (tab5_settings_get_wake_src(buf, sizeof(buf)) != ESP_OK) return false;
+   return strcmp(buf, target) == 0;
+}
 
 /* ── Connection mode ────────────────────────────────────────────────── */
 

--- a/main/voice.c
+++ b/main/voice.c
@@ -526,8 +526,15 @@ void voice_set_state(voice_state_t new_state, const char *detail) {
       extern void voice_wake_stream_arm(void);
       extern void voice_wake_stream_disarm(void);
       voice_wake_stream_on_state_change((int)new_state);
+      /* TT #617 — gate on wake_src NVS setting.  Only arm Dragon-side
+       * wake-stream if the user picked "dragon".  k144 / off paths
+       * leave the wake-stream task idling (it stays alive but disarmed
+       * so a runtime wake_src flip from k144 → dragon picks up
+       * without a reboot). */
       if (new_state == VOICE_STATE_READY && old != VOICE_STATE_READY) {
-         voice_wake_stream_arm();
+         if (tab5_settings_wake_src_is("dragon")) {
+            voice_wake_stream_arm();
+         }
       } else if (new_state == VOICE_STATE_IDLE && old != VOICE_STATE_IDLE) {
          voice_wake_stream_disarm();
       }

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -97,6 +97,21 @@ static size_t s_chain_llm_len;
 
 extern void tab5_debug_obs_event(const char *kind, const char *detail);
 
+static void wakeword_event_handler(voice_wakeword_event_t event, const char *text, void *user); /* TT #617 fwd-decl */
+
+/* TT #617 — Gate the K144 onboard wakeword on the wake_src NVS setting.
+ * "k144" → arm sherpa-ncnn on K144's own mic (current default for
+ * offline-capable wake).  Other values ("dragon", "off", future
+ * "ext_pcm") skip arming and let the other path own wake. */
+static esp_err_t voice_onboard_arm_k144_wakeword_internal(void) {
+   if (!tab5_settings_wake_src_is("k144")) {
+      ESP_LOGI(TAG, "wake_src != k144 — skipping K144 onboard wakeword arm");
+      tab5_debug_obs_event("wake_src", "skip_k144");
+      return ESP_OK;
+   }
+   return voice_wakeword_start(NULL, wakeword_event_handler, NULL);
+}
+
 /* ---------------------------------------------------------------------- */
 /*  Wakeword event bridge — voice_wakeword task → LVGL UI                  */
 /*                                                                        */
@@ -347,7 +362,7 @@ static void onboard_warmup_job(void *arg) {
        * end-phrase="save note", 32 KB dictation buffer, 4-hour cap.
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
-      esp_err_t we = voice_wakeword_start(NULL, wakeword_event_handler, NULL);
+      esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
          /* TT #580: post-Tab5-reflash, K144's previous-session audio +
           * asr units are still alive on the daemon.  Daemon refuses
@@ -509,7 +524,7 @@ static void onboard_reset_failover_job(void *arg) {
       /* Wakeword revival: same hook as the initial warmup path — once
        * K144 is reachable again, (re-)arm the always-on ASR chain.
        * Idempotent (start refuses if already running). */
-      esp_err_t we = voice_wakeword_start(NULL, wakeword_event_handler, NULL);
+      esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
          /* TT #580: still wedged after THIS reset.  Queue another (the
           * retry budget caps at 3/boot). */
@@ -798,7 +813,7 @@ static void onboard_chain_drain_task(void *arg) {
     * audio + asr units.  Idempotent (start refuses if already running),
     * and only meaningful if user has flipped back to a Dragon-using
     * vmode where wakeword is wanted — but cheap to call regardless. */
-   esp_err_t we = voice_wakeword_start(NULL, wakeword_event_handler, NULL);
+   esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
    if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
       ESP_LOGW(TAG, "wakeword re-arm after chain stop skipped: %s",
                esp_err_to_name(we));
@@ -902,5 +917,5 @@ int64_t voice_onboard_chain_uptime_ms(void) {
 esp_err_t voice_onboard_arm_wakeword(void) {
    if (s_m5_failover == M5_FAIL_UNAVAILABLE) return ESP_ERR_INVALID_STATE;
    voice_m5_llm_release();
-   return voice_wakeword_start(NULL, wakeword_event_handler, NULL);
+   return voice_onboard_arm_k144_wakeword_internal();
 }


### PR DESCRIPTION
## Summary
Lets the user pick which wakeword path runs at runtime, without recompile or reboot.

```
# K144 onboard (offline-capable, uses K144 mic)
curl -X POST 'http://Tab5:8080/tinkeron/wake_src?src=k144' -H 'Authorization: Bearer ...'

# Dragon-side whisper.cpp on Tab5 mic (better mic, needs WS)
curl -X POST 'http://Tab5:8080/tinkeron/wake_src?src=dragon' -H 'Authorization: Bearer ...'

# Off (orb tap only)
curl -X POST 'http://Tab5:8080/tinkeron/wake_src?src=off' -H 'Authorization: Bearer ...'
```

## Behavior
- New NVS key `wake_src` (default 'dragon')
- `tab5_settings_wake_src_is()` inline helper for gating
- K144 wakeword start gated via new `voice_onboard_arm_k144_wakeword_internal()` wrapper
- Dragon wake-stream arm gated in `voice_set_state` SPEAKING→READY edge
- `POST /tinkeron/wake_src` endpoint applies the switch immediately (disarm wrong path, arm right path)
- `GET /tinkeron/status` JSON surfaces the active wake_src

## Future
Once Path A custom K144 ext_pcm unit ships (task #131), add `ext_pcm` as a fourth value here — same gating mechanism.

Closes #617