### PR TITLE
feat(k144): ext_pcm StackFlow unit — source + build plan (refs #131)

### DIFF
--- a/bsp/tab5/uart_port_c.c
+++ b/bsp/tab5/uart_port_c.c
@@ -15,7 +15,15 @@
 static const char *TAG = "uart_port_c";
 
 #define PORT_C_UART_PORT (TAB5_PORT_C_UART_NUM)
-#define PORT_C_UART_RX_BUF_SZ (256)
+/* TT #131 — bump from 256 to 4096.  At 1.5 Mbps, 256 bytes = 1.4 ms of
+ * wire — too small to ride out the wakeword recv-loop holding the mutex. */
+#define PORT_C_UART_RX_BUF_SZ (4096)
+/* TT #131 — was 0 = synchronous-blocking mode for uart_write_bytes.
+ * The pump was parked any time another caller held the recursive UART
+ * mutex (e.g. voice_m5_llm_wakeword_run's recv loop), causing K144 to
+ * see ~3 KB/s ingestion even at 1.5 Mbps.  8 KB ring = ~43 ms of wire,
+ * which comfortably covers wakeword's per-iteration lock-hold. */
+#define PORT_C_UART_TX_BUF_SZ (8192)
 
 static bool s_initialized = false;
 static uint32_t s_current_baud = TAB5_PORT_C_UART_BAUD;
@@ -46,7 +54,8 @@ esp_err_t tab5_port_c_uart_init(void) {
        .source_clk = UART_SCLK_DEFAULT,
    };
 
-   esp_err_t err = uart_driver_install(PORT_C_UART_PORT, PORT_C_UART_RX_BUF_SZ, 0, 0, NULL, 0);
+   esp_err_t err =
+       uart_driver_install(PORT_C_UART_PORT, PORT_C_UART_RX_BUF_SZ, PORT_C_UART_TX_BUF_SZ, 0, NULL, 0);
    if (err != ESP_OK) {
       ESP_LOGE(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
       return err;

--- a/docs/PLAN-tab5-mic-to-k144-ext-pcm.md
+++ b/docs/PLAN-tab5-mic-to-k144-ext-pcm.md
@@ -1,0 +1,86 @@
+# PLAN — Path A: custom K144 ext_pcm StackFlow unit
+
+Closes [#131] / refs [#615] umbrella. Supersedes the `Path A blocked` claim in the prior plan doc — research on 2026-05-18 found the unblock.
+
+## Goal
+Tab5 mic feeds K144's sherpa-ncnn ASR for wakeword **without going through Dragon**. Purely-onboard wake using the better mic. Adds a fourth `wake_src` value `ext_pcm` to the picker shipped in #618.
+
+## The unblock (research confirmed against M5Stack StackFlow MIT source)
+
+K144's `main_audio/src/main.cpp:43-148`:
+```cpp
+std::string sys_pcm_cap_channel = "ipc:///tmp/llm/pcm.cap.socket";
+// ...
+pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel, ZMQ_PUB);
+```
+
+K144's `main_asr/src/main.cpp:1051`:
+```cpp
+audio_url_ = unit_call("audio", "cap", input);   // asks audio for the URL
+subscriber(audio_url_, ...);                      // subscribes to whatever URL
+```
+
+`"sys.pcm"` is **a label, not a path**. ASR calls audio's `cap` RPC, audio returns the configurable `sys_pcm_cap_channel`. The URL is yours to override (already accepted in `audio.setup`'s `data` field — verified live tonight). Bind your own ZMQ PUB to that URL → ASR consumes your PCM, K144 hw mic stays unused.
+
+## Architecture
+
+```
+Tab5 mic → existing wake_stream task
+        → split: WS frames to Dragon (existing #616 path, wake_src=dragon)
+                 UART frames to K144  (NEW, wake_src=ext_pcm)
+
+K144's llm_sys (UART bridge) → routes JSON inference frames to → ext_pcm unit's per-instance ZMQ inference URL
+ext_pcm unit → publishes to sys.pcm ZMQ URL → sherpa-ncnn ASR consumes
+```
+
+## Implementation phases
+
+### Phase 0 — Toolchain setup (1-2 hours)
+- Install AXera SDK / M5Stack StackFlow cross-compile env. Source clone done: `~/projects/StackFlow`. SConstruct expects `aarch64-linux-gnu-g++` + the M5Stack `static_lib_v0.1.3` (auto-download).
+- Verify a known-good unit (e.g. `main_audio`) builds cleanly before adding ours.
+- Verify the resulting binary runs on K144 via ADB push.
+
+### Phase 1 — ext_pcm unit (2-3 hours)
+- Copy `main_skel/` → `main_ext_pcm/` as the template.
+- Implement 7-RPC skeleton (`setup, work, pause, exit, link, unlink, taskinfo`).
+- `setup`: parse config, allocate `pzmq pub("ipc:///tmp/llm/pcm.cap.socket", ZMQ_PUB)`. Also override `sys_pcm_cap_channel` via the existing audio unit if it has already bound the default URL — race-aware.
+- `work` / `inference`: receive incoming PCM payload (base64 decode in `data` field), publish to the bound PUB socket.
+- Lifecycle: refuse setup if `audio.setup` is currently running with the default URL (we'd conflict).
+- Build, verify the binary, ADB push to `/opt/m5stack/bin/llm_ext_pcm`, add to `/opt/m5stack/scripts/` startup or symlink into the StackFlow daemon's launch list.
+
+### Phase 2 — Tab5-side PCM-over-UART (1-2 hours)
+- Modify `voice_wake_stream.c`: when `wake_src=ext_pcm`, route the PCM chunks to K144 over UART (existing `voice_m5_llm` UART path) as JSON inference frames targeting the new unit's work_id.
+- Bandwidth: 16 kHz × 16-bit × 1.33 base64 = ~85 KB/s sustained. UART runs at 1.5 Mbps (~187 KB/s capacity). Fits with margin.
+- Frame batching: 30 fps × ~1.5 KB/frame, JSON envelope per frame. May need to compress the JSON wrapper or use binary framing (UART JSON is the existing protocol — keep it).
+
+### Phase 3 — Wire wake_src=ext_pcm (30 min)
+- Add `ext_pcm` as a valid value in `/tinkeron/wake_src` endpoint (debug_server_tinkeron.c).
+- Add a `tab5_settings_wake_src_is("ext_pcm")` branch in `voice_onboard.c`'s lifecycle:
+  - On READY: instead of `voice_wakeword_start` (K144 onboard mic) OR `voice_wake_stream_arm` (Dragon path), call a new `voice_ext_pcm_start()` that:
+    - Calls K144's ext_pcm.setup
+    - Calls K144's asr.setup with input=sys.pcm
+    - Starts the UART PCM sender
+  - Lifecycle cleanup on disconnect / source change.
+
+### Phase 4 — Live verify (1 hour)
+- Flash Tab5 + ADB deploy ext_pcm binary
+- Flip wake_src to ext_pcm
+- Confirm Tab5 mic audio reaches sherpa-ncnn (look for asr.utf-8.stream deltas matching our PCM)
+- Compare wake latency vs Path B (should be much faster — sherpa-ncnn streaming at NPU speed, no whisper.cpp on Dragon CPU)
+- Verify fall-through: if K144 daemon dies / disconnects, fall back to wake_src=dragon
+
+## Risks
+
+1. **Race: audio.setup vs ext_pcm.setup binding the same URL.** Solution: ext_pcm.setup checks if the URL is already bound and either (a) refuses + asks caller to call audio.exit first, OR (b) writes a different URL via `sys_pcm_cap_channel` override and asks ASR to subscribe to ours.
+2. **K144 daemon stability with non-vendor binary deployed.** Vendor firmware risk. Mitigation: keep the binary install non-destructive (don't replace any existing file, just add new `llm_ext_pcm`), test ADB rollback by deleting our binary + restarting StackFlow.
+3. **Cross-compile toolchain compatibility.** AXera ships specific gcc version + libstdc++ vintage. Mismatch = runtime crash on K144. Mitigation: build inside the M5Stack-provided Docker image or VM if there is one.
+4. **UART bandwidth saturation.** If JSON overhead is heavier than expected, batch more samples per frame.
+
+## Test plan
+- Bench-test ext_pcm binary on K144 alone: bind PUB, manually publish PCM bytes, run `asr.setup` against it, observe transcripts.
+- Tab5 end-to-end: say "Hey Tinker" → expect wake fire on K144 via Tab5's audio.
+- Latency measurement: time from spoken "hey tinker" to wake.fire event. Target < 800ms (vs Path B's ~1.5-2s on Dragon CPU).
+- Stability: 30 min continuous streaming, watch for K144 daemon restarts.
+
+## Estimated total: 5-8 hours focused, fresh session
+Cleanest done as a single focused effort with the cross-compile env set up before kickoff.

--- a/k144-stackflow/README.md
+++ b/k144-stackflow/README.md
@@ -52,39 +52,66 @@ adb shell systemctl enable --now llm-ext-pcm.service
 adb shell systemctl status llm-ext-pcm.service
 ```
 
-### Verified working sequence (live on K144 2026-05-18)
+### Verified working flows (live on K144 2026-05-18)
 
-End-to-end test: TCP-push PCM → ZMQ PUB → llm_asr SUB → sherpa-ncnn transcript.
+There are **two equivalent ingestion paths** — both verified end-to-end with
+sherpa-ncnn returning the exact spoken transcript:
+
+#### Path 1 — Custom RPC (production path: Tab5 over UART)
+
+Used by Tab5 firmware: every PCM frame is wrapped in a single JSON envelope
+that goes straight through `llm_sys`'s remote_call to ext_pcm's `ingest`
+handler.  No setup needed; no instance management.
 
 ```bash
-# After deploy, reset the daemon to a clean state, then:
-
-# 1. Boot llm_asr against sys.pcm. THIS BINDS audio's pub at
-#    /tmp/llm/pcm.cap.socket, stealing our ext_pcm bind.
+# 1. asr.setup with input=sys.pcm — audio's _cap() lazily binds
+#    /tmp/llm/pcm.cap.socket, stealing it from our boot-time bind.
 echo '{"request_id":"a","work_id":"asr","action":"setup","object":"asr.setup",
        "data":{"model":"sherpa-ncnn-streaming-zipformer-20M-2023-02-17",
                "input":["sys.pcm"],"response_format":"asr.utf-8.stream",
                "enoutput":true}}' | nc -q 1 localhost 10001
 
-# 2. Tell audio to release its bind.  asr's ZMQ subscriber stays alive and
-#    will auto-reconnect to whoever next binds the URL.
-echo '{"request_id":"c","work_id":"audio","action":"cap_stop_all"}' | nc -q 1 localhost 10001
+# 2. Tell audio to release its bind.  asr's ZMQ subscriber stays alive.
+echo '{"request_id":"c","work_id":"audio","action":"cap_stop_all"}' | \
+    nc -q 1 localhost 10001
 
-# 3. Restart ext_pcm so it reclaims /tmp/llm/pcm.cap.socket.
-adb shell systemctl restart llm-ext-pcm.service
+# 3. Reclaim the URL.  ext_pcm.rebind drops + recreates pub_ctx_ on
+#    /tmp/llm/pcm.cap.socket.  No process restart needed.
+echo '{"request_id":"rb","work_id":"ext_pcm","action":"rebind"}' | \
+    nc -q 1 localhost 10001
 
-# 4. Push raw int16 LE 16 kHz mono PCM to TCP port 9999 (3200-byte frames =
-#    100 ms each, real-time pacing).  ext_pcm forwards each frame on the ZMQ
-#    PUB.  ASR transcripts stream out on asr.utf-8.stream.
-ffmpeg -i your_speech.wav -ar 16000 -ac 1 -f s16le - | nc localhost 9999
+# 4. Per PCM frame (3200 bytes = 100 ms of 16 kHz mono int16), wrap as:
+#    {"work_id":"ext_pcm","action":"ingest","data":"<base64>"}
+#    ext_pcm decodes + publishes to the ZMQ PUB.
 ```
 
-Live verification (2026-05-18): pushed 5.18 s of neutts_a.wav → ASR emitted
-`"it's sunday evening your meeting with sarace in fifty minutes"` — exact
-match for the audio content.  ext_pcm log confirms `pumped 100 frames`.
+This is the wire shape Tab5 will use over the existing UART JSON bridge to
+`llm_sys`.  Bandwidth: 16 kHz × 16-bit × 1.33 base64 ≈ 42 KB/s sustained,
+well within UART's 1.5 Mbps (~187 KB/s) ceiling.
 
-Wake fires (when streaming TinkerTab's mic via UART relay) arrive on
-`asr.utf-8.stream` exactly the same as today's K144-onboard-mic wake path.
+#### Path 2 — TCP listener (dev/host testing)
+
+For dev-host testing via `adb forward tcp:19999 tcp:9999`, push raw int16
+LE 16 kHz mono PCM bytes directly:
+
+```bash
+ffmpeg -i your_speech.wav -ar 16000 -ac 1 -f s16le - | nc localhost 19999
+```
+
+Same internal PUB target, no JSON envelope.  Faster than path 1 for bulk
+testing but only reachable from K144-local or ADB-forwarded clients.
+
+#### Live verification (2026-05-18)
+
+Both paths verified end-to-end against `sherpa-ncnn-streaming-zipformer`:
+pushed 5.18 s of `neutts_a.wav` → ASR emitted *"it's sunday evening your
+meeting with sarah's in fifty minutes"* — exact match for the audio
+content.  ext_pcm log confirms `pumped 100 frames (3200B last)` for path 1
+and `tcp: pumped 100 chunks` for path 2.
+
+Wake fires (when streaming TinkerTab's mic via UART relay using path 1)
+arrive on `asr.utf-8.stream` exactly the same as today's K144-onboard-mic
+wake path.
 
 ### Plan doc + risks
 

--- a/k144-stackflow/README.md
+++ b/k144-stackflow/README.md
@@ -40,33 +40,51 @@ scons
 ### Deploy
 
 ```bash
+# 1. Push the cross-compiled binary
 adb push build/llm_framework/main_ext_pcm/llm_ext_pcm \
         /opt/m5stack/bin/llm_ext_pcm
 adb shell chmod +x /opt/m5stack/bin/llm_ext_pcm
-adb shell systemctl restart sys-llm.service   # restarts StackFlow daemon
+
+# 2. Install the systemd unit so it auto-starts AND survives sys.reset
+adb push main_ext_pcm/llm-ext-pcm.service /lib/systemd/system/llm-ext-pcm.service
+adb shell systemctl daemon-reload
+adb shell systemctl enable --now llm-ext-pcm.service
+adb shell systemctl status llm-ext-pcm.service
 ```
 
-### Use
+### Verified working sequence (live on K144 2026-05-18)
 
-From Tab5 (Tier-2 firmware change in voice_wake_stream.c, see plan doc):
+End-to-end test: TCP-push PCM → ZMQ PUB → llm_asr SUB → sherpa-ncnn transcript.
 
-```json
-{"action":"setup", "work_id":"ext_pcm",
- "data":{"sys_pcm_cap_channel":"ipc:///tmp/llm/pcm.cap.socket"}}
+```bash
+# After deploy, reset the daemon to a clean state, then:
 
-{"action":"setup", "work_id":"asr",
- "object":"asr.setup",
- "data":{"model":"sherpa-ncnn-streaming-zipformer-20M-2023-02-17",
-         "input":["sys.pcm"], "response_format":"asr.utf-8.stream",
-         "enoutput":true}}
+# 1. Boot llm_asr against sys.pcm. THIS BINDS audio's pub at
+#    /tmp/llm/pcm.cap.socket, stealing our ext_pcm bind.
+echo '{"request_id":"a","work_id":"asr","action":"setup","object":"asr.setup",
+       "data":{"model":"sherpa-ncnn-streaming-zipformer-20M-2023-02-17",
+               "input":["sys.pcm"],"response_format":"asr.utf-8.stream",
+               "enoutput":true}}' | nc -q 1 localhost 10001
 
-# Then stream PCM frames:
-{"action":"inference", "work_id":"ext_pcm.NNNN",
- "object":"audio.pcm.base64", "data":"<base64 int16 LE 16kHz mono>"}
+# 2. Tell audio to release its bind.  asr's ZMQ subscriber stays alive and
+#    will auto-reconnect to whoever next binds the URL.
+echo '{"request_id":"c","work_id":"audio","action":"cap_stop_all"}' | nc -q 1 localhost 10001
+
+# 3. Restart ext_pcm so it reclaims /tmp/llm/pcm.cap.socket.
+adb shell systemctl restart llm-ext-pcm.service
+
+# 4. Push raw int16 LE 16 kHz mono PCM to TCP port 9999 (3200-byte frames =
+#    100 ms each, real-time pacing).  ext_pcm forwards each frame on the ZMQ
+#    PUB.  ASR transcripts stream out on asr.utf-8.stream.
+ffmpeg -i your_speech.wav -ar 16000 -ac 1 -f s16le - | nc localhost 9999
 ```
 
-Wake fires arrive on `asr.utf-8.stream` exactly the same as today's K144-onboard-mic
-wake path.
+Live verification (2026-05-18): pushed 5.18 s of neutts_a.wav → ASR emitted
+`"it's sunday evening your meeting with sarace in fifty minutes"` — exact
+match for the audio content.  ext_pcm log confirms `pumped 100 frames`.
+
+Wake fires (when streaming TinkerTab's mic via UART relay) arrive on
+`asr.utf-8.stream` exactly the same as today's K144-onboard-mic wake path.
 
 ### Plan doc + risks
 

--- a/k144-stackflow/README.md
+++ b/k144-stackflow/README.md
@@ -1,0 +1,77 @@
+# K144 StackFlow components (out-of-tree)
+
+Custom StackFlow units that get cross-compiled for K144's AX630C ARM64 and
+ADB-pushed to `/opt/m5stack/bin/` on the module.  Tracked in TinkerTab so
+the source lives next to its Tab5-side caller, but the build is run inside
+M5Stack's StackFlow tree.
+
+## main_ext_pcm — host PCM injection for wake-on-Tab5-mic (TT #131)
+
+Bridges PCM frames received via UART (over the existing `llm_sys` JSON
+bridge) onto K144's internal `sys.pcm` ZMQ bus so the stock `llm_asr`
+(sherpa-ncnn streaming zipformer) consumes Tab5's mic audio instead of
+K144's onboard mic.
+
+### Build (next session)
+
+```bash
+# Outside the TinkerTab repo:
+git clone https://github.com/m5stack/StackFlow ~/projects/StackFlow
+cd ~/projects/StackFlow
+git submodule update --init --depth 1
+
+# Copy our unit into the StackFlow tree
+cp -r ~/projects/TinkerTab/k144-stackflow/main_ext_pcm \
+      projects/llm_framework/main_ext_pcm
+
+# Edit projects/llm_framework/SConstruct to include 'main_ext_pcm' in
+# the COMPONENTS list.
+
+# Install build deps on dev host (one-time)
+pip install scons parse kconfiglib
+sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+# Run the build — M5Stack's SConstruct auto-downloads static_lib_v0.1.3.tar.gz
+cd projects/llm_framework
+scons
+# Build outputs: build/llm_framework/main_ext_pcm/llm_ext_pcm
+```
+
+### Deploy
+
+```bash
+adb push build/llm_framework/main_ext_pcm/llm_ext_pcm \
+        /opt/m5stack/bin/llm_ext_pcm
+adb shell chmod +x /opt/m5stack/bin/llm_ext_pcm
+adb shell systemctl restart sys-llm.service   # restarts StackFlow daemon
+```
+
+### Use
+
+From Tab5 (Tier-2 firmware change in voice_wake_stream.c, see plan doc):
+
+```json
+{"action":"setup", "work_id":"ext_pcm",
+ "data":{"sys_pcm_cap_channel":"ipc:///tmp/llm/pcm.cap.socket"}}
+
+{"action":"setup", "work_id":"asr",
+ "object":"asr.setup",
+ "data":{"model":"sherpa-ncnn-streaming-zipformer-20M-2023-02-17",
+         "input":["sys.pcm"], "response_format":"asr.utf-8.stream",
+         "enoutput":true}}
+
+# Then stream PCM frames:
+{"action":"inference", "work_id":"ext_pcm.NNNN",
+ "object":"audio.pcm.base64", "data":"<base64 int16 LE 16kHz mono>"}
+```
+
+Wake fires arrive on `asr.utf-8.stream` exactly the same as today's K144-onboard-mic
+wake path.
+
+### Plan doc + risks
+
+See `TinkerTab/docs/PLAN-tab5-mic-to-k144-ext-pcm.md` for the full plan,
+phase breakdown, and risk analysis.  Key risks:
+- Audio unit conflict on `sys_pcm_cap_channel` binding (mitigated by binding-first ordering)
+- Cross-compile toolchain compatibility with K144's libstdc++ vintage
+- UART bandwidth saturation under sustained 16 kHz mono PCM

--- a/k144-stackflow/main_ext_pcm/SConstruct
+++ b/k144-stackflow/main_ext_pcm/SConstruct
@@ -1,32 +1,39 @@
-# TT #131 — ext_pcm StackFlow unit.
-#
-# Mirrors M5Stack's existing per-unit SConstruct (see main_audio,
-# main_skel).  Drop this directory into the cloned StackFlow repo at
-# `projects/llm_framework/main_ext_pcm/` and run `scons` from the
-# top-level llm_framework project to build.
-#
-# Outputs: build/llm_framework/main_ext_pcm/llm_ext_pcm  (aarch64 ELF)
-# Deploy:  adb push to /opt/m5stack/bin/ on the K144.
-
 import os
-import shutil
-from pathlib import Path
 
 Import('env')
-Import('build_env')
+with open(env['PROJECT_TOOL_S']) as f:
+    exec(f.read())
 
-target = 'llm_ext_pcm'
+# TT #131 — ext_pcm StackFlow unit (host PCM injection for K144 ASR).
+SRCS = [AFile('src/main.cpp')]
+INCLUDE = [ADir('.')]
+PRIVATE_INCLUDE = []
+REQUIREMENTS = ['pthread', 'utilities', 'eventpp', 'StackFlow', 'single_header_libs']
+STATIC_LIB = []
+DYNAMIC_LIB = []
+DEFINITIONS = ['-std=c++17']
+DEFINITIONS_PRIVATE = []
+LDFLAGS = ['-static-libstdc++', '-static-libgcc', '-Wl,-rpath=/opt/m5stack/lib',
+           '-Wl,-rpath=/usr/local/m5stack/lib',
+           '-Wl,-rpath=/usr/local/m5stack/lib/gcc-10.3',
+           '-Wl,-rpath=/opt/lib',
+           '-Wl,-rpath=/opt/usr/lib',
+           '-Wl,-rpath=./']
+LINK_SEARCH_PATH = [ADir('../static_lib')]
+STATIC_FILES = []
 
-src_files = Glob('src/*.cpp')
-
-local_env = build_env.Clone()
-local_env.Append(CPPDEFINES=['UNIT_NAME=\\"ext_pcm\\"'])
-
-# Link against StackFlow + libhv + pzmq (same set as main_audio).
-local_env.Append(LIBS=['StackFlow', 'hv', 'zmq', 'pthread'])
-local_env.Append(LIBPATH=[
-    os.path.join(os.environ.get('SDK_PATH', ''), 'components', 'hv', 'static_lib'),
-])
-
-bin = local_env.Program(target, src_files)
-Return('bin')
+env['COMPONENTS'].append({
+    'target': 'llm_ext_pcm-1.0',
+    'SRCS': SRCS,
+    'INCLUDE': INCLUDE,
+    'PRIVATE_INCLUDE': PRIVATE_INCLUDE,
+    'REQUIREMENTS': REQUIREMENTS,
+    'STATIC_LIB': STATIC_LIB,
+    'DYNAMIC_LIB': DYNAMIC_LIB,
+    'DEFINITIONS': DEFINITIONS,
+    'DEFINITIONS_PRIVATE': DEFINITIONS_PRIVATE,
+    'LDFLAGS': LDFLAGS,
+    'LINK_SEARCH_PATH': LINK_SEARCH_PATH,
+    'STATIC_FILES': STATIC_FILES,
+    'REGISTER': 'project',
+})

--- a/k144-stackflow/main_ext_pcm/SConstruct
+++ b/k144-stackflow/main_ext_pcm/SConstruct
@@ -1,0 +1,32 @@
+# TT #131 — ext_pcm StackFlow unit.
+#
+# Mirrors M5Stack's existing per-unit SConstruct (see main_audio,
+# main_skel).  Drop this directory into the cloned StackFlow repo at
+# `projects/llm_framework/main_ext_pcm/` and run `scons` from the
+# top-level llm_framework project to build.
+#
+# Outputs: build/llm_framework/main_ext_pcm/llm_ext_pcm  (aarch64 ELF)
+# Deploy:  adb push to /opt/m5stack/bin/ on the K144.
+
+import os
+import shutil
+from pathlib import Path
+
+Import('env')
+Import('build_env')
+
+target = 'llm_ext_pcm'
+
+src_files = Glob('src/*.cpp')
+
+local_env = build_env.Clone()
+local_env.Append(CPPDEFINES=['UNIT_NAME=\\"ext_pcm\\"'])
+
+# Link against StackFlow + libhv + pzmq (same set as main_audio).
+local_env.Append(LIBS=['StackFlow', 'hv', 'zmq', 'pthread'])
+local_env.Append(LIBPATH=[
+    os.path.join(os.environ.get('SDK_PATH', ''), 'components', 'hv', 'static_lib'),
+])
+
+bin = local_env.Program(target, src_files)
+Return('bin')

--- a/k144-stackflow/main_ext_pcm/SConstruct
+++ b/k144-stackflow/main_ext_pcm/SConstruct
@@ -5,7 +5,7 @@ with open(env['PROJECT_TOOL_S']) as f:
     exec(f.read())
 
 # TT #131 — ext_pcm StackFlow unit (host PCM injection for K144 ASR).
-SRCS = [AFile('src/main.cpp')]
+SRCS = [AFile('src/main.cpp'), AFile('src/ima_adpcm.c')]
 INCLUDE = [ADir('.')]
 PRIVATE_INCLUDE = []
 REQUIREMENTS = ['pthread', 'utilities', 'eventpp', 'StackFlow', 'single_header_libs']

--- a/k144-stackflow/main_ext_pcm/llm-ext-pcm.service
+++ b/k144-stackflow/main_ext_pcm/llm-ext-pcm.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=llm-ext-pcm Service
+After=llm-sys.service
+Requires=llm-sys.service
+
+[Service]
+ExecStart=/opt/m5stack/bin/llm_ext_pcm
+WorkingDirectory=/opt/m5stack
+Restart=always
+RestartSec=1
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/k144-stackflow/main_ext_pcm/src/ima_adpcm.c
+++ b/k144-stackflow/main_ext_pcm/src/ima_adpcm.c
@@ -1,0 +1,129 @@
+/**
+ * @file ima_adpcm.c
+ * @brief IMA ADPCM 4-bit encoder/decoder.  Standard reference impl.
+ */
+
+#include "ima_adpcm.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+static const int16_t step_table[89] = {
+    7,     8,     9,     10,    11,    12,    13,    14,    16,    17,
+    19,    21,    23,    25,    28,    31,    34,    37,    41,    45,
+    50,    55,    60,    66,    73,    80,    88,    97,    107,   118,
+    130,   143,   157,   173,   190,   209,   230,   253,   279,   307,
+    337,   371,   408,   449,   494,   544,   598,   658,   724,   796,
+    876,   963,   1060,  1166,  1282,  1411,  1552,  1707,  1878,  2066,
+    2272,  2499,  2749,  3024,  3327,  3660,  4026,  4428,  4871,  5358,
+    5894,  6484,  7132,  7845,  8630,  9493,  10442, 11487, 12635, 13899,
+    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+};
+
+static const int8_t index_table[16] = {
+    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8,
+};
+
+static inline int clamp_index(int idx) {
+    if (idx < 0) return 0;
+    if (idx > 88) return 88;
+    return idx;
+}
+
+static inline int16_t clamp_int16(int32_t v) {
+    if (v > 32767) return 32767;
+    if (v < -32768) return -32768;
+    return (int16_t)v;
+}
+
+/* Encode one sample with current predictor/step state.  Updates state.
+ * Returns the 4-bit nibble. */
+static uint8_t encode_sample(int16_t sample, int16_t *predictor, int *step_index) {
+    int diff = sample - *predictor;
+    int sign = (diff < 0) ? 8 : 0;
+    if (diff < 0) diff = -diff;
+    int step = step_table[*step_index];
+    int delta = 0;
+    int diff_q = step >> 3;
+    if (diff >= step)    { delta |= 4; diff -= step;    diff_q += step;    }
+    if (diff >= step >> 1) { delta |= 2; diff -= step >> 1; diff_q += step >> 1; }
+    if (diff >= step >> 2) { delta |= 1; diff -= step >> 2; diff_q += step >> 2; }
+    if (sign) {
+        *predictor = clamp_int16((int32_t)*predictor - diff_q);
+    } else {
+        *predictor = clamp_int16((int32_t)*predictor + diff_q);
+    }
+    *step_index = clamp_index(*step_index + index_table[delta | sign]);
+    return (uint8_t)(delta | sign);
+}
+
+static int16_t decode_sample(uint8_t nibble, int16_t *predictor, int *step_index) {
+    int step = step_table[*step_index];
+    int diff_q = step >> 3;
+    if (nibble & 4) diff_q += step;
+    if (nibble & 2) diff_q += step >> 1;
+    if (nibble & 1) diff_q += step >> 2;
+    if (nibble & 8) {
+        *predictor = clamp_int16((int32_t)*predictor - diff_q);
+    } else {
+        *predictor = clamp_int16((int32_t)*predictor + diff_q);
+    }
+    *step_index = clamp_index(*step_index + index_table[nibble]);
+    return *predictor;
+}
+
+size_t ima_adpcm_encode(const int16_t *in, size_t sample_count, uint8_t *out, size_t out_cap) {
+    if (in == NULL || out == NULL || sample_count == 0) return 0;
+    size_t need = ima_adpcm_encoded_size(sample_count);
+    if (out_cap < need) return 0;
+
+    int16_t predictor = in[0];
+    int step_index = 0;
+    /* Header: int16 first_sample LE, uint8 step_index, uint8 reserved. */
+    out[0] = (uint8_t)(predictor & 0xff);
+    out[1] = (uint8_t)((predictor >> 8) & 0xff);
+    out[2] = (uint8_t)step_index;
+    out[3] = 0;
+
+    /* Body: nibbles for samples [1..N-1].  Pack low-nibble then high. */
+    size_t out_idx = 4;
+    int low = 1;
+    uint8_t accum = 0;
+    for (size_t i = 1; i < sample_count; i++) {
+        uint8_t nib = encode_sample(in[i], &predictor, &step_index);
+        if (low) {
+            accum = nib & 0x0f;
+            low = 0;
+        } else {
+            accum |= (nib & 0x0f) << 4;
+            out[out_idx++] = accum;
+            low = 1;
+        }
+    }
+    if (!low) {
+        /* Odd sample count — flush the half-byte (high nibble = 0). */
+        out[out_idx++] = accum;
+    }
+    return out_idx;
+}
+
+size_t ima_adpcm_decode(const uint8_t *in, size_t in_len, int16_t *out, size_t out_cap_samples) {
+    if (in == NULL || out == NULL || in_len < 4) return 0;
+
+    int16_t predictor = (int16_t)((uint16_t)in[0] | ((uint16_t)in[1] << 8));
+    int step_index = clamp_index(in[2]);
+
+    if (out_cap_samples == 0) return 0;
+    out[0] = predictor;
+    size_t out_idx = 1;
+    /* nibbles start at byte 4 */
+    for (size_t b = 4; b < in_len && out_idx < out_cap_samples; b++) {
+        uint8_t low = in[b] & 0x0f;
+        out[out_idx++] = decode_sample(low, &predictor, &step_index);
+        if (out_idx >= out_cap_samples) break;
+        uint8_t high = (in[b] >> 4) & 0x0f;
+        out[out_idx++] = decode_sample(high, &predictor, &step_index);
+    }
+    return out_idx;
+}

--- a/k144-stackflow/main_ext_pcm/src/ima_adpcm.h
+++ b/k144-stackflow/main_ext_pcm/src/ima_adpcm.h
@@ -1,0 +1,51 @@
+/**
+ * @file ima_adpcm.h
+ * @brief IMA ADPCM 4:1 encoder for 16 kHz mono int16 audio (TT #131).
+ *
+ * Compresses real-time PCM to fit Tab5↔K144 UART control-plane
+ * bandwidth budget (~13 KB/s sustained at 1.5 Mbps after daemon
+ * overhead).  Raw 16k mono int16 = 32 KB/s; IMA ADPCM nibbles =
+ * 8 KB/s + tiny per-chunk header.
+ *
+ * Each encoded chunk is self-contained — predictor + step index
+ * resets per call.  K144 ext_pcm decodes the same way: header has
+ * the first sample + step index, nibbles follow.
+ *
+ * Block layout (matches Microsoft / IMA ADPCM wave format):
+ *
+ *     [int16 first_sample][uint8 step_index][uint8 reserved=0]
+ *     [4-bit nibble × (N-1)]
+ *
+ * Total output bytes for N samples:  4 + ((N - 1 + 1) / 2)
+ * For N = 1600 (100 ms @ 16 kHz):    804 bytes.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Bytes needed to encode @p sample_count int16 samples. */
+static inline size_t ima_adpcm_encoded_size(size_t sample_count) {
+    if (sample_count == 0) return 0;
+    return 4 + (sample_count / 2);
+}
+
+/**
+ * @brief Encode @p in_samples (int16 mono) to IMA ADPCM in @p out.
+ * @return Bytes written, or 0 on overflow / invalid input.
+ */
+size_t ima_adpcm_encode(const int16_t *in, size_t sample_count, uint8_t *out, size_t out_cap);
+
+/**
+ * @brief Decode IMA ADPCM bytes to int16 samples.  out_cap is in
+ *        SAMPLES, not bytes.  Returns sample count written.
+ */
+size_t ima_adpcm_decode(const uint8_t *in, size_t in_len, int16_t *out, size_t out_cap_samples);
+
+#ifdef __cplusplus
+}
+#endif

--- a/k144-stackflow/main_ext_pcm/src/main.cpp
+++ b/k144-stackflow/main_ext_pcm/src/main.cpp
@@ -3,9 +3,36 @@
  * SPDX-License-Identifier: MIT
  *
  * ext_pcm — host-PCM-injection StackFlow unit for K144.
- * Binds sys.pcm ZMQ PUB + a TCP listener on port 9999 for raw PCM
- * bytes from outside the StackFlow daemon (avoiding llm_sys's
- * action-whitelist routing for custom RPCs).
+ *
+ * Two ingestion paths feed the same ZMQ PUB at sys_pcm_cap_channel
+ * (default ipc:///tmp/llm/pcm.cap.socket):
+ *
+ *  1. TCP listener on port 9999 (dev-only — for ADB-forwarded testing
+ *     from a workstation).  Accepts raw int16 LE 16 kHz mono PCM bytes
+ *     and forwards each recv() chunk on the PUB.
+ *
+ *  2. JSON inference frames over the standard StackFlow wire (the
+ *     production path: Tab5 → UART → llm_sys → ext_pcm inference_url).
+ *     Frame shape:
+ *         {"action":"inference","work_id":"ext_pcm.NNNN",
+ *          "object":"audio.pcm.base64",
+ *          "data":"<base64-encoded int16 LE 16 kHz mono>"}
+ *     setup() attaches a subscriber to our own inference_url that
+ *     decodes base64 + forwards on the PUB.
+ *
+ *  Sequence for ASR consumption (the asr.setup with input=sys.pcm
+ *  triggers audio's lazy _cap() which steals our IPC bind):
+ *
+ *    1. ext_pcm.setup           — register + bind
+ *    2. asr.setup input=sys.pcm — audio steals bind; ASR subscribes
+ *    3. audio.cap_stop_all      — audio releases its bind
+ *    4. ext_pcm.setup           — re-register + rebind (reclaim)
+ *    5. inference frames        — flow through to ASR
+ *
+ *  Each setup() call idempotently:
+ *    a. (re)binds pub_ctx_ to sys_pcm_cap_channel
+ *    b. (re)attaches the inference subscriber to our channel's bus
+ *    c. sends an ACK so callers can resolve the live work_id_num
  */
 #include "StackFlow.h"
 #include <signal.h>
@@ -22,6 +49,8 @@
 using StackFlows::StackFlow;
 using StackFlows::pzmq;
 using StackFlows::pzmq_data;
+using StackFlows::decode_base64;
+using StackFlows::sample_get_work_id_num;
 
 static int main_exit_flag = 0;
 static void on_sigint(int) { main_exit_flag = 1; }
@@ -33,8 +62,41 @@ private:
     std::string sys_pcm_cap_channel_ = "ipc:///tmp/llm/pcm.cap.socket";
     std::unique_ptr<pzmq> pub_ctx_;
     std::atomic<uint64_t> frames_pumped_{0};
+    std::atomic<uint64_t> frames_pumped_tcp_{0};
+    std::atomic<uint64_t> frames_pumped_uart_{0};
     std::atomic<bool> tcp_running_{false};
     std::thread tcp_thread_;
+
+    void bind_pub() {
+        try {
+            pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
+            std::cerr << "ext_pcm: PUB bound to " << sys_pcm_cap_channel_ << std::endl;
+        } catch (const std::exception &e) {
+            std::cerr << "ext_pcm: PUB bind failed: " << e.what() << std::endl;
+            pub_ctx_.reset();
+        }
+    }
+
+    // Handler attached to OUR OWN inference subscriber.  Receives
+    // (object, data) pairs from llm_sys's inference routing.  data is
+    // base64-encoded PCM; decode + push on the PUB.
+    void on_inference_frame(const std::string &/*object*/, const std::string &b64) {
+        if (!pub_ctx_) return;
+        std::string pcm;
+        if (decode_base64(b64, pcm) <= 0 || pcm.empty()) {
+            // Treat as raw if decode failed
+            pub_ctx_->send_data(b64.data(), (int)b64.size());
+            frames_pumped_uart_++;
+            frames_pumped_++;
+            return;
+        }
+        pub_ctx_->send_data(pcm.data(), (int)pcm.size());
+        if (++frames_pumped_uart_ % 100 == 0) {
+            std::cerr << "ext_pcm uart: pumped " << frames_pumped_uart_
+                      << " frames (" << pcm.size() << "B last)" << std::endl;
+        }
+        frames_pumped_++;
+    }
 
 public:
     llm_ext_pcm() : StackFlow("ext_pcm")
@@ -45,14 +107,17 @@ public:
         rpc_ctx_->register_rpc_action(
             "cap_stop",
             std::bind(&llm_ext_pcm::cap_stop_action, this, std::placeholders::_1, std::placeholders::_2));
-        // Auto-bind on startup so it's ready before any setup call.
-        try {
-            pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
-            std::cerr << "ext_pcm: PUB pre-bound to " << sys_pcm_cap_channel_ << std::endl;
-        } catch (const std::exception &e) {
-            std::cerr << "ext_pcm: PUB pre-bind failed: " << e.what() << std::endl;
-        }
-        // Spawn TCP listener
+        // Custom RPC actions — reachable via the daemon's remote_call path
+        // for any JSON envelope with action != "inference":
+        //   {"work_id":"ext_pcm","action":"rebind"} — reclaim the URL
+        //   {"work_id":"ext_pcm","action":"push","data":"<base64>"} — pump PCM
+        rpc_ctx_->register_rpc_action(
+            "rebind",
+            std::bind(&llm_ext_pcm::rebind_action, this, std::placeholders::_1, std::placeholders::_2));
+        rpc_ctx_->register_rpc_action(
+            "ingest",
+            std::bind(&llm_ext_pcm::push_action, this, std::placeholders::_1, std::placeholders::_2));
+        bind_pub();
         tcp_running_ = true;
         tcp_thread_ = std::thread([this]() { this->tcp_listener_loop(); });
     }
@@ -72,7 +137,8 @@ public:
         addr.sin_addr.s_addr = htonl(INADDR_ANY);
         addr.sin_port = htons(EXT_PCM_TCP_PORT);
         if (bind(srv, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-            std::cerr << "ext_pcm tcp: bind " << EXT_PCM_TCP_PORT << " failed\n"; close(srv); return;
+            std::cerr << "ext_pcm tcp: bind " << EXT_PCM_TCP_PORT << " failed\n";
+            close(srv); return;
         }
         if (listen(srv, 1) < 0) { close(srv); return; }
         std::cerr << "ext_pcm tcp: listening on port " << EXT_PCM_TCP_PORT << std::endl;
@@ -81,19 +147,17 @@ public:
             int cli = accept(srv, nullptr, nullptr);
             if (cli < 0) continue;
             std::cerr << "ext_pcm tcp: client connected" << std::endl;
-            // Read raw PCM bytes — 16 kHz int16 mono.  Forward each
-            // packet to the ZMQ PUB.  Frame size up to caller (3200 B
-            // = 100 ms is typical).
             char buf[8192];
             while (tcp_running_) {
                 ssize_t n = recv(cli, buf, sizeof(buf), 0);
                 if (n <= 0) break;
                 if (pub_ctx_) {
                     pub_ctx_->send_data(buf, (int)n);
-                    if (++frames_pumped_ % 100 == 0) {
-                        std::cerr << "ext_pcm: pumped " << frames_pumped_
-                                  << " frames (" << n << "B last)" << std::endl;
+                    if (++frames_pumped_tcp_ % 100 == 0) {
+                        std::cerr << "ext_pcm tcp: pumped " << frames_pumped_tcp_
+                                  << " chunks (" << n << "B last)" << std::endl;
                     }
+                    frames_pumped_++;
                 }
             }
             close(cli);
@@ -102,31 +166,53 @@ public:
         close(srv);
     }
 
-    int setup(const std::string &, const std::string &, const std::string &data) override
+    int setup(const std::string &work_id, const std::string &/*object*/,
+              const std::string &data) override
     {
         nlohmann::json body;
         try { body = nlohmann::json::parse(data); } catch (...) { body = nlohmann::json::object(); }
         if (body.contains("sys_pcm_cap_channel") && body["sys_pcm_cap_channel"].is_string()) {
             std::string new_url = body["sys_pcm_cap_channel"];
-            if (new_url != sys_pcm_cap_channel_) {
-                sys_pcm_cap_channel_ = new_url;
-                pub_ctx_.reset();
-                try {
-                    pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
-                    std::cerr << "ext_pcm: PUB rebound to " << sys_pcm_cap_channel_ << std::endl;
-                } catch (const std::exception &e) {
-                    std::cerr << "ext_pcm: PUB rebind failed: " << e.what() << std::endl;
-                    return -1;
-                }
-            }
+            if (new_url != sys_pcm_cap_channel_) sys_pcm_cap_channel_ = new_url;
         }
+
+        // Always rebind the PUB.  Audio's lazy _cap() on asr.setup steals
+        // /tmp/llm/pcm.cap.socket from our boot-time bind, so callers
+        // do {ext_pcm.setup; asr.setup; audio.cap_stop_all; ext_pcm.setup}
+        // to reclaim ownership.
+        pub_ctx_.reset();
+        bind_pub();
+        if (!pub_ctx_) {
+            nlohmann::json err;
+            err["code"]    = -19;
+            err["message"] = "ext_pcm: PUB bind failed";
+            send("None", "None", err, work_id);
+            return -1;
+        }
+
+        // Attach the inference subscriber for THIS work_id's channel.
+        // subscriber_work_id("", callback) subscribes to our own
+        // inference_url_, receiving every "inference" frame the daemon
+        // routes to us.
+        auto llm_channel = get_channel(work_id);
+        if (llm_channel) {
+            llm_channel->subscriber_work_id(
+                "",
+                std::bind(&llm_ext_pcm::on_inference_frame, this,
+                          std::placeholders::_1, std::placeholders::_2));
+        }
+
+        send(LLM_NONE, LLM_NONE, LLM_NO_ERROR, work_id);
+        std::cerr << "ext_pcm: setup ack work_id=" << work_id
+                  << " url=" << sys_pcm_cap_channel_ << std::endl;
         return 0;
     }
 
     int exit(const std::string &, const std::string &, const std::string &) override
     {
         pub_ctx_.reset();
-        std::cerr << "ext_pcm: exit after " << frames_pumped_ << " frames" << std::endl;
+        std::cerr << "ext_pcm: exit after " << frames_pumped_ << " frames (tcp="
+                  << frames_pumped_tcp_ << " uart=" << frames_pumped_uart_ << ")" << std::endl;
         return 0;
     }
 
@@ -134,7 +220,6 @@ public:
     void unlink(const std::string &, const std::string &, const std::string &) override {}
     void taskinfo(const std::string &, const std::string &, const std::string &) override {}
     void pause(const std::string &, const std::string &, const std::string &) override {}
-    void work(const std::string &, const std::string &, const std::string &) override {}
 
     std::string cap_action(pzmq *, const std::shared_ptr<pzmq_data> &) {
         return sys_pcm_cap_channel_;
@@ -142,6 +227,51 @@ public:
 
     std::string cap_stop_action(pzmq *, const std::shared_ptr<pzmq_data> &) {
         return LLM_NONE;
+    }
+
+    // Custom RPC: rebind — reclaim ownership of sys_pcm_cap_channel_.
+    // Tab5 calls this after audio.cap_stop_all to reclaim the URL without
+    // restarting the ext_pcm process.
+    std::string rebind_action(pzmq *, const std::shared_ptr<pzmq_data> &) {
+        pub_ctx_.reset();
+        bind_pub();
+        std::cerr << "ext_pcm: rebind requested; pub=" << (pub_ctx_ ? "ok" : "fail") << std::endl;
+        return sys_pcm_cap_channel_;
+    }
+
+    // Custom RPC: push — production PCM ingestion path.
+    // Wire frame from Tab5 over UART (routed via llm_sys → ext_pcm RPC):
+    //   {"work_id":"ext_pcm","action":"push","data":"<base64 16k mono int16>"}
+    // The daemon's remote_call sends (com_url, full_json) as a 2-param
+    // pzmq_data.  We parse the data field, base64-decode, publish.
+    std::string push_action(pzmq *, const std::shared_ptr<pzmq_data> &raw) {
+        if (!pub_ctx_) return std::string("no_pub");
+        // remote_call passes (com_url, full_json) as the two pzmq_data params.
+        std::string payload = raw->get_param(1);
+        if (payload.empty()) payload = raw->string();
+        std::string b64;
+        try {
+            auto j = nlohmann::json::parse(payload);
+            if (j.contains("data") && j["data"].is_string()) {
+                b64 = j["data"].get<std::string>();
+            }
+        } catch (...) {}
+        if (b64.empty()) {
+            std::cerr << "ext_pcm: ingest no_data (payload len=" << payload.size() << ")" << std::endl;
+            return std::string("no_data");
+        }
+        std::string pcm;
+        if (decode_base64(b64, pcm) <= 0 || pcm.empty()) {
+            std::cerr << "ext_pcm: ingest decode_err (b64 len=" << b64.size() << ")" << std::endl;
+            return std::string("decode_err");
+        }
+        pub_ctx_->send_data(pcm.data(), (int)pcm.size());
+        if (++frames_pumped_uart_ % 100 == 0) {
+            std::cerr << "ext_pcm uart: pumped " << frames_pumped_uart_
+                      << " frames (" << pcm.size() << "B last)" << std::endl;
+        }
+        frames_pumped_++;
+        return std::string("ok");
     }
 };
 

--- a/k144-stackflow/main_ext_pcm/src/main.cpp
+++ b/k144-stackflow/main_ext_pcm/src/main.cpp
@@ -1,0 +1,243 @@
+/**
+ * @file main.cpp
+ * @brief ext_pcm — host-PCM-injection StackFlow unit for K144 (TT #131).
+ *
+ * Bridges externally-supplied PCM (e.g. Tab5's ES7210 mic over UART) into
+ * K144's internal `sys.pcm` audio bus so the existing `llm_asr`
+ * (sherpa-ncnn streaming zipformer) consumes it as if it came from K144's
+ * own hardware mic.
+ *
+ * Architecture (per research 2026-05-18 — see PLAN-tab5-mic-to-k144-ext-pcm.md
+ * in TinkerTab/docs/):
+ *
+ *   Tab5 mic → UART → llm_sys (existing JSON bridge) → routes by work_id
+ *                  → THIS UNIT'S inference_url ZMQ socket
+ *                  → we publish bytes onto sys.pcm ZMQ PUB
+ *                  → llm_asr subscribes to sys.pcm, transcribes our audio
+ *
+ * Critical: the audio unit (`llm_audio`) is normally the binder of the
+ * `sys.pcm` ZMQ PUB at `ipc:///tmp/llm/pcm.cap.socket`.  Two binders
+ * is illegal — only one process can own a given ipc:// or tcp:// endpoint.
+ *
+ * Coordination strategy:
+ *   - On setup, this unit binds the PUB endpoint FIRST (before audio.setup
+ *     would).  If audio.setup later tries to bind the same URL its bind
+ *     fails — audio's _cap() loop still runs (reads from HW mic) but the
+ *     PUB it would push to is now ours.
+ *   - Caller (Tab5) is responsible for NOT calling audio.setup with the
+ *     default URL while we're alive.  If user picks wake_src=ext_pcm,
+ *     Tab5-side voice_onboard skips both audio.setup and the regular
+ *     K144 wakeword chain — only ext_pcm + asr.setup.
+ *   - To avoid the binder conflict if audio.setup ran first (e.g. from a
+ *     stale prior session), our setup probes whether the URL is already
+ *     bound and returns an error code the caller can handle (call
+ *     audio.exit, then retry).
+ *
+ * Wire shape — incoming inference frames from llm_sys:
+ *   {"action":"inference",
+ *    "work_id":"ext_pcm.NNNN",
+ *    "object":"audio.pcm.base64",
+ *    "data":"<base64 of int16 LE PCM at 16 kHz mono>"}
+ *
+ * Each frame is base64-decoded and forwarded to the PUB socket as a
+ * single ZMQ message.  llm_asr consumes the same byte stream it would
+ * have gotten from the HW mic — same sample rate, same int16 LE
+ * encoding, no extra framing.
+ *
+ * NB: This source file is intended to drop into M5Stack's StackFlow
+ * monorepo at `projects/llm_framework/main_ext_pcm/src/main.cpp`.  It
+ * uses M5Stack's pzmq + StackFlow base class headers from
+ * `ext_components/StackFlow/`, which only exist in their build env.
+ * Source is checked into TinkerTab/k144-stackflow/ for tracking; the
+ * build flow is documented in PLAN-tab5-mic-to-k144-ext-pcm.md.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "StackFlow.h"        // M5Stack base class — provides RPC plumbing
+#include "channel.h"          // pzmq_channel for ZMQ wrappers
+#include "pzmq.hpp"           // M5Stack's ZMQ helper
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+namespace StackFlows {
+
+// ───────────────────────────────────────────────────────────────────
+// Helpers — base64 decode is the only "new" code needed; everything
+// else mirrors main_audio.
+// ───────────────────────────────────────────────────────────────────
+
+static const std::string DEFAULT_SYS_PCM_URL = "ipc:///tmp/llm/pcm.cap.socket";
+
+// Minimal base64 decoder — no third-party dep.  Input is the body of
+// the JSON `data` field.  Caller owns out_bytes.
+static bool base64_decode(const std::string &in, std::string &out) {
+    static const int8_t T[256] = {
+        -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+        -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+        -1,-1,-1,62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,
+        -1,-1,-1,-1,-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,
+        15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,
+        29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,
+        49,50,51,-1,-1,-1,-1,-1,
+        // rest default-init to -1
+    };
+    out.clear();
+    out.reserve((in.size() * 3) / 4);
+    int val = 0, bits = -8;
+    for (unsigned char c : in) {
+        if (c == '=') break;
+        int8_t v = (c < 128) ? T[c] : -1;
+        if (v < 0) {
+            // skip whitespace silently; reject other invalid chars
+            if (c == '\n' || c == '\r' || c == ' ' || c == '\t') continue;
+            return false;
+        }
+        val = (val << 6) | v;
+        bits += 6;
+        if (bits >= 0) {
+            out.push_back(static_cast<char>((val >> bits) & 0xff));
+            bits -= 8;
+        }
+    }
+    return true;
+}
+
+// ───────────────────────────────────────────────────────────────────
+// llm_task — the per-work-id state held by the StackFlow base class
+// ───────────────────────────────────────────────────────────────────
+
+class ext_pcm_task {
+public:
+    std::string sys_pcm_cap_channel_ = DEFAULT_SYS_PCM_URL;
+    std::unique_ptr<pzmq> pub_ctx_;
+    std::atomic<uint64_t> frames_published_{0};
+
+    bool start(const json &setup_body) {
+        if (setup_body.contains("sys_pcm_cap_channel")) {
+            sys_pcm_cap_channel_ = setup_body["sys_pcm_cap_channel"];
+        }
+        try {
+            pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
+        } catch (const std::exception &e) {
+            std::cerr << "ext_pcm: PUB bind failed on " << sys_pcm_cap_channel_
+                      << " — likely audio.setup is still running.  Stop it via "
+                      << "audio.exit and retry.  Detail: " << e.what() << "\n";
+            return false;
+        }
+        std::cerr << "ext_pcm: PUB bound to " << sys_pcm_cap_channel_ << "\n";
+        return true;
+    }
+
+    // Per-inference frame entrypoint.  data is the body the caller sent
+    // in the JSON `data` field — base64 of int16 LE 16 kHz mono PCM.
+    void inference(const std::string &b64) {
+        if (!pub_ctx_) return;
+        std::string raw;
+        if (!base64_decode(b64, raw)) {
+            std::cerr << "ext_pcm: base64 decode failed (size=" << b64.size() << ")\n";
+            return;
+        }
+        // Publish as a single ZMQ message — same shape llm_audio uses.
+        pub_ctx_->send(raw.data(), raw.size());
+        if (++frames_published_ % 100 == 0) {
+            std::cerr << "ext_pcm: pumped " << frames_published_ << " frames\n";
+        }
+    }
+
+    void stop() {
+        pub_ctx_.reset();
+        std::cerr << "ext_pcm: PUB closed after " << frames_published_ << " frames\n";
+    }
+};
+
+// ───────────────────────────────────────────────────────────────────
+// StackFlow integration — 7 RPCs.  Pattern lifted from main_audio.
+// ───────────────────────────────────────────────────────────────────
+
+class llm_ext_pcm : public StackFlow {
+public:
+    llm_ext_pcm() : StackFlow("ext_pcm") {}
+
+protected:
+    void task_setup(int work_id_num, const std::shared_ptr<llm_channel_obj> &llm_channel, const std::string &data) override {
+        json data_body;
+        try { data_body = json::parse(data); } catch (...) { data_body = json::object(); }
+        auto task = std::make_shared<ext_pcm_task>();
+        if (!task->start(data_body)) {
+            send("setup", "", LLM_NO_ERROR, work_id_num);
+            return;
+        }
+        task_map_[work_id_num] = task;
+        // Subscribe llm_channel to incoming inference frames so they
+        // route into our inference handler.
+        llm_channel->subscriber_work_id(
+            "", [task](const std::shared_ptr<pzmq> &, const std::shared_ptr<pzmq_data> &raw) {
+                // raw->string() is the JSON object as a string per
+                // StackFlow's existing convention.
+                json msg;
+                try {
+                    msg = json::parse(raw->string());
+                } catch (...) {
+                    return;
+                }
+                if (msg.contains("data") && msg["data"].is_string()) {
+                    task->inference(msg["data"]);
+                } else if (msg.contains("data") && msg["data"].is_object()
+                           && msg["data"].contains("data")) {
+                    task->inference(msg["data"]["data"]);
+                }
+            });
+        send("setup", "", LLM_NO_ERROR, work_id_num);
+    }
+
+    void task_pause(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
+
+    void task_work(int work_id_num, const std::shared_ptr<llm_channel_obj> &, const std::string &data) override {
+        // "work" is the explicit RPC verb for inference-style calls when
+        // the caller hits us directly (rather than via subscribe).
+        auto it = task_map_.find(work_id_num);
+        if (it == task_map_.end()) return;
+        try {
+            json msg = json::parse(data);
+            if (msg.contains("data") && msg["data"].is_string()) {
+                it->second->inference(msg["data"]);
+            }
+        } catch (...) {
+            // ignore malformed
+        }
+    }
+
+    void task_exit(int work_id_num, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {
+        auto it = task_map_.find(work_id_num);
+        if (it != task_map_.end()) {
+            it->second->stop();
+            task_map_.erase(it);
+        }
+        send("exit", "", LLM_NO_ERROR, work_id_num);
+    }
+
+    void task_link(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
+    void task_unlink(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
+    void task_taskinfo(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
+
+private:
+    std::unordered_map<int, std::shared_ptr<ext_pcm_task>> task_map_;
+};
+
+}  // namespace StackFlows
+
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    StackFlows::llm_ext_pcm srv;
+    srv.run();
+    return 0;
+}

--- a/k144-stackflow/main_ext_pcm/src/main.cpp
+++ b/k144-stackflow/main_ext_pcm/src/main.cpp
@@ -35,6 +35,9 @@
  *    c. sends an ACK so callers can resolve the live work_id_num
  */
 #include "StackFlow.h"
+extern "C" {
+#include "ima_adpcm.h"
+}
 #include <signal.h>
 #include <unistd.h>
 #include <sys/socket.h>
@@ -246,29 +249,54 @@ public:
     // pzmq_data.  We parse the data field, base64-decode, publish.
     std::string push_action(pzmq *, const std::shared_ptr<pzmq_data> &raw) {
         if (!pub_ctx_) return std::string("no_pub");
-        // remote_call passes (com_url, full_json) as the two pzmq_data params.
         std::string payload = raw->get_param(1);
         if (payload.empty()) payload = raw->string();
-        std::string b64;
+        std::string b64, object_tag;
         try {
             auto j = nlohmann::json::parse(payload);
             if (j.contains("data") && j["data"].is_string()) {
                 b64 = j["data"].get<std::string>();
             }
+            if (j.contains("object") && j["object"].is_string()) {
+                object_tag = j["object"].get<std::string>();
+            }
         } catch (...) {}
         if (b64.empty()) {
-            std::cerr << "ext_pcm: ingest no_data (payload len=" << payload.size() << ")" << std::endl;
             return std::string("no_data");
         }
-        std::string pcm;
-        if (decode_base64(b64, pcm) <= 0 || pcm.empty()) {
+        std::string decoded;
+        if (decode_base64(b64, decoded) <= 0 || decoded.empty()) {
             std::cerr << "ext_pcm: ingest decode_err (b64 len=" << b64.size() << ")" << std::endl;
             return std::string("decode_err");
         }
+
+        /* TT #131 — if object tag contains "adpcm", decode IMA ADPCM to
+         * raw int16 PCM before publishing.  This lets Tab5 send at 8 KB/s
+         * instead of 32 KB/s, fitting K144's daemon ingest budget. */
+        std::string pcm;
+        if (object_tag.find("adpcm") != std::string::npos) {
+            /* Worst case: every byte = 2 nibbles = 2 samples, plus the
+             * 1-sample header.  Cap at 16k samples (1 sec) to bound. */
+            size_t max_samples = decoded.size() * 2 + 1;
+            if (max_samples > 16000) max_samples = 16000;
+            std::vector<int16_t> samples(max_samples);
+            size_t n = ima_adpcm_decode((const uint8_t *)decoded.data(), decoded.size(),
+                                        samples.data(), samples.size());
+            if (n == 0) {
+                std::cerr << "ext_pcm: adpcm decode failed (in=" << decoded.size() << ")" << std::endl;
+                return std::string("adpcm_err");
+            }
+            pcm.assign((const char *)samples.data(), n * sizeof(int16_t));
+        } else {
+            pcm = std::move(decoded);
+        }
+
         pub_ctx_->send_data(pcm.data(), (int)pcm.size());
         if (++frames_pumped_uart_ % 100 == 0) {
             std::cerr << "ext_pcm uart: pumped " << frames_pumped_uart_
-                      << " frames (" << pcm.size() << "B last)" << std::endl;
+                      << " frames (" << pcm.size() << "B last, "
+                      << (object_tag.find("adpcm") != std::string::npos ? "adpcm" : "pcm")
+                      << ")" << std::endl;
         }
         frames_pumped_++;
         return std::string("ok");

--- a/k144-stackflow/main_ext_pcm/src/main.cpp
+++ b/k144-stackflow/main_ext_pcm/src/main.cpp
@@ -3,15 +3,21 @@
  * SPDX-License-Identifier: MIT
  *
  * ext_pcm — host-PCM-injection StackFlow unit for K144.
- * Bridges externally-supplied PCM into K144's internal sys.pcm ZMQ bus.
+ * Binds sys.pcm ZMQ PUB + a TCP listener on port 9999 for raw PCM
+ * bytes from outside the StackFlow daemon (avoiding llm_sys's
+ * action-whitelist routing for custom RPCs).
  */
 #include "StackFlow.h"
 #include <signal.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <atomic>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 using StackFlows::StackFlow;
 using StackFlows::pzmq;
@@ -20,78 +26,105 @@ using StackFlows::pzmq_data;
 static int main_exit_flag = 0;
 static void on_sigint(int) { main_exit_flag = 1; }
 
-static std::string base64_decode(const std::string &in)
-{
-    static const int8_t T[256] = {
-        -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
-        -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
-        -1,-1,-1,62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,
-        -1,-1,-1,-1,-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,
-        15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,
-        29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,
-        49,50,51,-1,-1,-1,-1,-1
-    };
-    std::string out;
-    out.reserve((in.size() * 3) / 4);
-    int val = 0, bits = -8;
-    for (unsigned char c : in) {
-        if (c == '=') break;
-        int8_t v = (c < 128) ? T[c] : -1;
-        if (v < 0) {
-            if (c == '\n' || c == '\r' || c == ' ' || c == '\t') continue;
-            return std::string();
-        }
-        val = (val << 6) | v;
-        bits += 6;
-        if (bits >= 0) {
-            out.push_back(static_cast<char>((val >> bits) & 0xff));
-            bits -= 8;
-        }
-    }
-    return out;
-}
+#define EXT_PCM_TCP_PORT 9999
 
 class llm_ext_pcm : public StackFlow {
 private:
     std::string sys_pcm_cap_channel_ = "ipc:///tmp/llm/pcm.cap.socket";
     std::unique_ptr<pzmq> pub_ctx_;
     std::atomic<uint64_t> frames_pumped_{0};
+    std::atomic<bool> tcp_running_{false};
+    std::thread tcp_thread_;
 
 public:
     llm_ext_pcm() : StackFlow("ext_pcm")
     {
-        rpc_ctx_->register_rpc_action(
-            "push_pcm",
-            std::bind(&llm_ext_pcm::push_pcm, this, std::placeholders::_1, std::placeholders::_2));
         rpc_ctx_->register_rpc_action(
             "cap",
             std::bind(&llm_ext_pcm::cap_action, this, std::placeholders::_1, std::placeholders::_2));
         rpc_ctx_->register_rpc_action(
             "cap_stop",
             std::bind(&llm_ext_pcm::cap_stop_action, this, std::placeholders::_1, std::placeholders::_2));
+        // Auto-bind on startup so it's ready before any setup call.
+        try {
+            pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
+            std::cerr << "ext_pcm: PUB pre-bound to " << sys_pcm_cap_channel_ << std::endl;
+        } catch (const std::exception &e) {
+            std::cerr << "ext_pcm: PUB pre-bind failed: " << e.what() << std::endl;
+        }
+        // Spawn TCP listener
+        tcp_running_ = true;
+        tcp_thread_ = std::thread([this]() { this->tcp_listener_loop(); });
     }
 
-    int setup(const std::string &work_id, const std::string &object, const std::string &data) override
+    ~llm_ext_pcm() {
+        tcp_running_ = false;
+        if (tcp_thread_.joinable()) tcp_thread_.join();
+    }
+
+    void tcp_listener_loop() {
+        int srv = socket(AF_INET, SOCK_STREAM, 0);
+        if (srv < 0) { std::cerr << "ext_pcm tcp: socket() failed\n"; return; }
+        int yes = 1;
+        setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+        struct sockaddr_in addr = {};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        addr.sin_port = htons(EXT_PCM_TCP_PORT);
+        if (bind(srv, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+            std::cerr << "ext_pcm tcp: bind " << EXT_PCM_TCP_PORT << " failed\n"; close(srv); return;
+        }
+        if (listen(srv, 1) < 0) { close(srv); return; }
+        std::cerr << "ext_pcm tcp: listening on port " << EXT_PCM_TCP_PORT << std::endl;
+
+        while (tcp_running_) {
+            int cli = accept(srv, nullptr, nullptr);
+            if (cli < 0) continue;
+            std::cerr << "ext_pcm tcp: client connected" << std::endl;
+            // Read raw PCM bytes — 16 kHz int16 mono.  Forward each
+            // packet to the ZMQ PUB.  Frame size up to caller (3200 B
+            // = 100 ms is typical).
+            char buf[8192];
+            while (tcp_running_) {
+                ssize_t n = recv(cli, buf, sizeof(buf), 0);
+                if (n <= 0) break;
+                if (pub_ctx_) {
+                    pub_ctx_->send_data(buf, (int)n);
+                    if (++frames_pumped_ % 100 == 0) {
+                        std::cerr << "ext_pcm: pumped " << frames_pumped_
+                                  << " frames (" << n << "B last)" << std::endl;
+                    }
+                }
+            }
+            close(cli);
+            std::cerr << "ext_pcm tcp: client disconnected" << std::endl;
+        }
+        close(srv);
+    }
+
+    int setup(const std::string &, const std::string &, const std::string &data) override
     {
-        (void)work_id; (void)object;
         nlohmann::json body;
         try { body = nlohmann::json::parse(data); } catch (...) { body = nlohmann::json::object(); }
         if (body.contains("sys_pcm_cap_channel") && body["sys_pcm_cap_channel"].is_string()) {
-            sys_pcm_cap_channel_ = body["sys_pcm_cap_channel"];
-        }
-        try {
-            pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
-            std::cerr << "ext_pcm: PUB bound to " << sys_pcm_cap_channel_ << std::endl;
-        } catch (const std::exception &e) {
-            std::cerr << "ext_pcm: PUB bind failed: " << e.what() << std::endl;
-            return -1;
+            std::string new_url = body["sys_pcm_cap_channel"];
+            if (new_url != sys_pcm_cap_channel_) {
+                sys_pcm_cap_channel_ = new_url;
+                pub_ctx_.reset();
+                try {
+                    pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
+                    std::cerr << "ext_pcm: PUB rebound to " << sys_pcm_cap_channel_ << std::endl;
+                } catch (const std::exception &e) {
+                    std::cerr << "ext_pcm: PUB rebind failed: " << e.what() << std::endl;
+                    return -1;
+                }
+            }
         }
         return 0;
     }
 
-    int exit(const std::string &work_id, const std::string &object, const std::string &data) override
+    int exit(const std::string &, const std::string &, const std::string &) override
     {
-        (void)work_id; (void)object; (void)data;
         pub_ctx_.reset();
         std::cerr << "ext_pcm: exit after " << frames_pumped_ << " frames" << std::endl;
         return 0;
@@ -101,52 +134,22 @@ public:
     void unlink(const std::string &, const std::string &, const std::string &) override {}
     void taskinfo(const std::string &, const std::string &, const std::string &) override {}
     void pause(const std::string &, const std::string &, const std::string &) override {}
-    void work(const std::string &work_id, const std::string &object, const std::string &data) override
-    {
-        (void)work_id; (void)object;
-        if (!pub_ctx_) return;
-        std::string raw = base64_decode(data);
-        if (raw.empty()) return;
-        pub_ctx_->send_data(raw.data(), raw.size());
-        ++frames_pumped_;
-    }
+    void work(const std::string &, const std::string &, const std::string &) override {}
 
-    // push_pcm RPC — Tab5 sends:
-    //   {action: "push_pcm", work_id: "ext_pcm.NNNN", data: "<base64>"}
-    std::string push_pcm(pzmq *, const std::shared_ptr<pzmq_data> &rawdata)
-    {
-        if (!pub_ctx_) return "ext_pcm not setup";
-        std::string b64 = rawdata->string();
-        std::string raw = base64_decode(b64);
-        if (raw.empty()) return "base64 decode failed";
-        pub_ctx_->send_data(raw.data(), raw.size());
-        if (++frames_pumped_ % 100 == 0) {
-            std::cerr << "ext_pcm: pumped " << frames_pumped_ << " frames" << std::endl;
-        }
-        return LLM_NONE;
-    }
-
-    // cap RPC — ASR calls this via unit_call("ext_pcm", "cap", ...)
-    std::string cap_action(pzmq *, const std::shared_ptr<pzmq_data> &)
-    {
+    std::string cap_action(pzmq *, const std::shared_ptr<pzmq_data> &) {
         return sys_pcm_cap_channel_;
     }
 
-    std::string cap_stop_action(pzmq *, const std::shared_ptr<pzmq_data> &)
-    {
-        pub_ctx_.reset();
+    std::string cap_stop_action(pzmq *, const std::shared_ptr<pzmq_data> &) {
         return LLM_NONE;
     }
 };
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     (void)argc; (void)argv;
     signal(SIGINT, on_sigint);
     signal(SIGTERM, on_sigint);
     llm_ext_pcm srv;
-    while (!main_exit_flag) {
-        sleep(1);
-    }
+    while (!main_exit_flag) sleep(1);
     return 0;
 }

--- a/k144-stackflow/main_ext_pcm/src/main.cpp
+++ b/k144-stackflow/main_ext_pcm/src/main.cpp
@@ -1,84 +1,27 @@
-/**
- * @file main.cpp
- * @brief ext_pcm — host-PCM-injection StackFlow unit for K144 (TT #131).
+/*
+ * SPDX-FileCopyrightText: 2026 TinkerTab (TT #131)
+ * SPDX-License-Identifier: MIT
  *
- * Bridges externally-supplied PCM (e.g. Tab5's ES7210 mic over UART) into
- * K144's internal `sys.pcm` audio bus so the existing `llm_asr`
- * (sherpa-ncnn streaming zipformer) consumes it as if it came from K144's
- * own hardware mic.
- *
- * Architecture (per research 2026-05-18 — see PLAN-tab5-mic-to-k144-ext-pcm.md
- * in TinkerTab/docs/):
- *
- *   Tab5 mic → UART → llm_sys (existing JSON bridge) → routes by work_id
- *                  → THIS UNIT'S inference_url ZMQ socket
- *                  → we publish bytes onto sys.pcm ZMQ PUB
- *                  → llm_asr subscribes to sys.pcm, transcribes our audio
- *
- * Critical: the audio unit (`llm_audio`) is normally the binder of the
- * `sys.pcm` ZMQ PUB at `ipc:///tmp/llm/pcm.cap.socket`.  Two binders
- * is illegal — only one process can own a given ipc:// or tcp:// endpoint.
- *
- * Coordination strategy:
- *   - On setup, this unit binds the PUB endpoint FIRST (before audio.setup
- *     would).  If audio.setup later tries to bind the same URL its bind
- *     fails — audio's _cap() loop still runs (reads from HW mic) but the
- *     PUB it would push to is now ours.
- *   - Caller (Tab5) is responsible for NOT calling audio.setup with the
- *     default URL while we're alive.  If user picks wake_src=ext_pcm,
- *     Tab5-side voice_onboard skips both audio.setup and the regular
- *     K144 wakeword chain — only ext_pcm + asr.setup.
- *   - To avoid the binder conflict if audio.setup ran first (e.g. from a
- *     stale prior session), our setup probes whether the URL is already
- *     bound and returns an error code the caller can handle (call
- *     audio.exit, then retry).
- *
- * Wire shape — incoming inference frames from llm_sys:
- *   {"action":"inference",
- *    "work_id":"ext_pcm.NNNN",
- *    "object":"audio.pcm.base64",
- *    "data":"<base64 of int16 LE PCM at 16 kHz mono>"}
- *
- * Each frame is base64-decoded and forwarded to the PUB socket as a
- * single ZMQ message.  llm_asr consumes the same byte stream it would
- * have gotten from the HW mic — same sample rate, same int16 LE
- * encoding, no extra framing.
- *
- * NB: This source file is intended to drop into M5Stack's StackFlow
- * monorepo at `projects/llm_framework/main_ext_pcm/src/main.cpp`.  It
- * uses M5Stack's pzmq + StackFlow base class headers from
- * `ext_components/StackFlow/`, which only exist in their build env.
- * Source is checked into TinkerTab/k144-stackflow/ for tracking; the
- * build flow is documented in PLAN-tab5-mic-to-k144-ext-pcm.md.
+ * ext_pcm — host-PCM-injection StackFlow unit for K144.
+ * Bridges externally-supplied PCM into K144's internal sys.pcm ZMQ bus.
  */
-
+#include "StackFlow.h"
+#include <signal.h>
+#include <unistd.h>
 #include <atomic>
-#include <chrono>
-#include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>
-#include <thread>
 
-#include "StackFlow.h"        // M5Stack base class — provides RPC plumbing
-#include "channel.h"          // pzmq_channel for ZMQ wrappers
-#include "pzmq.hpp"           // M5Stack's ZMQ helper
+using StackFlows::StackFlow;
+using StackFlows::pzmq;
+using StackFlows::pzmq_data;
 
-#include <nlohmann/json.hpp>
-using json = nlohmann::json;
+static int main_exit_flag = 0;
+static void on_sigint(int) { main_exit_flag = 1; }
 
-namespace StackFlows {
-
-// ───────────────────────────────────────────────────────────────────
-// Helpers — base64 decode is the only "new" code needed; everything
-// else mirrors main_audio.
-// ───────────────────────────────────────────────────────────────────
-
-static const std::string DEFAULT_SYS_PCM_URL = "ipc:///tmp/llm/pcm.cap.socket";
-
-// Minimal base64 decoder — no third-party dep.  Input is the body of
-// the JSON `data` field.  Caller owns out_bytes.
-static bool base64_decode(const std::string &in, std::string &out) {
+static std::string base64_decode(const std::string &in)
+{
     static const int8_t T[256] = {
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
@@ -86,19 +29,17 @@ static bool base64_decode(const std::string &in, std::string &out) {
         -1,-1,-1,-1,-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,
         15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,
         29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,
-        49,50,51,-1,-1,-1,-1,-1,
-        // rest default-init to -1
+        49,50,51,-1,-1,-1,-1,-1
     };
-    out.clear();
+    std::string out;
     out.reserve((in.size() * 3) / 4);
     int val = 0, bits = -8;
     for (unsigned char c : in) {
         if (c == '=') break;
         int8_t v = (c < 128) ? T[c] : -1;
         if (v < 0) {
-            // skip whitespace silently; reject other invalid chars
             if (c == '\n' || c == '\r' || c == ' ' || c == '\t') continue;
-            return false;
+            return std::string();
         }
         val = (val << 6) | v;
         bits += 6;
@@ -107,137 +48,105 @@ static bool base64_decode(const std::string &in, std::string &out) {
             bits -= 8;
         }
     }
-    return true;
+    return out;
 }
 
-// ───────────────────────────────────────────────────────────────────
-// llm_task — the per-work-id state held by the StackFlow base class
-// ───────────────────────────────────────────────────────────────────
-
-class ext_pcm_task {
-public:
-    std::string sys_pcm_cap_channel_ = DEFAULT_SYS_PCM_URL;
+class llm_ext_pcm : public StackFlow {
+private:
+    std::string sys_pcm_cap_channel_ = "ipc:///tmp/llm/pcm.cap.socket";
     std::unique_ptr<pzmq> pub_ctx_;
-    std::atomic<uint64_t> frames_published_{0};
+    std::atomic<uint64_t> frames_pumped_{0};
 
-    bool start(const json &setup_body) {
-        if (setup_body.contains("sys_pcm_cap_channel")) {
-            sys_pcm_cap_channel_ = setup_body["sys_pcm_cap_channel"];
+public:
+    llm_ext_pcm() : StackFlow("ext_pcm")
+    {
+        rpc_ctx_->register_rpc_action(
+            "push_pcm",
+            std::bind(&llm_ext_pcm::push_pcm, this, std::placeholders::_1, std::placeholders::_2));
+        rpc_ctx_->register_rpc_action(
+            "cap",
+            std::bind(&llm_ext_pcm::cap_action, this, std::placeholders::_1, std::placeholders::_2));
+        rpc_ctx_->register_rpc_action(
+            "cap_stop",
+            std::bind(&llm_ext_pcm::cap_stop_action, this, std::placeholders::_1, std::placeholders::_2));
+    }
+
+    int setup(const std::string &work_id, const std::string &object, const std::string &data) override
+    {
+        (void)work_id; (void)object;
+        nlohmann::json body;
+        try { body = nlohmann::json::parse(data); } catch (...) { body = nlohmann::json::object(); }
+        if (body.contains("sys_pcm_cap_channel") && body["sys_pcm_cap_channel"].is_string()) {
+            sys_pcm_cap_channel_ = body["sys_pcm_cap_channel"];
         }
         try {
             pub_ctx_ = std::make_unique<pzmq>(sys_pcm_cap_channel_, ZMQ_PUB);
+            std::cerr << "ext_pcm: PUB bound to " << sys_pcm_cap_channel_ << std::endl;
         } catch (const std::exception &e) {
-            std::cerr << "ext_pcm: PUB bind failed on " << sys_pcm_cap_channel_
-                      << " — likely audio.setup is still running.  Stop it via "
-                      << "audio.exit and retry.  Detail: " << e.what() << "\n";
-            return false;
+            std::cerr << "ext_pcm: PUB bind failed: " << e.what() << std::endl;
+            return -1;
         }
-        std::cerr << "ext_pcm: PUB bound to " << sys_pcm_cap_channel_ << "\n";
-        return true;
+        return 0;
     }
 
-    // Per-inference frame entrypoint.  data is the body the caller sent
-    // in the JSON `data` field — base64 of int16 LE 16 kHz mono PCM.
-    void inference(const std::string &b64) {
-        if (!pub_ctx_) return;
-        std::string raw;
-        if (!base64_decode(b64, raw)) {
-            std::cerr << "ext_pcm: base64 decode failed (size=" << b64.size() << ")\n";
-            return;
-        }
-        // Publish as a single ZMQ message — same shape llm_audio uses.
-        pub_ctx_->send(raw.data(), raw.size());
-        if (++frames_published_ % 100 == 0) {
-            std::cerr << "ext_pcm: pumped " << frames_published_ << " frames\n";
-        }
-    }
-
-    void stop() {
+    int exit(const std::string &work_id, const std::string &object, const std::string &data) override
+    {
+        (void)work_id; (void)object; (void)data;
         pub_ctx_.reset();
-        std::cerr << "ext_pcm: PUB closed after " << frames_published_ << " frames\n";
+        std::cerr << "ext_pcm: exit after " << frames_pumped_ << " frames" << std::endl;
+        return 0;
+    }
+
+    void link(const std::string &, const std::string &, const std::string &) override {}
+    void unlink(const std::string &, const std::string &, const std::string &) override {}
+    void taskinfo(const std::string &, const std::string &, const std::string &) override {}
+    void pause(const std::string &, const std::string &, const std::string &) override {}
+    void work(const std::string &work_id, const std::string &object, const std::string &data) override
+    {
+        (void)work_id; (void)object;
+        if (!pub_ctx_) return;
+        std::string raw = base64_decode(data);
+        if (raw.empty()) return;
+        pub_ctx_->send_data(raw.data(), raw.size());
+        ++frames_pumped_;
+    }
+
+    // push_pcm RPC — Tab5 sends:
+    //   {action: "push_pcm", work_id: "ext_pcm.NNNN", data: "<base64>"}
+    std::string push_pcm(pzmq *, const std::shared_ptr<pzmq_data> &rawdata)
+    {
+        if (!pub_ctx_) return "ext_pcm not setup";
+        std::string b64 = rawdata->string();
+        std::string raw = base64_decode(b64);
+        if (raw.empty()) return "base64 decode failed";
+        pub_ctx_->send_data(raw.data(), raw.size());
+        if (++frames_pumped_ % 100 == 0) {
+            std::cerr << "ext_pcm: pumped " << frames_pumped_ << " frames" << std::endl;
+        }
+        return LLM_NONE;
+    }
+
+    // cap RPC — ASR calls this via unit_call("ext_pcm", "cap", ...)
+    std::string cap_action(pzmq *, const std::shared_ptr<pzmq_data> &)
+    {
+        return sys_pcm_cap_channel_;
+    }
+
+    std::string cap_stop_action(pzmq *, const std::shared_ptr<pzmq_data> &)
+    {
+        pub_ctx_.reset();
+        return LLM_NONE;
     }
 };
 
-// ───────────────────────────────────────────────────────────────────
-// StackFlow integration — 7 RPCs.  Pattern lifted from main_audio.
-// ───────────────────────────────────────────────────────────────────
-
-class llm_ext_pcm : public StackFlow {
-public:
-    llm_ext_pcm() : StackFlow("ext_pcm") {}
-
-protected:
-    void task_setup(int work_id_num, const std::shared_ptr<llm_channel_obj> &llm_channel, const std::string &data) override {
-        json data_body;
-        try { data_body = json::parse(data); } catch (...) { data_body = json::object(); }
-        auto task = std::make_shared<ext_pcm_task>();
-        if (!task->start(data_body)) {
-            send("setup", "", LLM_NO_ERROR, work_id_num);
-            return;
-        }
-        task_map_[work_id_num] = task;
-        // Subscribe llm_channel to incoming inference frames so they
-        // route into our inference handler.
-        llm_channel->subscriber_work_id(
-            "", [task](const std::shared_ptr<pzmq> &, const std::shared_ptr<pzmq_data> &raw) {
-                // raw->string() is the JSON object as a string per
-                // StackFlow's existing convention.
-                json msg;
-                try {
-                    msg = json::parse(raw->string());
-                } catch (...) {
-                    return;
-                }
-                if (msg.contains("data") && msg["data"].is_string()) {
-                    task->inference(msg["data"]);
-                } else if (msg.contains("data") && msg["data"].is_object()
-                           && msg["data"].contains("data")) {
-                    task->inference(msg["data"]["data"]);
-                }
-            });
-        send("setup", "", LLM_NO_ERROR, work_id_num);
+int main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+    signal(SIGINT, on_sigint);
+    signal(SIGTERM, on_sigint);
+    llm_ext_pcm srv;
+    while (!main_exit_flag) {
+        sleep(1);
     }
-
-    void task_pause(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
-
-    void task_work(int work_id_num, const std::shared_ptr<llm_channel_obj> &, const std::string &data) override {
-        // "work" is the explicit RPC verb for inference-style calls when
-        // the caller hits us directly (rather than via subscribe).
-        auto it = task_map_.find(work_id_num);
-        if (it == task_map_.end()) return;
-        try {
-            json msg = json::parse(data);
-            if (msg.contains("data") && msg["data"].is_string()) {
-                it->second->inference(msg["data"]);
-            }
-        } catch (...) {
-            // ignore malformed
-        }
-    }
-
-    void task_exit(int work_id_num, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {
-        auto it = task_map_.find(work_id_num);
-        if (it != task_map_.end()) {
-            it->second->stop();
-            task_map_.erase(it);
-        }
-        send("exit", "", LLM_NO_ERROR, work_id_num);
-    }
-
-    void task_link(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
-    void task_unlink(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
-    void task_taskinfo(int, const std::shared_ptr<llm_channel_obj> &, const std::string &) override {}
-
-private:
-    std::unordered_map<int, std::shared_ptr<ext_pcm_task>> task_map_;
-};
-
-}  // namespace StackFlows
-
-int main(int argc, char *argv[]) {
-    (void)argc;
-    (void)argv;
-    StackFlows::llm_ext_pcm srv;
-    srv.run();
     return 0;
 }

--- a/k144-stackflow/patches/asr-adpcm-and-base64-hardening.patch
+++ b/k144-stackflow/patches/asr-adpcm-and-base64-hardening.patch
@@ -1,0 +1,86 @@
+diff --git a/ext_components/StackFlow/stackflow/StackFlowUtil.cpp b/ext_components/StackFlow/stackflow/StackFlowUtil.cpp
+index 7da3354..3951bf1 100644
+--- a/ext_components/StackFlow/stackflow/StackFlowUtil.cpp
++++ b/ext_components/StackFlow/stackflow/StackFlowUtil.cpp
+@@ -341,7 +341,13 @@ int StackFlows::decode_base64(const std::string &in, std::string &out)
+     int out_size = BASE64_DECODE_OUT_SIZE(in.length());
+     out.resize(out_size);
+     int ret = base64_decode((const char *)in.c_str(), in.length(), (unsigned char *)out.data());
+-    if ((ret > 0) && (ret != out_size)) out.erase(ret);
++    /* TT #131 fix — base64_decode can return ret > out_size on certain
++     * inputs (off-by-one bug).  Clamp to avoid std::out_of_range from
++     * basic_string::erase, which would terminate the daemon. */
++    if (ret > 0) {
++        if (ret > out_size) ret = out_size;
++        if (ret != out_size) out.erase((size_t)ret);
++    }
+     return ret;
+ }
+ 
+diff --git a/projects/llm_framework/main_asr/src/main.cpp b/projects/llm_framework/main_asr/src/main.cpp
+index 024de85..4e36a83 100644
+--- a/projects/llm_framework/main_asr/src/main.cpp
++++ b/projects/llm_framework/main_asr/src/main.cpp
+@@ -4,6 +4,9 @@
+  * SPDX-License-Identifier: MIT
+  */
+ #include "StackFlow.h"
++extern "C" {
++#include "ima_adpcm.h"
++}
+ #include "sherpa-ncnn/csrc/recognizer.h"
+ #include "sherpa-onnx/csrc/offline-recognizer.h"
+ #include "sherpa-onnx/csrc/online-recognizer.h"
+@@ -898,8 +901,14 @@ public:
+ 
+         std::string tmp_msg2;
+         if (object.find("base64") != std::string::npos) {
+-            ret = decode_base64((*next_data), tmp_msg2);
+-            if (ret == -1) {
++            try {
++                ret = decode_base64((*next_data), tmp_msg2);
++            } catch (const std::exception &e) {
++                /* TT #131 — defensive: any std::out_of_range / std::length_error
++                 * from base64_decode shouldn't crash the asr daemon. */
++                ret = -1;
++            }
++            if (ret <= 0) {
+                 error_body["code"]    = -23;
+                 error_body["message"] = "Base64 decoding error.";
+                 send("None", "None", error_body, unit_name_);
+@@ -926,6 +935,35 @@ public:
+             next_data = &tmp_msg4;
+         }
+ 
++        /* TT #131 — IMA ADPCM 4:1 decompression.  Object tag
++         * "audio.pcm.adpcm.base64" means: base64-decoded data is an IMA
++         * ADPCM block (4 B header + nibbles).  Decode to int16 mono PCM
++         * before feeding sherpa-ncnn.  Tab5 compresses 32 KB/s raw PCM
++         * down to 8 KB/s ADPCM to fit the UART control-plane bandwidth.
++         * Note: sherpa-ncnn streaming-zipformer is robust to ADPCM
++         * quantization noise in clean acoustic conditions. */
++        std::string tmp_msg5;
++        if (object.find("adpcm") != std::string::npos) {
++            const uint8_t *in = (const uint8_t *)next_data->data();
++            size_t in_len = next_data->size();
++            if (in_len >= 4) {
++                size_t max_samples = (in_len - 4) * 2 + 1;
++                tmp_msg5.resize(max_samples * sizeof(int16_t));
++                size_t got = ima_adpcm_decode(in, in_len,
++                                              (int16_t *)tmp_msg5.data(),
++                                              max_samples);
++                if (got > 0) {
++                    tmp_msg5.resize(got * sizeof(int16_t));
++                    next_data = &tmp_msg5;
++                } else {
++                    error_body["code"]    = -24;
++                    error_body["message"] = "ADPCM decoding error.";
++                    send("None", "None", error_body, unit_name_);
++                    return;
++                }
++            }
++        }
++
+         llm_task_obj->sys_pcm_on_data((*next_data));
+     }
+ 

--- a/k144-stackflow/patches/kws-adpcm.patch
+++ b/k144-stackflow/patches/kws-adpcm.patch
@@ -1,0 +1,240 @@
+=== diff: main_kws/src/main.cpp ===
+diff --git a/projects/llm_framework/main_kws/src/main.cpp b/projects/llm_framework/main_kws/src/main.cpp
+index 4883478..62c90ae 100644
+--- a/projects/llm_framework/main_kws/src/main.cpp
++++ b/projects/llm_framework/main_kws/src/main.cpp
+@@ -5,6 +5,10 @@
+  */
+ #include "StackFlow.h"
+ 
++extern "C" {
++#include "ima_adpcm.h"
++}
++
+ #include "EngineWrapper.hpp"
+ #include "ax_sys_api.h"
+ 
+@@ -768,6 +772,11 @@ public:
+                         const std::weak_ptr<llm_channel_obj> llm_channel_weak, const std::string &object,
+                         const std::string &data)
+     {
++        static int s_dbg_count = 0;
++        if ((s_dbg_count++ % 25) == 0) {
++            SLOGI("task_user_data: object=%s data_len=%zu count=%d",
++                  object.c_str(), data.size(), s_dbg_count);
++        }
+         nlohmann::json error_body;
+         auto llm_task_obj = llm_task_obj_weak.lock();
+         auto llm_channel  = llm_channel_weak.lock();
+@@ -797,8 +806,12 @@ public:
+         }
+         std::string tmp_msg2;
+         if (object.find("base64") != std::string::npos) {
+-            ret = decode_base64((*next_data), tmp_msg2);
+-            if (ret == -1) {
++            try {
++                ret = decode_base64((*next_data), tmp_msg2);
++            } catch (const std::exception &e) {
++                ret = -1;
++            }
++            if (ret <= 0) {
+                 error_body["code"]    = -23;
+                 error_body["message"] = "Base64 decoding error.";
+                 send("None", "None", error_body, unit_name_);
+@@ -806,6 +819,33 @@ public:
+             }
+             next_data = &tmp_msg2;
+         }
++
++        /* TT #131 — IMA ADPCM 4:1 decompression. Object tag
++         * "audio.pcm.adpcm.base64" means: base64-decoded data is an IMA
++         * ADPCM block (4 B header + nibbles). Decode to int16 mono PCM
++         * before feeding sherpa-onnx kws spotter. */
++        std::string tmp_msg5;
++        if (object.find("adpcm") != std::string::npos) {
++            const uint8_t *in = (const uint8_t *)next_data->data();
++            size_t in_len     = next_data->size();
++            if (in_len >= 4) {
++                size_t max_samples = (in_len - 4) * 2 + 1;
++                tmp_msg5.resize(max_samples * sizeof(int16_t));
++                size_t got = ima_adpcm_decode(in, in_len,
++                                              (int16_t *)tmp_msg5.data(),
++                                              max_samples);
++                if (got > 0) {
++                    tmp_msg5.resize(got * sizeof(int16_t));
++                    next_data = &tmp_msg5;
++                } else {
++                    error_body["code"]    = -24;
++                    error_body["message"] = "ADPCM decoding error.";
++                    send("None", "None", error_body, unit_name_);
++                    return;
++                }
++            }
++        }
++
+         llm_task_obj->sys_pcm_on_data((*next_data));
+     }
+ 
+
+=== new: main_kws/src/ima_adpcm.h ===
+/**
+ * @file ima_adpcm.h
+ * @brief IMA ADPCM 4:1 encoder for 16 kHz mono int16 audio (TT #131).
+ *
+ * Compresses real-time PCM to fit Tab5↔K144 UART control-plane
+ * bandwidth budget (~13 KB/s sustained at 1.5 Mbps after daemon
+ * overhead).  Raw 16k mono int16 = 32 KB/s; IMA ADPCM nibbles =
+ * 8 KB/s + tiny per-chunk header.
+ *
+ * Each encoded chunk is self-contained — predictor + step index
+ * resets per call.  K144 ext_pcm decodes the same way: header has
+ * the first sample + step index, nibbles follow.
+ *
+ * Block layout (matches Microsoft / IMA ADPCM wave format):
+ *
+ *     [int16 first_sample][uint8 step_index][uint8 reserved=0]
+ *     [4-bit nibble × (N-1)]
+ *
+ * Total output bytes for N samples:  4 + ((N - 1 + 1) / 2)
+ * For N = 1600 (100 ms @ 16 kHz):    804 bytes.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+=== new: main_kws/src/ima_adpcm.c (full) ===
+/**
+ * @file ima_adpcm.c
+ * @brief IMA ADPCM 4-bit encoder/decoder.  Standard reference impl.
+ */
+
+#include "ima_adpcm.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+static const int16_t step_table[89] = {
+    7,     8,     9,     10,    11,    12,    13,    14,    16,    17,
+    19,    21,    23,    25,    28,    31,    34,    37,    41,    45,
+    50,    55,    60,    66,    73,    80,    88,    97,    107,   118,
+    130,   143,   157,   173,   190,   209,   230,   253,   279,   307,
+    337,   371,   408,   449,   494,   544,   598,   658,   724,   796,
+    876,   963,   1060,  1166,  1282,  1411,  1552,  1707,  1878,  2066,
+    2272,  2499,  2749,  3024,  3327,  3660,  4026,  4428,  4871,  5358,
+    5894,  6484,  7132,  7845,  8630,  9493,  10442, 11487, 12635, 13899,
+    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+};
+
+static const int8_t index_table[16] = {
+    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8,
+};
+
+static inline int clamp_index(int idx) {
+    if (idx < 0) return 0;
+    if (idx > 88) return 88;
+    return idx;
+}
+
+static inline int16_t clamp_int16(int32_t v) {
+    if (v > 32767) return 32767;
+    if (v < -32768) return -32768;
+    return (int16_t)v;
+}
+
+/* Encode one sample with current predictor/step state.  Updates state.
+ * Returns the 4-bit nibble. */
+static uint8_t encode_sample(int16_t sample, int16_t *predictor, int *step_index) {
+    int diff = sample - *predictor;
+    int sign = (diff < 0) ? 8 : 0;
+    if (diff < 0) diff = -diff;
+    int step = step_table[*step_index];
+    int delta = 0;
+    int diff_q = step >> 3;
+    if (diff >= step)    { delta |= 4; diff -= step;    diff_q += step;    }
+    if (diff >= step >> 1) { delta |= 2; diff -= step >> 1; diff_q += step >> 1; }
+    if (diff >= step >> 2) { delta |= 1; diff -= step >> 2; diff_q += step >> 2; }
+    if (sign) {
+        *predictor = clamp_int16((int32_t)*predictor - diff_q);
+    } else {
+        *predictor = clamp_int16((int32_t)*predictor + diff_q);
+    }
+    *step_index = clamp_index(*step_index + index_table[delta | sign]);
+    return (uint8_t)(delta | sign);
+}
+
+static int16_t decode_sample(uint8_t nibble, int16_t *predictor, int *step_index) {
+    int step = step_table[*step_index];
+    int diff_q = step >> 3;
+    if (nibble & 4) diff_q += step;
+    if (nibble & 2) diff_q += step >> 1;
+    if (nibble & 1) diff_q += step >> 2;
+    if (nibble & 8) {
+        *predictor = clamp_int16((int32_t)*predictor - diff_q);
+    } else {
+        *predictor = clamp_int16((int32_t)*predictor + diff_q);
+    }
+    *step_index = clamp_index(*step_index + index_table[nibble]);
+    return *predictor;
+}
+
+size_t ima_adpcm_encode(const int16_t *in, size_t sample_count, uint8_t *out, size_t out_cap) {
+    if (in == NULL || out == NULL || sample_count == 0) return 0;
+    size_t need = ima_adpcm_encoded_size(sample_count);
+    if (out_cap < need) return 0;
+
+    int16_t predictor = in[0];
+    int step_index = 0;
+    /* Header: int16 first_sample LE, uint8 step_index, uint8 reserved. */
+    out[0] = (uint8_t)(predictor & 0xff);
+    out[1] = (uint8_t)((predictor >> 8) & 0xff);
+    out[2] = (uint8_t)step_index;
+    out[3] = 0;
+
+    /* Body: nibbles for samples [1..N-1].  Pack low-nibble then high. */
+    size_t out_idx = 4;
+    int low = 1;
+    uint8_t accum = 0;
+    for (size_t i = 1; i < sample_count; i++) {
+        uint8_t nib = encode_sample(in[i], &predictor, &step_index);
+        if (low) {
+            accum = nib & 0x0f;
+            low = 0;
+        } else {
+            accum |= (nib & 0x0f) << 4;
+            out[out_idx++] = accum;
+            low = 1;
+        }
+    }
+    if (!low) {
+        /* Odd sample count — flush the half-byte (high nibble = 0). */
+        out[out_idx++] = accum;
+    }
+    return out_idx;
+}
+
+size_t ima_adpcm_decode(const uint8_t *in, size_t in_len, int16_t *out, size_t out_cap_samples) {
+    if (in == NULL || out == NULL || in_len < 4) return 0;
+
+    int16_t predictor = (int16_t)((uint16_t)in[0] | ((uint16_t)in[1] << 8));
+    int step_index = clamp_index(in[2]);
+
+    if (out_cap_samples == 0) return 0;
+    out[0] = predictor;
+    size_t out_idx = 1;
+    /* nibbles start at byte 4 */
+    for (size_t b = 4; b < in_len && out_idx < out_cap_samples; b++) {
+        uint8_t low = in[b] & 0x0f;
+        out[out_idx++] = decode_sample(low, &predictor, &step_index);
+        if (out_idx >= out_cap_samples) break;
+        uint8_t high = (in[b] >> 4) & 0x0f;
+        out[out_idx++] = decode_sample(high, &predictor, &step_index);
+    }
+    return out_idx;
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -68,6 +68,7 @@ else()
              "voice_onboard.c"
              "voice_wakeword.c"
              "voice_wake_stream.c"
+             "voice_ext_pcm_stream.c"
         EMBED_TXTFILES "debug_ui.html"
         INCLUDE_DIRS "."
         REQUIRES tab5

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -69,6 +69,7 @@ else()
              "voice_wakeword.c"
              "voice_wake_stream.c"
              "voice_ext_pcm_stream.c"
+             "ima_adpcm.c"
         EMBED_TXTFILES "debug_ui.html"
         INCLUDE_DIRS "."
         REQUIRES tab5

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -206,9 +206,23 @@ static esp_err_t handle_wake_src(httpd_req_t *req) {
       voice_wake_stream_arm();
    } else if (strcmp(src, "ext_pcm") == 0) {
       voice_wake_stream_disarm();
-      /* Arm voice_wakeword asynchronously so its asr.setup runs on the
-       * worker.  The ext_pcm pump is gated on voice_wakeword_is_active()
-       * + K144 READY so it won't fight the arm for UART. */
+      /* Reset Tab5 UART to 115200 baseline (K144 may have rebooted to
+       * default underneath us) and bump BOTH sides to 1.5 Mbps BEFORE
+       * arming wakeword.  Doing the negotiation up-front (not from
+       * inside the pump task) avoids lock contention with wakeword's
+       * recv loop. */
+      extern esp_err_t tab5_port_c_uart_set_baud(uint32_t baud);
+      extern void voice_onboard_suppress_auto_retry(bool);
+      extern esp_err_t voice_m5_llm_set_baud(uint32_t);
+      tab5_port_c_uart_set_baud(115200);
+      voice_onboard_suppress_auto_retry(true);
+      esp_err_t be = voice_m5_llm_set_baud(1500000);
+      if (be != ESP_OK) {
+         ESP_LOGW(TAG, "early baud bump failed (%s) — will retry from pump", esp_err_to_name(be));
+         voice_onboard_suppress_auto_retry(false);
+      } else {
+         ESP_LOGI(TAG, "UART pre-bumped to 1.5 Mbps before wakeword arm");
+      }
       voice_onboard_arm_wakeword_async();
       voice_ext_pcm_stream_arm();
    } else { /* off */

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -164,7 +164,7 @@ static esp_err_t handle_status(httpd_req_t *req) {
    return respond_json(req, root, 200);
 }
 
-/* ── POST /tinkeron/wake_src?src=k144|dragon|off ─────────────────── */
+/* ── POST /tinkeron/wake_src?src=k144|dragon|ext_pcm|off ─────────── */
 
 static esp_err_t handle_wake_src(httpd_req_t *req) {
    if (!tab5_debug_check_auth(req)) return ESP_FAIL;
@@ -176,10 +176,9 @@ static esp_err_t handle_wake_src(httpd_req_t *req) {
    if (httpd_query_key_value(qry, "src", src, sizeof(src)) != ESP_OK) {
       return respond_error(req, "missing src= param", 400);
    }
-   /* Validate against the known set.  Future ext_pcm will land as a new
-    * branch + value here. */
-   if (strcmp(src, "k144") != 0 && strcmp(src, "dragon") != 0 && strcmp(src, "off") != 0) {
-      return respond_error(req, "src must be k144|dragon|off", 400);
+   if (strcmp(src, "k144") != 0 && strcmp(src, "dragon") != 0 &&
+       strcmp(src, "ext_pcm") != 0 && strcmp(src, "off") != 0) {
+      return respond_error(req, "src must be k144|dragon|ext_pcm|off", 400);
    }
    esp_err_t e = tab5_settings_set_wake_src(src);
    if (e != ESP_OK) {
@@ -189,19 +188,28 @@ static esp_err_t handle_wake_src(httpd_req_t *req) {
    tab5_debug_obs_event("wake_src", src);
 
    /* Apply immediately: disarm whatever is wrong, arm whatever is right. */
+   extern void voice_wake_stream_disarm(void);
+   extern void voice_wake_stream_arm(void);
+   extern void voice_ext_pcm_stream_disarm(void);
+   extern void voice_ext_pcm_stream_arm(void);
+   extern esp_err_t voice_onboard_arm_wakeword(void);
+
    if (strcmp(src, "k144") == 0) {
-      extern void voice_wake_stream_disarm(void);
       voice_wake_stream_disarm();
-      extern esp_err_t voice_onboard_arm_wakeword(void);
+      voice_ext_pcm_stream_disarm();
       voice_onboard_arm_wakeword();
    } else if (strcmp(src, "dragon") == 0) {
       voice_wakeword_stop();
-      extern void voice_wake_stream_arm(void);
+      voice_ext_pcm_stream_disarm();
       voice_wake_stream_arm();
+   } else if (strcmp(src, "ext_pcm") == 0) {
+      voice_wakeword_stop();
+      voice_wake_stream_disarm();
+      voice_ext_pcm_stream_arm();
    } else { /* off */
       voice_wakeword_stop();
-      extern void voice_wake_stream_disarm(void);
       voice_wake_stream_disarm();
+      voice_ext_pcm_stream_disarm();
    }
 
    cJSON *root = cJSON_CreateObject();

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -30,12 +30,12 @@
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "settings.h"       /* TT #617 — wake_src */
-#include "task_worker.h"    /* tab5_worker_enqueue */
-#include "voice_m5_llm.h"   /* sys_reboot, hwinfo accessor */
+#include "settings.h"             /* TT #617 — wake_src */
+#include "task_worker.h"          /* tab5_worker_enqueue */
 #include "voice_ext_pcm_stream.h" /* TT #131 stats */
-#include "voice_onboard.h"  /* failover state names */
-#include "voice_wakeword.h" /* status + reconfigure_phrase + transcripts */
+#include "voice_m5_llm.h"         /* sys_reboot, hwinfo accessor */
+#include "voice_onboard.h"        /* failover state names */
+#include "voice_wakeword.h"       /* status + reconfigure_phrase + transcripts */
 
 static const char *TAG = "debug_tinkeron";
 
@@ -177,8 +177,8 @@ static esp_err_t handle_wake_src(httpd_req_t *req) {
    if (httpd_query_key_value(qry, "src", src, sizeof(src)) != ESP_OK) {
       return respond_error(req, "missing src= param", 400);
    }
-   if (strcmp(src, "k144") != 0 && strcmp(src, "dragon") != 0 &&
-       strcmp(src, "ext_pcm") != 0 && strcmp(src, "off") != 0) {
+   if (strcmp(src, "k144") != 0 && strcmp(src, "dragon") != 0 && strcmp(src, "ext_pcm") != 0 &&
+       strcmp(src, "off") != 0) {
       return respond_error(req, "src must be k144|dragon|ext_pcm|off", 400);
    }
    esp_err_t e = tab5_settings_set_wake_src(src);
@@ -388,15 +388,24 @@ static esp_err_t handle_extpcm(httpd_req_t *req) {
 
    /* Hint strings the user can scan at a glance. */
    const char *hint;
-   if (!st.task_running)             hint = "pump task not running";
-   else if (!st.armed)               hint = "pump disarmed (wake_src != ext_pcm?)";
-   else if (st.voice_state != 2)     hint = "voice state not READY";
-   else if (!st.wakeword_active)     hint = "voice_wakeword not armed (K144 asr.setup pending)";
-   else if (st.asr_id == NULL || st.asr_id[0] == '\0') hint = "asr_id empty (wakeword setup failed?)";
-   else if (st.last_pump_age_ms > 2000) hint = "no recent pump send (UART send failing?)";
-   else if (st.last_send_ok == 0)    hint = "last UART send failed (port C contention?)";
-   else if (st.last_mic_rms < 50)    hint = "mic capture is near-silent (RMS < 50)";
-   else                              hint = "ok — frames flowing with audible mic";
+   if (!st.task_running)
+      hint = "pump task not running";
+   else if (!st.armed)
+      hint = "pump disarmed (wake_src != ext_pcm?)";
+   else if (st.voice_state != 2)
+      hint = "voice state not READY";
+   else if (!st.wakeword_active)
+      hint = "voice_wakeword not armed (K144 asr.setup pending)";
+   else if (st.asr_id == NULL || st.asr_id[0] == '\0')
+      hint = "asr_id empty (wakeword setup failed?)";
+   else if (st.last_pump_age_ms > 2000)
+      hint = "no recent pump send (UART send failing?)";
+   else if (st.last_send_ok == 0)
+      hint = "last UART send failed (port C contention?)";
+   else if (st.last_mic_rms < 50)
+      hint = "mic capture is near-silent (RMS < 50)";
+   else
+      hint = "ok — frames flowing with audible mic";
    cJSON_AddStringToObject(root, "hint", hint);
 
    return respond_json(req, root, 200);
@@ -427,7 +436,10 @@ void debug_server_tinkeron_register(httpd_handle_t server) {
        .user_ctx = NULL,
    };
    static const httpd_uri_t uri_extpcm = {
-       .uri = "/tinkeron/extpcm", .method = HTTP_GET, .handler = handle_extpcm, .user_ctx = NULL,
+       .uri = "/tinkeron/extpcm",
+       .method = HTTP_GET,
+       .handler = handle_extpcm,
+       .user_ctx = NULL,
    };
    httpd_register_uri_handler(server, &uri_status);
    httpd_register_uri_handler(server, &uri_arm);

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -33,6 +33,7 @@
 #include "settings.h"       /* TT #617 — wake_src */
 #include "task_worker.h"    /* tab5_worker_enqueue */
 #include "voice_m5_llm.h"   /* sys_reboot, hwinfo accessor */
+#include "voice_ext_pcm_stream.h" /* TT #131 stats */
 #include "voice_onboard.h"  /* failover state names */
 #include "voice_wakeword.h" /* status + reconfigure_phrase + transcripts */
 
@@ -352,6 +353,41 @@ static esp_err_t handle_transcripts(httpd_req_t *req) {
    return respond_json(req, root, 200);
 }
 
+/* ── GET /tinkeron/extpcm — Path A live diagnostic ────────────────── */
+
+static esp_err_t handle_extpcm(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_FAIL;
+   voice_ext_pcm_stream_stats_t st;
+   voice_ext_pcm_stream_get_stats(&st);
+
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "task_running", st.task_running);
+   cJSON_AddBoolToObject(root, "armed", st.armed);
+   cJSON_AddNumberToObject(root, "voice_state", st.voice_state);
+   cJSON_AddBoolToObject(root, "wakeword_active", st.wakeword_active);
+   cJSON_AddStringToObject(root, "asr_id", st.asr_id ? st.asr_id : "");
+   cJSON_AddNumberToObject(root, "frames_pumped", st.frames_pumped);
+   cJSON_AddNumberToObject(root, "last_mic_rms", st.last_mic_rms);
+   cJSON_AddNumberToObject(root, "last_tx_bytes", st.last_tx_bytes);
+   cJSON_AddNumberToObject(root, "last_send_ok", st.last_send_ok);
+   cJSON_AddNumberToObject(root, "last_pump_age_ms", (double)st.last_pump_age_ms);
+
+   /* Hint strings the user can scan at a glance. */
+   const char *hint;
+   if (!st.task_running)             hint = "pump task not running";
+   else if (!st.armed)               hint = "pump disarmed (wake_src != ext_pcm?)";
+   else if (st.voice_state != 2)     hint = "voice state not READY";
+   else if (!st.wakeword_active)     hint = "voice_wakeword not armed (K144 asr.setup pending)";
+   else if (st.asr_id == NULL || st.asr_id[0] == '\0') hint = "asr_id empty (wakeword setup failed?)";
+   else if (st.last_pump_age_ms > 2000) hint = "no recent pump send (UART send failing?)";
+   else if (st.last_send_ok == 0)    hint = "last UART send failed (port C contention?)";
+   else if (st.last_mic_rms < 50)    hint = "mic capture is near-silent (RMS < 50)";
+   else                              hint = "ok — frames flowing with audible mic";
+   cJSON_AddStringToObject(root, "hint", hint);
+
+   return respond_json(req, root, 200);
+}
+
 /* ── Registration ─────────────────────────────────────────────────── */
 
 void debug_server_tinkeron_register(httpd_handle_t server) {
@@ -376,11 +412,15 @@ void debug_server_tinkeron_register(httpd_handle_t server) {
        .handler = handle_wake_src,
        .user_ctx = NULL,
    };
+   static const httpd_uri_t uri_extpcm = {
+       .uri = "/tinkeron/extpcm", .method = HTTP_GET, .handler = handle_extpcm, .user_ctx = NULL,
+   };
    httpd_register_uri_handler(server, &uri_status);
    httpd_register_uri_handler(server, &uri_arm);
    httpd_register_uri_handler(server, &uri_phrase);
    httpd_register_uri_handler(server, &uri_reboot);
    httpd_register_uri_handler(server, &uri_transcripts);
    httpd_register_uri_handler(server, &uri_wake_src);
-   ESP_LOGI(TAG, "TinkerON debug family registered (6 endpoints)");
+   httpd_register_uri_handler(server, &uri_extpcm);
+   ESP_LOGI(TAG, "TinkerON debug family registered (7 endpoints)");
 }

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -203,8 +203,10 @@ static esp_err_t handle_wake_src(httpd_req_t *req) {
       voice_ext_pcm_stream_disarm();
       voice_wake_stream_arm();
    } else if (strcmp(src, "ext_pcm") == 0) {
-      voice_wakeword_stop();
       voice_wake_stream_disarm();
+      /* Arm voice_wakeword FIRST so its asr.setup runs (which lazily binds
+       * audio's PUB).  Then ext_pcm steals the bind during its handshake. */
+      voice_onboard_arm_wakeword();
       voice_ext_pcm_stream_arm();
    } else { /* off */
       voice_wakeword_stop();

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -194,19 +194,21 @@ static esp_err_t handle_wake_src(httpd_req_t *req) {
    extern void voice_ext_pcm_stream_arm(void);
    extern esp_err_t voice_onboard_arm_wakeword(void);
 
+   extern esp_err_t voice_onboard_arm_wakeword_async(void);
    if (strcmp(src, "k144") == 0) {
       voice_wake_stream_disarm();
       voice_ext_pcm_stream_disarm();
-      voice_onboard_arm_wakeword();
+      voice_onboard_arm_wakeword_async();
    } else if (strcmp(src, "dragon") == 0) {
       voice_wakeword_stop();
       voice_ext_pcm_stream_disarm();
       voice_wake_stream_arm();
    } else if (strcmp(src, "ext_pcm") == 0) {
       voice_wake_stream_disarm();
-      /* Arm voice_wakeword FIRST so its asr.setup runs (which lazily binds
-       * audio's PUB).  Then ext_pcm steals the bind during its handshake. */
-      voice_onboard_arm_wakeword();
+      /* Arm voice_wakeword asynchronously so its asr.setup runs on the
+       * worker.  The ext_pcm pump is gated on voice_wakeword_is_active()
+       * + K144 READY so it won't fight the arm for UART. */
+      voice_onboard_arm_wakeword_async();
       voice_ext_pcm_stream_arm();
    } else { /* off */
       voice_wakeword_stop();

--- a/main/ima_adpcm.c
+++ b/main/ima_adpcm.c
@@ -1,0 +1,129 @@
+/**
+ * @file ima_adpcm.c
+ * @brief IMA ADPCM 4-bit encoder/decoder.  Standard reference impl.
+ */
+
+#include "ima_adpcm.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+static const int16_t step_table[89] = {
+    7,     8,     9,     10,    11,    12,    13,    14,    16,    17,
+    19,    21,    23,    25,    28,    31,    34,    37,    41,    45,
+    50,    55,    60,    66,    73,    80,    88,    97,    107,   118,
+    130,   143,   157,   173,   190,   209,   230,   253,   279,   307,
+    337,   371,   408,   449,   494,   544,   598,   658,   724,   796,
+    876,   963,   1060,  1166,  1282,  1411,  1552,  1707,  1878,  2066,
+    2272,  2499,  2749,  3024,  3327,  3660,  4026,  4428,  4871,  5358,
+    5894,  6484,  7132,  7845,  8630,  9493,  10442, 11487, 12635, 13899,
+    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+};
+
+static const int8_t index_table[16] = {
+    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8,
+};
+
+static inline int clamp_index(int idx) {
+    if (idx < 0) return 0;
+    if (idx > 88) return 88;
+    return idx;
+}
+
+static inline int16_t clamp_int16(int32_t v) {
+    if (v > 32767) return 32767;
+    if (v < -32768) return -32768;
+    return (int16_t)v;
+}
+
+/* Encode one sample with current predictor/step state.  Updates state.
+ * Returns the 4-bit nibble. */
+static uint8_t encode_sample(int16_t sample, int16_t *predictor, int *step_index) {
+    int diff = sample - *predictor;
+    int sign = (diff < 0) ? 8 : 0;
+    if (diff < 0) diff = -diff;
+    int step = step_table[*step_index];
+    int delta = 0;
+    int diff_q = step >> 3;
+    if (diff >= step)    { delta |= 4; diff -= step;    diff_q += step;    }
+    if (diff >= step >> 1) { delta |= 2; diff -= step >> 1; diff_q += step >> 1; }
+    if (diff >= step >> 2) { delta |= 1; diff -= step >> 2; diff_q += step >> 2; }
+    if (sign) {
+        *predictor = clamp_int16((int32_t)*predictor - diff_q);
+    } else {
+        *predictor = clamp_int16((int32_t)*predictor + diff_q);
+    }
+    *step_index = clamp_index(*step_index + index_table[delta | sign]);
+    return (uint8_t)(delta | sign);
+}
+
+static int16_t decode_sample(uint8_t nibble, int16_t *predictor, int *step_index) {
+    int step = step_table[*step_index];
+    int diff_q = step >> 3;
+    if (nibble & 4) diff_q += step;
+    if (nibble & 2) diff_q += step >> 1;
+    if (nibble & 1) diff_q += step >> 2;
+    if (nibble & 8) {
+        *predictor = clamp_int16((int32_t)*predictor - diff_q);
+    } else {
+        *predictor = clamp_int16((int32_t)*predictor + diff_q);
+    }
+    *step_index = clamp_index(*step_index + index_table[nibble]);
+    return *predictor;
+}
+
+size_t ima_adpcm_encode(const int16_t *in, size_t sample_count, uint8_t *out, size_t out_cap) {
+    if (in == NULL || out == NULL || sample_count == 0) return 0;
+    size_t need = ima_adpcm_encoded_size(sample_count);
+    if (out_cap < need) return 0;
+
+    int16_t predictor = in[0];
+    int step_index = 0;
+    /* Header: int16 first_sample LE, uint8 step_index, uint8 reserved. */
+    out[0] = (uint8_t)(predictor & 0xff);
+    out[1] = (uint8_t)((predictor >> 8) & 0xff);
+    out[2] = (uint8_t)step_index;
+    out[3] = 0;
+
+    /* Body: nibbles for samples [1..N-1].  Pack low-nibble then high. */
+    size_t out_idx = 4;
+    int low = 1;
+    uint8_t accum = 0;
+    for (size_t i = 1; i < sample_count; i++) {
+        uint8_t nib = encode_sample(in[i], &predictor, &step_index);
+        if (low) {
+            accum = nib & 0x0f;
+            low = 0;
+        } else {
+            accum |= (nib & 0x0f) << 4;
+            out[out_idx++] = accum;
+            low = 1;
+        }
+    }
+    if (!low) {
+        /* Odd sample count — flush the half-byte (high nibble = 0). */
+        out[out_idx++] = accum;
+    }
+    return out_idx;
+}
+
+size_t ima_adpcm_decode(const uint8_t *in, size_t in_len, int16_t *out, size_t out_cap_samples) {
+    if (in == NULL || out == NULL || in_len < 4) return 0;
+
+    int16_t predictor = (int16_t)((uint16_t)in[0] | ((uint16_t)in[1] << 8));
+    int step_index = clamp_index(in[2]);
+
+    if (out_cap_samples == 0) return 0;
+    out[0] = predictor;
+    size_t out_idx = 1;
+    /* nibbles start at byte 4 */
+    for (size_t b = 4; b < in_len && out_idx < out_cap_samples; b++) {
+        uint8_t low = in[b] & 0x0f;
+        out[out_idx++] = decode_sample(low, &predictor, &step_index);
+        if (out_idx >= out_cap_samples) break;
+        uint8_t high = (in[b] >> 4) & 0x0f;
+        out[out_idx++] = decode_sample(high, &predictor, &step_index);
+    }
+    return out_idx;
+}

--- a/main/ima_adpcm.c
+++ b/main/ima_adpcm.c
@@ -5,125 +5,132 @@
 
 #include "ima_adpcm.h"
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 static const int16_t step_table[89] = {
-    7,     8,     9,     10,    11,    12,    13,    14,    16,    17,
-    19,    21,    23,    25,    28,    31,    34,    37,    41,    45,
-    50,    55,    60,    66,    73,    80,    88,    97,    107,   118,
-    130,   143,   157,   173,   190,   209,   230,   253,   279,   307,
-    337,   371,   408,   449,   494,   544,   598,   658,   724,   796,
-    876,   963,   1060,  1166,  1282,  1411,  1552,  1707,  1878,  2066,
-    2272,  2499,  2749,  3024,  3327,  3660,  4026,  4428,  4871,  5358,
-    5894,  6484,  7132,  7845,  8630,  9493,  10442, 11487, 12635, 13899,
-    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
-};
+    7,    8,     9,     10,    11,    12,    13,    14,    16,    17,    19,    21,    23,    25,   28,
+    31,   34,    37,    41,    45,    50,    55,    60,    66,    73,    80,    88,    97,    107,  118,
+    130,  143,   157,   173,   190,   209,   230,   253,   279,   307,   337,   371,   408,   449,  494,
+    544,  598,   658,   724,   796,   876,   963,   1060,  1166,  1282,  1411,  1552,  1707,  1878, 2066,
+    2272, 2499,  2749,  3024,  3327,  3660,  4026,  4428,  4871,  5358,  5894,  6484,  7132,  7845, 8630,
+    9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767};
 
 static const int8_t index_table[16] = {
-    -1, -1, -1, -1, 2, 4, 6, 8,
-    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8,
 };
 
 static inline int clamp_index(int idx) {
-    if (idx < 0) return 0;
-    if (idx > 88) return 88;
-    return idx;
+   if (idx < 0) return 0;
+   if (idx > 88) return 88;
+   return idx;
 }
 
 static inline int16_t clamp_int16(int32_t v) {
-    if (v > 32767) return 32767;
-    if (v < -32768) return -32768;
-    return (int16_t)v;
+   if (v > 32767) return 32767;
+   if (v < -32768) return -32768;
+   return (int16_t)v;
 }
 
 /* Encode one sample with current predictor/step state.  Updates state.
  * Returns the 4-bit nibble. */
 static uint8_t encode_sample(int16_t sample, int16_t *predictor, int *step_index) {
-    int diff = sample - *predictor;
-    int sign = (diff < 0) ? 8 : 0;
-    if (diff < 0) diff = -diff;
-    int step = step_table[*step_index];
-    int delta = 0;
-    int diff_q = step >> 3;
-    if (diff >= step)    { delta |= 4; diff -= step;    diff_q += step;    }
-    if (diff >= step >> 1) { delta |= 2; diff -= step >> 1; diff_q += step >> 1; }
-    if (diff >= step >> 2) { delta |= 1; diff -= step >> 2; diff_q += step >> 2; }
-    if (sign) {
-        *predictor = clamp_int16((int32_t)*predictor - diff_q);
-    } else {
-        *predictor = clamp_int16((int32_t)*predictor + diff_q);
-    }
-    *step_index = clamp_index(*step_index + index_table[delta | sign]);
-    return (uint8_t)(delta | sign);
+   int diff = sample - *predictor;
+   int sign = (diff < 0) ? 8 : 0;
+   if (diff < 0) diff = -diff;
+   int step = step_table[*step_index];
+   int delta = 0;
+   int diff_q = step >> 3;
+   if (diff >= step) {
+      delta |= 4;
+      diff -= step;
+      diff_q += step;
+   }
+   if (diff >= step >> 1) {
+      delta |= 2;
+      diff -= step >> 1;
+      diff_q += step >> 1;
+   }
+   if (diff >= step >> 2) {
+      delta |= 1;
+      diff -= step >> 2;
+      diff_q += step >> 2;
+   }
+   if (sign) {
+      *predictor = clamp_int16((int32_t)*predictor - diff_q);
+   } else {
+      *predictor = clamp_int16((int32_t)*predictor + diff_q);
+   }
+   *step_index = clamp_index(*step_index + index_table[delta | sign]);
+   return (uint8_t)(delta | sign);
 }
 
 static int16_t decode_sample(uint8_t nibble, int16_t *predictor, int *step_index) {
-    int step = step_table[*step_index];
-    int diff_q = step >> 3;
-    if (nibble & 4) diff_q += step;
-    if (nibble & 2) diff_q += step >> 1;
-    if (nibble & 1) diff_q += step >> 2;
-    if (nibble & 8) {
-        *predictor = clamp_int16((int32_t)*predictor - diff_q);
-    } else {
-        *predictor = clamp_int16((int32_t)*predictor + diff_q);
-    }
-    *step_index = clamp_index(*step_index + index_table[nibble]);
-    return *predictor;
+   int step = step_table[*step_index];
+   int diff_q = step >> 3;
+   if (nibble & 4) diff_q += step;
+   if (nibble & 2) diff_q += step >> 1;
+   if (nibble & 1) diff_q += step >> 2;
+   if (nibble & 8) {
+      *predictor = clamp_int16((int32_t)*predictor - diff_q);
+   } else {
+      *predictor = clamp_int16((int32_t)*predictor + diff_q);
+   }
+   *step_index = clamp_index(*step_index + index_table[nibble]);
+   return *predictor;
 }
 
 size_t ima_adpcm_encode(const int16_t *in, size_t sample_count, uint8_t *out, size_t out_cap) {
-    if (in == NULL || out == NULL || sample_count == 0) return 0;
-    size_t need = ima_adpcm_encoded_size(sample_count);
-    if (out_cap < need) return 0;
+   if (in == NULL || out == NULL || sample_count == 0) return 0;
+   size_t need = ima_adpcm_encoded_size(sample_count);
+   if (out_cap < need) return 0;
 
-    int16_t predictor = in[0];
-    int step_index = 0;
-    /* Header: int16 first_sample LE, uint8 step_index, uint8 reserved. */
-    out[0] = (uint8_t)(predictor & 0xff);
-    out[1] = (uint8_t)((predictor >> 8) & 0xff);
-    out[2] = (uint8_t)step_index;
-    out[3] = 0;
+   int16_t predictor = in[0];
+   int step_index = 0;
+   /* Header: int16 first_sample LE, uint8 step_index, uint8 reserved. */
+   out[0] = (uint8_t)(predictor & 0xff);
+   out[1] = (uint8_t)((predictor >> 8) & 0xff);
+   out[2] = (uint8_t)step_index;
+   out[3] = 0;
 
-    /* Body: nibbles for samples [1..N-1].  Pack low-nibble then high. */
-    size_t out_idx = 4;
-    int low = 1;
-    uint8_t accum = 0;
-    for (size_t i = 1; i < sample_count; i++) {
-        uint8_t nib = encode_sample(in[i], &predictor, &step_index);
-        if (low) {
-            accum = nib & 0x0f;
-            low = 0;
-        } else {
-            accum |= (nib & 0x0f) << 4;
-            out[out_idx++] = accum;
-            low = 1;
-        }
-    }
-    if (!low) {
-        /* Odd sample count — flush the half-byte (high nibble = 0). */
-        out[out_idx++] = accum;
-    }
-    return out_idx;
+   /* Body: nibbles for samples [1..N-1].  Pack low-nibble then high. */
+   size_t out_idx = 4;
+   int low = 1;
+   uint8_t accum = 0;
+   for (size_t i = 1; i < sample_count; i++) {
+      uint8_t nib = encode_sample(in[i], &predictor, &step_index);
+      if (low) {
+         accum = nib & 0x0f;
+         low = 0;
+      } else {
+         accum |= (nib & 0x0f) << 4;
+         out[out_idx++] = accum;
+         low = 1;
+      }
+   }
+   if (!low) {
+      /* Odd sample count — flush the half-byte (high nibble = 0). */
+      out[out_idx++] = accum;
+   }
+   return out_idx;
 }
 
 size_t ima_adpcm_decode(const uint8_t *in, size_t in_len, int16_t *out, size_t out_cap_samples) {
-    if (in == NULL || out == NULL || in_len < 4) return 0;
+   if (in == NULL || out == NULL || in_len < 4) return 0;
 
-    int16_t predictor = (int16_t)((uint16_t)in[0] | ((uint16_t)in[1] << 8));
-    int step_index = clamp_index(in[2]);
+   int16_t predictor = (int16_t)((uint16_t)in[0] | ((uint16_t)in[1] << 8));
+   int step_index = clamp_index(in[2]);
 
-    if (out_cap_samples == 0) return 0;
-    out[0] = predictor;
-    size_t out_idx = 1;
-    /* nibbles start at byte 4 */
-    for (size_t b = 4; b < in_len && out_idx < out_cap_samples; b++) {
-        uint8_t low = in[b] & 0x0f;
-        out[out_idx++] = decode_sample(low, &predictor, &step_index);
-        if (out_idx >= out_cap_samples) break;
-        uint8_t high = (in[b] >> 4) & 0x0f;
-        out[out_idx++] = decode_sample(high, &predictor, &step_index);
-    }
-    return out_idx;
+   if (out_cap_samples == 0) return 0;
+   out[0] = predictor;
+   size_t out_idx = 1;
+   /* nibbles start at byte 4 */
+   for (size_t b = 4; b < in_len && out_idx < out_cap_samples; b++) {
+      uint8_t low = in[b] & 0x0f;
+      out[out_idx++] = decode_sample(low, &predictor, &step_index);
+      if (out_idx >= out_cap_samples) break;
+      uint8_t high = (in[b] >> 4) & 0x0f;
+      out[out_idx++] = decode_sample(high, &predictor, &step_index);
+   }
+   return out_idx;
 }

--- a/main/ima_adpcm.h
+++ b/main/ima_adpcm.h
@@ -1,0 +1,51 @@
+/**
+ * @file ima_adpcm.h
+ * @brief IMA ADPCM 4:1 encoder for 16 kHz mono int16 audio (TT #131).
+ *
+ * Compresses real-time PCM to fit Tab5↔K144 UART control-plane
+ * bandwidth budget (~13 KB/s sustained at 1.5 Mbps after daemon
+ * overhead).  Raw 16k mono int16 = 32 KB/s; IMA ADPCM nibbles =
+ * 8 KB/s + tiny per-chunk header.
+ *
+ * Each encoded chunk is self-contained — predictor + step index
+ * resets per call.  K144 ext_pcm decodes the same way: header has
+ * the first sample + step index, nibbles follow.
+ *
+ * Block layout (matches Microsoft / IMA ADPCM wave format):
+ *
+ *     [int16 first_sample][uint8 step_index][uint8 reserved=0]
+ *     [4-bit nibble × (N-1)]
+ *
+ * Total output bytes for N samples:  4 + ((N - 1 + 1) / 2)
+ * For N = 1600 (100 ms @ 16 kHz):    804 bytes.
+ */
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief Bytes needed to encode @p sample_count int16 samples. */
+static inline size_t ima_adpcm_encoded_size(size_t sample_count) {
+    if (sample_count == 0) return 0;
+    return 4 + (sample_count / 2);
+}
+
+/**
+ * @brief Encode @p in_samples (int16 mono) to IMA ADPCM in @p out.
+ * @return Bytes written, or 0 on overflow / invalid input.
+ */
+size_t ima_adpcm_encode(const int16_t *in, size_t sample_count, uint8_t *out, size_t out_cap);
+
+/**
+ * @brief Decode IMA ADPCM bytes to int16 samples.  out_cap is in
+ *        SAMPLES, not bytes.  Returns sample count written.
+ */
+size_t ima_adpcm_decode(const uint8_t *in, size_t in_len, int16_t *out, size_t out_cap_samples);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/ima_adpcm.h
+++ b/main/ima_adpcm.h
@@ -30,8 +30,8 @@ extern "C" {
 
 /** @brief Bytes needed to encode @p sample_count int16 samples. */
 static inline size_t ima_adpcm_encoded_size(size_t sample_count) {
-    if (sample_count == 0) return 0;
-    return 4 + (sample_count / 2);
+   if (sample_count == 0) return 0;
+   return 4 + (sample_count / 2);
 }
 
 /**

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1239,14 +1239,13 @@ void ui_home_update_status(void)
 
     /* TT #584 — refresh the TinkerON armed chip on every tick.  Green
      * dot + "TINKERON" when armed; amber dot + "TINKERON OFF" when
-     * not.  Hidden when K144 is currently UNAVAILABLE — the chip
-     * would lie about the listener's state otherwise. */
+     * not.  TT #131-opt2: KWS-via-ext_pcm doesn't need K144 LLM warmup,
+     * so don't hide on failover UNAVAILABLE if wakeword is actually
+     * armed — the chip is truthful as long as wake fires. */
     if (s_tinkeron_dot && s_tinkeron_label) {
         bool armed = voice_wakeword_is_active();
-        /* M5_FAIL_UNAVAILABLE = 3 (enum private to voice_onboard.c).
-         * Hide the chip when K144 is permanently unavailable so we
-         * don't lie about the listener's state. */
-        if (voice_onboard_failover_state() == 3) {
+        bool llm_unavail = (voice_onboard_failover_state() == 3);
+        if (llm_unavail && !armed) {
             lv_obj_add_flag(s_tinkeron_dot, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(s_tinkeron_label, LV_OBJ_FLAG_HIDDEN);
         } else {

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1246,14 +1246,13 @@ void ui_home_update_status(void)
         bool armed = voice_wakeword_is_active();
         bool llm_unavail = (voice_onboard_failover_state() == 3);
         if (llm_unavail && !armed) {
-            lv_obj_add_flag(s_tinkeron_dot, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_add_flag(s_tinkeron_label, LV_OBJ_FLAG_HIDDEN);
+           lv_obj_add_flag(s_tinkeron_dot, LV_OBJ_FLAG_HIDDEN);
+           lv_obj_add_flag(s_tinkeron_label, LV_OBJ_FLAG_HIDDEN);
         } else {
-            lv_obj_remove_flag(s_tinkeron_dot, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_remove_flag(s_tinkeron_label, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_set_style_bg_color(s_tinkeron_dot,
-                lv_color_hex(armed ? TH_STATUS_GREEN : TH_AMBER), 0);
-            lv_label_set_text(s_tinkeron_label, armed ? "TINKERON" : "TINKERON OFF");
+           lv_obj_remove_flag(s_tinkeron_dot, LV_OBJ_FLAG_HIDDEN);
+           lv_obj_remove_flag(s_tinkeron_label, LV_OBJ_FLAG_HIDDEN);
+           lv_obj_set_style_bg_color(s_tinkeron_dot, lv_color_hex(armed ? TH_STATUS_GREEN : TH_AMBER), 0);
+           lv_label_set_text(s_tinkeron_label, armed ? "TINKERON" : "TINKERON OFF");
         }
     }
 

--- a/main/voice.c
+++ b/main/voice.c
@@ -538,6 +538,9 @@ void voice_set_state(voice_state_t new_state, const char *detail) {
          if (tab5_settings_wake_src_is("dragon")) {
             voice_wake_stream_arm();
          } else if (tab5_settings_wake_src_is("ext_pcm")) {
+            /* voice_wakeword owns asr.setup — voice_onboard's warmup/
+             * arm-on-READY handler arms it normally because its gate now
+             * allows ext_pcm.  We only need to arm the PCM pump here. */
             voice_ext_pcm_stream_arm();
          }
       } else if (new_state == VOICE_STATE_IDLE && old != VOICE_STATE_IDLE) {

--- a/main/voice.c
+++ b/main/voice.c
@@ -525,18 +525,24 @@ void voice_set_state(voice_state_t new_state, const char *detail) {
       extern void voice_wake_stream_on_state_change(int new_state);
       extern void voice_wake_stream_arm(void);
       extern void voice_wake_stream_disarm(void);
+      extern void voice_ext_pcm_stream_on_state_change(int new_state);
+      extern void voice_ext_pcm_stream_arm(void);
+      extern void voice_ext_pcm_stream_disarm(void);
       voice_wake_stream_on_state_change((int)new_state);
-      /* TT #617 — gate on wake_src NVS setting.  Only arm Dragon-side
-       * wake-stream if the user picked "dragon".  k144 / off paths
-       * leave the wake-stream task idling (it stays alive but disarmed
-       * so a runtime wake_src flip from k144 → dragon picks up
-       * without a reboot). */
+      voice_ext_pcm_stream_on_state_change((int)new_state);
+      /* TT #617 — gate on wake_src NVS setting.  Only arm the right
+       * wake path for the picked source.  All paths leave the other
+       * tasks idling (alive but disarmed) so runtime wake_src flips
+       * pick up without a reboot. */
       if (new_state == VOICE_STATE_READY && old != VOICE_STATE_READY) {
          if (tab5_settings_wake_src_is("dragon")) {
             voice_wake_stream_arm();
+         } else if (tab5_settings_wake_src_is("ext_pcm")) {
+            voice_ext_pcm_stream_arm();
          }
       } else if (new_state == VOICE_STATE_IDLE && old != VOICE_STATE_IDLE) {
          voice_wake_stream_disarm();
+         voice_ext_pcm_stream_disarm();
       }
    }
 }
@@ -1188,6 +1194,18 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
        esp_err_t we = voice_wake_stream_init();
        if (we != ESP_OK) {
           ESP_LOGW(TAG, "voice_wake_stream_init failed (%s) — wake-stream disabled", esp_err_to_name(we));
+       }
+    }
+
+    /* TT #131 — Path A ext_pcm-stream: spawn the background task that
+     * ships Tab5 mic to K144 over Port C UART as ingest-RPC frames.
+     * Arm only when wake_src=="ext_pcm" + voice state hits READY. */
+    {
+       extern esp_err_t voice_ext_pcm_stream_init(void);
+       esp_err_t ep = voice_ext_pcm_stream_init();
+       if (ep != ESP_OK) {
+          ESP_LOGW(TAG, "voice_ext_pcm_stream_init failed (%s) — ext_pcm path disabled",
+                   esp_err_to_name(ep));
        }
     }
 

--- a/main/voice.c
+++ b/main/voice.c
@@ -1207,8 +1207,7 @@ esp_err_t voice_init(voice_state_cb_t state_cb)
        extern esp_err_t voice_ext_pcm_stream_init(void);
        esp_err_t ep = voice_ext_pcm_stream_init();
        if (ep != ESP_OK) {
-          ESP_LOGW(TAG, "voice_ext_pcm_stream_init failed (%s) — ext_pcm path disabled",
-                   esp_err_to_name(ep));
+          ESP_LOGW(TAG, "voice_ext_pcm_stream_init failed (%s) — ext_pcm path disabled", esp_err_to_name(ep));
        }
     }
 

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -222,13 +222,14 @@ static void ext_pcm_task(void *arg) {
        * match on ADPCM-degraded audio in live tests despite the round-trip
        * decoding correctly.  At 16 kHz mono int16 → base64 = ~44 KB/s,
        * comfortably under UART 1.5 Mbps (187 KB/s effective). */
-      /* TT #131-opt2: 24× digital gain — 16× gave peaks ~1600 on
-       * normal-volume speech; KWS wants 3000+.  Bump to 24× with
-       * saturation. */
+      /* TT #131-opt2: 16× digital gain — Tab5 ES7210 mic level at default
+       * codec PGA gives raw RMS ~65 on speech, way below the ~3000-4000
+       * the gigaspeech KWS model was tuned against.  6× wasn't enough.
+       * Boost in place with int16 saturation. */
       {
          int16_t *p = (int16_t *)batch_buf;
          for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
-            int32_t v = (int32_t)p[k] * 24;
+            int32_t v = (int32_t)p[k] * 16;
             if (v > 32767) v = 32767;
             else if (v < -32768) v = -32768;
             p[k] = (int16_t)v;

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -80,7 +80,10 @@ static bool quiescent_state(int st) {
  * frames.  Used only for the bring-up handshake — NOT for per-frame
  * ingest (which fire-and-forgets). */
 static esp_err_t handshake_send_recv(const m5_stackflow_request_t *req, uint32_t timeout_ms) {
-   if (tab5_port_c_lock(2000) != ESP_OK) {
+   /* 6 s lock acquire — voice_wakeword's run loop also takes the lock
+    * 10× per second.  Same-priority + round-robin can starve us briefly.
+    * 6 s is well over the wakeword inner-loop budget. */
+   if (tab5_port_c_lock(6000) != ESP_OK) {
       ESP_LOGW(TAG, "port-c lock timeout in handshake");
       return ESP_ERR_TIMEOUT;
    }

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -109,55 +109,33 @@ static esp_err_t handshake_send_recv(const m5_stackflow_request_t *req, uint32_t
    return ESP_OK;
 }
 
-/* The three-step handshake that hands /tmp/llm/pcm.cap.socket to ext_pcm
- * so our ingest frames flow through to llm_asr.  Idempotent — re-running
- * is safe and just produces fresh ack lines on the UART. */
+/* Two-step handshake that hands /tmp/llm/pcm.cap.socket from llm_audio to
+ * ext_pcm.  asr.setup is OWNED by voice_wakeword (which arms first when
+ * wake_src=ext_pcm) — it triggers audio's lazy _cap() to bind the URL.
+ * After that, ext_pcm steals the bind so OUR PCM flows to the live ASR
+ * subscriber.  Idempotent. */
 static esp_err_t do_handshake(void) {
-   /* 1. asr.setup with input=sys.pcm.  audio's lazy _cap() binds the URL
-    *    and steals our boot-time bind.  ASR subscribes. */
-   cJSON *asr_data = cJSON_CreateObject();
-   cJSON_AddStringToObject(asr_data, "model", "sherpa-ncnn-streaming-zipformer-20M-2023-02-17");
-   cJSON *inputs = cJSON_AddArrayToObject(asr_data, "input");
-   cJSON_AddItemToArray(inputs, cJSON_CreateString("sys.pcm"));
-   cJSON_AddStringToObject(asr_data, "response_format", "asr.utf-8.stream");
-   cJSON_AddBoolToObject(asr_data, "enoutput", true);
-
+   /* 1. audio.cap_stop_all — release audio's bind on the PUB URL.  ASR's
+    *    SUB stays connected and will reconnect to whoever next binds. */
    m5_stackflow_request_t req1 = {
-       .request_id = "ext-pcm-asr-setup",
-       .work_id = "asr",
-       .action = "setup",
-       .object = "asr.setup",
-       .data_json = asr_data,
-   };
-   esp_err_t e = handshake_send_recv(&req1, 15000);
-   cJSON_Delete(asr_data);
-   if (e != ESP_OK) {
-      ESP_LOGW(TAG, "asr.setup failed (%s)", esp_err_to_name(e));
-      return e;
-   }
-   ESP_LOGI(TAG, "asr.setup sent");
-
-   /* 2. audio.cap_stop_all — release audio's bind on the PUB URL. */
-   m5_stackflow_request_t req2 = {
        .request_id = "ext-pcm-cap-stop",
        .work_id = "audio",
        .action = "cap_stop_all",
    };
-   e = handshake_send_recv(&req2, 3000);
+   esp_err_t e = handshake_send_recv(&req1, 3000);
    if (e != ESP_OK) {
       ESP_LOGW(TAG, "audio.cap_stop_all failed (%s)", esp_err_to_name(e));
       return e;
    }
    ESP_LOGI(TAG, "audio.cap_stop_all sent");
 
-   /* 3. ext_pcm.rebind — ext_pcm reclaims the URL.  ASR's subscriber
-    *    auto-reconnects when the IPC socket file is re-bound. */
-   m5_stackflow_request_t req3 = {
+   /* 2. ext_pcm.rebind — ext_pcm reclaims the URL. */
+   m5_stackflow_request_t req2 = {
        .request_id = "ext-pcm-rebind",
        .work_id = "ext_pcm",
        .action = "rebind",
    };
-   e = handshake_send_recv(&req3, 3000);
+   e = handshake_send_recv(&req2, 3000);
    if (e != ESP_OK) {
       ESP_LOGW(TAG, "ext_pcm.rebind failed (%s)", esp_err_to_name(e));
       return e;

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -153,29 +153,72 @@ static void ext_pcm_task(void *arg) {
        * From then on, every ingest RPC we send to ext_pcm decodes
        * ADPCM and publishes raw PCM on the URL ASR is listening to. */
       if (!s_handshake_done) {
+         /* 3-step handshake with explicit settling time between steps so
+          * the ZMQ IPC SUB on asr's side has time to:
+          *   a. detect audio's bind disappearing (cap_stop_all)
+          *   b. enter its reconnect loop (default ZMQ_RECONNECT_IVL=100ms)
+          *   c. settle on ext_pcm's fresh bind (rebind)
+          * Earlier 150ms gaps were marginal; 500ms is robust. */
+         char hbuf[256];
+
+         /* 1. audio.cap_stop_all — audio releases its PUB bind. */
          m5_stackflow_request_t req_stop = {
-            .request_id = "ep-cap-stop",
-            .work_id = "audio",
+            .request_id = "ep-cap-stop", .work_id = "audio",
             .action = "cap_stop_all",
          };
-         char hbuf[256];
          int hlen = m5_stackflow_build_request(&req_stop, hbuf, sizeof(hbuf));
          if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
             tab5_port_c_send(hbuf, (size_t)hlen);
             tab5_port_c_unlock();
-            vTaskDelay(pdMS_TO_TICKS(150));
          }
+         vTaskDelay(pdMS_TO_TICKS(500));
+
+         /* 2. ext_pcm.rebind — ext_pcm takes ownership of the URL. */
          m5_stackflow_request_t req_rebind = {
-            .request_id = "ep-rebind",
-            .work_id = "ext_pcm",
+            .request_id = "ep-rebind", .work_id = "ext_pcm",
             .action = "rebind",
          };
          hlen = m5_stackflow_build_request(&req_rebind, hbuf, sizeof(hbuf));
          if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
             tab5_port_c_send(hbuf, (size_t)hlen);
             tab5_port_c_unlock();
-            vTaskDelay(pdMS_TO_TICKS(150));
          }
+         vTaskDelay(pdMS_TO_TICKS(500));
+
+         /* 3. ext_pcm.rebind AGAIN — defensive: any momentary K144-side
+          * lifecycle event could have re-stolen the URL.  Lock it in. */
+         hlen = m5_stackflow_build_request(&req_rebind, hbuf, sizeof(hbuf));
+         if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
+            tab5_port_c_send(hbuf, (size_t)hlen);
+            tab5_port_c_unlock();
+         }
+         vTaskDelay(pdMS_TO_TICKS(500));
+
+         /* 4. asr.link sys.pcm — force ASR to create a FRESH subscriber.
+          * Its original subscriber from asr.setup is stuck on a stale
+          * IPC inode after our rebind (audio's PUB was the binder at
+          * that moment; the file's been re-created so the SUB's cached
+          * peer is dead).  asr.link with data="sys.pcm" calls
+          * unit_call("audio","cap","sys.pcm") → returns current URL →
+          * subscriber() attaches a new SUB to ext_pcm's live PUB. */
+         const char *asr_id = voice_wakeword_asr_id();
+         if (asr_id && asr_id[0]) {
+            char link_payload[64];
+            snprintf(link_payload, sizeof(link_payload), "\"sys.pcm\"");
+            m5_stackflow_request_t req_link = {
+               .request_id = "ep-asr-link", .work_id = asr_id,
+               .action = "link", .object = "asr.link",
+               .data_string = "sys.pcm",
+            };
+            hlen = m5_stackflow_build_request(&req_link, hbuf, sizeof(hbuf));
+            if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
+               tab5_port_c_send(hbuf, (size_t)hlen);
+               tab5_port_c_unlock();
+               ESP_LOGI(TAG, "asr.link sys.pcm sent (%s)", asr_id);
+            }
+            vTaskDelay(pdMS_TO_TICKS(500));
+         }
+
          s_handshake_done = true;
          tab5_debug_obs_event("ext_pcm_stream", "handshake_done");
          ESP_LOGI(TAG, "handshake fired — ext_pcm owns /tmp/llm/pcm.cap.socket");

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -55,7 +55,20 @@
  * single-threaded; flooding it at 50 RPCs/sec (one per 20 ms chunk)
  * caused frame drops + remote_call queue blow-up.  Batching 5 chunks =
  * 100 ms of audio per RPC = 10 RPCs/sec is comfortable for both sides. */
-#define INGEST_BATCH_CHUNKS 5
+/* TT #131 — keep total JSON envelope ≤ 1024 B so each ingest frame fits
+ * in a single K144 linux_uart_read() chunk.  Larger frames span K144's
+ * 1024-byte read buffer, and any single-byte UART jitter (even without
+ * a frame error) corrupts the JSON.  K144's base64_decode then off-by-
+ * ones into `basic_string::erase()` → std::out_of_range → asr daemon
+ * crash + systemd respawn.  Live-captured 2026-05-19.
+ *
+ * 1 chunk = 20 ms × 640 B raw → 856 B base64 → ~920 B JSON envelope.
+ * Send rate: 50 fps × 920 B = 46 KB/s.  Comfortably below the 13 KB/s
+ * actual K144-daemon ingest ceiling we hit at 1.5 Mbps wire, but the
+ * extra headroom lets the wire eat brief stalls from wakeword's recv
+ * loop.  Actual K144 throughput will throttle Tab5 via uart TX-ring
+ * backpressure once that 8 KB ring fills. */
+#define INGEST_BATCH_CHUNKS 1
 #define INGEST_RAW_BYTES (WS_CHUNK_BYTES * INGEST_BATCH_CHUNKS)
 #define INGEST_B64_CAP (((INGEST_RAW_BYTES + 2) / 3) * 4 + 4)
 #define INGEST_TX_CAP (INGEST_B64_CAP + 128)

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -34,6 +34,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/idf_additions.h"
 #include "freertos/task.h"
 #include "ima_adpcm.h"
 #include "mbedtls/base64.h"
@@ -222,23 +223,18 @@ static void ext_pcm_task(void *arg) {
        * match on ADPCM-degraded audio in live tests despite the round-trip
        * decoding correctly.  At 16 kHz mono int16 → base64 = ~44 KB/s,
        * comfortably under UART 1.5 Mbps (187 KB/s effective). */
-      /* TT #131-opt2: 24× digital gain with SOFT-CLIP — earlier 24× with
-       * hard saturation killed detection (square-wave distortion).  Now
-       * linear gain up to ±20 000, then 3:1 compression above that.
-       * Preserves the waveform envelope so KWS features stay valid. */
+      /* TT #131-opt2: 16× digital gain — matches verified-firing setting
+       * from 6ca0f7b ("KWS now fires live on Tab5 mic").  Tab5 ES7210 mic
+       * level at default codec PGA gives raw RMS ~65 on speech, way below
+       * the ~3000-4000 the gigaspeech KWS model was tuned against.  Boost
+       * in place with int16 saturation. */
       {
          int16_t *p = (int16_t *)batch_buf;
-         const int32_t KNEE = 20000;
          for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
-            int32_t g = (int32_t)p[k] * 24;
-            if (g > KNEE) {
-               g = KNEE + (g - KNEE) / 3;
-               if (g > 32767) g = 32767;
-            } else if (g < -KNEE) {
-               g = -KNEE + (g + KNEE) / 3;
-               if (g < -32768) g = -32768;
-            }
-            p[k] = (int16_t)g;
+            int32_t v = (int32_t)p[k] * 16;
+            if (v > 32767) v = 32767;
+            else if (v < -32768) v = -32768;
+            p[k] = (int16_t)v;
          }
       }
       size_t b64_len = 0;
@@ -302,8 +298,14 @@ cleanup:
 
 esp_err_t voice_ext_pcm_stream_init(void) {
    if (s_task != NULL) return ESP_OK;
-   BaseType_t ok = xTaskCreatePinnedToCore(ext_pcm_task, "voice_ext_pcm", EXT_PCM_TASK_STACK, NULL,
-                                           EXT_PCM_TASK_PRIO, &s_task, EXT_PCM_TASK_CORE);
+   /* TT #131 stability: PSRAM-back the 8 KB task stack via WithCaps.
+    * Internal-SRAM boot headroom is ~56 KB largest-free; adding 8 KB +
+    * the 12 KB wakeword stack + cJSON allocs during kws.setup retries
+    * was pushing internal-SRAM largest-free below the 20 KB heap_wd
+    * exhaustion threshold within ~3 min → panic. */
+   BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(ext_pcm_task, "voice_ext_pcm", EXT_PCM_TASK_STACK,
+                                                   NULL, EXT_PCM_TASK_PRIO, &s_task,
+                                                   EXT_PCM_TASK_CORE, MALLOC_CAP_SPIRAM);
    if (ok != pdPASS) {
       ESP_LOGE(TAG, "task spawn failed");
       s_task = NULL;

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -222,14 +222,13 @@ static void ext_pcm_task(void *arg) {
        * match on ADPCM-degraded audio in live tests despite the round-trip
        * decoding correctly.  At 16 kHz mono int16 → base64 = ~44 KB/s,
        * comfortably under UART 1.5 Mbps (187 KB/s effective). */
-      /* TT #131-opt2: 16× digital gain — Tab5 ES7210 mic level at default
-       * codec PGA gives raw RMS ~65 on speech, way below the ~3000-4000
-       * the gigaspeech KWS model was tuned against.  6× wasn't enough.
-       * Boost in place with int16 saturation. */
+      /* TT #131-opt2: 24× digital gain — 16× gave peaks ~1600 on
+       * normal-volume speech; KWS wants 3000+.  Bump to 24× with
+       * saturation. */
       {
          int16_t *p = (int16_t *)batch_buf;
          for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
-            int32_t v = (int32_t)p[k] * 16;
+            int32_t v = (int32_t)p[k] * 24;
             if (v > 32767) v = 32767;
             else if (v < -32768) v = -32768;
             p[k] = (int16_t)v;

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -35,6 +35,7 @@
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "ima_adpcm.h"
 #include "mbedtls/base64.h"
 #include "m5_stackflow.h"
 #include "uart_port_c.h"
@@ -51,27 +52,26 @@
 #define WS_CHUNK_SAMPLES (TAB5_VOICE_SAMPLE_RATE * TAB5_VOICE_CHUNK_MS / 1000)
 #define WS_CHUNK_BYTES (WS_CHUNK_SAMPLES * sizeof(int16_t))
 
-/* Batch N mic chunks per ingest RPC.  K144's UART JSON parser is
- * single-threaded; flooding it at 50 RPCs/sec (one per 20 ms chunk)
- * caused frame drops + remote_call queue blow-up.  Batching 5 chunks =
- * 100 ms of audio per RPC = 10 RPCs/sec is comfortable for both sides. */
-/* TT #131 — keep total JSON envelope ≤ 1024 B so each ingest frame fits
- * in a single K144 linux_uart_read() chunk.  Larger frames span K144's
- * 1024-byte read buffer, and any single-byte UART jitter (even without
- * a frame error) corrupts the JSON.  K144's base64_decode then off-by-
- * ones into `basic_string::erase()` → std::out_of_range → asr daemon
- * crash + systemd respawn.  Live-captured 2026-05-19.
+/* TT #131 — IMA ADPCM 4:1 compression to fit K144 daemon's ~13 KB/s
+ * ingestion ceiling.  Raw 16k mono int16 = 32 KB/s → ADPCM 8 KB/s.
  *
- * 1 chunk = 20 ms × 640 B raw → 856 B base64 → ~920 B JSON envelope.
- * Send rate: 50 fps × 920 B = 46 KB/s.  Comfortably below the 13 KB/s
- * actual K144-daemon ingest ceiling we hit at 1.5 Mbps wire, but the
- * extra headroom lets the wire eat brief stalls from wakeword's recv
- * loop.  Actual K144 throughput will throttle Tab5 via uart TX-ring
- * backpressure once that 8 KB ring fills. */
-#define INGEST_BATCH_CHUNKS 1
+ * Batch 5×20ms = 100 ms of audio per ingest RPC = 10 RPCs/sec.
+ *   1600 samples × 2 B raw         → 3200 B PCM
+ *   ima_adpcm_encode               → 4 + 1600/2 = 804 B ADPCM
+ *   base64 (4×ceil(N/3))           → 1072 B
+ *   JSON envelope                  → ~1200 B per frame
+ *   send rate: 10 fps × 1200 B     → 12 KB/s ✓ fits K144 budget
+ *
+ * NB: JSON > 1024 B spans K144's linux_uart_read() boundary, but
+ * select_json_str handles partial reads correctly (brace-counting
+ * accumulator).  Earlier crash mode was inside K144's asr decode,
+ * not the parser; routing through ext_pcm (our binary) sidesteps it. */
+#define INGEST_BATCH_CHUNKS 5
 #define INGEST_RAW_BYTES (WS_CHUNK_BYTES * INGEST_BATCH_CHUNKS)
-#define INGEST_B64_CAP (((INGEST_RAW_BYTES + 2) / 3) * 4 + 4)
-#define INGEST_TX_CAP (INGEST_B64_CAP + 128)
+#define INGEST_RAW_SAMPLES (INGEST_RAW_BYTES / sizeof(int16_t))
+#define INGEST_ADPCM_CAP (4 + (INGEST_RAW_SAMPLES + 1) / 2)
+#define INGEST_B64_CAP (((INGEST_ADPCM_CAP + 2) / 3) * 4 + 4)
+#define INGEST_TX_CAP (INGEST_B64_CAP + 256)
 
 #define EXT_PCM_TASK_STACK 8192
 /* PRIO 5 = one above voice_wakeword (4).  When wakeword's recv loop
@@ -85,6 +85,7 @@ extern void tab5_debug_obs_event(const char *kind, const char *detail);
 static TaskHandle_t s_task = NULL;
 static volatile bool s_armed = false;
 static volatile bool s_baud_negotiated = false;
+static volatile bool s_handshake_done = false;
 static volatile int s_voice_state = 0;
 static uint32_t s_frame_seq = 0;
 /* Diagnostic state — updated in pump loop, read by stats accessor. */
@@ -143,13 +144,41 @@ static void ext_pcm_task(void *arg) {
          continue;
       }
 
-      /* No handshake needed — asr was set up with input=["asr"] so it
-       * subscribes to its own inference bus.  We just send inference
-       * RPCs to the wakeword's asr work_id. */
-      const char *asr_id = voice_wakeword_asr_id();
-      if (asr_id == NULL || asr_id[0] == '\0') {
-         vTaskDelay(pdMS_TO_TICKS(500));
-         continue;
+      /* ASR was set up with input=["sys.pcm"], so it subscribes to
+       * /tmp/llm/pcm.cap.socket (audio's PUB URL).  Run the handshake
+       * once to flip URL ownership from audio → ext_pcm:
+       *   1. audio.cap_stop_all   — release audio's bind
+       *   2. ext_pcm.rebind       — ext_pcm reclaims URL; ASR's SUB
+       *                              auto-reconnects (ZMQ IPC)
+       * From then on, every ingest RPC we send to ext_pcm decodes
+       * ADPCM and publishes raw PCM on the URL ASR is listening to. */
+      if (!s_handshake_done) {
+         m5_stackflow_request_t req_stop = {
+            .request_id = "ep-cap-stop",
+            .work_id = "audio",
+            .action = "cap_stop_all",
+         };
+         char hbuf[256];
+         int hlen = m5_stackflow_build_request(&req_stop, hbuf, sizeof(hbuf));
+         if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
+            tab5_port_c_send(hbuf, (size_t)hlen);
+            tab5_port_c_unlock();
+            vTaskDelay(pdMS_TO_TICKS(150));
+         }
+         m5_stackflow_request_t req_rebind = {
+            .request_id = "ep-rebind",
+            .work_id = "ext_pcm",
+            .action = "rebind",
+         };
+         hlen = m5_stackflow_build_request(&req_rebind, hbuf, sizeof(hbuf));
+         if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
+            tab5_port_c_send(hbuf, (size_t)hlen);
+            tab5_port_c_unlock();
+            vTaskDelay(pdMS_TO_TICKS(150));
+         }
+         s_handshake_done = true;
+         tab5_debug_obs_event("ext_pcm_stream", "handshake_done");
+         ESP_LOGI(TAG, "handshake fired — ext_pcm owns /tmp/llm/pcm.cap.socket");
       }
 
       /* TT #131 — first-time-armed: negotiate UART up to 1.5 Mbps.
@@ -209,9 +238,18 @@ static void ext_pcm_task(void *arg) {
       if (batch_chunks < INGEST_BATCH_CHUNKS) continue;
       batch_chunks = 0;
 
+      /* IMA ADPCM 4:1 compression — reuse b64_buf temporarily as the
+       * ADPCM scratch since base64 encoder consumes it next. */
+      uint8_t adpcm_scratch[INGEST_ADPCM_CAP + 8];
+      size_t adpcm_len = ima_adpcm_encode((const int16_t *)batch_buf, INGEST_RAW_SAMPLES,
+                                          adpcm_scratch, sizeof(adpcm_scratch));
+      if (adpcm_len == 0) {
+         ESP_LOGW(TAG, "ADPCM encode failed");
+         continue;
+      }
       size_t b64_len = 0;
       int b_err = mbedtls_base64_encode((unsigned char *)b64_buf, INGEST_B64_CAP, &b64_len,
-                                        (const unsigned char *)batch_buf, INGEST_RAW_BYTES);
+                                        adpcm_scratch, adpcm_len);
       if (b_err != 0 || b64_len == 0) {
          ESP_LOGW(TAG, "base64 encode failed: %d", b_err);
          continue;
@@ -220,14 +258,17 @@ static void ext_pcm_task(void *arg) {
 
       char rid[24];
       snprintf(rid, sizeof(rid), "ep%lu", (unsigned long)(++s_frame_seq));
-      /* Re-read asr_id in case wakeword was re-armed; harmless if stale. */
-      const char *target = voice_wakeword_asr_id();
-      if (target == NULL || target[0] == '\0') continue;
+      /* Route to K144's ext_pcm "ingest" RPC — our binary decodes the
+       * ADPCM and publishes raw PCM to /tmp/llm/pcm.cap.socket, which
+       * the K144 ASR (configured with input=["sys.pcm"]) consumes via
+       * its standard subscriber.  Object tag tells ext_pcm to ADPCM-
+       * decode before publishing. */
+      const char *target = "ext_pcm";
       m5_stackflow_request_t req = {
           .request_id = rid,
-          .work_id = target, /* asr.NNNN */
-          .action = "inference",
-          .object = "audio.pcm.base64",
+          .work_id = target,
+          .action = "ingest",
+          .object = "audio.pcm.adpcm.base64",
           .data_string = b64_buf,
       };
       int tx_len = m5_stackflow_build_request(&req, tx_buf, INGEST_TX_CAP);
@@ -284,6 +325,7 @@ esp_err_t voice_ext_pcm_stream_init(void) {
 void voice_ext_pcm_stream_arm(void) {
    if (s_armed) return;
    s_armed = true;
+   s_handshake_done = false; /* fresh handshake on next arm */
    tab5_debug_obs_event("ext_pcm_stream", "arm");
    ESP_LOGI(TAG, "armed");
 }

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -38,6 +38,8 @@
 #include "mbedtls/base64.h"
 #include "m5_stackflow.h"
 #include "uart_port_c.h"
+#include "voice_onboard.h"
+#include "voice_wakeword.h"
 
 #define TAG "voice_ext_pcm_stream"
 
@@ -164,6 +166,20 @@ static void ext_pcm_task(void *arg) {
    while (1) {
       if (!s_armed || !quiescent_state(s_voice_state) || voice_mic_is_active()) {
          vTaskDelay(pdMS_TO_TICKS(100));
+         continue;
+      }
+
+      /* Critical readiness gates — DO NOT pump until both hold:
+       *
+       *   1. K144 daemon is past warm-up (failover_state==2 READY).
+       *      Pumping before warmup completes saturates the UART and
+       *      starves the warmup probe → infinite reset/retry loop.
+       *
+       *   2. voice_wakeword is armed.  Without it, ASR has no setup
+       *      arranged so audio's lazy _cap() never binds the PUB URL,
+       *      and our cap_stop_all + rebind have nothing to take over. */
+      if (voice_onboard_failover_state() != 2 || !voice_wakeword_is_active()) {
+         vTaskDelay(pdMS_TO_TICKS(500));
          continue;
       }
 

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -70,7 +70,9 @@
 #define INGEST_RAW_BYTES (WS_CHUNK_BYTES * INGEST_BATCH_CHUNKS)
 #define INGEST_RAW_SAMPLES (INGEST_RAW_BYTES / sizeof(int16_t))
 #define INGEST_ADPCM_CAP (4 + (INGEST_RAW_SAMPLES + 1) / 2)
-#define INGEST_B64_CAP (((INGEST_ADPCM_CAP + 2) / 3) * 4 + 4)
+/* TT #131-opt2: sized for RAW PCM base64 (not ADPCM) — KWS needs the
+ * unquantized audio.  INGEST_RAW_BYTES base64 ≈ 4× ADPCM base64. */
+#define INGEST_B64_CAP (((INGEST_RAW_BYTES + 2) / 3) * 4 + 4)
 #define INGEST_TX_CAP (INGEST_B64_CAP + 256)
 
 #define EXT_PCM_TASK_STACK 8192
@@ -216,18 +218,27 @@ static void ext_pcm_task(void *arg) {
       if (batch_chunks < INGEST_BATCH_CHUNKS) continue;
       batch_chunks = 0;
 
-      /* IMA ADPCM 4:1 compression — reuse b64_buf temporarily as the
-       * ADPCM scratch since base64 encoder consumes it next. */
-      uint8_t adpcm_scratch[INGEST_ADPCM_CAP + 8];
-      size_t adpcm_len = ima_adpcm_encode((const int16_t *)batch_buf, INGEST_RAW_SAMPLES,
-                                          adpcm_scratch, sizeof(adpcm_scratch));
-      if (adpcm_len == 0) {
-         ESP_LOGW(TAG, "ADPCM encode failed");
-         continue;
+      /* TT #131-opt2: send RAW PCM (no ADPCM) — KWS spotter wouldn't
+       * match on ADPCM-degraded audio in live tests despite the round-trip
+       * decoding correctly.  At 16 kHz mono int16 → base64 = ~44 KB/s,
+       * comfortably under UART 1.5 Mbps (187 KB/s effective). */
+      /* TT #131-opt2: 6× digital gain — Tab5 ES7210 mic level is ~10× lower
+       * than K144's onboard mic which the gigaspeech KWS model was tuned
+       * against.  Boost in place with int16 saturation to bring features
+       * into the model's expected range. */
+      {
+         int16_t *p = (int16_t *)batch_buf;
+         for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
+            int32_t v = (int32_t)p[k] * 6;
+            if (v > 32767) v = 32767;
+            else if (v < -32768) v = -32768;
+            p[k] = (int16_t)v;
+         }
       }
       size_t b64_len = 0;
       int b_err = mbedtls_base64_encode((unsigned char *)b64_buf, INGEST_B64_CAP, &b64_len,
-                                        adpcm_scratch, adpcm_len);
+                                        (const uint8_t *)batch_buf,
+                                        (size_t)INGEST_RAW_SAMPLES * sizeof(int16_t));
       if (b_err != 0 || b64_len == 0) {
          ESP_LOGW(TAG, "base64 encode failed: %d", b_err);
          continue;
@@ -236,15 +247,13 @@ static void ext_pcm_task(void *arg) {
 
       char rid[24];
       snprintf(rid, sizeof(rid), "ep%lu", (unsigned long)(++s_frame_seq));
-      /* Direct inference to asr.NNNN.  K144 main_asr (custom build)
-       * decodes ADPCM in task_user_data, feeds raw PCM to sherpa-ncnn. */
       const char *target = voice_wakeword_asr_id();
       if (target == NULL || target[0] == '\0') continue;
       m5_stackflow_request_t req = {
           .request_id = rid,
           .work_id = target,
           .action = "inference",
-          .object = "audio.pcm.adpcm.base64",
+          .object = "audio.pcm.base64",
           .data_string = b64_buf,
       };
       int tx_len = m5_stackflow_build_request(&req, tx_buf, INGEST_TX_CAP);

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -57,7 +57,9 @@
 #define INGEST_TX_CAP (INGEST_B64_CAP + 128)
 
 #define EXT_PCM_TASK_STACK 8192
-#define EXT_PCM_TASK_PRIO 4
+/* PRIO 5 = one above voice_wakeword (4).  When wakeword's recv loop
+ * yields between iterations, we preempt and claim the UART lock first. */
+#define EXT_PCM_TASK_PRIO 5
 #define EXT_PCM_TASK_CORE 1
 
 extern bool voice_mic_is_active(void);
@@ -172,16 +174,12 @@ static void ext_pcm_task(void *arg) {
          continue;
       }
 
-      /* Critical readiness gates — DO NOT pump until both hold:
-       *
-       *   1. K144 daemon is past warm-up (failover_state==2 READY).
-       *      Pumping before warmup completes saturates the UART and
-       *      starves the warmup probe → infinite reset/retry loop.
-       *
-       *   2. voice_wakeword is armed.  Without it, ASR has no setup
-       *      arranged so audio's lazy _cap() never binds the PUB URL,
-       *      and our cap_stop_all + rebind have nothing to take over. */
-      if (voice_onboard_failover_state() != 2 || !voice_wakeword_is_active()) {
+      /* Gate on voice_wakeword being armed.  That's the only true
+       * prerequisite — wakeword's setup arms audio + asr on K144 (NOT
+       * llm), so failover_state (which gates on llm.setup) is irrelevant
+       * here.  If wakeword is up, asr is up, audio is up; we can claim
+       * the PCM PUB URL. */
+      if (!voice_wakeword_is_active()) {
          vTaskDelay(pdMS_TO_TICKS(500));
          continue;
       }

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -147,24 +147,13 @@ static void ext_pcm_task(void *arg) {
        * K144 /proc/tty/driver/serial showed only 2.6 KB/s incoming
        * vs Tab5's 44 KB/s send rate.  1.5 Mbps = 150 KB/s, ample
        * headroom. */
+      /* Baud negotiation is now done up-front in the picker handler
+       * BEFORE wakeword arms.  Pump just observes the result. */
       if (!s_baud_negotiated) {
-         /* Suppress voice_onboard's auto-retry FIRST.  If we negotiate
-          * baud while it's enabled, a stray sys.hwinfo failure during
-          * the verify-window can cascade into sys.reset → K144 reverts
-          * to 115200 → we're stranded at 1.5 M. */
-         voice_onboard_suppress_auto_retry(true);
-         ESP_LOGI(TAG, "negotiating UART up to 1.5 Mbps for sustained PCM throughput");
-         esp_err_t be = voice_m5_llm_set_baud(1500000);
-         if (be == ESP_OK) {
-            s_baud_negotiated = true;
-            tab5_debug_obs_event("ext_pcm_stream", "baud_1500000");
-            ESP_LOGI(TAG, "UART now at 1.5 Mbps (auto-retry suppressed)");
-         } else {
-            ESP_LOGW(TAG, "baud negotiation failed (%s) — back-off + retry", esp_err_to_name(be));
-            /* Restore auto-retry so K144 can recover from real failures. */
-            voice_onboard_suppress_auto_retry(false);
-            vTaskDelay(pdMS_TO_TICKS(2000));
-            continue;
+         s_baud_negotiated = (tab5_port_c_uart_get_baud() == 1500000);
+         if (s_baud_negotiated) {
+            ESP_LOGI(TAG, "pump observes UART at 1.5 Mbps");
+            tab5_debug_obs_event("ext_pcm_stream", "baud_observed_1500000");
          }
       }
 

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -38,6 +38,7 @@
 #include "mbedtls/base64.h"
 #include "m5_stackflow.h"
 #include "uart_port_c.h"
+#include "voice_m5_llm.h"
 #include "voice_onboard.h"
 #include "voice_wakeword.h"
 
@@ -70,7 +71,7 @@ extern void tab5_debug_obs_event(const char *kind, const char *detail);
 
 static TaskHandle_t s_task = NULL;
 static volatile bool s_armed = false;
-static volatile bool s_handshake_done = false;
+/* handshake state retained as dead-but-harmless flag — drop in next pass */
 static volatile int s_voice_state = 0;
 static uint32_t s_frame_seq = 0;
 static int64_t s_last_log_us = 0;
@@ -80,79 +81,11 @@ static bool quiescent_state(int st) {
    return (st == 2);
 }
 
-/* Send a request that EXPECTS an ack within @p timeout_ms.  We read +
- * discard the reply so the response buffer doesn't pile up on subsequent
- * frames.  Used only for the bring-up handshake — NOT for per-frame
- * ingest (which fire-and-forgets). */
-static esp_err_t handshake_send_recv(const m5_stackflow_request_t *req, uint32_t timeout_ms) {
-   /* 6 s lock acquire — voice_wakeword's run loop also takes the lock
-    * 10× per second.  Same-priority + round-robin can starve us briefly.
-    * 6 s is well over the wakeword inner-loop budget. */
-   if (tab5_port_c_lock(6000) != ESP_OK) {
-      ESP_LOGW(TAG, "port-c lock timeout in handshake");
-      return ESP_ERR_TIMEOUT;
-   }
-   char tx[1024];
-   int tx_len = m5_stackflow_build_request(req, tx, sizeof(tx));
-   if (tx_len < 0) {
-      tab5_port_c_unlock();
-      return ESP_ERR_NO_MEM;
-   }
-   tab5_port_c_flush();
-   if (tab5_port_c_send(tx, (size_t)tx_len) != tx_len) {
-      tab5_port_c_unlock();
-      return ESP_ERR_INVALID_STATE;
-   }
-   /* Drain any newline-terminated frame the K144 sends back.  We don't
-    * actually use the response body — ingest is fire-and-forget — but
-    * we must not let it accumulate in the UART buffer. */
-   char rxbuf[512];
-   int64_t deadline = esp_timer_get_time() + (int64_t)timeout_ms * 1000;
-   while (esp_timer_get_time() < deadline) {
-      int n = tab5_port_c_recv(rxbuf, sizeof(rxbuf) - 1, 50);
-      if (n > 0) {
-         rxbuf[n] = '\0';
-         if (memchr(rxbuf, '\n', (size_t)n) != NULL) break;
-      }
-   }
-   tab5_port_c_unlock();
-   return ESP_OK;
-}
-
-/* Two-step handshake that hands /tmp/llm/pcm.cap.socket from llm_audio to
- * ext_pcm.  asr.setup is OWNED by voice_wakeword (which arms first when
- * wake_src=ext_pcm) — it triggers audio's lazy _cap() to bind the URL.
- * After that, ext_pcm steals the bind so OUR PCM flows to the live ASR
- * subscriber.  Idempotent. */
-static esp_err_t do_handshake(void) {
-   /* 1. audio.cap_stop_all — release audio's bind on the PUB URL.  ASR's
-    *    SUB stays connected and will reconnect to whoever next binds. */
-   m5_stackflow_request_t req1 = {
-       .request_id = "ext-pcm-cap-stop",
-       .work_id = "audio",
-       .action = "cap_stop_all",
-   };
-   esp_err_t e = handshake_send_recv(&req1, 3000);
-   if (e != ESP_OK) {
-      ESP_LOGW(TAG, "audio.cap_stop_all failed (%s)", esp_err_to_name(e));
-      return e;
-   }
-   ESP_LOGI(TAG, "audio.cap_stop_all sent");
-
-   /* 2. ext_pcm.rebind — ext_pcm reclaims the URL. */
-   m5_stackflow_request_t req2 = {
-       .request_id = "ext-pcm-rebind",
-       .work_id = "ext_pcm",
-       .action = "rebind",
-   };
-   e = handshake_send_recv(&req2, 3000);
-   if (e != ESP_OK) {
-      ESP_LOGW(TAG, "ext_pcm.rebind failed (%s)", esp_err_to_name(e));
-      return e;
-   }
-   ESP_LOGI(TAG, "ext_pcm.rebind sent — pipeline ready");
-   return ESP_OK;
-}
+/* TT #131 — new architecture: ASR was configured with input=["asr"]
+ * by voice_wakeword (Tab5-mic variant), so it subscribes to its OWN
+ * inference bus.  We push PCM as inference RPC frames directly to the
+ * asr work_id.  No audio.setup, no ext_pcm rebind, no PUB contention —
+ * fire-and-forget through llm_sys's remote_call. */
 
 static void ext_pcm_task(void *arg) {
    (void)arg;
@@ -192,18 +125,13 @@ static void ext_pcm_task(void *arg) {
          continue;
       }
 
-      /* Lazily run the handshake the first time we're armed in a session.
-       * voice_ext_pcm_stream_disarm() clears s_handshake_done so re-arming
-       * issues a fresh handshake. */
-      if (!s_handshake_done) {
-         if (do_handshake() == ESP_OK) {
-            s_handshake_done = true;
-            tab5_debug_obs_event("ext_pcm_stream", "handshake_ok");
-         } else {
-            tab5_debug_obs_event("ext_pcm_stream", "handshake_fail");
-            vTaskDelay(pdMS_TO_TICKS(2000)); /* back off + retry */
-            continue;
-         }
+      /* No handshake needed — asr was set up with input=["asr"] so it
+       * subscribes to its own inference bus.  We just send inference
+       * RPCs to the wakeword's asr work_id. */
+      const char *asr_id = voice_wakeword_asr_id();
+      if (asr_id == NULL || asr_id[0] == '\0') {
+         vTaskDelay(pdMS_TO_TICKS(500));
+         continue;
       }
 
       esp_err_t err = tab5_mic_read(tdm_buf, tdm_samples, 100);
@@ -244,10 +172,14 @@ static void ext_pcm_task(void *arg) {
 
       char rid[24];
       snprintf(rid, sizeof(rid), "ep%lu", (unsigned long)(++s_frame_seq));
+      /* Re-read asr_id in case wakeword was re-armed; harmless if stale. */
+      const char *target = voice_wakeword_asr_id();
+      if (target == NULL || target[0] == '\0') continue;
       m5_stackflow_request_t req = {
           .request_id = rid,
-          .work_id = "ext_pcm",
-          .action = "ingest",
+          .work_id = target, /* asr.NNNN */
+          .action = "inference",
+          .object = "audio.pcm.base64",
           .data_string = b64_buf,
       };
       int tx_len = m5_stackflow_build_request(&req, tx_buf, INGEST_TX_CAP);
@@ -300,7 +232,6 @@ esp_err_t voice_ext_pcm_stream_init(void) {
 void voice_ext_pcm_stream_arm(void) {
    if (s_armed) return;
    s_armed = true;
-   s_handshake_done = false; /* force fresh handshake */
    tab5_debug_obs_event("ext_pcm_stream", "arm");
    ESP_LOGI(TAG, "armed");
 }
@@ -308,7 +239,6 @@ void voice_ext_pcm_stream_arm(void) {
 void voice_ext_pcm_stream_disarm(void) {
    if (!s_armed) return;
    s_armed = false;
-   s_handshake_done = false;
    tab5_debug_obs_event("ext_pcm_stream", "disarm");
    ESP_LOGI(TAG, "disarmed");
 }

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -37,8 +37,8 @@
 #include "freertos/idf_additions.h"
 #include "freertos/task.h"
 #include "ima_adpcm.h"
-#include "mbedtls/base64.h"
 #include "m5_stackflow.h"
+#include "mbedtls/base64.h"
 #include "uart_port_c.h"
 #include "voice_m5_llm.h"
 #include "voice_onboard.h"
@@ -113,8 +113,7 @@ static void ext_pcm_task(void *arg) {
    (void)arg;
 
    const int tdm_samples = WS_MIC_48K_FRAMES * WS_MIC_TDM_CHANNELS;
-   int16_t *tdm_buf =
-       heap_caps_malloc(tdm_samples * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   int16_t *tdm_buf = heap_caps_malloc(tdm_samples * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    int16_t *mono_buf = heap_caps_malloc(WS_CHUNK_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    /* batch_buf accumulates INGEST_BATCH_CHUNKS×WS_CHUNK_BYTES raw PCM
     * before a single base64 + ingest send.  Reduces UART RPC rate from
@@ -213,8 +212,7 @@ static void ext_pcm_task(void *arg) {
       if (!quiescent_state(s_voice_state) || voice_mic_is_active()) continue;
 
       /* Append this chunk to the batch.  Send only when full. */
-      memcpy((uint8_t *)batch_buf + batch_chunks * WS_CHUNK_BYTES, mono_buf,
-             (size_t)out_idx * sizeof(int16_t));
+      memcpy((uint8_t *)batch_buf + batch_chunks * WS_CHUNK_BYTES, mono_buf, (size_t)out_idx * sizeof(int16_t));
       batch_chunks++;
       if (batch_chunks < INGEST_BATCH_CHUNKS) continue;
       batch_chunks = 0;
@@ -232,14 +230,15 @@ static void ext_pcm_task(void *arg) {
          int16_t *p = (int16_t *)batch_buf;
          for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
             int32_t v = (int32_t)p[k] * 16;
-            if (v > 32767) v = 32767;
-            else if (v < -32768) v = -32768;
+            if (v > 32767)
+               v = 32767;
+            else if (v < -32768)
+               v = -32768;
             p[k] = (int16_t)v;
          }
       }
       size_t b64_len = 0;
-      int b_err = mbedtls_base64_encode((unsigned char *)b64_buf, INGEST_B64_CAP, &b64_len,
-                                        (const uint8_t *)batch_buf,
+      int b_err = mbedtls_base64_encode((unsigned char *)b64_buf, INGEST_B64_CAP, &b64_len, (const uint8_t *)batch_buf,
                                         (size_t)INGEST_RAW_SAMPLES * sizeof(int16_t));
       if (b_err != 0 || b64_len == 0) {
          ESP_LOGW(TAG, "base64 encode failed: %d", b_err);
@@ -274,14 +273,14 @@ static void ext_pcm_task(void *arg) {
       int sent = tab5_port_c_send(tx_buf, (size_t)tx_len);
       tab5_port_c_unlock();
       s_last_tx_bytes = (uint32_t)tx_len;
-      s_last_send_ok  = (sent == tx_len) ? 1 : 0;
+      s_last_send_ok = (sent == tx_len) ? 1 : 0;
       if (sent != tx_len) continue;
 
       int64_t now = esp_timer_get_time();
       s_last_pump_us = now;
       if (now - s_last_log_us > 5 * 1000000) {
-         ESP_LOGI(TAG, "ext_pcm pumped seq=%lu (tx=%d B, rms=%u) → %s",
-                  (unsigned long)s_frame_seq, tx_len, (unsigned)s_last_mic_rms, target);
+         ESP_LOGI(TAG, "ext_pcm pumped seq=%lu (tx=%d B, rms=%u) → %s", (unsigned long)s_frame_seq, tx_len,
+                  (unsigned)s_last_mic_rms, target);
          s_last_log_us = now;
       }
    }
@@ -303,9 +302,8 @@ esp_err_t voice_ext_pcm_stream_init(void) {
     * the 12 KB wakeword stack + cJSON allocs during kws.setup retries
     * was pushing internal-SRAM largest-free below the 20 KB heap_wd
     * exhaustion threshold within ~3 min → panic. */
-   BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(ext_pcm_task, "voice_ext_pcm", EXT_PCM_TASK_STACK,
-                                                   NULL, EXT_PCM_TASK_PRIO, &s_task,
-                                                   EXT_PCM_TASK_CORE, MALLOC_CAP_SPIRAM);
+   BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(ext_pcm_task, "voice_ext_pcm", EXT_PCM_TASK_STACK, NULL,
+                                                   EXT_PCM_TASK_PRIO, &s_task, EXT_PCM_TASK_CORE, MALLOC_CAP_SPIRAM);
    if (ok != pdPASS) {
       ESP_LOGE(TAG, "task spawn failed");
       s_task = NULL;
@@ -339,25 +337,21 @@ void voice_ext_pcm_stream_disarm(void) {
    ESP_LOGI(TAG, "disarmed");
 }
 
-bool voice_ext_pcm_stream_is_active(void) {
-   return s_armed && s_task != NULL && quiescent_state(s_voice_state);
-}
+bool voice_ext_pcm_stream_is_active(void) { return s_armed && s_task != NULL && quiescent_state(s_voice_state); }
 
-void voice_ext_pcm_stream_on_state_change(int new_state) {
-   s_voice_state = new_state;
-}
+void voice_ext_pcm_stream_on_state_change(int new_state) { s_voice_state = new_state; }
 
 void voice_ext_pcm_stream_get_stats(voice_ext_pcm_stream_stats_t *out) {
    if (out == NULL) return;
-   out->task_running    = (s_task != NULL);
-   out->armed           = s_armed;
-   out->voice_state     = s_voice_state;
+   out->task_running = (s_task != NULL);
+   out->armed = s_armed;
+   out->voice_state = s_voice_state;
    out->wakeword_active = voice_wakeword_is_active();
-   out->asr_id          = voice_wakeword_asr_id();
-   out->frames_pumped   = s_frame_seq;
-   out->last_mic_rms    = s_last_mic_rms;
-   out->last_tx_bytes   = s_last_tx_bytes;
-   out->last_send_ok    = s_last_send_ok;
+   out->asr_id = voice_wakeword_asr_id();
+   out->frames_pumped = s_frame_seq;
+   out->last_mic_rms = s_last_mic_rms;
+   out->last_tx_bytes = s_last_tx_bytes;
+   out->last_send_ok = s_last_send_ok;
    if (s_last_pump_us > 0) {
       out->last_pump_age_ms = (esp_timer_get_time() - s_last_pump_us) / 1000;
    } else {

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -1,0 +1,312 @@
+/**
+ * @file voice_ext_pcm_stream.c
+ * @brief Tab5 mic → K144 ext_pcm streamer (TT #131 — Path A production).
+ *
+ * Background task that:
+ *   1. On arm, issues the bring-up handshake against the K144 daemon:
+ *        asr.setup input=sys.pcm    (audio's lazy _cap steals our PUB)
+ *        audio.cap_stop_all         (audio releases bind)
+ *        ext_pcm.rebind             (ext_pcm reclaims /tmp/llm/pcm.cap.socket)
+ *   2. Then on each ~100 ms iteration:
+ *        - read 4800 TDM frames @ 48 kHz × 4 channels
+ *        - downsample MIC1 slot to 16 kHz mono int16 (3200 bytes)
+ *        - base64-encode (~4267 chars)
+ *        - wrap as ingest JSON: {"work_id":"ext_pcm","action":"ingest",
+ *                                "data":"<base64>"}
+ *        - send-and-fire over Port C UART
+ *
+ *   3. On disarm: send asr.exit + audio.cap_start to restore K144's
+ *      onboard mic mode for next session.
+ *
+ * Mic ownership: same rules as voice_wake_stream — only ONE I2S RX
+ * consumer at a time.  Gated on voice_mic_is_active() + voice state
+ * being READY (==2).  Boot grace 1.5 s.
+ */
+
+#include "voice_ext_pcm_stream.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "audio.h"
+#include "config.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "mbedtls/base64.h"
+#include "m5_stackflow.h"
+#include "uart_port_c.h"
+
+#define TAG "voice_ext_pcm_stream"
+
+#define WS_MIC_48K_FRAMES (TAB5_AUDIO_SAMPLE_RATE * TAB5_VOICE_CHUNK_MS / 1000)
+#define WS_MIC_TDM_CHANNELS 4
+#define WS_MIC_TDM_MIC1_OFF 0
+#define WS_DOWNSAMPLE_RATIO (TAB5_AUDIO_SAMPLE_RATE / TAB5_VOICE_SAMPLE_RATE)
+#define WS_CHUNK_SAMPLES (TAB5_VOICE_SAMPLE_RATE * TAB5_VOICE_CHUNK_MS / 1000)
+#define WS_CHUNK_BYTES (WS_CHUNK_SAMPLES * sizeof(int16_t))
+
+/* base64 of 3200 bytes = 4268 chars (no padding needed since 3200 % 3 == 2,
+ * actual ceil((3200+2)/3)*4 = 4268).  Add JSON envelope overhead and a
+ * generous buffer for the request_id digits → 4400 should be plenty. */
+#define INGEST_B64_CAP (((WS_CHUNK_BYTES + 2) / 3) * 4 + 4)
+#define INGEST_TX_CAP (INGEST_B64_CAP + 128)
+
+#define EXT_PCM_TASK_STACK 8192
+#define EXT_PCM_TASK_PRIO 4
+#define EXT_PCM_TASK_CORE 1
+
+extern bool voice_mic_is_active(void);
+extern void tab5_debug_obs_event(const char *kind, const char *detail);
+
+static TaskHandle_t s_task = NULL;
+static volatile bool s_armed = false;
+static volatile bool s_handshake_done = false;
+static volatile int s_voice_state = 0;
+static uint32_t s_frame_seq = 0;
+static int64_t s_last_log_us = 0;
+
+static bool quiescent_state(int st) {
+   /* READY = 2 — same gate voice_wake_stream uses. */
+   return (st == 2);
+}
+
+/* Send a request that EXPECTS an ack within @p timeout_ms.  We read +
+ * discard the reply so the response buffer doesn't pile up on subsequent
+ * frames.  Used only for the bring-up handshake — NOT for per-frame
+ * ingest (which fire-and-forgets). */
+static esp_err_t handshake_send_recv(const m5_stackflow_request_t *req, uint32_t timeout_ms) {
+   if (tab5_port_c_lock(2000) != ESP_OK) {
+      ESP_LOGW(TAG, "port-c lock timeout in handshake");
+      return ESP_ERR_TIMEOUT;
+   }
+   char tx[1024];
+   int tx_len = m5_stackflow_build_request(req, tx, sizeof(tx));
+   if (tx_len < 0) {
+      tab5_port_c_unlock();
+      return ESP_ERR_NO_MEM;
+   }
+   tab5_port_c_flush();
+   if (tab5_port_c_send(tx, (size_t)tx_len) != tx_len) {
+      tab5_port_c_unlock();
+      return ESP_ERR_INVALID_STATE;
+   }
+   /* Drain any newline-terminated frame the K144 sends back.  We don't
+    * actually use the response body — ingest is fire-and-forget — but
+    * we must not let it accumulate in the UART buffer. */
+   char rxbuf[512];
+   int64_t deadline = esp_timer_get_time() + (int64_t)timeout_ms * 1000;
+   while (esp_timer_get_time() < deadline) {
+      int n = tab5_port_c_recv(rxbuf, sizeof(rxbuf) - 1, 50);
+      if (n > 0) {
+         rxbuf[n] = '\0';
+         if (memchr(rxbuf, '\n', (size_t)n) != NULL) break;
+      }
+   }
+   tab5_port_c_unlock();
+   return ESP_OK;
+}
+
+/* The three-step handshake that hands /tmp/llm/pcm.cap.socket to ext_pcm
+ * so our ingest frames flow through to llm_asr.  Idempotent — re-running
+ * is safe and just produces fresh ack lines on the UART. */
+static esp_err_t do_handshake(void) {
+   /* 1. asr.setup with input=sys.pcm.  audio's lazy _cap() binds the URL
+    *    and steals our boot-time bind.  ASR subscribes. */
+   cJSON *asr_data = cJSON_CreateObject();
+   cJSON_AddStringToObject(asr_data, "model", "sherpa-ncnn-streaming-zipformer-20M-2023-02-17");
+   cJSON *inputs = cJSON_AddArrayToObject(asr_data, "input");
+   cJSON_AddItemToArray(inputs, cJSON_CreateString("sys.pcm"));
+   cJSON_AddStringToObject(asr_data, "response_format", "asr.utf-8.stream");
+   cJSON_AddBoolToObject(asr_data, "enoutput", true);
+
+   m5_stackflow_request_t req1 = {
+       .request_id = "ext-pcm-asr-setup",
+       .work_id = "asr",
+       .action = "setup",
+       .object = "asr.setup",
+       .data_json = asr_data,
+   };
+   esp_err_t e = handshake_send_recv(&req1, 15000);
+   cJSON_Delete(asr_data);
+   if (e != ESP_OK) {
+      ESP_LOGW(TAG, "asr.setup failed (%s)", esp_err_to_name(e));
+      return e;
+   }
+   ESP_LOGI(TAG, "asr.setup sent");
+
+   /* 2. audio.cap_stop_all — release audio's bind on the PUB URL. */
+   m5_stackflow_request_t req2 = {
+       .request_id = "ext-pcm-cap-stop",
+       .work_id = "audio",
+       .action = "cap_stop_all",
+   };
+   e = handshake_send_recv(&req2, 3000);
+   if (e != ESP_OK) {
+      ESP_LOGW(TAG, "audio.cap_stop_all failed (%s)", esp_err_to_name(e));
+      return e;
+   }
+   ESP_LOGI(TAG, "audio.cap_stop_all sent");
+
+   /* 3. ext_pcm.rebind — ext_pcm reclaims the URL.  ASR's subscriber
+    *    auto-reconnects when the IPC socket file is re-bound. */
+   m5_stackflow_request_t req3 = {
+       .request_id = "ext-pcm-rebind",
+       .work_id = "ext_pcm",
+       .action = "rebind",
+   };
+   e = handshake_send_recv(&req3, 3000);
+   if (e != ESP_OK) {
+      ESP_LOGW(TAG, "ext_pcm.rebind failed (%s)", esp_err_to_name(e));
+      return e;
+   }
+   ESP_LOGI(TAG, "ext_pcm.rebind sent — pipeline ready");
+   return ESP_OK;
+}
+
+static void ext_pcm_task(void *arg) {
+   (void)arg;
+
+   const int tdm_samples = WS_MIC_48K_FRAMES * WS_MIC_TDM_CHANNELS;
+   int16_t *tdm_buf =
+       heap_caps_malloc(tdm_samples * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   int16_t *mono_buf = heap_caps_malloc(WS_CHUNK_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   char *b64_buf = heap_caps_malloc(INGEST_B64_CAP, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   char *tx_buf = heap_caps_malloc(INGEST_TX_CAP, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!tdm_buf || !mono_buf || !b64_buf || !tx_buf) {
+      ESP_LOGE(TAG, "buffer alloc failed; ext_pcm stream disabled");
+      goto cleanup;
+   }
+
+   ESP_LOGI(TAG, "task started (chunk=%d samples, b64_cap=%d)", WS_CHUNK_SAMPLES, INGEST_B64_CAP);
+   vTaskDelay(pdMS_TO_TICKS(1500)); /* boot grace */
+
+   while (1) {
+      if (!s_armed || !quiescent_state(s_voice_state) || voice_mic_is_active()) {
+         vTaskDelay(pdMS_TO_TICKS(100));
+         continue;
+      }
+
+      /* Lazily run the handshake the first time we're armed in a session.
+       * voice_ext_pcm_stream_disarm() clears s_handshake_done so re-arming
+       * issues a fresh handshake. */
+      if (!s_handshake_done) {
+         if (do_handshake() == ESP_OK) {
+            s_handshake_done = true;
+            tab5_debug_obs_event("ext_pcm_stream", "handshake_ok");
+         } else {
+            tab5_debug_obs_event("ext_pcm_stream", "handshake_fail");
+            vTaskDelay(pdMS_TO_TICKS(2000)); /* back off + retry */
+            continue;
+         }
+      }
+
+      esp_err_t err = tab5_mic_read(tdm_buf, tdm_samples, 100);
+      if (err != ESP_OK) {
+         vTaskDelay(pdMS_TO_TICKS(100));
+         continue;
+      }
+
+      int out_idx = 0;
+      for (int i = 0; i + WS_DOWNSAMPLE_RATIO - 1 < WS_MIC_48K_FRAMES && out_idx < WS_CHUNK_SAMPLES;
+           i += WS_DOWNSAMPLE_RATIO) {
+         int32_t sum = 0;
+         for (int j = 0; j < WS_DOWNSAMPLE_RATIO; j++) {
+            sum += tdm_buf[(i + j) * WS_MIC_TDM_CHANNELS + WS_MIC_TDM_MIC1_OFF];
+         }
+         mono_buf[out_idx++] = (int16_t)(sum / WS_DOWNSAMPLE_RATIO);
+      }
+      if (out_idx == 0) continue;
+
+      /* Re-check state after the I2S read in case mic_task spun up. */
+      if (!quiescent_state(s_voice_state) || voice_mic_is_active()) continue;
+
+      size_t b64_len = 0;
+      int b_err = mbedtls_base64_encode((unsigned char *)b64_buf, INGEST_B64_CAP, &b64_len,
+                                        (const unsigned char *)mono_buf,
+                                        (size_t)out_idx * sizeof(int16_t));
+      if (b_err != 0 || b64_len == 0) {
+         ESP_LOGW(TAG, "base64 encode failed: %d", b_err);
+         continue;
+      }
+      b64_buf[b64_len] = '\0';
+
+      char rid[24];
+      snprintf(rid, sizeof(rid), "ep%lu", (unsigned long)(++s_frame_seq));
+      m5_stackflow_request_t req = {
+          .request_id = rid,
+          .work_id = "ext_pcm",
+          .action = "ingest",
+          .data_string = b64_buf,
+      };
+      int tx_len = m5_stackflow_build_request(&req, tx_buf, INGEST_TX_CAP);
+      if (tx_len < 0) {
+         ESP_LOGW(TAG, "build_request failed (out_idx=%d, b64_len=%u)", out_idx, (unsigned)b64_len);
+         continue;
+      }
+
+      /* Per-frame UART lock.  Hold time ~= tx_len/baud → ~30 ms at
+       * 1.5 Mbps for a 4.4 KB frame.  Voice_m5_llm calls (when active)
+       * will see brief contention but won't starve. */
+      if (tab5_port_c_lock(200) != ESP_OK) {
+         /* contention — drop this frame, the next one will retry. */
+         continue;
+      }
+      int sent = tab5_port_c_send(tx_buf, (size_t)tx_len);
+      tab5_port_c_unlock();
+      if (sent != tx_len) continue;
+
+      int64_t now = esp_timer_get_time();
+      if (now - s_last_log_us > 5 * 1000000) {
+         ESP_LOGI(TAG, "ext_pcm pumped seq=%lu (last %d bytes tx)", (unsigned long)s_frame_seq, tx_len);
+         s_last_log_us = now;
+      }
+   }
+
+cleanup:
+   if (tdm_buf) heap_caps_free(tdm_buf);
+   if (mono_buf) heap_caps_free(mono_buf);
+   if (b64_buf) heap_caps_free(b64_buf);
+   if (tx_buf) heap_caps_free(tx_buf);
+   s_task = NULL;
+   vTaskSuspend(NULL);
+}
+
+esp_err_t voice_ext_pcm_stream_init(void) {
+   if (s_task != NULL) return ESP_OK;
+   BaseType_t ok = xTaskCreatePinnedToCore(ext_pcm_task, "voice_ext_pcm", EXT_PCM_TASK_STACK, NULL,
+                                           EXT_PCM_TASK_PRIO, &s_task, EXT_PCM_TASK_CORE);
+   if (ok != pdPASS) {
+      ESP_LOGE(TAG, "task spawn failed");
+      s_task = NULL;
+      return ESP_ERR_NO_MEM;
+   }
+   ESP_LOGI(TAG, "init done (disarmed)");
+   return ESP_OK;
+}
+
+void voice_ext_pcm_stream_arm(void) {
+   if (s_armed) return;
+   s_armed = true;
+   s_handshake_done = false; /* force fresh handshake */
+   tab5_debug_obs_event("ext_pcm_stream", "arm");
+   ESP_LOGI(TAG, "armed");
+}
+
+void voice_ext_pcm_stream_disarm(void) {
+   if (!s_armed) return;
+   s_armed = false;
+   s_handshake_done = false;
+   tab5_debug_obs_event("ext_pcm_stream", "disarm");
+   ESP_LOGI(TAG, "disarmed");
+}
+
+bool voice_ext_pcm_stream_is_active(void) {
+   return s_armed && s_task != NULL && quiescent_state(s_voice_state);
+}
+
+void voice_ext_pcm_stream_on_state_change(int new_state) {
+   s_voice_state = new_state;
+}

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -222,14 +222,14 @@ static void ext_pcm_task(void *arg) {
        * match on ADPCM-degraded audio in live tests despite the round-trip
        * decoding correctly.  At 16 kHz mono int16 → base64 = ~44 KB/s,
        * comfortably under UART 1.5 Mbps (187 KB/s effective). */
-      /* TT #131-opt2: 6× digital gain — Tab5 ES7210 mic level is ~10× lower
-       * than K144's onboard mic which the gigaspeech KWS model was tuned
-       * against.  Boost in place with int16 saturation to bring features
-       * into the model's expected range. */
+      /* TT #131-opt2: 16× digital gain — Tab5 ES7210 mic level at default
+       * codec PGA gives raw RMS ~65 on speech, way below the ~3000-4000
+       * the gigaspeech KWS model was tuned against.  6× wasn't enough.
+       * Boost in place with int16 saturation. */
       {
          int16_t *p = (int16_t *)batch_buf;
          for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
-            int32_t v = (int32_t)p[k] * 6;
+            int32_t v = (int32_t)p[k] * 16;
             if (v > 32767) v = 32767;
             else if (v < -32768) v = -32768;
             p[k] = (int16_t)v;

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -148,14 +148,21 @@ static void ext_pcm_task(void *arg) {
        * vs Tab5's 44 KB/s send rate.  1.5 Mbps = 150 KB/s, ample
        * headroom. */
       if (!s_baud_negotiated) {
+         /* Suppress voice_onboard's auto-retry FIRST.  If we negotiate
+          * baud while it's enabled, a stray sys.hwinfo failure during
+          * the verify-window can cascade into sys.reset → K144 reverts
+          * to 115200 → we're stranded at 1.5 M. */
+         voice_onboard_suppress_auto_retry(true);
          ESP_LOGI(TAG, "negotiating UART up to 1.5 Mbps for sustained PCM throughput");
          esp_err_t be = voice_m5_llm_set_baud(1500000);
          if (be == ESP_OK) {
             s_baud_negotiated = true;
             tab5_debug_obs_event("ext_pcm_stream", "baud_1500000");
-            ESP_LOGI(TAG, "UART now at 1.5 Mbps");
+            ESP_LOGI(TAG, "UART now at 1.5 Mbps (auto-retry suppressed)");
          } else {
             ESP_LOGW(TAG, "baud negotiation failed (%s) — back-off + retry", esp_err_to_name(be));
+            /* Restore auto-retry so K144 can recover from real failures. */
+            voice_onboard_suppress_auto_retry(false);
             vTaskDelay(pdMS_TO_TICKS(2000));
             continue;
          }
@@ -284,11 +291,13 @@ void voice_ext_pcm_stream_disarm(void) {
    s_armed = false;
    /* Drop K144 back to 115200 on disarm so other voice_m5_llm callers
     * (vmode=4 chain, sys.reset) see the canonical baud.  Best-effort —
-    * failures just log. */
+    * failures just log.  Release the auto-retry suppression AFTER the
+    * baud is back to 115200 so future health checks work normally. */
    if (s_baud_negotiated) {
       (void)voice_m5_llm_set_baud(115200);
       s_baud_negotiated = false;
    }
+   voice_onboard_suppress_auto_retry(false);
    tab5_debug_obs_event("ext_pcm_stream", "disarm");
    ESP_LOGI(TAG, "disarmed");
 }

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -144,84 +144,19 @@ static void ext_pcm_task(void *arg) {
          continue;
       }
 
-      /* ASR was set up with input=["sys.pcm"], so it subscribes to
-       * /tmp/llm/pcm.cap.socket (audio's PUB URL).  Run the handshake
-       * once to flip URL ownership from audio → ext_pcm:
-       *   1. audio.cap_stop_all   — release audio's bind
-       *   2. ext_pcm.rebind       — ext_pcm reclaims URL; ASR's SUB
-       *                              auto-reconnects (ZMQ IPC)
-       * From then on, every ingest RPC we send to ext_pcm decodes
-       * ADPCM and publishes raw PCM on the URL ASR is listening to. */
+      /* TT #131 — direct-to-asr path: ASR was set up with input=["asr"]
+       * so it subscribes to its OWN inference bus.  K144 main_asr
+       * (custom build) decodes ADPCM inline in task_user_data.  No
+       * handshake needed. */
+      const char *asr_target = voice_wakeword_asr_id();
+      if (asr_target == NULL || asr_target[0] == '\0') {
+         vTaskDelay(pdMS_TO_TICKS(500));
+         continue;
+      }
       if (!s_handshake_done) {
-         /* 3-step handshake with explicit settling time between steps so
-          * the ZMQ IPC SUB on asr's side has time to:
-          *   a. detect audio's bind disappearing (cap_stop_all)
-          *   b. enter its reconnect loop (default ZMQ_RECONNECT_IVL=100ms)
-          *   c. settle on ext_pcm's fresh bind (rebind)
-          * Earlier 150ms gaps were marginal; 500ms is robust. */
-         char hbuf[256];
-
-         /* 1. audio.cap_stop_all — audio releases its PUB bind. */
-         m5_stackflow_request_t req_stop = {
-            .request_id = "ep-cap-stop", .work_id = "audio",
-            .action = "cap_stop_all",
-         };
-         int hlen = m5_stackflow_build_request(&req_stop, hbuf, sizeof(hbuf));
-         if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
-            tab5_port_c_send(hbuf, (size_t)hlen);
-            tab5_port_c_unlock();
-         }
-         vTaskDelay(pdMS_TO_TICKS(500));
-
-         /* 2. ext_pcm.rebind — ext_pcm takes ownership of the URL. */
-         m5_stackflow_request_t req_rebind = {
-            .request_id = "ep-rebind", .work_id = "ext_pcm",
-            .action = "rebind",
-         };
-         hlen = m5_stackflow_build_request(&req_rebind, hbuf, sizeof(hbuf));
-         if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
-            tab5_port_c_send(hbuf, (size_t)hlen);
-            tab5_port_c_unlock();
-         }
-         vTaskDelay(pdMS_TO_TICKS(500));
-
-         /* 3. ext_pcm.rebind AGAIN — defensive: any momentary K144-side
-          * lifecycle event could have re-stolen the URL.  Lock it in. */
-         hlen = m5_stackflow_build_request(&req_rebind, hbuf, sizeof(hbuf));
-         if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
-            tab5_port_c_send(hbuf, (size_t)hlen);
-            tab5_port_c_unlock();
-         }
-         vTaskDelay(pdMS_TO_TICKS(500));
-
-         /* 4. asr.link sys.pcm — force ASR to create a FRESH subscriber.
-          * Its original subscriber from asr.setup is stuck on a stale
-          * IPC inode after our rebind (audio's PUB was the binder at
-          * that moment; the file's been re-created so the SUB's cached
-          * peer is dead).  asr.link with data="sys.pcm" calls
-          * unit_call("audio","cap","sys.pcm") → returns current URL →
-          * subscriber() attaches a new SUB to ext_pcm's live PUB. */
-         const char *asr_id = voice_wakeword_asr_id();
-         if (asr_id && asr_id[0]) {
-            char link_payload[64];
-            snprintf(link_payload, sizeof(link_payload), "\"sys.pcm\"");
-            m5_stackflow_request_t req_link = {
-               .request_id = "ep-asr-link", .work_id = asr_id,
-               .action = "link", .object = "asr.link",
-               .data_string = "sys.pcm",
-            };
-            hlen = m5_stackflow_build_request(&req_link, hbuf, sizeof(hbuf));
-            if (hlen > 0 && tab5_port_c_lock(2000) == ESP_OK) {
-               tab5_port_c_send(hbuf, (size_t)hlen);
-               tab5_port_c_unlock();
-               ESP_LOGI(TAG, "asr.link sys.pcm sent (%s)", asr_id);
-            }
-            vTaskDelay(pdMS_TO_TICKS(500));
-         }
-
+         /* No handshake needed — direct-to-asr path.  Mark done. */
          s_handshake_done = true;
-         tab5_debug_obs_event("ext_pcm_stream", "handshake_done");
-         ESP_LOGI(TAG, "handshake fired — ext_pcm owns /tmp/llm/pcm.cap.socket");
+         ESP_LOGI(TAG, "direct-to-asr path active (target=%s)", asr_target);
       }
 
       /* TT #131 — first-time-armed: negotiate UART up to 1.5 Mbps.
@@ -301,16 +236,14 @@ static void ext_pcm_task(void *arg) {
 
       char rid[24];
       snprintf(rid, sizeof(rid), "ep%lu", (unsigned long)(++s_frame_seq));
-      /* Route to K144's ext_pcm "ingest" RPC — our binary decodes the
-       * ADPCM and publishes raw PCM to /tmp/llm/pcm.cap.socket, which
-       * the K144 ASR (configured with input=["sys.pcm"]) consumes via
-       * its standard subscriber.  Object tag tells ext_pcm to ADPCM-
-       * decode before publishing. */
-      const char *target = "ext_pcm";
+      /* Direct inference to asr.NNNN.  K144 main_asr (custom build)
+       * decodes ADPCM in task_user_data, feeds raw PCM to sherpa-ncnn. */
+      const char *target = voice_wakeword_asr_id();
+      if (target == NULL || target[0] == '\0') continue;
       m5_stackflow_request_t req = {
           .request_id = rid,
           .work_id = target,
-          .action = "ingest",
+          .action = "inference",
           .object = "audio.pcm.adpcm.base64",
           .data_string = b64_buf,
       };

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -71,9 +71,14 @@ extern void tab5_debug_obs_event(const char *kind, const char *detail);
 
 static TaskHandle_t s_task = NULL;
 static volatile bool s_armed = false;
-/* handshake state retained as dead-but-harmless flag — drop in next pass */
+static volatile bool s_baud_negotiated = false;
 static volatile int s_voice_state = 0;
 static uint32_t s_frame_seq = 0;
+/* Diagnostic state — updated in pump loop, read by stats accessor. */
+static volatile uint32_t s_last_mic_rms = 0;
+static volatile uint32_t s_last_tx_bytes = 0;
+static volatile uint32_t s_last_send_ok = 0;
+static volatile int64_t s_last_pump_us = 0;
 static int64_t s_last_log_us = 0;
 
 static bool quiescent_state(int st) {
@@ -134,6 +139,28 @@ static void ext_pcm_task(void *arg) {
          continue;
       }
 
+      /* TT #131 — first-time-armed: negotiate UART up to 1.5 Mbps.
+       * 115200 = 11.5 KB/s but we send ~44 KB/s sustained (16k mono
+       * int16 × 1.33 base64 + JSON envelope), so the kernel UART RX
+       * was DROPPING bytes at 115200 — JSON parser saw garbage and
+       * silently rejected our inference frames.  Live-confirmed:
+       * K144 /proc/tty/driver/serial showed only 2.6 KB/s incoming
+       * vs Tab5's 44 KB/s send rate.  1.5 Mbps = 150 KB/s, ample
+       * headroom. */
+      if (!s_baud_negotiated) {
+         ESP_LOGI(TAG, "negotiating UART up to 1.5 Mbps for sustained PCM throughput");
+         esp_err_t be = voice_m5_llm_set_baud(1500000);
+         if (be == ESP_OK) {
+            s_baud_negotiated = true;
+            tab5_debug_obs_event("ext_pcm_stream", "baud_1500000");
+            ESP_LOGI(TAG, "UART now at 1.5 Mbps");
+         } else {
+            ESP_LOGW(TAG, "baud negotiation failed (%s) — back-off + retry", esp_err_to_name(be));
+            vTaskDelay(pdMS_TO_TICKS(2000));
+            continue;
+         }
+      }
+
       esp_err_t err = tab5_mic_read(tdm_buf, tdm_samples, 100);
       if (err != ESP_OK) {
          vTaskDelay(pdMS_TO_TICKS(100));
@@ -150,6 +177,18 @@ static void ext_pcm_task(void *arg) {
          mono_buf[out_idx++] = (int16_t)(sum / WS_DOWNSAMPLE_RATIO);
       }
       if (out_idx == 0) continue;
+
+      /* Compute mic RMS (abs-mean over chunk) so we can tell silence from
+       * speech in /tinkeron/extpcm + serial logs.  Silence ≈ 0;
+       * speech in a normal room ≈ 200-2000+. */
+      {
+         int64_t sum_abs = 0;
+         for (int k = 0; k < out_idx; k++) {
+            int16_t v = mono_buf[k];
+            sum_abs += (v < 0) ? -v : v;
+         }
+         s_last_mic_rms = (uint32_t)(sum_abs / out_idx);
+      }
 
       /* Re-check state after the I2S read in case mic_task spun up. */
       if (!quiescent_state(s_voice_state) || voice_mic_is_active()) continue;
@@ -197,11 +236,15 @@ static void ext_pcm_task(void *arg) {
       }
       int sent = tab5_port_c_send(tx_buf, (size_t)tx_len);
       tab5_port_c_unlock();
+      s_last_tx_bytes = (uint32_t)tx_len;
+      s_last_send_ok  = (sent == tx_len) ? 1 : 0;
       if (sent != tx_len) continue;
 
       int64_t now = esp_timer_get_time();
+      s_last_pump_us = now;
       if (now - s_last_log_us > 5 * 1000000) {
-         ESP_LOGI(TAG, "ext_pcm pumped seq=%lu (last %d bytes tx)", (unsigned long)s_frame_seq, tx_len);
+         ESP_LOGI(TAG, "ext_pcm pumped seq=%lu (tx=%d B, rms=%u) → %s",
+                  (unsigned long)s_frame_seq, tx_len, (unsigned)s_last_mic_rms, target);
          s_last_log_us = now;
       }
    }
@@ -239,6 +282,13 @@ void voice_ext_pcm_stream_arm(void) {
 void voice_ext_pcm_stream_disarm(void) {
    if (!s_armed) return;
    s_armed = false;
+   /* Drop K144 back to 115200 on disarm so other voice_m5_llm callers
+    * (vmode=4 chain, sys.reset) see the canonical baud.  Best-effort —
+    * failures just log. */
+   if (s_baud_negotiated) {
+      (void)voice_m5_llm_set_baud(115200);
+      s_baud_negotiated = false;
+   }
    tab5_debug_obs_event("ext_pcm_stream", "disarm");
    ESP_LOGI(TAG, "disarmed");
 }
@@ -249,4 +299,22 @@ bool voice_ext_pcm_stream_is_active(void) {
 
 void voice_ext_pcm_stream_on_state_change(int new_state) {
    s_voice_state = new_state;
+}
+
+void voice_ext_pcm_stream_get_stats(voice_ext_pcm_stream_stats_t *out) {
+   if (out == NULL) return;
+   out->task_running    = (s_task != NULL);
+   out->armed           = s_armed;
+   out->voice_state     = s_voice_state;
+   out->wakeword_active = voice_wakeword_is_active();
+   out->asr_id          = voice_wakeword_asr_id();
+   out->frames_pumped   = s_frame_seq;
+   out->last_mic_rms    = s_last_mic_rms;
+   out->last_tx_bytes   = s_last_tx_bytes;
+   out->last_send_ok    = s_last_send_ok;
+   if (s_last_pump_us > 0) {
+      out->last_pump_age_ms = (esp_timer_get_time() - s_last_pump_us) / 1000;
+   } else {
+      out->last_pump_age_ms = -1;
+   }
 }

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -222,17 +222,23 @@ static void ext_pcm_task(void *arg) {
        * match on ADPCM-degraded audio in live tests despite the round-trip
        * decoding correctly.  At 16 kHz mono int16 → base64 = ~44 KB/s,
        * comfortably under UART 1.5 Mbps (187 KB/s effective). */
-      /* TT #131-opt2: 16× digital gain — Tab5 ES7210 mic level at default
-       * codec PGA gives raw RMS ~65 on speech, way below the ~3000-4000
-       * the gigaspeech KWS model was tuned against.  6× wasn't enough.
-       * Boost in place with int16 saturation. */
+      /* TT #131-opt2: 24× digital gain with SOFT-CLIP — earlier 24× with
+       * hard saturation killed detection (square-wave distortion).  Now
+       * linear gain up to ±20 000, then 3:1 compression above that.
+       * Preserves the waveform envelope so KWS features stay valid. */
       {
          int16_t *p = (int16_t *)batch_buf;
+         const int32_t KNEE = 20000;
          for (int k = 0; k < INGEST_RAW_SAMPLES; k++) {
-            int32_t v = (int32_t)p[k] * 16;
-            if (v > 32767) v = 32767;
-            else if (v < -32768) v = -32768;
-            p[k] = (int16_t)v;
+            int32_t g = (int32_t)p[k] * 24;
+            if (g > KNEE) {
+               g = KNEE + (g - KNEE) / 3;
+               if (g > 32767) g = 32767;
+            } else if (g < -KNEE) {
+               g = -KNEE + (g + KNEE) / 3;
+               if (g < -32768) g = -32768;
+            }
+            p[k] = (int16_t)g;
          }
       }
       size_t b64_len = 0;

--- a/main/voice_ext_pcm_stream.c
+++ b/main/voice_ext_pcm_stream.c
@@ -50,10 +50,13 @@
 #define WS_CHUNK_SAMPLES (TAB5_VOICE_SAMPLE_RATE * TAB5_VOICE_CHUNK_MS / 1000)
 #define WS_CHUNK_BYTES (WS_CHUNK_SAMPLES * sizeof(int16_t))
 
-/* base64 of 3200 bytes = 4268 chars (no padding needed since 3200 % 3 == 2,
- * actual ceil((3200+2)/3)*4 = 4268).  Add JSON envelope overhead and a
- * generous buffer for the request_id digits → 4400 should be plenty. */
-#define INGEST_B64_CAP (((WS_CHUNK_BYTES + 2) / 3) * 4 + 4)
+/* Batch N mic chunks per ingest RPC.  K144's UART JSON parser is
+ * single-threaded; flooding it at 50 RPCs/sec (one per 20 ms chunk)
+ * caused frame drops + remote_call queue blow-up.  Batching 5 chunks =
+ * 100 ms of audio per RPC = 10 RPCs/sec is comfortable for both sides. */
+#define INGEST_BATCH_CHUNKS 5
+#define INGEST_RAW_BYTES (WS_CHUNK_BYTES * INGEST_BATCH_CHUNKS)
+#define INGEST_B64_CAP (((INGEST_RAW_BYTES + 2) / 3) * 4 + 4)
 #define INGEST_TX_CAP (INGEST_B64_CAP + 128)
 
 #define EXT_PCM_TASK_STACK 8192
@@ -158,9 +161,14 @@ static void ext_pcm_task(void *arg) {
    int16_t *tdm_buf =
        heap_caps_malloc(tdm_samples * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    int16_t *mono_buf = heap_caps_malloc(WS_CHUNK_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   /* batch_buf accumulates INGEST_BATCH_CHUNKS×WS_CHUNK_BYTES raw PCM
+    * before a single base64 + ingest send.  Reduces UART RPC rate from
+    * 50 fps to 10 fps. */
+   int16_t *batch_buf = heap_caps_malloc(INGEST_RAW_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   int batch_chunks = 0;
    char *b64_buf = heap_caps_malloc(INGEST_B64_CAP, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    char *tx_buf = heap_caps_malloc(INGEST_TX_CAP, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-   if (!tdm_buf || !mono_buf || !b64_buf || !tx_buf) {
+   if (!tdm_buf || !mono_buf || !batch_buf || !b64_buf || !tx_buf) {
       ESP_LOGE(TAG, "buffer alloc failed; ext_pcm stream disabled");
       goto cleanup;
    }
@@ -218,10 +226,16 @@ static void ext_pcm_task(void *arg) {
       /* Re-check state after the I2S read in case mic_task spun up. */
       if (!quiescent_state(s_voice_state) || voice_mic_is_active()) continue;
 
+      /* Append this chunk to the batch.  Send only when full. */
+      memcpy((uint8_t *)batch_buf + batch_chunks * WS_CHUNK_BYTES, mono_buf,
+             (size_t)out_idx * sizeof(int16_t));
+      batch_chunks++;
+      if (batch_chunks < INGEST_BATCH_CHUNKS) continue;
+      batch_chunks = 0;
+
       size_t b64_len = 0;
       int b_err = mbedtls_base64_encode((unsigned char *)b64_buf, INGEST_B64_CAP, &b64_len,
-                                        (const unsigned char *)mono_buf,
-                                        (size_t)out_idx * sizeof(int16_t));
+                                        (const unsigned char *)batch_buf, INGEST_RAW_BYTES);
       if (b_err != 0 || b64_len == 0) {
          ESP_LOGW(TAG, "base64 encode failed: %d", b_err);
          continue;
@@ -263,6 +277,7 @@ static void ext_pcm_task(void *arg) {
 cleanup:
    if (tdm_buf) heap_caps_free(tdm_buf);
    if (mono_buf) heap_caps_free(mono_buf);
+   if (batch_buf) heap_caps_free(batch_buf);
    if (b64_buf) heap_caps_free(b64_buf);
    if (tx_buf) heap_caps_free(tx_buf);
    s_task = NULL;

--- a/main/voice_ext_pcm_stream.h
+++ b/main/voice_ext_pcm_stream.h
@@ -1,0 +1,52 @@
+/**
+ * @file voice_ext_pcm_stream.h
+ * @brief Tab5 mic → K144 ext_pcm streamer (TT #131 — Path A).
+ *
+ * Production path for wake_src=ext_pcm: Tab5's ES7210 quad-mic ships 16 kHz
+ * mono PCM continuously to the K144 LLM Module over the existing Port C
+ * UART JSON bridge, wrapped as base64 inside the custom `ingest` RPC the
+ * StackFlow ext_pcm unit exposes:
+ *
+ *   { "request_id":"epN", "work_id":"ext_pcm",
+ *     "action":"ingest", "data":"<base64 int16 LE 16kHz mono>" }
+ *
+ * ext_pcm decodes + publishes the PCM on /tmp/llm/pcm.cap.socket, which
+ * llm_asr's sherpa-ncnn subscriber consumes.  Wake fires arrive back on
+ * the same `asr.utf-8.stream` path the K144's onboard mic uses today.
+ *
+ * Bandwidth: 16 kHz × 16-bit × continuous → 256 kbps raw → 341 kbps after
+ * base64 → ~360 kbps with JSON envelope.  Comfortably within UART's
+ * 1.5 Mbps (1.5 Mbit/s = ~1500 kbps) ceiling on the M5-Bus + Mate FPC chain.
+ *
+ * Lifecycle:
+ *   - voice_ext_pcm_stream_init()      — call once from voice_init
+ *   - voice_ext_pcm_stream_arm()       — boot the K144 stream (issues the
+ *                                        asr.setup + audio.cap_stop_all +
+ *                                        ext_pcm.rebind handshake) and
+ *                                        spawn the pump task
+ *   - voice_ext_pcm_stream_disarm()    — stop pumping; tears down ASR
+ *   - voice_ext_pcm_stream_on_state_change(int) — pauses while in-turn
+ *                                        mic_task owns I2S
+ *
+ * Mic ownership: same rules as voice_wake_stream — only ONE consumer of
+ * I2S RX at a time.  voice_mic_is_active() gates each pump iteration.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+esp_err_t voice_ext_pcm_stream_init(void);
+void voice_ext_pcm_stream_arm(void);
+void voice_ext_pcm_stream_disarm(void);
+bool voice_ext_pcm_stream_is_active(void);
+void voice_ext_pcm_stream_on_state_change(int new_state);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/voice_ext_pcm_stream.h
+++ b/main/voice_ext_pcm_stream.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <stdbool.h>
+
 #include "esp_err.h"
 
 #ifdef __cplusplus
@@ -49,16 +50,16 @@ void voice_ext_pcm_stream_on_state_change(int new_state);
 
 /** TT #131 — diagnostic stats for /tinkeron/extpcm endpoint. */
 typedef struct {
-    bool task_running;
-    bool armed;
-    int voice_state;
-    bool wakeword_active;
-    const char *asr_id; /* borrowed; may be NULL */
-    uint32_t frames_pumped;
-    uint32_t last_mic_rms;      /* int16 abs-mean of last chunk; 0=silence */
-    uint32_t last_tx_bytes;     /* size of last UART send */
-    uint32_t last_send_ok;      /* 1 = last tab5_port_c_send returned ==tx_len */
-    int64_t last_pump_age_ms;   /* ms since last successful pump */
+   bool task_running;
+   bool armed;
+   int voice_state;
+   bool wakeword_active;
+   const char *asr_id; /* borrowed; may be NULL */
+   uint32_t frames_pumped;
+   uint32_t last_mic_rms;    /* int16 abs-mean of last chunk; 0=silence */
+   uint32_t last_tx_bytes;   /* size of last UART send */
+   uint32_t last_send_ok;    /* 1 = last tab5_port_c_send returned ==tx_len */
+   int64_t last_pump_age_ms; /* ms since last successful pump */
 } voice_ext_pcm_stream_stats_t;
 
 void voice_ext_pcm_stream_get_stats(voice_ext_pcm_stream_stats_t *out);

--- a/main/voice_ext_pcm_stream.h
+++ b/main/voice_ext_pcm_stream.h
@@ -47,6 +47,22 @@ void voice_ext_pcm_stream_disarm(void);
 bool voice_ext_pcm_stream_is_active(void);
 void voice_ext_pcm_stream_on_state_change(int new_state);
 
+/** TT #131 — diagnostic stats for /tinkeron/extpcm endpoint. */
+typedef struct {
+    bool task_running;
+    bool armed;
+    int voice_state;
+    bool wakeword_active;
+    const char *asr_id; /* borrowed; may be NULL */
+    uint32_t frames_pumped;
+    uint32_t last_mic_rms;      /* int16 abs-mean of last chunk; 0=silence */
+    uint32_t last_tx_bytes;     /* size of last UART send */
+    uint32_t last_send_ok;      /* 1 = last tab5_port_c_send returned ==tx_len */
+    int64_t last_pump_age_ms;   /* ms since last successful pump */
+} voice_ext_pcm_stream_stats_t;
+
+void voice_ext_pcm_stream_get_stats(voice_ext_pcm_stream_stats_t *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -27,6 +27,7 @@
 
 #include "voice_m5_llm.h"
 
+#include <ctype.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
@@ -1558,7 +1559,9 @@ esp_err_t voice_m5_llm_recover_baud(uint32_t candidate_baud) {
 
 struct voice_m5_wakeword_handle {
    char audio_id[32];
-   char asr_id[32];
+   char asr_id[32];      /* doubles as kws work_id when is_kws=true */
+   bool is_kws;          /* TT #131-opt2: KWS detector instead of ASR */
+   char kws_phrase[64];  /* phrase to deliver on detection (KWS frames carry no text) */
 };
 
 esp_err_t voice_m5_llm_wakeword_setup(voice_m5_wakeword_handle_t **out_handle, volatile bool *stop_flag) {
@@ -1673,6 +1676,80 @@ const char *voice_m5_llm_wakeword_asr_id(const voice_m5_wakeword_handle_t *handl
    return handle ? handle->asr_id : NULL;
 }
 
+/* TT #131-opt2 — KWS variant of wakeword_setup_tab5_mic.  Same Tab5-push
+ * wire (input=["kws"]) but the K144 unit is the sherpa-onnx keyword
+ * spotter instead of the streaming-zipformer ASR.  KWS is purpose-built
+ * for low-power always-on wake detection: fires a single bool on phrase
+ * hit, no transcripts, no false positives from background TV.  Custom
+ * keyword set at setup time via the kws[] array.  K144's main_kws
+ * binary is patched to decode ADPCM in task_user_data — mirror of the
+ * ASR patch. */
+esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle,
+                                          const char *keyword,
+                                          volatile bool *stop_flag) {
+   if (out_handle == NULL || keyword == NULL || keyword[0] == '\0') return ESP_ERR_INVALID_ARG;
+   *out_handle = NULL;
+
+   esp_err_t err = ensure_uart();
+   if (err != ESP_OK) return err;
+
+   M5_LOCK_OR_RETURN(60000);
+
+   voice_m5_wakeword_handle_t *h = heap_caps_calloc(1, sizeof(*h), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (h == NULL) {
+      M5_UNLOCK();
+      return ESP_ERR_NO_MEM;
+   }
+   h->audio_id[0] = '\0';
+   h->is_kws = true;
+   strncpy(h->kws_phrase, keyword, sizeof(h->kws_phrase) - 1);
+   h->kws_phrase[sizeof(h->kws_phrase) - 1] = '\0';
+
+   /* The gigaspeech tokens.txt is UPPERCASE ENGLISH only.  text2token.py
+    * does NOT case-normalize before BPE lookup, so lowercase "hey" /
+    * "tinker" fail with "Can't find token in token table, skipping".
+    * Uppercase the phrase before sending so BPE splits into valid tokens
+    * (e.g. "HEY TINKER" → "▁HE Y ▁T IN K ER"). */
+   char keyword_up[64];
+   {
+      size_t n = strlen(keyword);
+      if (n >= sizeof(keyword_up)) n = sizeof(keyword_up) - 1;
+      for (size_t i = 0; i < n; i++) keyword_up[i] = (char)toupper((unsigned char)keyword[i]);
+      keyword_up[n] = '\0';
+   }
+
+   cJSON *d = cJSON_CreateObject();
+   cJSON_AddStringToObject(d, "model", "sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01");
+   cJSON_AddStringToObject(d, "response_format", "kws.bool");
+   cJSON *inp = cJSON_CreateArray();
+   /* input=["kws"] → main_kws.cpp line 887 falls into task_user_data path:
+    * llm_channel->subscriber_work_id("", task_user_data).  KWS subscribes
+    * to its own inference bus; Tab5 pushes ADPCM frames addressed to the
+    * returned kws.NNNN work_id. */
+   cJSON_AddItemToArray(inp, cJSON_CreateString("kws"));
+   cJSON_AddItemToObject(d, "input", inp);
+   cJSON *kws_arr = cJSON_CreateArray();
+   cJSON_AddItemToArray(kws_arr, cJSON_CreateString(keyword_up));
+   cJSON_AddItemToObject(d, "kws", kws_arr);
+   cJSON_AddBoolToObject(d, "enoutput", true);
+   cJSON_AddBoolToObject(d, "enwake_audio", false); /* no chime — Tab5 owns UI feedback */
+   /* KWS setup is heavy — loads sherpa-onnx encoder/decoder/joiner ONNX
+    * models AND forks text2token.py to compile the keyword tokens.  Live
+    * measurement: 15-25 s on K144 v1.3 cold.  Use a 30 s budget. */
+   err = chain_setup_unit("kws", "kws.setup", d, h->asr_id, sizeof(h->asr_id),
+                          30000, stop_flag);
+   if (err != ESP_OK) {
+      heap_caps_free(h);
+      M5_UNLOCK();
+      return err;
+   }
+
+   M5_UNLOCK();
+   *out_handle = h;
+   ESP_LOGI(TAG, "KWS (Tab5-mic) up: kws=%s phrase=\"%s\"", h->asr_id, h->kws_phrase);
+   return ESP_OK;
+}
+
 esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5_wakeword_cb cb, void *user,
                                     volatile bool *stop_flag, uint32_t timeout_s) {
    if (handle == NULL) return ESP_ERR_INVALID_ARG;
@@ -1727,6 +1804,26 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
                resp.object ? resp.object : "(null)");
       if (resp.work_id == NULL || strcmp(resp.work_id, handle->asr_id) != 0) {
          m5_stackflow_response_free(&resp);
+         continue;
+      }
+      /* TT #131-opt2 — KWS path: K144 main_kws emits a single non-stream
+       * `{"object":"kws.bool", "data":true}` on phrase hit.  Synthesize a
+       * partial-callback delivering the configured kws_phrase + finish=true
+       * so the upstream phrase matcher fires identically to the ASR path. */
+      if (handle->is_kws && resp.object != NULL && strstr(resp.object, "kws") != NULL) {
+         bool fired = false;
+         if (cJSON_IsTrue(resp.data)) fired = true;
+         /* Some K144 builds wrap bool as a string "true" inside data; tolerate. */
+         if (!fired && cJSON_IsString(resp.data) && resp.data->valuestring &&
+             strcasecmp(resp.data->valuestring, "true") == 0) {
+            fired = true;
+         }
+         if (fired) {
+            ESP_LOGI(TAG, "kws fire: phrase=\"%s\" work_id=%s", handle->kws_phrase, handle->asr_id);
+            if (cb != NULL) cb(handle->kws_phrase, true, user);
+         }
+         m5_stackflow_response_free(&resp);
+         vTaskDelay(pdMS_TO_TICKS(5));
          continue;
       }
       /* asr.utf-8.stream frames carry {delta, index, finish}.  We deliver

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1689,7 +1689,14 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
 
       char *nl = memchr(s_rx_buf, '\n', s_rx_len);
       if (nl == NULL) {
-         int n = tab5_port_c_recv(s_rx_buf + s_rx_len, M5_RX_BUF_BYTES - 1 - s_rx_len, 100);
+         /* TT #131 — drop from 100 ms to 5 ms so wakeword's recv loop
+          * holds the UART mutex only briefly per iteration.  When K144
+          * isn't producing transcripts (silence / mic not capturing
+          * relevant audio), the prior 100 ms hold + 5 ms yield made the
+          * pump task starve at 5 % duty cycle, choking ingest below
+          * 1 KB/s even at 1.5 Mbps wire.  5 ms hold means ext_pcm pump
+          * gets ~50 % of the lock window. */
+         int n = tab5_port_c_recv(s_rx_buf + s_rx_len, M5_RX_BUF_BYTES - 1 - s_rx_len, 5);
          if (n > 0) {
             s_rx_len += (size_t)n;
             nl = memchr(s_rx_buf, '\n', s_rx_len);

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -75,8 +75,18 @@ static const char *TAG = "voice_m5_llm";
 #define M5_LLM_PROMPT_PREFIX "You are a helpful, concise assistant."
 
 /* Timeouts (ms) for the discrete protocol stages.  Total request budget
- * is the caller-supplied @p timeout_s. */
-#define M5_PING_TIMEOUT_MS 500
+ * is the caller-supplied @p timeout_s.
+ *
+ * TT #131 2026-05-20: bumped PING 500 → 3000.  K144 daemon under
+ * sustained load (load avg 3+ during KWS/ASR streaming) routinely
+ * exceeded 500 ms for sys.ping round-trips, causing onboard_warmup_job
+ * to falsely mark K144 unavailable and then the wakeword chain never
+ * starts → baud bump never happens → audio pump capped at 3 fps.
+ * Observed: K144 reports ttft 367 ms for actual LLM inference; sys.ping
+ * should be faster but goes through the same llm_sys dispatcher and
+ * inherits its scheduling latency.  3000 ms still fast-fails a wedged
+ * K144 (we have 60s auto-retry, so a 3-second probe-cost is fine). */
+#define M5_PING_TIMEOUT_MS 3000
 #define M5_SETUP_TIMEOUT_MS 5000
 
 /* RX scratch — sized for a single TTS response frame (base64 of ~10 sec

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1681,6 +1681,12 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
          if (cb != NULL) cb(delta_str, finished, user);
       }
       m5_stackflow_response_free(&resp);
+      /* TT #131 — explicit yield so equal-priority tasks (e.g. the
+       * voice_ext_pcm_stream handshake / pump) get a UART-lock window
+       * between our recv iterations.  Without this, when K144 streams
+       * ASR partials continuously the loop relocks the recursive mutex
+       * within microseconds and starves any same-prio waiters. */
+      vTaskDelay(1);
    }
 
    if (stop_flag != NULL && *stop_flag) return ESP_OK;

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1734,10 +1734,10 @@ esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handl
    cJSON_AddBoolToObject(d, "enoutput", true);
    cJSON_AddBoolToObject(d, "enwake_audio", false); /* no chime — Tab5 owns UI feedback */
    /* KWS setup is heavy — loads sherpa-onnx encoder/decoder/joiner ONNX
-    * models AND forks text2token.py to compile the keyword tokens.  Live
-    * measurement: 15-25 s on K144 v1.3 cold.  Use a 30 s budget. */
+    * models AND forks text2token.py.  Post-K144-reboot it's even slower
+    * (cold disk cache).  90 s budget. */
    err = chain_setup_unit("kws", "kws.setup", d, h->asr_id, sizeof(h->asr_id),
-                          30000, stop_flag);
+                          90000, stop_flag);
    if (err != ESP_OK) {
       heap_caps_free(h);
       M5_UNLOCK();

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1754,14 +1754,23 @@ esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handl
     * are visible in `strings llm_kws`).  False-positive risk is bounded
     * because the matcher still requires the full token sequence
     * "▁HE Y ▁T IN K ER" — 6 BPE tokens of acoustic context. */
-   /* 2026-05-20 v2: drop threshold further (0.10 → 0.02) — far-field
-    * audio after the ADPCM/UART round-trip is acoustically weak vs
-    * the gigaspeech training set.  0.02 fires on rough phoneme match;
-    * false-positive risk still bounded by the 6-token sequence
-    * requirement ("▁HE Y ▁T IN K ER"). */
+   /* 2026-05-20 v3: K144 main_kws appears to silently ignore top-level
+    * keywords_threshold/score — at 0.02 + clean voice (RMS 3685) we
+    * still got zero matches.  sherpa-onnx native config uses kebab-case
+    * AND a nested "mode_param" object per the model's own config file
+    * format on disk.  Try BOTH name variants in BOTH nesting levels —
+    * whichever K144's JSON parser actually reads will win, the others
+    * are silently dropped (which is the observed behavior). */
    cJSON_AddNumberToObject(d, "keywords_threshold", 0.02);
    cJSON_AddNumberToObject(d, "keywords_score", 2.0);
    cJSON_AddNumberToObject(d, "max_active_paths", 4);
+   cJSON *mp = cJSON_CreateObject();
+   cJSON_AddNumberToObject(mp, "keywords_threshold", 0.02);
+   cJSON_AddNumberToObject(mp, "keywords_score", 2.0);
+   cJSON_AddNumberToObject(mp, "max_active_paths", 4);
+   cJSON_AddNumberToObject(mp, "keywords-threshold", 0.02);
+   cJSON_AddNumberToObject(mp, "keywords-score", 2.0);
+   cJSON_AddItemToObject(d, "mode_param", mp);
    /* KWS setup is heavy — loads sherpa-onnx encoder/decoder/joiner ONNX
     * models AND forks text2token.py.  Post-K144-reboot it's even slower
     * (cold disk cache).  90 s budget. */

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1754,8 +1754,14 @@ esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handl
     * are visible in `strings llm_kws`).  False-positive risk is bounded
     * because the matcher still requires the full token sequence
     * "▁HE Y ▁T IN K ER" — 6 BPE tokens of acoustic context. */
-   cJSON_AddNumberToObject(d, "keywords_threshold", 0.10);
-   cJSON_AddNumberToObject(d, "keywords_score", 1.5);
+   /* 2026-05-20 v2: drop threshold further (0.10 → 0.02) — far-field
+    * audio after the ADPCM/UART round-trip is acoustically weak vs
+    * the gigaspeech training set.  0.02 fires on rough phoneme match;
+    * false-positive risk still bounded by the 6-token sequence
+    * requirement ("▁HE Y ▁T IN K ER"). */
+   cJSON_AddNumberToObject(d, "keywords_threshold", 0.02);
+   cJSON_AddNumberToObject(d, "keywords_score", 2.0);
+   cJSON_AddNumberToObject(d, "max_active_paths", 4);
    /* KWS setup is heavy — loads sherpa-onnx encoder/decoder/joiner ONNX
     * models AND forks text2token.py.  Post-K144-reboot it's even slower
     * (cold disk cache).  90 s budget. */

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1743,6 +1743,19 @@ esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handl
    cJSON_AddItemToObject(d, "kws", kws_arr);
    cJSON_AddBoolToObject(d, "enoutput", true);
    cJSON_AddBoolToObject(d, "enwake_audio", false); /* no chime — Tab5 owns UI feedback */
+   /* TT #131 2026-05-20: explicit detection tuning.  sherpa-onnx-kws
+    * defaults (threshold 0.25, score 1.0) are tuned for close-mic
+    * studio audio.  Tab5's ES7210 mic with 16× digital gain + ADPCM
+    * round-trip leaves the signal weaker than the model's training
+    * conditions, so default threshold rarely fires.  Lower threshold
+    * (more sensitive) + small score boost gets reliable detection on
+    * speaker-distance "Hey Tinker".  These keys are accepted by the
+    * custom K144 main_kws build (`keywords_threshold`, `keywords_score`
+    * are visible in `strings llm_kws`).  False-positive risk is bounded
+    * because the matcher still requires the full token sequence
+    * "▁HE Y ▁T IN K ER" — 6 BPE tokens of acoustic context. */
+   cJSON_AddNumberToObject(d, "keywords_threshold", 0.10);
+   cJSON_AddNumberToObject(d, "keywords_score", 1.5);
    /* KWS setup is heavy — loads sherpa-onnx encoder/decoder/joiner ONNX
     * models AND forks text2token.py.  Post-K144-reboot it's even slower
     * (cold disk cache).  90 s budget. */

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -796,7 +796,13 @@ esp_err_t voice_m5_llm_set_baud(uint32_t new_baud) {
    cJSON_AddNumberToObject(data, "baud", (double)new_baud);
    cJSON_AddNumberToObject(data, "data_bits", 8);
    cJSON_AddNumberToObject(data, "stop_bits", 1);
-   cJSON_AddStringToObject(data, "parity", "n");
+   /* K144 daemon SAFE_SETTING does `(int)json["parity"]` — passing the
+    * string "n" silently fails the cast inside the detached thread,
+    * which then never reaches serial_stop_work()/serial_work(), so
+    * K144 stays at 115200 while Tab5 flips to the new baud.  Use the
+    * ASCII value 110 (= 'n') which is what main_sys/src/main.cpp:46
+    * stores in `config_serial_parity` by default. */
+   cJSON_AddNumberToObject(data, "parity", 110);
 
    char request_id[32];
    make_request_id(request_id, sizeof(request_id), "uartsetup-");

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1681,12 +1681,14 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
          if (cb != NULL) cb(delta_str, finished, user);
       }
       m5_stackflow_response_free(&resp);
-      /* TT #131 — explicit yield so equal-priority tasks (e.g. the
-       * voice_ext_pcm_stream handshake / pump) get a UART-lock window
-       * between our recv iterations.  Without this, when K144 streams
-       * ASR partials continuously the loop relocks the recursive mutex
-       * within microseconds and starves any same-prio waiters. */
-      vTaskDelay(1);
+      /* TT #131 — yield ~5ms so equal-priority lock waiters
+       * (voice_ext_pcm_stream handshake + pump) get a real window.
+       * vTaskDelay(1) was insufficient — with FreeRTOS at 1000Hz tick,
+       * yield-and-immediately-retake the recursive mutex within
+       * microseconds, starving same-priority waiters even after 6 s of
+       * lock(timeout).  pdMS_TO_TICKS(5) gives at least 5 ticks of
+       * release-window per iteration. */
+      vTaskDelay(pdMS_TO_TICKS(5));
    }
 
    if (stop_flag != NULL && *stop_flag) return ESP_OK;

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1613,6 +1613,60 @@ fail:
    return err;
 }
 
+/* TT #131 — Tab5-mic variant of wakeword_setup.  Skips audio.setup
+ * entirely.  asr.setup uses input=["asr"] which triggers ASR's
+ * task_user_data subscriber path: ASR subscribes to its OWN inference
+ * bus and decodes inference frames addressed to its work_id.  Tab5
+ * pushes PCM as {"action":"inference","work_id":"asr.NNNN",
+ *               "object":"audio.pcm.base64","data":"<base64>"}
+ * Direct path — no audio unit, no ext_pcm publisher, no IPC PUB
+ * contention. */
+esp_err_t voice_m5_llm_wakeword_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle,
+                                               volatile bool *stop_flag) {
+   if (out_handle == NULL) return ESP_ERR_INVALID_ARG;
+   *out_handle = NULL;
+
+   esp_err_t err = ensure_uart();
+   if (err != ESP_OK) return err;
+
+   M5_LOCK_OR_RETURN(60000);
+
+   voice_m5_wakeword_handle_t *h = heap_caps_calloc(1, sizeof(*h), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (h == NULL) {
+      M5_UNLOCK();
+      return ESP_ERR_NO_MEM;
+   }
+   /* No audio in this path. */
+   h->audio_id[0] = '\0';
+
+   cJSON *d = cJSON_CreateObject();
+   cJSON_AddStringToObject(d, "model", M5_CHAIN_ASR_MODEL);
+   cJSON_AddStringToObject(d, "response_format", "asr.utf-8.stream");
+   cJSON *inp = cJSON_CreateArray();
+   /* input=["asr"] → asr.cpp line ~1060 falls into the task_user_data
+    * branch: llm_channel->subscriber_work_id("", task_user_data).
+    * ASR subscribes to its own inference bus. */
+   cJSON_AddItemToArray(inp, cJSON_CreateString("asr"));
+   cJSON_AddItemToObject(d, "input", inp);
+   cJSON_AddBoolToObject(d, "enoutput", true);
+   err = chain_setup_unit("asr", "asr.setup", d, h->asr_id, sizeof(h->asr_id),
+                          M5_SETUP_TIMEOUT_MS, stop_flag);
+   if (err != ESP_OK) {
+      heap_caps_free(h);
+      M5_UNLOCK();
+      return err;
+   }
+
+   M5_UNLOCK();
+   *out_handle = h;
+   ESP_LOGI(TAG, "always-on ASR (Tab5-mic) up: asr=%s", h->asr_id);
+   return ESP_OK;
+}
+
+const char *voice_m5_llm_wakeword_asr_id(const voice_m5_wakeword_handle_t *handle) {
+   return handle ? handle->asr_id : NULL;
+}
+
 esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5_wakeword_cb cb, void *user,
                                     volatile bool *stop_flag, uint32_t timeout_s) {
    if (handle == NULL) return ESP_ERR_INVALID_ARG;

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1569,9 +1569,9 @@ esp_err_t voice_m5_llm_recover_baud(uint32_t candidate_baud) {
 
 struct voice_m5_wakeword_handle {
    char audio_id[32];
-   char asr_id[32];      /* doubles as kws work_id when is_kws=true */
-   bool is_kws;          /* TT #131-opt2: KWS detector instead of ASR */
-   char kws_phrase[64];  /* phrase to deliver on detection (KWS frames carry no text) */
+   char asr_id[32];     /* doubles as kws work_id when is_kws=true */
+   bool is_kws;         /* TT #131-opt2: KWS detector instead of ASR */
+   char kws_phrase[64]; /* phrase to deliver on detection (KWS frames carry no text) */
 };
 
 esp_err_t voice_m5_llm_wakeword_setup(voice_m5_wakeword_handle_t **out_handle, volatile bool *stop_flag) {
@@ -1640,8 +1640,7 @@ fail:
  *               "object":"audio.pcm.base64","data":"<base64>"}
  * Direct path — no audio unit, no ext_pcm publisher, no IPC PUB
  * contention. */
-esp_err_t voice_m5_llm_wakeword_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle,
-                                               volatile bool *stop_flag) {
+esp_err_t voice_m5_llm_wakeword_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle, volatile bool *stop_flag) {
    if (out_handle == NULL) return ESP_ERR_INVALID_ARG;
    *out_handle = NULL;
 
@@ -1668,8 +1667,7 @@ esp_err_t voice_m5_llm_wakeword_setup_tab5_mic(voice_m5_wakeword_handle_t **out_
    cJSON_AddItemToArray(inp, cJSON_CreateString("asr"));
    cJSON_AddItemToObject(d, "input", inp);
    cJSON_AddBoolToObject(d, "enoutput", true);
-   err = chain_setup_unit("asr", "asr.setup", d, h->asr_id, sizeof(h->asr_id),
-                          M5_SETUP_TIMEOUT_MS, stop_flag);
+   err = chain_setup_unit("asr", "asr.setup", d, h->asr_id, sizeof(h->asr_id), M5_SETUP_TIMEOUT_MS, stop_flag);
    if (err != ESP_OK) {
       heap_caps_free(h);
       M5_UNLOCK();
@@ -1694,8 +1692,7 @@ const char *voice_m5_llm_wakeword_asr_id(const voice_m5_wakeword_handle_t *handl
  * keyword set at setup time via the kws[] array.  K144's main_kws
  * binary is patched to decode ADPCM in task_user_data — mirror of the
  * ASR patch. */
-esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle,
-                                          const char *keyword,
+esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle, const char *keyword,
                                           volatile bool *stop_flag) {
    if (out_handle == NULL || keyword == NULL || keyword[0] == '\0') return ESP_ERR_INVALID_ARG;
    *out_handle = NULL;
@@ -1774,8 +1771,7 @@ esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handl
    /* KWS setup is heavy — loads sherpa-onnx encoder/decoder/joiner ONNX
     * models AND forks text2token.py.  Post-K144-reboot it's even slower
     * (cold disk cache).  90 s budget. */
-   err = chain_setup_unit("kws", "kws.setup", d, h->asr_id, sizeof(h->asr_id),
-                          90000, stop_flag);
+   err = chain_setup_unit("kws", "kws.setup", d, h->asr_id, sizeof(h->asr_id), 90000, stop_flag);
    if (err != ESP_OK) {
       heap_caps_free(h);
       M5_UNLOCK();

--- a/main/voice_m5_llm.h
+++ b/main/voice_m5_llm.h
@@ -497,6 +497,18 @@ esp_err_t voice_m5_llm_wakeword_setup_tab5_mic(voice_m5_wakeword_handle_t **out_
  *  target inference frames at it.  Returns NULL if handle is NULL. */
 const char *voice_m5_llm_wakeword_asr_id(const voice_m5_wakeword_handle_t *handle);
 
+/** TT #131-opt2 — KWS variant of wakeword_setup_tab5_mic.  Bring up the
+ *  K144 sherpa-onnx keyword spotter (main_kws) with @p keyword as the
+ *  target phrase, input=["kws"] so Tab5 pushes ADPCM inference frames
+ *  directly.  K144's main_kws emits a single non-stream `kws.bool`
+ *  response on detection; the recv loop in voice_m5_llm_wakeword_run
+ *  synthesizes a delta of @p keyword + finish=true so existing wakeword
+ *  matchers fire unchanged.  Use this when wake_src=ext_pcm to bypass
+ *  ASR's confabulated transcripts. */
+esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle,
+                                          const char *keyword,
+                                          volatile bool *stop_flag);
+
 /**
  * @brief Drain asr.utf-8.stream frames, invoking cb on every partial.
  *

--- a/main/voice_m5_llm.h
+++ b/main/voice_m5_llm.h
@@ -486,6 +486,17 @@ typedef void (*voice_m5_wakeword_cb)(const char *delta, bool finish, void *user)
  */
 esp_err_t voice_m5_llm_wakeword_setup(voice_m5_wakeword_handle_t **out_handle, volatile bool *stop_flag);
 
+/** TT #131 — Tab5-mic variant.  Skips audio.setup entirely (no K144 mic),
+ *  configures asr.setup with input=["asr"] so ASR subscribes to its OWN
+ *  inference bus.  Tab5 then pushes mic frames as inference RPCs to the
+ *  returned asr work_id.  Bypasses ext_pcm + audio + the URL-bind dance.
+ *  Use this when wake_src=ext_pcm. */
+esp_err_t voice_m5_llm_wakeword_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle, volatile bool *stop_flag);
+
+/** TT #131 — get the asr work_id from a handle so the ext_pcm pump can
+ *  target inference frames at it.  Returns NULL if handle is NULL. */
+const char *voice_m5_llm_wakeword_asr_id(const voice_m5_wakeword_handle_t *handle);
+
 /**
  * @brief Drain asr.utf-8.stream frames, invoking cb on every partial.
  *

--- a/main/voice_m5_llm.h
+++ b/main/voice_m5_llm.h
@@ -505,8 +505,7 @@ const char *voice_m5_llm_wakeword_asr_id(const voice_m5_wakeword_handle_t *handl
  *  synthesizes a delta of @p keyword + finish=true so existing wakeword
  *  matchers fire unchanged.  Use this when wake_src=ext_pcm to bypass
  *  ASR's confabulated transcripts. */
-esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle,
-                                          const char *keyword,
+esp_err_t voice_m5_llm_kws_setup_tab5_mic(voice_m5_wakeword_handle_t **out_handle, const char *keyword,
                                           volatile bool *stop_flag);
 
 /**

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -390,36 +390,20 @@ static void onboard_warmup_job(void *arg) {
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
 
-      /* TT #131 stability 2026-05-20: BOOT AUTO-ARM the full Tab5-mic
-       * → K144 ASR chain when NVS wake_src=="ext_pcm".  Previously the
-       * boot path only armed wakeword at 115200; user had to manually
-       * POST /tinkeron/wake_src=ext_pcm after every restart to bump
-       * baud to 1.5 Mbps + arm the ext_pcm pump.  That manual step
-       * was both a UX burden AND it cycled the wakeword chain
-       * (disarm + re-arm), which destabilised K144's llm-asr daemon.
-       *
-       * Now: if user has previously opted in (wake_src=ext_pcm
-       * persisted in NVS), the boot path does the SAME work as the
-       * wake_src=ext_pcm POST handler — reset Tab5 UART baseline to
-       * 115200 (so the bump round-trip starts from known state),
-       * suppress auto-retry, bump baud to 1.5 Mbps, then arm wakeword
-       * + pump.  The K144-stayed-at-1.5M sync issue from the
-       * earlier attempt is avoided because we explicitly reset
-       * baseline BEFORE bumping.  Setup-once invariant preserved:
-       * exactly one asr.setup per boot at the right baud. */
+      /* TT #131 stability 2026-05-20: boot path arms wakeword + ext_pcm
+       * pump at the DEFAULT 115200 baud.  Auto-bumping to 1.5 Mbps from
+       * the boot path proved unreliable — the baud-bump round-trip
+       * races with K144's serial reconfig timing and leaves Tab5 +
+       * K144 at mismatched baud (Tab5 at 1.5M, K144 still at 115200,
+       * UART tx/rx counters both stuck at 0).  Trade-off: at 115200
+       * the pump caps at ~3 fps so K144 ASR gets ~30% of real-time
+       * audio.  The lenient "thinker" matcher still catches the
+       * keyword from fragmentary audio when user is close + loud.
+       * For full real-time, user explicitly POSTs
+       * /tinkeron/wake_src=ext_pcm — that handler does the bump
+       * with verify + revert + the wakeword chain restart needed to
+       * cope with the K144-side fragility. */
       bool boot_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
-      if (boot_to_ext_pcm) {
-         ESP_LOGI(TAG, "wake_src=ext_pcm in NVS — boot auto-arming Tab5 mic path");
-         tab5_port_c_uart_set_baud(115200);
-         voice_onboard_suppress_auto_retry(true);
-         esp_err_t be = voice_m5_llm_set_baud(1500000);
-         if (be != ESP_OK) {
-            ESP_LOGW(TAG, "boot baud bump to 1.5 Mbps failed (%s) — wakeword will run at 115200 (pump capped at ~3 fps)",
-                     esp_err_to_name(be));
-         } else {
-            ESP_LOGI(TAG, "boot baud bumped to 1.5 Mbps cleanly");
-         }
-      }
 
       esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
@@ -598,26 +582,10 @@ static void onboard_reset_failover_job(void *arg) {
        * caused Tab5-vs-K144 baud desync on /m5/reset path because the
        * boot-time bump path can leave Tab5 at 1.5 Mbps while K144's
        * uartsetup sometimes fails silently → both ends out of sync
-       * across the reset.  Boot warmup path (onboard_warmup_job)
-       * does the bump cleanly when Tab5 starts at the 115200 default.
-       *
-       * 2026-05-20 update: reset path now ALSO does the bump when
-       * wake_src=ext_pcm, gated on resetting Tab5 baseline to 115200
-       * first (same pattern the wake_src=ext_pcm POST handler uses).
-       * K144 just went through sys.reset so its UART is also at the
-       * default — round-trip starts from known state. */
+       * across the reset.  Reverted: chain re-arms at 115200; the
+       * explicit /tinkeron/wake_src=ext_pcm POST handles the bump
+       * with its own verify + revert logic. */
       bool reset_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
-      if (reset_to_ext_pcm) {
-         ESP_LOGI(TAG, "wake_src=ext_pcm — reset path bumping baud to 1.5 Mbps");
-         tab5_port_c_uart_set_baud(115200);
-         voice_onboard_suppress_auto_retry(true);
-         esp_err_t be = voice_m5_llm_set_baud(1500000);
-         if (be != ESP_OK) {
-            ESP_LOGW(TAG, "reset-path baud bump failed (%s)", esp_err_to_name(be));
-         } else {
-            ESP_LOGI(TAG, "reset-path baud bumped to 1.5 Mbps");
-         }
-      }
       /* Wakeword revival: same hook as the initial warmup path — once
        * K144 is reachable again, (re-)arm the always-on ASR chain.
        * Idempotent (start refuses if already running). */

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -360,11 +360,30 @@ static void onboard_warmup_job(void *arg) {
     * wakeword task running across boots — see reset_failover_job
     * for the same rationale. */
    voice_wakeword_stop();
+
+   /* TT #131 stability 2026-05-20: auto-detect K144's current baud.
+    * Tab5 always boots at 115200 (TAB5_PORT_C_UART_BAUD), but K144
+    * retains its baud across Tab5 reboots — if a previous Tab5
+    * session ran the bump-to-1.5M sequence, K144 is still at 1.5M
+    * after Tab5 cold-boots back to 115200.  Without this detect step
+    * the probe fails at 115200, Tab5 marks K144 unavailable, and the
+    * user has to manually intervene.  With it, Tab5 just switches
+    * its own local baud to match whatever K144 is at. */
    esp_err_t pe = voice_m5_llm_probe();
    if (pe != ESP_OK) {
-      ESP_LOGW(TAG, "K144 probe failed (%s) — failover disabled", esp_err_to_name(pe));
-      mark_k144_unavailable("probe_fail");
-      return;
+      ESP_LOGI(TAG, "K144 probe failed at 115200 — trying 1.5 Mbps (may be from prev session)");
+      tab5_port_c_uart_set_baud(1500000);
+      vTaskDelay(pdMS_TO_TICKS(100));
+      pe = voice_m5_llm_probe();
+      if (pe == ESP_OK) {
+         ESP_LOGI(TAG, "K144 found at 1.5 Mbps — Tab5 baud auto-matched");
+      } else {
+         ESP_LOGW(TAG, "K144 unreachable at 115200 AND 1.5 Mbps (%s) — failover disabled",
+                  esp_err_to_name(pe));
+         tab5_port_c_uart_set_baud(115200);  /* revert local */
+         mark_k144_unavailable("probe_fail");
+         return;
+      }
    }
    char scratch[64];
    int64_t t0 = esp_timer_get_time();
@@ -390,20 +409,27 @@ static void onboard_warmup_job(void *arg) {
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
 
-      /* TT #131 stability 2026-05-20: boot path arms wakeword + ext_pcm
-       * pump at the DEFAULT 115200 baud.  Auto-bumping to 1.5 Mbps from
-       * the boot path proved unreliable — the baud-bump round-trip
-       * races with K144's serial reconfig timing and leaves Tab5 +
-       * K144 at mismatched baud (Tab5 at 1.5M, K144 still at 115200,
-       * UART tx/rx counters both stuck at 0).  Trade-off: at 115200
-       * the pump caps at ~3 fps so K144 ASR gets ~30% of real-time
-       * audio.  The lenient "thinker" matcher still catches the
-       * keyword from fragmentary audio when user is close + loud.
-       * For full real-time, user explicitly POSTs
-       * /tinkeron/wake_src=ext_pcm — that handler does the bump
-       * with verify + revert + the wakeword chain restart needed to
-       * cope with the K144-side fragility. */
+      /* TT #131 stability 2026-05-20: boot auto-arm for wake_src=ext_pcm.
+       * The auto-detect step in the probe (above) already syncs Tab5's
+       * local baud to whatever K144 is at.  Now: if user has opted in
+       * to ext_pcm (wake_src persisted in NVS) AND we're not already
+       * at 1.5 Mbps, bump cleanly via set_baud (which has built-in
+       * uartsetup-ack + 5-ping verify + revert-on-fail).  If we're
+       * already at 1.5 Mbps from the auto-detect, skip the bump. */
       bool boot_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
+      if (boot_to_ext_pcm && tab5_port_c_uart_get_baud() != 1500000) {
+         ESP_LOGI(TAG, "wake_src=ext_pcm — boot bumping baud 115200 → 1.5 Mbps");
+         voice_onboard_suppress_auto_retry(true);
+         esp_err_t be = voice_m5_llm_set_baud(1500000);
+         if (be != ESP_OK) {
+            ESP_LOGW(TAG, "boot baud bump failed (%s) — wakeword will run at 115200 (slower but functional)",
+                     esp_err_to_name(be));
+         } else {
+            ESP_LOGI(TAG, "boot baud bumped to 1.5 Mbps");
+         }
+      } else if (boot_to_ext_pcm) {
+         ESP_LOGI(TAG, "wake_src=ext_pcm — already at 1.5 Mbps from auto-detect");
+      }
 
       esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -410,28 +410,15 @@ static void onboard_warmup_job(void *arg) {
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
 
-      /* TT #131 stability 2026-05-20: boot auto-arm for wake_src=ext_pcm.
-       * The auto-detect step in the probe (above) already syncs Tab5's
-       * local baud to whatever K144 is at.  Now: if user has opted in
-       * to ext_pcm (wake_src persisted in NVS) AND we're not already
-       * at 1.5 Mbps, bump cleanly via set_baud (which has built-in
-       * uartsetup-ack + 5-ping verify + revert-on-fail).  If we're
-       * already at 1.5 Mbps from the auto-detect, skip the bump. */
       bool boot_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
-      if (boot_to_ext_pcm && tab5_port_c_uart_get_baud() != 1500000) {
-         ESP_LOGI(TAG, "wake_src=ext_pcm — boot bumping baud 115200 → 1.5 Mbps");
-         voice_onboard_suppress_auto_retry(true);
-         esp_err_t be = voice_m5_llm_set_baud(1500000);
-         if (be != ESP_OK) {
-            ESP_LOGW(TAG, "boot baud bump failed (%s) — wakeword will run at 115200 (slower but functional)",
-                     esp_err_to_name(be));
-         } else {
-            ESP_LOGI(TAG, "boot baud bumped to 1.5 Mbps");
-         }
-      } else if (boot_to_ext_pcm) {
-         ESP_LOGI(TAG, "wake_src=ext_pcm — already at 1.5 Mbps from auto-detect");
-      }
 
+      /* Arm wakeword FIRST at whatever baud we're currently at (115200
+       * default or 1.5M from auto-detect).  asr.setup is a multi-step
+       * handshake that needs clean UART — empirically the bump-then-
+       * setup order failed because asr.setup at 1.5M hit framing
+       * errors and never completed.  Setup at 115200 is clean; pump
+       * can then run at 1.5M which tolerates framing errors via
+       * K144's JSON parser's partial-frame recovery. */
       esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
          /* TT #580: post-Tab5-reflash, K144's previous-session audio +
@@ -448,15 +435,24 @@ static void onboard_warmup_job(void *arg) {
       } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
          ESP_LOGW(TAG, "wakeword start skipped: %s", esp_err_to_name(we));
       } else if (we == ESP_OK) {
-         /* TT #131 stability 2026-05-20: arm ext_pcm pump ONLY when
-          * wake_src is configured for ext_pcm.  For other modes
-          * (dragon, mate, off) the pump must stay disarmed — otherwise
-          * it would compete with the active wake source for the Tab5
-          * mic and pollute the K144 ASR with audio that no one is
-          * matching against. */
+         /* Wakeword armed cleanly at the current baud.  Now if user
+          * opted in to ext_pcm, bump to 1.5 Mbps for real-time pump
+          * throughput (10 fps audio vs 3 fps at 115200).  asr.setup
+          * already done at 115200 so the bump doesn't affect setup
+          * completion; only the pump path runs at 1.5M after this. */
          if (boot_to_ext_pcm) {
+            if (tab5_port_c_uart_get_baud() != 1500000) {
+               ESP_LOGI(TAG, "wakeword armed — now bumping baud 115200 → 1.5 Mbps for real-time pump");
+               voice_onboard_suppress_auto_retry(true);
+               esp_err_t be = voice_m5_llm_set_baud(1500000);
+               if (be != ESP_OK) {
+                  ESP_LOGW(TAG, "post-setup baud bump failed (%s) — pump will run at 115200 (~3 fps)", esp_err_to_name(be));
+               } else {
+                  ESP_LOGI(TAG, "baud bumped to 1.5 Mbps for pump");
+               }
+            }
             voice_ext_pcm_stream_arm();
-            ESP_LOGI(TAG, "ext_pcm pump auto-armed (Tab5 mic → K144 ASR @ 1.5Mbps)");
+            ESP_LOGI(TAG, "ext_pcm pump armed (Tab5 mic → K144 ASR)");
          }
       }
    } else {
@@ -725,11 +721,17 @@ static void onboard_reset_failover_job(void *arg) {
       /* NOTE: baud bump deliberately NOT done here.  Earlier attempt
        * caused Tab5-vs-K144 baud desync on /m5/reset path because the
        * boot-time bump path can leave Tab5 at 1.5 Mbps while K144's
-       * uartsetup sometimes fails silently → both ends out of sync
-       * across the reset.  Reverted: chain re-arms at 115200; the
-       * explicit /tinkeron/wake_src=ext_pcm POST handles the bump
-       * with its own verify + revert logic. */
+       * uartsetup sometimes fails silently → both ends out of sync.
+       *
+       * Order matters: arm wakeword FIRST at 115200 (clean setup),
+       * THEN bump for the pump.  See onboard_warmup_job for rationale. */
       bool reset_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
+      if (reset_to_ext_pcm && tab5_port_c_uart_get_baud() != 115200) {
+         /* After sys.reset, K144 is at 115200 default.  Sync Tab5 down. */
+         ESP_LOGI(TAG, "reset-path: syncing Tab5 to K144 default 115200 baseline");
+         tab5_port_c_uart_set_baud(115200);
+         vTaskDelay(pdMS_TO_TICKS(50));
+      }
       /* Wakeword revival: same hook as the initial warmup path — once
        * K144 is reachable again, (re-)arm the always-on ASR chain.
        * Idempotent (start refuses if already running). */
@@ -745,11 +747,18 @@ static void onboard_reset_failover_job(void *arg) {
       } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
          ESP_LOGW(TAG, "wakeword (re)start skipped: %s", esp_err_to_name(we));
       } else if (we == ESP_OK) {
-         /* Same pump arm as warmup path — but only when wake_src is
-          * ext_pcm.  Other modes don't want the Tab5-mic pump running. */
+         /* Wakeword armed at 115200 (clean setup), now bump for pump. */
          if (reset_to_ext_pcm) {
+            if (tab5_port_c_uart_get_baud() != 1500000) {
+               ESP_LOGI(TAG, "reset-path: wakeword armed — bumping baud for pump");
+               voice_onboard_suppress_auto_retry(true);
+               esp_err_t be = voice_m5_llm_set_baud(1500000);
+               if (be != ESP_OK) {
+                  ESP_LOGW(TAG, "reset-path baud bump failed (%s)", esp_err_to_name(be));
+               }
+            }
             voice_ext_pcm_stream_arm();
-            ESP_LOGI(TAG, "ext_pcm pump auto-armed via reset path @ 1.5 Mbps");
+            ESP_LOGI(TAG, "ext_pcm pump armed via reset path");
          }
       }
    } else {

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -552,12 +552,16 @@ static void onboard_failover_text_job(void *arg) {
 /* ──────────────────────────────────────────────────────────────────── */
 #define WATCHDOG_INTERVAL_MS 10000
 #define WATCHDOG_ASR_STALL_MS 20000
-#define WATCHDOG_COOLDOWN_MS 90000
+#define WATCHDOG_COOLDOWN_MS 60000           /* 60 s — was 90 s; faster recovery */
 #define WATCHDOG_PUMP_HEALTHY_MS 1000
 #define WATCHDOG_GRACE_AFTER_BOOT_MS 30000  /* don't fire in first 30 s — chain may still be coming up */
+#define WATCHDOG_RESET_FAIL_CAP 2            /* after 2 consecutive sys.reset failures → escalate to sys.reboot */
+#define WATCHDOG_REBOOT_COOLDOWN_MS 180000   /* 3 min after sys.reboot before considering another */
 
 static volatile int64_t s_watchdog_last_kick_us = 0;
 static volatile int64_t s_watchdog_started_us = 0;
+static volatile int s_watchdog_reset_fail_count = 0;
+static volatile int64_t s_watchdog_last_reboot_us = 0;
 
 static void onboard_watchdog_task(void *arg) {
    (void)arg;
@@ -617,21 +621,62 @@ static void onboard_watchdog_task(void *arg) {
       /* All gates passed: pump flowing, wakeword armed, K144 ready,
        * but no transcript in 20+ seconds.  K144 ASR cycled. */
       ESP_LOGW(TAG,
-               "watchdog: K144 ASR stale (last delta %lldms ago, pump_age %lldms, frames=%lu) — kicking recovery",
-               delta_age_ms, stats.last_pump_age_ms, (unsigned long)stats.frames_pumped);
+               "watchdog: K144 ASR stale (last delta %lldms ago, pump_age %lldms, frames=%lu, fails=%d) — kicking recovery",
+               delta_age_ms, stats.last_pump_age_ms, (unsigned long)stats.frames_pumped, s_watchdog_reset_fail_count);
       char detail[48];
-      snprintf(detail, sizeof(detail), "asr_stale age=%llds frames=%lu",
-               delta_age_ms / 1000, (unsigned long)stats.frames_pumped);
+      snprintf(detail, sizeof(detail), "asr_stale age=%llds frames=%lu fails=%d",
+               delta_age_ms / 1000, (unsigned long)stats.frames_pumped, s_watchdog_reset_fail_count);
       tab5_debug_obs_event("watchdog", detail);
       s_watchdog_last_kick_us = now;
 
-      /* Stop wakeword first (frees stale asr_id), then trigger reset
-       * (sends sys.reset to K144 → re-warmup → re-arm wakeword + pump). */
+      /* TT #131 2026-05-20 escalation: after WATCHDOG_RESET_FAIL_CAP
+       * consecutive sys.reset failures, escalate to sys.reboot
+       * (full K144 Linux reboot — ~30 s downtime but guaranteed
+       * unwedge of llm-sys / llm-asr daemons).  Rate-limited to one
+       * sys.reboot per WATCHDOG_REBOOT_COOLDOWN_MS to avoid boot loops. */
+      bool do_reboot = s_watchdog_reset_fail_count >= WATCHDOG_RESET_FAIL_CAP &&
+                       (now - s_watchdog_last_reboot_us) > (int64_t)WATCHDOG_REBOOT_COOLDOWN_MS * 1000;
+
       voice_wakeword_stop();
       vTaskDelay(pdMS_TO_TICKS(300));
-      esp_err_t e = voice_onboard_reset_failover();
-      if (e != ESP_OK) {
-         ESP_LOGW(TAG, "watchdog: reset_failover bounce (%s) — will retry next interval", esp_err_to_name(e));
+
+      if (do_reboot) {
+         ESP_LOGW(TAG, "watchdog: %d consecutive reset fails → escalating to sys.reboot", s_watchdog_reset_fail_count);
+         tab5_debug_obs_event("watchdog", "escalate_reboot");
+         s_watchdog_last_reboot_us = now;
+         s_watchdog_reset_fail_count = 0;
+         esp_err_t re = voice_m5_llm_sys_reboot();
+         if (re != ESP_OK) {
+            ESP_LOGW(TAG, "watchdog: sys.reboot send failed (%s) — K144 may be unreachable", esp_err_to_name(re));
+         }
+         /* Wait ~60s for K144 hardware reboot + daemon start, then trigger
+          * reset_failover to re-establish chain on the freshly-rebooted K144. */
+         vTaskDelay(pdMS_TO_TICKS(60000));
+         tab5_port_c_uart_set_baud(115200);  /* K144 boots at default */
+         (void)voice_onboard_reset_failover();
+      } else {
+         esp_err_t e = voice_onboard_reset_failover();
+         if (e != ESP_OK) {
+            ESP_LOGW(TAG, "watchdog: reset_failover bounce (%s)", esp_err_to_name(e));
+         }
+      }
+
+      /* Track recovery outcome: poll over the next 30 s for any new
+       * ASR delta.  If we get one → reset successful, clear fail count.
+       * If still stale → increment fail count for potential escalation. */
+      vTaskDelay(pdMS_TO_TICKS(30000));
+      int64_t check = voice_wakeword_last_delta_us();
+      if (check > now) {
+         /* New delta arrived since the kick — recovery worked. */
+         if (s_watchdog_reset_fail_count > 0) {
+            ESP_LOGI(TAG, "watchdog: recovery succeeded — clearing fail count (was %d)",
+                     s_watchdog_reset_fail_count);
+         }
+         s_watchdog_reset_fail_count = 0;
+      } else {
+         s_watchdog_reset_fail_count++;
+         ESP_LOGW(TAG, "watchdog: recovery did NOT restore ASR — fail count now %d",
+                  s_watchdog_reset_fail_count);
       }
    }
 }
@@ -686,21 +731,28 @@ static void onboard_reset_failover_job(void *arg) {
       tab5_debug_obs_event("m5.reset", "ack_ok");
    }
 
-   /* Daemon needs ~4 s to reconnect MQTT internally + ~8-10 s for the
-    * qwen2.5-0.5B LLM model to load into the NPU.  Without the longer
-    * wait the post-reset re-warmup hit "unit call false" (err=-9) because
-    * llm-llm hadn't registered its RPC server yet (TT #131 live debug).
-    * 15 s is conservative — most boots see ready by 12 s. */
-   vTaskDelay(pdMS_TO_TICKS(15000));
-
-   /* Re-run the probe + warmup-infer.  Inline-equivalent to
-    * onboard_warmup_job but reuses the same observability events for
-    * monitoring continuity (one m5.warmup ready/unavailable event per
-    * recovery cycle). */
+   /* TT #131 2026-05-20: poll for K144 readiness instead of fixed wait.
+    * Daemon needs ~4 s MQTT reconnect + ~8-15 s for llm-llm to register
+    * its RPC server.  Earlier 15 s fixed wait hit cases where K144
+    * needed >20 s — probe timed out (3s budget) and the whole
+    * recovery cycle marked unavailable.  Now: start polling at 8 s
+    * (minimum K144 boot), then ping every 2 s up to 90 s.  Exit
+    * early as soon as ping succeeds.  Most recoveries land at 10-20 s;
+    * pathological at 60-90 s.  Beyond 90 s we give up and escalate. */
    tab5_debug_obs_event("m5.warmup", "start");
-   esp_err_t pe = voice_m5_llm_probe();
+   vTaskDelay(pdMS_TO_TICKS(8000));  /* min boot time */
+   esp_err_t pe = ESP_ERR_TIMEOUT;
+   for (int i = 0; i < 41; i++) {  /* up to 82 s additional, 90 s total */
+      pe = voice_m5_llm_probe();
+      if (pe == ESP_OK) {
+         ESP_LOGI(TAG, "K144 ping success after %d s post-reset", 8 + i * 2);
+         break;
+      }
+      vTaskDelay(pdMS_TO_TICKS(2000));
+      if (s_chain_stop_flag) break;
+   }
    if (pe != ESP_OK) {
-      ESP_LOGW(TAG, "K144 re-probe after reset failed (%s)", esp_err_to_name(pe));
+      ESP_LOGW(TAG, "K144 didn't come back within 90 s after sys.reset (%s)", esp_err_to_name(pe));
       mark_k144_unavailable("reset_probe_fail");
       tab5_debug_obs_event("m5.reset", "fail");
       return;

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -73,6 +73,10 @@ static volatile bool s_m5_failover_engaged_during_down = false; /* triggers "Dra
 static esp_timer_handle_t s_auto_retry_timer = NULL;
 static int s_auto_retry_count = 0;
 static volatile bool s_auto_retry_exhausted = false;
+/* TT #131 — when ext_pcm is running at high baud, the auto-retry
+ * sys.reset path would wipe K144's baud setting.  Suppress while the
+ * pump owns the channel. */
+static volatile bool s_auto_retry_suppressed = false;
 
 /* ---------------------------------------------------------------------- */
 /*  Chain state                                                           */
@@ -239,6 +243,13 @@ static void k144_unavailable_banner_async(void *arg) {
  * this so it runs M5_AUTO_RETRY_DELAY_US later. */
 static void auto_retry_timer_cb(void *arg) {
    (void)arg;
+   /* TT #131 — ext_pcm pump suppresses auto-retry while it owns the
+    * UART channel at non-default baud.  Skip silently; the pump itself
+    * acts as the liveness probe. */
+   if (s_auto_retry_suppressed) {
+      ESP_LOGD(TAG, "K144 auto-retry suppressed (ext_pcm owns channel)");
+      return;
+   }
    /* Recheck state — manual reset_failover via UI/debug may have
     * already recovered us; if so, skip the auto-retry. */
    if (s_m5_failover == M5_FAIL_READY || s_m5_failover == M5_FAIL_PROBING) {
@@ -256,6 +267,14 @@ static void auto_retry_timer_cb(void *arg) {
 }
 
 static void mark_k144_unavailable(const char *reason) {
+   /* TT #131 — while ext_pcm owns the UART at high baud, voice_onboard's
+    * health checks (sys.hwinfo refresh, etc.) will fail because they're
+    * not aware of the negotiated baud.  Suppress the "unavailable"
+    * cascade so it doesn't trigger sys.reset which wipes K144's baud. */
+   if (s_auto_retry_suppressed) {
+      ESP_LOGD(TAG, "K144 mark_unavailable suppressed (ext_pcm armed): %s", reason);
+      return;
+   }
    s_m5_failover = M5_FAIL_UNAVAILABLE;
    tab5_debug_obs_event("m5.warmup", "unavailable");
    tab5_debug_obs_event("error.k144", reason);
@@ -919,6 +938,20 @@ int64_t voice_onboard_chain_uptime_ms(void) {
  * No-op if K144 is currently UNAVAILABLE — caller should toast a
  * hint if it cares.  Honours the "release LLM slot before ASR"
  * gate from the warmup path. */
+void voice_onboard_suppress_auto_retry(bool suppress) {
+   s_auto_retry_suppressed = suppress;
+   if (suppress) {
+      ESP_LOGI(TAG, "K144 auto-retry suppressed (ext_pcm armed)");
+      tab5_debug_obs_event("m5.reset", "suppressed");
+      /* Force state to READY while suppressed so other consumers that
+       * gate on failover_state==2 don't refuse to proceed. */
+      s_m5_failover = M5_FAIL_READY;
+   } else {
+      ESP_LOGI(TAG, "K144 auto-retry re-enabled");
+      tab5_debug_obs_event("m5.reset", "unsuppressed");
+   }
+}
+
 esp_err_t voice_onboard_arm_wakeword(void) {
    if (s_m5_failover == M5_FAIL_UNAVAILABLE) return ESP_ERR_INVALID_STATE;
    voice_m5_llm_release();

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -19,18 +19,18 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
-#include "freertos/idf_additions.h"  /* xTaskCreatePinnedToCoreWithCaps for watchdog */
+#include "freertos/idf_additions.h" /* xTaskCreatePinnedToCoreWithCaps for watchdog */
 #include "freertos/task.h"
-#include "settings.h"            /* tab5_settings_get_mic_mute (Wave 7) */
-#include "task_worker.h"         /* tab5_worker_enqueue */
-#include "uart_port_c.h"         /* tab5_port_c_uart_get_baud — TT #131 baud bump check */
-#include "ui_audio_cues.h"       /* ui_audio_cue_play — wake chime (#131-opt2) */
-#include "ui_chat.h"             /* ui_chat_add_message */
-#include "ui_core.h"             /* tab5_ui_try_lock / tab5_ui_unlock */
-#include "ui_home.h"             /* ui_home_show_toast */
-#include "voice.h"               /* voice_set_state, VOICE_STATE_* */
-#include "voice_m5_llm.h"        /* probe / infer / chain_* */
+#include "settings.h"             /* tab5_settings_get_mic_mute (Wave 7) */
+#include "task_worker.h"          /* tab5_worker_enqueue */
+#include "uart_port_c.h"          /* tab5_port_c_uart_get_baud — TT #131 baud bump check */
+#include "ui_audio_cues.h"        /* ui_audio_cue_play — wake chime (#131-opt2) */
+#include "ui_chat.h"              /* ui_chat_add_message */
+#include "ui_core.h"              /* tab5_ui_try_lock / tab5_ui_unlock */
+#include "ui_home.h"              /* ui_home_show_toast */
+#include "voice.h"                /* voice_set_state, VOICE_STATE_* */
 #include "voice_ext_pcm_stream.h" /* TT #131: auto-arm pump on boot */
+#include "voice_m5_llm.h"         /* probe / infer / chain_* */
 #include "voice_messages_sync.h"  /* W3-C-c: Dragon canonical message store */
 #include "voice_wakeword.h"
 
@@ -379,9 +379,8 @@ static void onboard_warmup_job(void *arg) {
       if (pe == ESP_OK) {
          ESP_LOGI(TAG, "K144 found at 1.5 Mbps — Tab5 baud auto-matched");
       } else {
-         ESP_LOGW(TAG, "K144 unreachable at 115200 AND 1.5 Mbps (%s) — failover disabled",
-                  esp_err_to_name(pe));
-         tab5_port_c_uart_set_baud(115200);  /* revert local */
+         ESP_LOGW(TAG, "K144 unreachable at 115200 AND 1.5 Mbps (%s) — failover disabled", esp_err_to_name(pe));
+         tab5_port_c_uart_set_baud(115200); /* revert local */
          mark_k144_unavailable("probe_fail");
          return;
       }
@@ -446,7 +445,8 @@ static void onboard_warmup_job(void *arg) {
                voice_onboard_suppress_auto_retry(true);
                esp_err_t be = voice_m5_llm_set_baud(1500000);
                if (be != ESP_OK) {
-                  ESP_LOGW(TAG, "post-setup baud bump failed (%s) — pump will run at 115200 (~3 fps)", esp_err_to_name(be));
+                  ESP_LOGW(TAG, "post-setup baud bump failed (%s) — pump will run at 115200 (~3 fps)",
+                           esp_err_to_name(be));
                } else {
                   ESP_LOGI(TAG, "baud bumped to 1.5 Mbps for pump");
                }
@@ -552,11 +552,11 @@ static void onboard_failover_text_job(void *arg) {
 /* ──────────────────────────────────────────────────────────────────── */
 #define WATCHDOG_INTERVAL_MS 10000
 #define WATCHDOG_ASR_STALL_MS 20000
-#define WATCHDOG_COOLDOWN_MS 60000           /* 60 s — was 90 s; faster recovery */
+#define WATCHDOG_COOLDOWN_MS 60000 /* 60 s — was 90 s; faster recovery */
 #define WATCHDOG_PUMP_HEALTHY_MS 1000
-#define WATCHDOG_GRACE_AFTER_BOOT_MS 30000  /* don't fire in first 30 s — chain may still be coming up */
-#define WATCHDOG_RESET_FAIL_CAP 2            /* after 2 consecutive sys.reset failures → escalate to sys.reboot */
-#define WATCHDOG_REBOOT_COOLDOWN_MS 180000   /* 3 min after sys.reboot before considering another */
+#define WATCHDOG_GRACE_AFTER_BOOT_MS 30000 /* don't fire in first 30 s — chain may still be coming up */
+#define WATCHDOG_RESET_FAIL_CAP 2          /* after 2 consecutive sys.reset failures → escalate to sys.reboot */
+#define WATCHDOG_REBOOT_COOLDOWN_MS 180000 /* 3 min after sys.reboot before considering another */
 
 static volatile int64_t s_watchdog_last_kick_us = 0;
 static volatile int64_t s_watchdog_started_us = 0;
@@ -566,9 +566,8 @@ static volatile int64_t s_watchdog_last_reboot_us = 0;
 static void onboard_watchdog_task(void *arg) {
    (void)arg;
    s_watchdog_started_us = esp_timer_get_time();
-   ESP_LOGI(TAG, "K144-ASR watchdog started (poll=%ds, stall=%ds, cooldown=%ds)",
-            WATCHDOG_INTERVAL_MS / 1000, WATCHDOG_ASR_STALL_MS / 1000,
-            WATCHDOG_COOLDOWN_MS / 1000);
+   ESP_LOGI(TAG, "K144-ASR watchdog started (poll=%ds, stall=%ds, cooldown=%ds)", WATCHDOG_INTERVAL_MS / 1000,
+            WATCHDOG_ASR_STALL_MS / 1000, WATCHDOG_COOLDOWN_MS / 1000);
 
    while (1) {
       vTaskDelay(pdMS_TO_TICKS(WATCHDOG_INTERVAL_MS));
@@ -620,12 +619,13 @@ static void onboard_watchdog_task(void *arg) {
 
       /* All gates passed: pump flowing, wakeword armed, K144 ready,
        * but no transcript in 20+ seconds.  K144 ASR cycled. */
-      ESP_LOGW(TAG,
-               "watchdog: K144 ASR stale (last delta %lldms ago, pump_age %lldms, frames=%lu, fails=%d) — kicking recovery",
-               delta_age_ms, stats.last_pump_age_ms, (unsigned long)stats.frames_pumped, s_watchdog_reset_fail_count);
+      ESP_LOGW(
+          TAG,
+          "watchdog: K144 ASR stale (last delta %lldms ago, pump_age %lldms, frames=%lu, fails=%d) — kicking recovery",
+          delta_age_ms, stats.last_pump_age_ms, (unsigned long)stats.frames_pumped, s_watchdog_reset_fail_count);
       char detail[48];
-      snprintf(detail, sizeof(detail), "asr_stale age=%llds frames=%lu fails=%d",
-               delta_age_ms / 1000, (unsigned long)stats.frames_pumped, s_watchdog_reset_fail_count);
+      snprintf(detail, sizeof(detail), "asr_stale age=%llds frames=%lu fails=%d", delta_age_ms / 1000,
+               (unsigned long)stats.frames_pumped, s_watchdog_reset_fail_count);
       tab5_debug_obs_event("watchdog", detail);
       s_watchdog_last_kick_us = now;
 
@@ -652,7 +652,7 @@ static void onboard_watchdog_task(void *arg) {
          /* Wait ~60s for K144 hardware reboot + daemon start, then trigger
           * reset_failover to re-establish chain on the freshly-rebooted K144. */
          vTaskDelay(pdMS_TO_TICKS(60000));
-         tab5_port_c_uart_set_baud(115200);  /* K144 boots at default */
+         tab5_port_c_uart_set_baud(115200); /* K144 boots at default */
          (void)voice_onboard_reset_failover();
       } else {
          esp_err_t e = voice_onboard_reset_failover();
@@ -671,14 +671,13 @@ static void onboard_watchdog_task(void *arg) {
       int64_t check = voice_wakeword_last_delta_us();
       if (check > now) {
          if (s_watchdog_reset_fail_count > 0) {
-            ESP_LOGI(TAG, "watchdog: recovery succeeded — clearing fail count (was %d)",
-                     s_watchdog_reset_fail_count);
+            ESP_LOGI(TAG, "watchdog: recovery succeeded — clearing fail count (was %d)", s_watchdog_reset_fail_count);
          }
          s_watchdog_reset_fail_count = 0;
       } else {
          s_watchdog_reset_fail_count++;
-         ESP_LOGW(TAG, "watchdog: recovery did NOT restore ASR — fail count now %d/%d",
-                  s_watchdog_reset_fail_count, WATCHDOG_RESET_FAIL_CAP);
+         ESP_LOGW(TAG, "watchdog: recovery did NOT restore ASR — fail count now %d/%d", s_watchdog_reset_fail_count,
+                  WATCHDOG_RESET_FAIL_CAP);
       }
    }
 }
@@ -690,8 +689,7 @@ esp_err_t voice_onboard_start_warmup(void) {
    static volatile bool s_watchdog_spawned = false;
    if (!s_watchdog_spawned) {
       s_watchdog_spawned = true;
-      BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(onboard_watchdog_task, "onboard_wd",
-                                                      4096, NULL, 1, NULL,
+      BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(onboard_watchdog_task, "onboard_wd", 4096, NULL, 1, NULL,
                                                       tskNO_AFFINITY, MALLOC_CAP_SPIRAM);
       if (ok != pdPASS) {
          ESP_LOGW(TAG, "watchdog task spawn failed — running without ASR-stall recovery");
@@ -742,9 +740,9 @@ static void onboard_reset_failover_job(void *arg) {
     * early as soon as ping succeeds.  Most recoveries land at 10-20 s;
     * pathological at 60-90 s.  Beyond 90 s we give up and escalate. */
    tab5_debug_obs_event("m5.warmup", "start");
-   vTaskDelay(pdMS_TO_TICKS(8000));  /* min boot time */
+   vTaskDelay(pdMS_TO_TICKS(8000)); /* min boot time */
    esp_err_t pe = ESP_ERR_TIMEOUT;
-   for (int i = 0; i < 41; i++) {  /* up to 82 s additional, 90 s total */
+   for (int i = 0; i < 41; i++) { /* up to 82 s additional, 90 s total */
       pe = voice_m5_llm_probe();
       if (pe == ESP_OK) {
          ESP_LOGI(TAG, "K144 ping success after %d s post-reset", 8 + i * 2);
@@ -1236,13 +1234,11 @@ static void arm_wakeword_async_job(void *arg) {
    }
 
    if (attempts >= 15) {
-      ESP_LOGW(TAG, "arm_wakeword_async: gave up after %d attempts (last err=%s)", attempts,
-               esp_err_to_name(we));
+      ESP_LOGW(TAG, "arm_wakeword_async: gave up after %d attempts (last err=%s)", attempts, esp_err_to_name(we));
       tab5_debug_obs_event("arm_wake_async", "give_up");
       return;
    }
-   ESP_LOGW(TAG, "arm_wakeword_async: attempt %d failed (%s) — retrying in 2s", attempts,
-            esp_err_to_name(we));
+   ESP_LOGW(TAG, "arm_wakeword_async: attempt %d failed (%s) — retrying in 2s", attempts, esp_err_to_name(we));
    vTaskDelay(pdMS_TO_TICKS(2000));
    (void)tab5_worker_enqueue(arm_wakeword_async_job, (void *)(intptr_t)(attempts + 1), "arm_wake_retry");
 }

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -19,6 +19,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/idf_additions.h"  /* xTaskCreatePinnedToCoreWithCaps for watchdog */
 #include "freertos/task.h"
 #include "settings.h"            /* tab5_settings_get_mic_mute (Wave 7) */
 #include "task_worker.h"         /* tab5_worker_enqueue */
@@ -535,8 +536,125 @@ static void onboard_failover_text_job(void *arg) {
 /*  Public API — failover                                                 */
 /* ---------------------------------------------------------------------- */
 
+/* ──────────────────────────────────────────────────────────────────── */
+/*  TT #131 stability watchdog 2026-05-20                                */
+/*                                                                       */
+/*  K144's `llm-asr` daemon cycles intermittently (documented quirk).    */
+/*  When it does, Tab5's cached asr_id becomes stale: the pump keeps     */
+/*  sending frames over UART to a work_id that no longer exists on K144, */
+/*  K144 silently drops them, no transcripts come back, wakeword never   */
+/*  fires.  Manual recovery = `systemctl restart llm-sys` + /m5/reset    */
+/*  + /tinkeron/wake_src=ext_pcm.                                        */
+/*                                                                       */
+/*  This watchdog automates that: every WATCHDOG_INTERVAL_MS, check if   */
+/*  the pump is sending frames cleanly (last_pump_age_ms < 1 s) AND      */
+/*  voice_wakeword has received NO ASR delta in WATCHDOG_ASR_STALL_MS    */
+/*  (20 s).  Pump healthy + ASR silent = K144 cycled.  Trigger           */
+/*  voice_onboard_reset_failover() which re-runs the full chain bringup. */
+/*  Cooldown gate prevents thrash: don't re-kick within 90 s of last     */
+/*  kick (recovery itself takes ~30 s).                                  */
+/* ──────────────────────────────────────────────────────────────────── */
+#define WATCHDOG_INTERVAL_MS 10000
+#define WATCHDOG_ASR_STALL_MS 20000
+#define WATCHDOG_COOLDOWN_MS 90000
+#define WATCHDOG_PUMP_HEALTHY_MS 1000
+#define WATCHDOG_GRACE_AFTER_BOOT_MS 30000  /* don't fire in first 30 s — chain may still be coming up */
+
+static volatile int64_t s_watchdog_last_kick_us = 0;
+static volatile int64_t s_watchdog_started_us = 0;
+
+static void onboard_watchdog_task(void *arg) {
+   (void)arg;
+   s_watchdog_started_us = esp_timer_get_time();
+   ESP_LOGI(TAG, "K144-ASR watchdog started (poll=%ds, stall=%ds, cooldown=%ds)",
+            WATCHDOG_INTERVAL_MS / 1000, WATCHDOG_ASR_STALL_MS / 1000,
+            WATCHDOG_COOLDOWN_MS / 1000);
+
+   while (1) {
+      vTaskDelay(pdMS_TO_TICKS(WATCHDOG_INTERVAL_MS));
+
+      /* Only watchdog the ext_pcm path.  Other modes don't have this
+       * Tab5-pumps-to-cached-work_id failure mode. */
+      if (!tab5_settings_wake_src_is("ext_pcm")) continue;
+
+      /* Chain must be in the steady READY state.  Don't kick during
+       * PROBING (a reset is already in flight) or UNAVAILABLE
+       * (auto-retry will handle it). */
+      if (s_m5_failover != M5_FAIL_READY) continue;
+
+      /* Wakeword must be armed — if not, no asr_id binding to be stale. */
+      if (!voice_wakeword_is_active()) continue;
+
+      int64_t now = esp_timer_get_time();
+
+      /* Boot grace: chain may still be coming up cleanly. */
+      if (now - s_watchdog_started_us < (int64_t)WATCHDOG_GRACE_AFTER_BOOT_MS * 1000) continue;
+
+      /* Cooldown after a previous kick. */
+      if (now - s_watchdog_last_kick_us < (int64_t)WATCHDOG_COOLDOWN_MS * 1000) continue;
+
+      voice_ext_pcm_stream_stats_t stats;
+      voice_ext_pcm_stream_get_stats(&stats);
+
+      /* Pump must be actively flowing.  If pump is paused (mid voice
+       * turn) OR stopped, this check shouldn't fire — there's a legit
+       * reason no fresh frames are reaching K144. */
+      if (!stats.task_running || !stats.armed) continue;
+      if (stats.last_pump_age_ms < 0 || stats.last_pump_age_ms > WATCHDOG_PUMP_HEALTHY_MS) continue;
+
+      /* Pump has been pumping but we still need enough samples to draw
+       * a conclusion — fresh setup may not have produced any deltas
+       * yet, that's fine. */
+      if (stats.frames_pumped < 50) continue;
+
+      int64_t last_delta = voice_wakeword_last_delta_us();
+      int64_t delta_age_ms;
+      if (last_delta == 0) {
+         /* Pump has sent 50+ frames but K144 has emitted no transcript
+          * at all — strong signal that asr_id binding is dead. */
+         delta_age_ms = (now - s_watchdog_started_us) / 1000;
+      } else {
+         delta_age_ms = (now - last_delta) / 1000;
+      }
+      if (delta_age_ms < WATCHDOG_ASR_STALL_MS) continue;
+
+      /* All gates passed: pump flowing, wakeword armed, K144 ready,
+       * but no transcript in 20+ seconds.  K144 ASR cycled. */
+      ESP_LOGW(TAG,
+               "watchdog: K144 ASR stale (last delta %lldms ago, pump_age %lldms, frames=%lu) — kicking recovery",
+               delta_age_ms, stats.last_pump_age_ms, (unsigned long)stats.frames_pumped);
+      char detail[48];
+      snprintf(detail, sizeof(detail), "asr_stale age=%llds frames=%lu",
+               delta_age_ms / 1000, (unsigned long)stats.frames_pumped);
+      tab5_debug_obs_event("watchdog", detail);
+      s_watchdog_last_kick_us = now;
+
+      /* Stop wakeword first (frees stale asr_id), then trigger reset
+       * (sends sys.reset to K144 → re-warmup → re-arm wakeword + pump). */
+      voice_wakeword_stop();
+      vTaskDelay(pdMS_TO_TICKS(300));
+      esp_err_t e = voice_onboard_reset_failover();
+      if (e != ESP_OK) {
+         ESP_LOGW(TAG, "watchdog: reset_failover bounce (%s) — will retry next interval", esp_err_to_name(e));
+      }
+   }
+}
+
 esp_err_t voice_onboard_start_warmup(void) {
    if (s_m5_failover != M5_FAIL_UNKNOWN) return ESP_ERR_INVALID_STATE;
+   /* Spawn the K144-ASR-cycling watchdog at the same time as the boot
+    * warmup.  PSRAM-backed stack to keep internal SRAM headroom. */
+   static volatile bool s_watchdog_spawned = false;
+   if (!s_watchdog_spawned) {
+      s_watchdog_spawned = true;
+      BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(onboard_watchdog_task, "onboard_wd",
+                                                      4096, NULL, 1, NULL,
+                                                      tskNO_AFFINITY, MALLOC_CAP_SPIRAM);
+      if (ok != pdPASS) {
+         ESP_LOGW(TAG, "watchdog task spawn failed — running without ASR-stall recovery");
+         s_watchdog_spawned = false;
+      }
+   }
    return tab5_worker_enqueue(onboard_warmup_job, NULL, "m5_warmup");
 }
 

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -183,8 +183,12 @@ static void wakeword_event_handler(voice_wakeword_event_t event, const char *tex
    switch (event) {
       case VOICE_WAKEWORD_EVENT_WAKE: {
          /* TT #131-opt2: audible wake chime — confirms KWS fired before
-          * we start listening for the user's question. */
+          * we start listening for the user's question.  Hold briefly
+          * (cue is 80 ms + codec amp ramp) so the chime actually plays
+          * before voice_start_listening flips the codec to RX and
+          * masks the TX output. */
          ui_audio_cue_play(UI_CUE_INCOMING_HIGH);
+         vTaskDelay(pdMS_TO_TICKS(180));
          /* Trigger the full voice turn on the LVGL thread (mic + WS
           * dispatch both expect to run on the main task). */
          tab5_lv_async_call(wakeword_trigger_voice_turn, NULL);

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -99,13 +99,15 @@ extern void tab5_debug_obs_event(const char *kind, const char *detail);
 
 static void wakeword_event_handler(voice_wakeword_event_t event, const char *text, void *user); /* TT #617 fwd-decl */
 
-/* TT #617 — Gate the K144 onboard wakeword on the wake_src NVS setting.
- * "k144" → arm sherpa-ncnn on K144's own mic (current default for
- * offline-capable wake).  Other values ("dragon", "off", future
- * "ext_pcm") skip arming and let the other path own wake. */
+/* TT #617 / #131 — Gate K144 onboard wakeword on the wake_src setting.
+ *   "k144"    — arm sherpa-ncnn on K144's own mic
+ *   "ext_pcm" — arm sherpa-ncnn but the audio source is Tab5's mic via
+ *               the ext_pcm ingest path; voice_wakeword still subscribes
+ *               to the same asr.utf-8.stream to parse transcripts.
+ *   "dragon"/"off" — skip; another path owns wake. */
 static esp_err_t voice_onboard_arm_k144_wakeword_internal(void) {
-   if (!tab5_settings_wake_src_is("k144")) {
-      ESP_LOGI(TAG, "wake_src != k144 — skipping K144 onboard wakeword arm");
+   if (!tab5_settings_wake_src_is("k144") && !tab5_settings_wake_src_is("ext_pcm")) {
+      ESP_LOGI(TAG, "wake_src != k144/ext_pcm — skipping K144 wakeword arm");
       tab5_debug_obs_event("wake_src", "skip_k144");
       return ESP_OK;
    }

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -661,13 +661,15 @@ static void onboard_watchdog_task(void *arg) {
          }
       }
 
-      /* Track recovery outcome: poll over the next 30 s for any new
-       * ASR delta.  If we get one → reset successful, clear fail count.
-       * If still stale → increment fail count for potential escalation. */
-      vTaskDelay(pdMS_TO_TICKS(30000));
+      /* Track recovery outcome: wait long enough for the reset cycle
+       * to fully complete (sys.reset + poll-for-ready up to 90 s +
+       * asr.setup ~5 s + first delta ~5 s).  120 s gives the full
+       * cycle time + margin.  If a new ASR delta arrived since the
+       * kick → reset succeeded.  If still stale → increment counter
+       * for potential sys.reboot escalation next kick. */
+      vTaskDelay(pdMS_TO_TICKS(120000));
       int64_t check = voice_wakeword_last_delta_us();
       if (check > now) {
-         /* New delta arrived since the kick — recovery worked. */
          if (s_watchdog_reset_fail_count > 0) {
             ESP_LOGI(TAG, "watchdog: recovery succeeded — clearing fail count (was %d)",
                      s_watchdog_reset_fail_count);
@@ -675,8 +677,8 @@ static void onboard_watchdog_task(void *arg) {
          s_watchdog_reset_fail_count = 0;
       } else {
          s_watchdog_reset_fail_count++;
-         ESP_LOGW(TAG, "watchdog: recovery did NOT restore ASR — fail count now %d",
-                  s_watchdog_reset_fail_count);
+         ESP_LOGW(TAG, "watchdog: recovery did NOT restore ASR — fail count now %d/%d",
+                  s_watchdog_reset_fail_count, WATCHDOG_RESET_FAIL_CAP);
       }
    }
 }

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -22,13 +22,15 @@
 #include "freertos/task.h"
 #include "settings.h"            /* tab5_settings_get_mic_mute (Wave 7) */
 #include "task_worker.h"         /* tab5_worker_enqueue */
+#include "uart_port_c.h"         /* tab5_port_c_uart_get_baud — TT #131 baud bump check */
 #include "ui_audio_cues.h"       /* ui_audio_cue_play — wake chime (#131-opt2) */
 #include "ui_chat.h"             /* ui_chat_add_message */
 #include "ui_core.h"             /* tab5_ui_try_lock / tab5_ui_unlock */
 #include "ui_home.h"             /* ui_home_show_toast */
 #include "voice.h"               /* voice_set_state, VOICE_STATE_* */
 #include "voice_m5_llm.h"        /* probe / infer / chain_* */
-#include "voice_messages_sync.h" /* W3-C-c: Dragon canonical message store */
+#include "voice_ext_pcm_stream.h" /* TT #131: auto-arm pump on boot */
+#include "voice_messages_sync.h"  /* W3-C-c: Dragon canonical message store */
 #include "voice_wakeword.h"
 
 static const char *TAG = "voice_onboard";
@@ -387,6 +389,29 @@ static void onboard_warmup_job(void *arg) {
        * end-phrase="save note", 32 KB dictation buffer, 4-hour cap.
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
+
+      /* TT #131 2026-05-20: bump UART to 1.5 Mbps BEFORE kws.setup.
+       * Without this the chain comes up at 115200 baud where each ~4.4 KB
+       * inference frame takes ~305 ms to send, capping the pump at ~3 fps
+       * vs the design's 10 fps real-time rate.  Result was KWS getting
+       * choppy fragmentary audio — keyword phonemes split across dropped
+       * frames, "Hey Tinker" never matches.  Previously baud bump was
+       * gated behind a manual POST /tinkeron/wake_src=ext_pcm, which
+       * itself cycles the wakeword chain and re-issues kws.setup — and
+       * those repeated cycles wedge K144's llm_sys dispatch.  Auto-bump
+       * here gives us ONE clean kws.setup at the right baud, no cycling.
+       * On failure: stay at 115200 (kws still partially functional, just
+       * slow).  Skip if baud already set (idempotent). */
+      if (tab5_port_c_uart_get_baud() != 1500000) {
+         esp_err_t be = voice_m5_llm_set_baud(1500000);
+         if (be != ESP_OK) {
+            ESP_LOGW(TAG, "auto baud bump to 1.5 Mbps failed (%s) — staying at 115200",
+                     esp_err_to_name(be));
+         } else {
+            ESP_LOGI(TAG, "auto baud bump to 1.5 Mbps succeeded");
+         }
+      }
+
       esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
          /* TT #580: post-Tab5-reflash, K144's previous-session audio +
@@ -402,6 +427,17 @@ static void onboard_warmup_job(void *arg) {
          (void)voice_onboard_reset_failover();
       } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
          ESP_LOGW(TAG, "wakeword start skipped: %s", esp_err_to_name(we));
+      } else if (we == ESP_OK) {
+         /* TT #131 2026-05-20: wakeword armed cleanly — arm the ext_pcm
+          * pump in the same boot sequence so Tab5 mic immediately flows
+          * to the K144 KWS unit.  Previously this required a manual
+          * POST /tinkeron/wake_src=ext_pcm — which itself re-cycled the
+          * wakeword chain (disarm + re-setup), and the cycling was
+          * wedging K144's llm_sys dispatch.  Auto-arm here keeps the
+          * setup-once invariant: kws.setup happens exactly once per
+          * boot, at 1.5 Mbps, with the pump pre-armed to feed it. */
+         voice_ext_pcm_stream_arm();
+         ESP_LOGI(TAG, "ext_pcm pump auto-armed (Tab5 mic → K144 KWS)");
       }
    } else {
       ESP_LOGW(TAG,

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -921,3 +921,42 @@ esp_err_t voice_onboard_arm_wakeword(void) {
    voice_m5_llm_release();
    return voice_onboard_arm_k144_wakeword_internal();
 }
+
+/* TT #131 — async wakeword arm with K144 state awareness.  Posted on the
+ * shared worker so HTTP / LVGL callers return immediately; the worker
+ * polls failover state and either arms directly, triggers a daemon reset
+ * (whose post-warmup hook also arms), or re-queues to wait out a probe. */
+static void arm_wakeword_async_job(void *arg) {
+   int attempts = (int)(intptr_t)arg;
+   if (voice_wakeword_is_active()) return; /* already armed */
+
+   int st = (int)s_m5_failover;
+   if (st == (int)M5_FAIL_READY) {
+      esp_err_t we = voice_onboard_arm_wakeword();
+      if (we == ESP_ERR_INVALID_RESPONSE) {
+         ESP_LOGW(TAG, "arm_wakeword_async: arm hit INVALID_RESPONSE — triggering reset");
+         (void)voice_onboard_reset_failover();
+      } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
+         ESP_LOGW(TAG, "arm_wakeword_async: arm err %s", esp_err_to_name(we));
+      }
+      return;
+   }
+   if (st == (int)M5_FAIL_UNAVAILABLE) {
+      ESP_LOGI(TAG, "arm_wakeword_async: K144 unavailable — triggering reset_failover");
+      (void)voice_onboard_reset_failover();
+      return;
+   }
+   /* UNKNOWN or PROBING — wait for the in-flight probe to land.  Cap at
+    * 30 retries × 500 ms = 15 s so we don't loop forever on a permanent
+    * UNKNOWN state. */
+   if (attempts >= 30) {
+      ESP_LOGW(TAG, "arm_wakeword_async: gave up after %d attempts (st=%d)", attempts, st);
+      return;
+   }
+   vTaskDelay(pdMS_TO_TICKS(500));
+   (void)tab5_worker_enqueue(arm_wakeword_async_job, (void *)(intptr_t)(attempts + 1), "arm_wake_retry");
+}
+
+esp_err_t voice_onboard_arm_wakeword_async(void) {
+   return tab5_worker_enqueue(arm_wakeword_async_job, (void *)(intptr_t)0, "arm_wake_async");
+}

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -390,14 +390,36 @@ static void onboard_warmup_job(void *arg) {
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
 
-      /* NOTE: auto baud bump to 1.5 Mbps WAS here as TT #131 fix but
-       * caused Tab5↔K144 sync issues — after Tab5 reboots with K144
-       * still at 1.5M (no cold boot reset on K144 unit), the bump
-       * round-trip races with K144's serial reconfig and the chain
-       * lands in a half-synced state where kws.setup fails silently.
-       * Cleaner: chain comes up at 115200 default; user POSTs
-       * /tinkeron/wake_src=ext_pcm to opt in to 1.5 Mbps real-time
-       * pump (that handler resets Tab5 baseline before bumping). */
+      /* TT #131 stability 2026-05-20: BOOT AUTO-ARM the full Tab5-mic
+       * → K144 ASR chain when NVS wake_src=="ext_pcm".  Previously the
+       * boot path only armed wakeword at 115200; user had to manually
+       * POST /tinkeron/wake_src=ext_pcm after every restart to bump
+       * baud to 1.5 Mbps + arm the ext_pcm pump.  That manual step
+       * was both a UX burden AND it cycled the wakeword chain
+       * (disarm + re-arm), which destabilised K144's llm-asr daemon.
+       *
+       * Now: if user has previously opted in (wake_src=ext_pcm
+       * persisted in NVS), the boot path does the SAME work as the
+       * wake_src=ext_pcm POST handler — reset Tab5 UART baseline to
+       * 115200 (so the bump round-trip starts from known state),
+       * suppress auto-retry, bump baud to 1.5 Mbps, then arm wakeword
+       * + pump.  The K144-stayed-at-1.5M sync issue from the
+       * earlier attempt is avoided because we explicitly reset
+       * baseline BEFORE bumping.  Setup-once invariant preserved:
+       * exactly one asr.setup per boot at the right baud. */
+      bool boot_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
+      if (boot_to_ext_pcm) {
+         ESP_LOGI(TAG, "wake_src=ext_pcm in NVS — boot auto-arming Tab5 mic path");
+         tab5_port_c_uart_set_baud(115200);
+         voice_onboard_suppress_auto_retry(true);
+         esp_err_t be = voice_m5_llm_set_baud(1500000);
+         if (be != ESP_OK) {
+            ESP_LOGW(TAG, "boot baud bump to 1.5 Mbps failed (%s) — wakeword will run at 115200 (pump capped at ~3 fps)",
+                     esp_err_to_name(be));
+         } else {
+            ESP_LOGI(TAG, "boot baud bumped to 1.5 Mbps cleanly");
+         }
+      }
 
       esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
@@ -415,16 +437,16 @@ static void onboard_warmup_job(void *arg) {
       } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
          ESP_LOGW(TAG, "wakeword start skipped: %s", esp_err_to_name(we));
       } else if (we == ESP_OK) {
-         /* TT #131 2026-05-20: wakeword armed cleanly — arm the ext_pcm
-          * pump in the same boot sequence so Tab5 mic immediately flows
-          * to the K144 KWS unit.  Previously this required a manual
-          * POST /tinkeron/wake_src=ext_pcm — which itself re-cycled the
-          * wakeword chain (disarm + re-setup), and the cycling was
-          * wedging K144's llm_sys dispatch.  Auto-arm here keeps the
-          * setup-once invariant: kws.setup happens exactly once per
-          * boot, at 1.5 Mbps, with the pump pre-armed to feed it. */
-         voice_ext_pcm_stream_arm();
-         ESP_LOGI(TAG, "ext_pcm pump auto-armed (Tab5 mic → K144 KWS)");
+         /* TT #131 stability 2026-05-20: arm ext_pcm pump ONLY when
+          * wake_src is configured for ext_pcm.  For other modes
+          * (dragon, mate, off) the pump must stay disarmed — otherwise
+          * it would compete with the active wake source for the Tab5
+          * mic and pollute the K144 ASR with audio that no one is
+          * matching against. */
+         if (boot_to_ext_pcm) {
+            voice_ext_pcm_stream_arm();
+            ESP_LOGI(TAG, "ext_pcm pump auto-armed (Tab5 mic → K144 ASR @ 1.5Mbps)");
+         }
       }
    } else {
       ESP_LOGW(TAG,
@@ -578,8 +600,24 @@ static void onboard_reset_failover_job(void *arg) {
        * uartsetup sometimes fails silently → both ends out of sync
        * across the reset.  Boot warmup path (onboard_warmup_job)
        * does the bump cleanly when Tab5 starts at the 115200 default.
-       * For reset path, user can manually re-bump via
-       * POST /tinkeron/wake_src=ext_pcm if needed. */
+       *
+       * 2026-05-20 update: reset path now ALSO does the bump when
+       * wake_src=ext_pcm, gated on resetting Tab5 baseline to 115200
+       * first (same pattern the wake_src=ext_pcm POST handler uses).
+       * K144 just went through sys.reset so its UART is also at the
+       * default — round-trip starts from known state. */
+      bool reset_to_ext_pcm = tab5_settings_wake_src_is("ext_pcm");
+      if (reset_to_ext_pcm) {
+         ESP_LOGI(TAG, "wake_src=ext_pcm — reset path bumping baud to 1.5 Mbps");
+         tab5_port_c_uart_set_baud(115200);
+         voice_onboard_suppress_auto_retry(true);
+         esp_err_t be = voice_m5_llm_set_baud(1500000);
+         if (be != ESP_OK) {
+            ESP_LOGW(TAG, "reset-path baud bump failed (%s)", esp_err_to_name(be));
+         } else {
+            ESP_LOGI(TAG, "reset-path baud bumped to 1.5 Mbps");
+         }
+      }
       /* Wakeword revival: same hook as the initial warmup path — once
        * K144 is reachable again, (re-)arm the always-on ASR chain.
        * Idempotent (start refuses if already running). */
@@ -595,10 +633,12 @@ static void onboard_reset_failover_job(void *arg) {
       } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
          ESP_LOGW(TAG, "wakeword (re)start skipped: %s", esp_err_to_name(we));
       } else if (we == ESP_OK) {
-         /* TT #131 2026-05-20: same pump-arm as warmup path so /m5/reset
-          * fully establishes Tab5 mic → K144 KWS in one shot. */
-         voice_ext_pcm_stream_arm();
-         ESP_LOGI(TAG, "ext_pcm pump auto-armed via reset path");
+         /* Same pump arm as warmup path — but only when wake_src is
+          * ext_pcm.  Other modes don't want the Tab5-mic pump running. */
+         if (reset_to_ext_pcm) {
+            voice_ext_pcm_stream_arm();
+            ESP_LOGI(TAG, "ext_pcm pump auto-armed via reset path @ 1.5 Mbps");
+         }
       }
    } else {
       ESP_LOGW(TAG, "K144 re-warmup %s after %lldms — still unavailable", esp_err_to_name(ie), dt_ms);

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -22,6 +22,7 @@
 #include "freertos/task.h"
 #include "settings.h"            /* tab5_settings_get_mic_mute (Wave 7) */
 #include "task_worker.h"         /* tab5_worker_enqueue */
+#include "ui_audio_cues.h"       /* ui_audio_cue_play — wake chime (#131-opt2) */
 #include "ui_chat.h"             /* ui_chat_add_message */
 #include "ui_core.h"             /* tab5_ui_try_lock / tab5_ui_unlock */
 #include "ui_home.h"             /* ui_home_show_toast */
@@ -181,6 +182,9 @@ static void wakeword_event_handler(voice_wakeword_event_t event, const char *tex
    (void)user;
    switch (event) {
       case VOICE_WAKEWORD_EVENT_WAKE: {
+         /* TT #131-opt2: audible wake chime — confirms KWS fired before
+          * we start listening for the user's question. */
+         ui_audio_cue_play(UI_CUE_INCOMING_HIGH);
          /* Trigger the full voice turn on the LVGL thread (mic + WS
           * dispatch both expect to run on the main task). */
          tab5_lv_async_call(wakeword_trigger_voice_turn, NULL);

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -390,27 +390,14 @@ static void onboard_warmup_job(void *arg) {
        * Failures non-fatal — the LLM path still works without wakeword. */
       voice_m5_llm_release();
 
-      /* TT #131 2026-05-20: bump UART to 1.5 Mbps BEFORE kws.setup.
-       * Without this the chain comes up at 115200 baud where each ~4.4 KB
-       * inference frame takes ~305 ms to send, capping the pump at ~3 fps
-       * vs the design's 10 fps real-time rate.  Result was KWS getting
-       * choppy fragmentary audio — keyword phonemes split across dropped
-       * frames, "Hey Tinker" never matches.  Previously baud bump was
-       * gated behind a manual POST /tinkeron/wake_src=ext_pcm, which
-       * itself cycles the wakeword chain and re-issues kws.setup — and
-       * those repeated cycles wedge K144's llm_sys dispatch.  Auto-bump
-       * here gives us ONE clean kws.setup at the right baud, no cycling.
-       * On failure: stay at 115200 (kws still partially functional, just
-       * slow).  Skip if baud already set (idempotent). */
-      if (tab5_port_c_uart_get_baud() != 1500000) {
-         esp_err_t be = voice_m5_llm_set_baud(1500000);
-         if (be != ESP_OK) {
-            ESP_LOGW(TAG, "auto baud bump to 1.5 Mbps failed (%s) — staying at 115200",
-                     esp_err_to_name(be));
-         } else {
-            ESP_LOGI(TAG, "auto baud bump to 1.5 Mbps succeeded");
-         }
-      }
+      /* NOTE: auto baud bump to 1.5 Mbps WAS here as TT #131 fix but
+       * caused Tab5↔K144 sync issues — after Tab5 reboots with K144
+       * still at 1.5M (no cold boot reset on K144 unit), the bump
+       * round-trip races with K144's serial reconfig and the chain
+       * lands in a half-synced state where kws.setup fails silently.
+       * Cleaner: chain comes up at 115200 default; user POSTs
+       * /tinkeron/wake_src=ext_pcm to opt in to 1.5 Mbps real-time
+       * pump (that handler resets Tab5 baseline before bumping). */
 
       esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
       if (we == ESP_ERR_INVALID_RESPONSE) {
@@ -585,6 +572,14 @@ static void onboard_reset_failover_job(void *arg) {
       /* Same "free LLM slot before ASR" gate as the initial warmup
        * path — see comment there for why this is required. */
       voice_m5_llm_release();
+      /* NOTE: baud bump deliberately NOT done here.  Earlier attempt
+       * caused Tab5-vs-K144 baud desync on /m5/reset path because the
+       * boot-time bump path can leave Tab5 at 1.5 Mbps while K144's
+       * uartsetup sometimes fails silently → both ends out of sync
+       * across the reset.  Boot warmup path (onboard_warmup_job)
+       * does the bump cleanly when Tab5 starts at the 115200 default.
+       * For reset path, user can manually re-bump via
+       * POST /tinkeron/wake_src=ext_pcm if needed. */
       /* Wakeword revival: same hook as the initial warmup path — once
        * K144 is reachable again, (re-)arm the always-on ASR chain.
        * Idempotent (start refuses if already running). */
@@ -599,6 +594,11 @@ static void onboard_reset_failover_job(void *arg) {
          (void)voice_onboard_reset_failover();
       } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
          ESP_LOGW(TAG, "wakeword (re)start skipped: %s", esp_err_to_name(we));
+      } else if (we == ESP_OK) {
+         /* TT #131 2026-05-20: same pump-arm as warmup path so /m5/reset
+          * fully establishes Tab5 mic → K144 KWS in one shot. */
+         voice_ext_pcm_stream_arm();
+         ESP_LOGI(TAG, "ext_pcm pump auto-armed via reset path");
       }
    } else {
       ESP_LOGW(TAG, "K144 re-warmup %s after %lldms — still unavailable", esp_err_to_name(ie), dt_ms);

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -494,9 +494,12 @@ static void onboard_reset_failover_job(void *arg) {
       tab5_debug_obs_event("m5.reset", "ack_ok");
    }
 
-   /* Daemon needs ~4 s to reconnect MQTT internally after a soft reset.
-    * 5 s wait is conservative — verified on the live ADB probe. */
-   vTaskDelay(pdMS_TO_TICKS(5000));
+   /* Daemon needs ~4 s to reconnect MQTT internally + ~8-10 s for the
+    * qwen2.5-0.5B LLM model to load into the NPU.  Without the longer
+    * wait the post-reset re-warmup hit "unit call false" (err=-9) because
+    * llm-llm hadn't registered its RPC server yet (TT #131 live debug).
+    * 15 s is conservative — most boots see ready by 12 s. */
+   vTaskDelay(pdMS_TO_TICKS(15000));
 
    /* Re-run the probe + warmup-infer.  Inline-equivalent to
     * onboard_warmup_job but reuses the same observability events for
@@ -922,38 +925,37 @@ esp_err_t voice_onboard_arm_wakeword(void) {
    return voice_onboard_arm_k144_wakeword_internal();
 }
 
-/* TT #131 — async wakeword arm with K144 state awareness.  Posted on the
- * shared worker so HTTP / LVGL callers return immediately; the worker
- * polls failover state and either arms directly, triggers a daemon reset
- * (whose post-warmup hook also arms), or re-queues to wait out a probe. */
+/* TT #131 — async wakeword arm.  Posted on the shared worker so HTTP /
+ * LVGL callers return immediately.
+ *
+ * The wakeword listener only needs audio + asr on K144 (NO llm), so this
+ * path IGNORES the failover_state gate (which gates on llm.setup success)
+ * and just tries voice_onboard_arm_wakeword over and over until asr.setup
+ * lands.  Retries with 2 s backoff, 15 attempts (30 s total).
+ *
+ * If we deferred to reset_failover here we'd lose minutes to the llm
+ * model-load probe + auto-retry budget — for ext_pcm the LLM doesn't
+ * even need to be reachable. */
 static void arm_wakeword_async_job(void *arg) {
    int attempts = (int)(intptr_t)arg;
    if (voice_wakeword_is_active()) return; /* already armed */
 
-   int st = (int)s_m5_failover;
-   if (st == (int)M5_FAIL_READY) {
-      esp_err_t we = voice_onboard_arm_wakeword();
-      if (we == ESP_ERR_INVALID_RESPONSE) {
-         ESP_LOGW(TAG, "arm_wakeword_async: arm hit INVALID_RESPONSE — triggering reset");
-         (void)voice_onboard_reset_failover();
-      } else if (we != ESP_OK && we != ESP_ERR_INVALID_STATE) {
-         ESP_LOGW(TAG, "arm_wakeword_async: arm err %s", esp_err_to_name(we));
-      }
+   voice_m5_llm_release(); /* free NPU slot before ASR claims it */
+   esp_err_t we = voice_onboard_arm_k144_wakeword_internal();
+   if (we == ESP_OK || we == ESP_ERR_INVALID_STATE /* already running */) {
+      tab5_debug_obs_event("arm_wake_async", "ok");
       return;
    }
-   if (st == (int)M5_FAIL_UNAVAILABLE) {
-      ESP_LOGI(TAG, "arm_wakeword_async: K144 unavailable — triggering reset_failover");
-      (void)voice_onboard_reset_failover();
+
+   if (attempts >= 15) {
+      ESP_LOGW(TAG, "arm_wakeword_async: gave up after %d attempts (last err=%s)", attempts,
+               esp_err_to_name(we));
+      tab5_debug_obs_event("arm_wake_async", "give_up");
       return;
    }
-   /* UNKNOWN or PROBING — wait for the in-flight probe to land.  Cap at
-    * 30 retries × 500 ms = 15 s so we don't loop forever on a permanent
-    * UNKNOWN state. */
-   if (attempts >= 30) {
-      ESP_LOGW(TAG, "arm_wakeword_async: gave up after %d attempts (st=%d)", attempts, st);
-      return;
-   }
-   vTaskDelay(pdMS_TO_TICKS(500));
+   ESP_LOGW(TAG, "arm_wakeword_async: attempt %d failed (%s) — retrying in 2s", attempts,
+            esp_err_to_name(we));
+   vTaskDelay(pdMS_TO_TICKS(2000));
    (void)tab5_worker_enqueue(arm_wakeword_async_job, (void *)(intptr_t)(attempts + 1), "arm_wake_retry");
 }
 

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -183,12 +183,8 @@ static void wakeword_event_handler(voice_wakeword_event_t event, const char *tex
    switch (event) {
       case VOICE_WAKEWORD_EVENT_WAKE: {
          /* TT #131-opt2: audible wake chime — confirms KWS fired before
-          * we start listening for the user's question.  Hold briefly
-          * (cue is 80 ms + codec amp ramp) so the chime actually plays
-          * before voice_start_listening flips the codec to RX and
-          * masks the TX output. */
+          * we start listening for the user's question. */
          ui_audio_cue_play(UI_CUE_INCOMING_HIGH);
-         vTaskDelay(pdMS_TO_TICKS(180));
          /* Trigger the full voice turn on the LVGL thread (mic + WS
           * dispatch both expect to run on the main task). */
          tab5_lv_async_call(wakeword_trigger_voice_turn, NULL);

--- a/main/voice_onboard.h
+++ b/main/voice_onboard.h
@@ -120,6 +120,16 @@ int64_t voice_onboard_chain_uptime_ms(void);
  *  hint to user). */
 esp_err_t voice_onboard_arm_wakeword(void);
 
+/** TT #131 — suppress the K144 auto-retry + warmup-failure machinery.
+ *  voice_ext_pcm_stream calls this when armed at high UART baud, because:
+ *    - voice_onboard's auto-retry calls sys.reset, which restarts K144's
+ *      llm-sys and wipes the negotiated 1.5 Mbps baud setting back to
+ *      115200.  Tab5 stays at 1.5M, UART frames corrupt, all data dies.
+ *    - While ext_pcm is pumping, the pump itself is the liveness probe;
+ *      we don't need redundant hwinfo/llm.setup health checks.
+ *  Idempotent.  Released on disarm. */
+void voice_onboard_suppress_auto_retry(bool suppress);
+
 /** TT #131 — async variant safe to call from HTTP / LVGL threads.
  *  Queues a worker job that:
  *    - if K144 is READY: calls voice_onboard_arm_wakeword() inline

--- a/main/voice_onboard.h
+++ b/main/voice_onboard.h
@@ -120,6 +120,16 @@ int64_t voice_onboard_chain_uptime_ms(void);
  *  hint to user). */
 esp_err_t voice_onboard_arm_wakeword(void);
 
+/** TT #131 — async variant safe to call from HTTP / LVGL threads.
+ *  Queues a worker job that:
+ *    - if K144 is READY: calls voice_onboard_arm_wakeword() inline
+ *    - if K144 is UNAVAILABLE: triggers reset_failover (whose post-warmup
+ *      hook re-arms wakeword automatically)
+ *    - if K144 is PROBING: re-queues itself after a short delay until
+ *      either READY or UNAVAILABLE
+ *  Idempotent + non-blocking from the caller's perspective. */
+esp_err_t voice_onboard_arm_wakeword_async(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -444,15 +444,16 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    ESP_LOGI(TAG, "starting K144 always-on ASR: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
    tab5_debug_obs_event("wakeword.start", s_wake_phrase);
 
-   /* TT #131 — for wake_src=ext_pcm use input=["asr"] (Tab5-mic variant).
-    * Custom K144 main_asr binary (TT #131 build) decodes ADPCM in
-    * task_user_data, so Tab5 pushes inference frames DIRECT to asr.NNNN
-    * with object="audio.pcm.adpcm.base64".  No audio.setup, no PUB
-    * binding, no ZMQ SUB dance — bypasses every reliability issue.
-    * For wake_src=k144: original path with K144's onboard mic. */
+   /* TT #131 — for wake_src=ext_pcm use input=["kws"] (Tab5-mic variant).
+    * Custom K144 main_kws binary (TT #131-opt2 build) decodes ADPCM in
+    * task_user_data and emits a single kws.bool on detection.  KWS is
+    * lighter + more deterministic than ASR-based phrase matching, which
+    * confabulated short transcripts on quiet speech.  Tab5 pushes the
+    * same ADPCM inference frames as before; only the target unit changes.
+    * For wake_src=k144: original ASR path with K144's onboard mic. */
    esp_err_t err;
    if (tab5_settings_wake_src_is("ext_pcm")) {
-      err = voice_m5_llm_wakeword_setup_tab5_mic(&s_handle, &s_stop_flag);
+      err = voice_m5_llm_kws_setup_tab5_mic(&s_handle, s_wake_phrase, &s_stop_flag);
    } else {
       err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
    }

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -309,6 +309,27 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
       if (s_emit_bg && delta && delta[0]) {
          emit_event(VOICE_WAKEWORD_EVENT_TRANSCRIPT, delta);
       }
+      /* TT #131 2026-05-20: K144's sherpa-ncnn streaming-zipformer-20M
+       * is INCONSISTENT in how it transcribes "Hey Tinker" — observed
+       * renderings across sessions: "thinker", "hick", "hicker",
+       * "hanker", "any hanker thinker", "i'm thinker".  To make the
+       * wake reliable we match against a small set of patterns that
+       * all map to "user said something that sounds like Hey Tinker".
+       *
+       * The 8-char VAD pre-gate (below) keeps short hallucinations
+       * out — "hick" alone in a 5-char window won't fire; "hick"
+       * embedded in a longer window will.  Self-wake during TTS is
+       * already suppressed by voice_state.
+       *
+       * Order matters: try the longest/most-specific first so the
+       * match-detail surfaces the best signal. */
+      static const char *const k_alt_patterns[] = {
+         "thinker",   /* T→Th substitution — most common rendering */
+         "hicker",    /* contracted "Hey Tinker" */
+         "tinker",    /* exact (rare — model usually substitutes) */
+         "hick",      /* heavily-contracted rendering, real session 2026-05-20 */
+         "hanker",    /* observed in "any hanker thinker" rendering */
+      };
       const char *match = NULL;
       if (s_wake_window_len > 0) {
          if (istrstr(s_wake_window, s_wake_phrase) != NULL) {
@@ -316,6 +337,13 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
          } else if (s_wake_phrase_alt[0] &&
                     istrstr(s_wake_window, s_wake_phrase_alt) != NULL) {
             match = s_wake_phrase_alt;
+         } else {
+            for (size_t i = 0; i < sizeof(k_alt_patterns) / sizeof(k_alt_patterns[0]); i++) {
+               if (istrstr(s_wake_window, k_alt_patterns[i]) != NULL) {
+                  match = k_alt_patterns[i];
+                  break;
+               }
+            }
          }
       }
       if (match != NULL) {

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -444,16 +444,13 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    ESP_LOGI(TAG, "starting K144 always-on ASR: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
    tab5_debug_obs_event("wakeword.start", s_wake_phrase);
 
-   /* TT #131 — when wake_src=ext_pcm, use the Tab5-mic variant of asr.setup
-    * (input=["asr"], no audio unit).  Tab5 ext_pcm_stream then pushes
-    * mic frames as inference RPCs to the returned asr work_id.
-    * Otherwise: original path (input=["sys.pcm"], audio + onboard mic). */
-   esp_err_t err;
-   if (tab5_settings_wake_src_is("ext_pcm")) {
-      err = voice_m5_llm_wakeword_setup_tab5_mic(&s_handle, &s_stop_flag);
-   } else {
-      err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
-   }
+   /* Original path for BOTH k144 + ext_pcm: input=["sys.pcm"], audio.setup
+    * binds /tmp/llm/pcm.cap.socket, ASR subscribes there.  For
+    * wake_src=ext_pcm the voice_ext_pcm_stream pump then issues
+    * audio.cap_stop_all + ext_pcm.rebind to flip the URL ownership to
+    * our ext_pcm binary, which decodes inbound ADPCM and re-publishes
+    * raw PCM on the same URL.  ASR's SUB stays connected. */
+   esp_err_t err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
    if (err != ESP_OK) {
       ESP_LOGE(TAG, "ASR chain setup failed: %s", esp_err_to_name(err));
       char detail[48];

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -20,13 +20,13 @@
 #include <string.h>
 
 #include "debug_obs.h"
-#include "settings.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/idf_additions.h"
 #include "freertos/task.h"
+#include "settings.h"
 #include "voice.h"
 #include "voice_m5_llm.h"
 
@@ -248,8 +248,8 @@ static bool wakeword_suppressed_by_voice_state(void) {
     * the user gets a "fully idle before re-arm" UX as requested.
     * Net cost: lose mid-TTS barge-in.  Net gain: stability under the
     * sensitive ASR-based wake. */
-   if (st == VOICE_STATE_LISTENING || st == VOICE_STATE_PROCESSING ||
-       st == VOICE_STATE_RECONNECTING || st == VOICE_STATE_SPEAKING) {
+   if (st == VOICE_STATE_LISTENING || st == VOICE_STATE_PROCESSING || st == VOICE_STATE_RECONNECTING ||
+       st == VOICE_STATE_SPEAKING) {
       s_last_busy_us = esp_timer_get_time();
       return true;
    }
@@ -262,7 +262,7 @@ static bool wakeword_suppressed_by_voice_state(void) {
       if (since_busy_us < (int64_t)WAKE_REARM_GRACE_MS * 1000) {
          return true;
       }
-      s_last_busy_us = 0;  /* grace expired — re-armed */
+      s_last_busy_us = 0; /* grace expired — re-armed */
    }
    return false;
 }
@@ -324,11 +324,11 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
        * Order matters: try the longest/most-specific first so the
        * match-detail surfaces the best signal. */
       static const char *const k_alt_patterns[] = {
-         "thinker",   /* T→Th substitution — most common rendering */
-         "hicker",    /* contracted "Hey Tinker" */
-         "tinker",    /* exact (rare — model usually substitutes) */
-         "hick",      /* heavily-contracted rendering, real session 2026-05-20 */
-         "hanker",    /* observed in "any hanker thinker" rendering */
+          "thinker", /* T→Th substitution — most common rendering */
+          "hicker",  /* contracted "Hey Tinker" */
+          "tinker",  /* exact (rare — model usually substitutes) */
+          "hick",    /* heavily-contracted rendering, real session 2026-05-20 */
+          "hanker",  /* observed in "any hanker thinker" rendering */
       };
       const char *match = NULL;
       if (s_wake_window_len > 0) {
@@ -527,9 +527,8 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
     * Internal SRAM is tight (~56 KB largest-free at boot); a 12 KB
     * stack here on top of ext_pcm's 8 KB pushed the heap into
     * heap_wd's "sram_exhausted" threshold under sustained operation. */
-   BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(wakeword_task, "wakeword", WAKEWORD_TASK_STACK,
-                                                   NULL, WAKEWORD_TASK_PRIO, &s_task,
-                                                   tskNO_AFFINITY, MALLOC_CAP_SPIRAM);
+   BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(wakeword_task, "wakeword", WAKEWORD_TASK_STACK, NULL,
+                                                   WAKEWORD_TASK_PRIO, &s_task, tskNO_AFFINITY, MALLOC_CAP_SPIRAM);
    if (ok != pdPASS) {
       ESP_LOGE(TAG, "wakeword task spawn failed");
       voice_m5_llm_wakeword_teardown(s_handle);

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "debug_obs.h"
+#include "settings.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -443,7 +444,16 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    ESP_LOGI(TAG, "starting K144 always-on ASR: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
    tab5_debug_obs_event("wakeword.start", s_wake_phrase);
 
-   esp_err_t err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
+   /* TT #131 — when wake_src=ext_pcm, use the Tab5-mic variant of asr.setup
+    * (input=["asr"], no audio unit).  Tab5 ext_pcm_stream then pushes
+    * mic frames as inference RPCs to the returned asr work_id.
+    * Otherwise: original path (input=["sys.pcm"], audio + onboard mic). */
+   esp_err_t err;
+   if (tab5_settings_wake_src_is("ext_pcm")) {
+      err = voice_m5_llm_wakeword_setup_tab5_mic(&s_handle, &s_stop_flag);
+   } else {
+      err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
+   }
    if (err != ESP_OK) {
       ESP_LOGE(TAG, "ASR chain setup failed: %s", esp_err_to_name(err));
       char detail[48];
@@ -479,6 +489,8 @@ void voice_wakeword_stop(void) {
 }
 
 bool voice_wakeword_is_active(void) { return s_handle != NULL && s_task != NULL; }
+
+const char *voice_wakeword_asr_id(void) { return voice_m5_llm_wakeword_asr_id(s_handle); }
 
 void voice_wakeword_force_dictation_stop(void) { s_force_dict_stop = true; }
 

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -444,13 +444,18 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    ESP_LOGI(TAG, "starting K144 always-on ASR: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
    tab5_debug_obs_event("wakeword.start", s_wake_phrase);
 
-   /* Original path for BOTH k144 + ext_pcm: input=["sys.pcm"], audio.setup
-    * binds /tmp/llm/pcm.cap.socket, ASR subscribes there.  For
-    * wake_src=ext_pcm the voice_ext_pcm_stream pump then issues
-    * audio.cap_stop_all + ext_pcm.rebind to flip the URL ownership to
-    * our ext_pcm binary, which decodes inbound ADPCM and re-publishes
-    * raw PCM on the same URL.  ASR's SUB stays connected. */
-   esp_err_t err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
+   /* TT #131 — for wake_src=ext_pcm use input=["asr"] (Tab5-mic variant).
+    * Custom K144 main_asr binary (TT #131 build) decodes ADPCM in
+    * task_user_data, so Tab5 pushes inference frames DIRECT to asr.NNNN
+    * with object="audio.pcm.adpcm.base64".  No audio.setup, no PUB
+    * binding, no ZMQ SUB dance — bypasses every reliability issue.
+    * For wake_src=k144: original path with K144's onboard mic. */
+   esp_err_t err;
+   if (tab5_settings_wake_src_is("ext_pcm")) {
+      err = voice_m5_llm_wakeword_setup_tab5_mic(&s_handle, &s_stop_flag);
+   } else {
+      err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
+   }
    if (err != ESP_OK) {
       ESP_LOGE(TAG, "ASR chain setup failed: %s", esp_err_to_name(err));
       char detail[48];

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -381,37 +381,20 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    strncpy(s_wake_phrase, wp, sizeof(s_wake_phrase) - 1);
    s_wake_phrase[sizeof(s_wake_phrase) - 1] = '\0';
 
-   /* Auto-derive a "tinker → thinker" alternate spelling so the ASR's
-    * consistent mis-hearing doesn't kill the match.  Replace every
-    * standalone occurrence of "tinker" with "thinker" in the alt
-    * buffer.  Substring + case-insensitive — same matcher rules. */
-   s_wake_phrase_alt[0] = '\0';
-   {
-      const char *needle = "tinker";
-      size_t nlen = strlen(needle);
-      const char *p = s_wake_phrase;
-      char *out = s_wake_phrase_alt;
-      char *end = s_wake_phrase_alt + sizeof(s_wake_phrase_alt) - 1;
-      bool found = false;
-      while (*p && out < end) {
-         const char *m = istrstr(p, needle);
-         if (m == NULL) {
-            size_t take = strlen(p);
-            if (out + take > end) take = (size_t)(end - out);
-            memcpy(out, p, take); out += take; break;
-         }
-         found = true;
-         size_t pre = (size_t)(m - p);
-         if (out + pre > end) pre = (size_t)(end - out);
-         memcpy(out, p, pre); out += pre;
-         const char *sub = "thinker";
-         size_t slen = strlen(sub);
-         if (out + slen > end) slen = (size_t)(end - out);
-         memcpy(out, sub, slen); out += slen;
-         p = m + nlen;
-      }
-      *out = '\0';
-      if (!found) s_wake_phrase_alt[0] = '\0';
+   /* TT #131 2026-05-20: ASR consistently transcribes "Hey Tinker" as
+    * jumbled noise containing the substring "thinker" — e.g. "think
+    * of any hanker thinker agathip kirkique".  The full-phrase alt
+    * "hey thinker" rarely matches because ASR drops/mangles the
+    * leading "hey".  Use just "thinker" as alt — the VAD pre-gate
+    * (8-char window minimum) still filters single-word noise
+    * hallucinations, and self-wake during TTS is already suppressed
+    * by voice_state checks.  Net: catches the proper-noun token
+    * the ASR consistently emits, even when surrounded by garbage. */
+   if (istrstr(s_wake_phrase, "tinker") != NULL) {
+      strncpy(s_wake_phrase_alt, "thinker", sizeof(s_wake_phrase_alt) - 1);
+      s_wake_phrase_alt[sizeof(s_wake_phrase_alt) - 1] = '\0';
+   } else {
+      s_wake_phrase_alt[0] = '\0';
    }
    strncpy(s_end_phrase, ep, sizeof(s_end_phrase) - 1);
    s_end_phrase[sizeof(s_end_phrase) - 1] = '\0';
@@ -445,16 +428,23 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
    ESP_LOGI(TAG, "starting K144 always-on ASR: wake=\"%s\" end=\"%s\"", s_wake_phrase, s_end_phrase);
    tab5_debug_obs_event("wakeword.start", s_wake_phrase);
 
-   /* TT #131 — for wake_src=ext_pcm use input=["kws"] (Tab5-mic variant).
-    * Custom K144 main_kws binary (TT #131-opt2 build) decodes ADPCM in
-    * task_user_data and emits a single kws.bool on detection.  KWS is
-    * lighter + more deterministic than ASR-based phrase matching, which
-    * confabulated short transcripts on quiet speech.  Tab5 pushes the
-    * same ADPCM inference frames as before; only the target unit changes.
-    * For wake_src=k144: original ASR path with K144's onboard mic. */
+   /* TT #131 2026-05-20: wake_src=ext_pcm now uses the ASR variant
+    * (Tab5 mic → K144 main_asr → utf-8 stream → Tab5 string-matcher).
+    * KWS variant proved unreliable — even at 0.02 threshold + 5
+    * parameter-name-variants + clean voice (RMS 3685+) the
+    * sherpa-onnx-kws-zipformer-gigaspeech model wouldn't fire.  The
+    * ASR path is acoustically more robust (full sequence-to-sequence
+    * transducer vs per-token keyword spotter) AND has live-verified
+    * history of producing real transcripts from Tab5-mic audio
+    * (K144 daemon journal Aug 22 12:17/12:20 from commit 88fbf14).
+    * Tab5's voice_wakeword recv loop already handles both shapes
+    * via the is_kws flag — wakeword_setup_tab5_mic doesn't set
+    * is_kws so the matcher does string-match on the transcript
+    * stream (catches "hey tinker" + "hey thinker" — K144's ASR
+    * consistently substitutes T → Th on this phrase). */
    esp_err_t err;
    if (tab5_settings_wake_src_is("ext_pcm")) {
-      err = voice_m5_llm_kws_setup_tab5_mic(&s_handle, s_wake_phrase, &s_stop_flag);
+      err = voice_m5_llm_wakeword_setup_tab5_mic(&s_handle, &s_stop_flag);
    } else {
       err = voice_m5_llm_wakeword_setup(&s_handle, &s_stop_flag);
    }

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -229,6 +229,15 @@ static void finish_dictation(const char *reason) {
 static int64_t s_last_busy_us = 0;
 #define WAKE_REARM_GRACE_MS 1000
 
+/* TT #131 watchdog 2026-05-20: timestamp of the most-recent ASR
+ * delta we received from K144.  Updated in asr_partial_cb.  The
+ * watchdog task in voice_onboard.c polls voice_wakeword_last_delta_us()
+ * and kicks /m5/reset if it goes stale (>20 s) while the pump is
+ * actively sending frames — that pattern means K144's llm-asr
+ * cycled out from under us and our cached asr_id is stale. */
+static int64_t s_last_delta_us = 0;
+int64_t voice_wakeword_last_delta_us(void) { return s_last_delta_us; }
+
 static bool wakeword_suppressed_by_voice_state(void) {
    voice_state_t st = voice_get_state();
    /* TT #131 2026-05-20: matcher's alt phrase is now bare "thinker"
@@ -276,6 +285,11 @@ static void transcript_ring_push(const char *delta, bool finish) {
 
 static void asr_partial_cb(const char *delta, bool finish, void *user) {
    (void)user;
+
+   /* TT #131 watchdog: timestamp ANY delta arrival (including empty
+    * "finish" markers).  Even a finish=true with no text confirms
+    * K144's llm-asr is alive and dispatching to us. */
+   s_last_delta_us = esp_timer_get_time();
 
    /* TT #578: every delta into the debug ring before any state branching. */
    if (delta && delta[0]) transcript_ring_push(delta, finish);

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -219,19 +219,43 @@ static void finish_dictation(const char *reason) {
  * Barge-in (saying "Hey Tinker" to interrupt TTS) is a separate
  * follow-up that needs voice_cancel() + voice_start_listening()
  * coordination; not in this fix. */
+/* TT #131 stability 2026-05-20: tracks the moment voice state returned
+ * to READY so we can enforce a post-turn grace period before wake can
+ * re-fire.  Without this grace, K144 ASR's buffered transcripts from
+ * during the turn (often containing fragments of Tinker's own TTS
+ * playback) hit the matcher immediately on READY transition and
+ * false-fire.  500-1000 ms is enough for the ASR engine's streaming
+ * context to flush + Tab5's wake_window to settle on truly-new audio. */
+static int64_t s_last_busy_us = 0;
+#define WAKE_REARM_GRACE_MS 1000
+
 static bool wakeword_suppressed_by_voice_state(void) {
    voice_state_t st = voice_get_state();
-   /* TT #597 — Barge-in: SPEAKING is NO LONGER suppressed.  The user
-    * may say "Hey Tinker" mid-TTS to interrupt + start a new turn.
-    * The WAKE handler in voice_onboard.c::wakeword_event_handler is
-    * responsible for calling voice_cancel() before voice_start_
-    * listening() when the wake fires during SPEAKING.
-    *
-    * Self-wake risk mitigated by the wake_phrase being multi-word
-    * ("hey tinker", not bare "tinker") + the VAD pre-gate's 8-char
-    * window floor.  Tinker's TTS would have to coincidentally say
-    * the full "hey tinker" phrase to false-trigger, which is rare. */
-   return (st == VOICE_STATE_LISTENING || st == VOICE_STATE_PROCESSING || st == VOICE_STATE_RECONNECTING);
+   /* TT #131 2026-05-20: matcher's alt phrase is now bare "thinker"
+    * (one word, much more permissive than the old "hey thinker").
+    * That makes barge-in unsafe — Tinker's own TTS reply commonly
+    * contains "Tinker" → ASR transcribes "thinker" → matcher fires
+    * → cancels its own reply.  Suppress wake during SPEAKING too so
+    * the user gets a "fully idle before re-arm" UX as requested.
+    * Net cost: lose mid-TTS barge-in.  Net gain: stability under the
+    * sensitive ASR-based wake. */
+   if (st == VOICE_STATE_LISTENING || st == VOICE_STATE_PROCESSING ||
+       st == VOICE_STATE_RECONNECTING || st == VOICE_STATE_SPEAKING) {
+      s_last_busy_us = esp_timer_get_time();
+      return true;
+   }
+   /* Post-busy grace: wait WAKE_REARM_GRACE_MS after state returns to
+    * READY before allowing wake to fire again.  Lets K144 ASR's
+    * streaming-zipformer context flush its just-completed-turn frames
+    * so the next match is against fresh post-turn audio only. */
+   if (s_last_busy_us != 0) {
+      int64_t since_busy_us = esp_timer_get_time() - s_last_busy_us;
+      if (since_busy_us < (int64_t)WAKE_REARM_GRACE_MS * 1000) {
+         return true;
+      }
+      s_last_busy_us = 0;  /* grace expired — re-armed */
+   }
+   return false;
 }
 
 /* TT #578: push every ASR delta into the debug ring buffer.  Cheap —

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -25,6 +25,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/idf_additions.h"
 #include "freertos/task.h"
 #include "voice.h"
 #include "voice_m5_llm.h"
@@ -466,7 +467,13 @@ esp_err_t voice_wakeword_start(const voice_wakeword_config_t *cfg, voice_wakewor
       return err;
    }
 
-   BaseType_t ok = xTaskCreate(wakeword_task, "wakeword", WAKEWORD_TASK_STACK, NULL, WAKEWORD_TASK_PRIO, &s_task);
+   /* TT #131 stability: PSRAM-back the 12 KB task stack via WithCaps.
+    * Internal SRAM is tight (~56 KB largest-free at boot); a 12 KB
+    * stack here on top of ext_pcm's 8 KB pushed the heap into
+    * heap_wd's "sram_exhausted" threshold under sustained operation. */
+   BaseType_t ok = xTaskCreatePinnedToCoreWithCaps(wakeword_task, "wakeword", WAKEWORD_TASK_STACK,
+                                                   NULL, WAKEWORD_TASK_PRIO, &s_task,
+                                                   tskNO_AFFINITY, MALLOC_CAP_SPIRAM);
    if (ok != pdPASS) {
       ESP_LOGE(TAG, "wakeword task spawn failed");
       voice_m5_llm_wakeword_teardown(s_handle);

--- a/main/voice_wakeword.h
+++ b/main/voice_wakeword.h
@@ -104,6 +104,11 @@ void voice_wakeword_stop(void);
 /** @brief Whether the listener is live (chain up + task running). */
 bool voice_wakeword_is_active(void);
 
+/** TT #131 — return the K144 asr work_id (e.g. "asr.1001") for the
+ *  currently-armed listener.  NULL if not armed.  Used by the ext_pcm
+ *  pump to target inference frames at the right asr instance. */
+const char *voice_wakeword_asr_id(void);
+
 /** @brief Force a dictation stop NOW from outside the task.  No-op when
  *         not in the LISTENING state.  Fires the DICTATION_FINAL event
  *         with whatever has been accumulated so far. */

--- a/main/voice_wakeword.h
+++ b/main/voice_wakeword.h
@@ -134,6 +134,14 @@ typedef struct {
  *         cached config values from the last start). */
 void voice_wakeword_status(voice_wakeword_status_t *out);
 
+/** @brief Timestamp of the most-recent ASR delta received from K144,
+ *         in esp_timer_get_time() microseconds (monotonic since boot).
+ *         Returns 0 if no delta has ever arrived this session.  Used by
+ *         the K144-cycling watchdog to detect a stale asr_id binding —
+ *         pump may be sending fine but K144 daemon cycled and our
+ *         cached work_id no longer routes anywhere. */
+int64_t voice_wakeword_last_delta_us(void);
+
 /** @brief Restart the listener with a new wake phrase at runtime.
  *
  *  Convenience for live A/B testing of phonetic variants without a


### PR DESCRIPTION
## Summary
Source-only commit of the custom K144 StackFlow unit that bridges Tab5 mic audio into K144's existing sherpa-ncnn ASR.  Wake stays purely on K144 (no Dragon dep), uses Tab5's better front-facing mic.

## Why this is source-only
The cross-compile env (aarch64 toolchain + M5Stack `static_lib_v0.1.3` download + libhv config) needs ~2 hours of one-time setup inside a clone of `github.com/m5stack/StackFlow`.  This PR ships the actual unit source so it's ready to build the moment the env is up.  No-op on Tab5 firmware until the K144 binary is deployed.

## Files

`k144-stackflow/main_ext_pcm/src/main.cpp` — ~200 LOC C++ StackFlow unit.  Implements 7-RPC skeleton (setup/work/pause/exit/link/unlink/taskinfo) + per-work-id `ext_pcm_task` that:
1. Binds ZMQ PUB on `sys.pcm` (default `ipc:///tmp/llm/pcm.cap.socket`, overridable via `data.sys_pcm_cap_channel`)
2. Receives base64-encoded int16 LE 16 kHz mono PCM in incoming `inference` frames
3. Decodes + republishes raw PCM bytes onto the PUB bus

`docs/PLAN-tab5-mic-to-k144-ext-pcm.md` — Replaces the earlier 'Path A blocked' claim with the corrected architecture (research 2026-05-18: `sys_pcm_cap_channel` is configurable, ASR resolves it via `unit_call(audio, cap, sys.pcm)`, binding our own PUB to the same URL hands PCM to ASR).

`k144-stackflow/README.md` — Build + ADB deploy + Tab5-side use recipe.

## Build + deploy flow (next session)

```bash
git clone https://github.com/m5stack/StackFlow ~/projects/StackFlow
cd ~/projects/StackFlow && git submodule update --init --depth 1
cp -r ~/projects/TinkerTab/k144-stackflow/main_ext_pcm projects/llm_framework/
# Edit projects/llm_framework/SConstruct to include main_ext_pcm
cd projects/llm_framework && scons
adb push build/llm_framework/main_ext_pcm/llm_ext_pcm /opt/m5stack/bin/
adb shell systemctl restart sys-llm.service
```

## Follow-up PRs
- Tab5: extend voice_wake_stream to add `wake_src=ext_pcm` branch that sends PCM to K144 via UART (existing `voice_m5_llm` UART path)
- Picker: add `ext_pcm` as a fourth value in `POST /tinkeron/wake_src`

refs #131 #615