### PR TITLE
TT #625 Wave A: voice_cancel resets wakeword + vmode/dictation gates (closes #625)

### DIFF
--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "config.h"
+#include "debug_obs.h" /* TT #625 Wave A.2: mode.cancel_for_switch */
 #include "esp_log.h"
 #include "lvgl.h"
 #include "settings.h"
@@ -493,6 +494,20 @@ static void persist_and_notify_dragon(void)
     * UI interactions; the cue closes that gap.  Worker-dispatched so
     * the LVGL caller doesn't block. */
    ui_audio_cue_play(UI_CUE_MODE_SWITCH);
+
+   /* TT #625 Wave A.2 (R6) — vmode change mid-turn used to orphan the
+    * in-flight Dragon STT/LLM/TTS.  Now: if voice is mid-turn, cancel
+    * it cleanly first (voice_cancel also resets wakeword + pauses pump
+    * via Wave A.1), then let the config_update fire so the NEXT turn
+    * uses the new mode.  Toast tells the user what happened. */
+   voice_state_t vs_at_switch = voice_get_state();
+   if (vs_at_switch != VOICE_STATE_IDLE && vs_at_switch != VOICE_STATE_READY) {
+      ESP_LOGI(TAG, "vmode change while voice in state %d — cancelling first", (int)vs_at_switch);
+      tab5_debug_obs_event("mode.cancel_for_switch", "");
+      voice_cancel();
+      extern void ui_home_show_toast(const char *);
+      ui_home_show_toast("Switched mode — current turn stopped");
+   }
 
    /* Persist the three tiers + the derived voice_mode + (optional) llm_model. */
    tab5_settings_set_int_tier(s_int_tier);

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -3642,6 +3642,11 @@ void cb_notes_fab_tap(lv_event_t *e) {
    esp_err_t err = voice_start_dictation();
    if (err != ESP_OK) {
       ESP_LOGW(TAG, "Notes FAB tap: voice_start_dictation failed: %s", esp_err_to_name(err));
+      /* TT #625 Wave A.3 — surface mic-busy refusal so the user knows
+       * why the tap appeared to no-op.  Other failure modes (already
+       * dictating, init not done) also benefit from the same toast. */
+      extern void ui_home_show_toast(const char *);
+      ui_home_show_toast("Voice busy — wait for current turn");
    }
 }
 

--- a/main/voice.c
+++ b/main/voice.c
@@ -59,10 +59,12 @@
 #include "voice_billing.h"   /* SOLID-audit SRP-3: receipt + budget + cap-downgrade */
 #include "voice_codec.h"     /* #262: OPUS encode/decode wrapper */
 #include "voice_dictation.h" /* PR 1: dictation pipeline state machine */
+#include "voice_ext_pcm_stream.h" /* TT #625 Wave A.1: pump pause on voice_cancel */
 #include "voice_m5_llm.h"    /* TT #317 Phase 4: K144 LLM Module failover */
 #include "voice_modes.h"     /* TT #331 Wave 23 SRP-A2: 5-tier mode dispatch */
 #include "voice_solo.h"      /* W4-B (TT #375): vmode=5 SOLO_DIRECT mic-audio dispatch */
 #include "voice_video.h"     /* #266: live JPEG streaming */
+#include "voice_wakeword.h"  /* TT #625 Wave A.1: force dictation stop on voice_cancel */
 #include "voice_widget_ws.h" /* SOLID-audit SRP-2: widget WS verb dispatch */
 #include "voice_ws_proto.h"  /* TT #331 Wave 23 SRP-A1: WS proto layer */
 #include "widget.h"
@@ -1753,6 +1755,16 @@ esp_err_t voice_start_dictation(void)
       ESP_LOGE(TAG, "Not initialized");
       return ESP_ERR_INVALID_STATE;
    }
+   /* TT #625 Wave A.3 (R7) — mic-busy refuse.  Without this, tapping
+    * Dictate while a Dragon voice turn was mid-PROCESSING spawned a
+    * second mic task on the same I2S RX slot → audio corruption,
+    * both transcripts garbage.  Refuse with a logged obs event;
+    * caller (ui_notes::dictate_chip_tap_cb) shows a toast. */
+   if (s_mic_running) {
+      ESP_LOGW(TAG, "voice_start_dictation refused — mic busy");
+      tab5_debug_obs_event("voice.refused", "dictation_mic_busy");
+      return ESP_ERR_INVALID_STATE;
+   }
     /* TT #328 Wave 9 — when WS is up, require READY state (existing
      * behaviour).  When WS is DOWN (offline-fallback path), accept
      * READY or IDLE or RECONNECTING since those are all valid
@@ -2141,7 +2153,53 @@ esp_err_t voice_cancel(void)
         voice_set_state(VOICE_STATE_IDLE, "cancelled");
     }
 
+    /* TT #625 Wave A.1 (R2) — fix the "can't stop the conversation" loop.
+     * The wakeword module runs its own state machine that drains K144 ASR
+     * partials independent of voice_state.  When the user taps X, we
+     * stop the mic + Dragon side cleanly above — but without this call
+     * the wakeword stays in ST_LISTENING, keeps appending to dict_buf,
+     * and on 5 s of silence fires DICTATION_FINAL which can re-open
+     * voice_start_listening invisibly.  Force the wakeword back to IDLE
+     * here so the next ASR partial goes through the wake matcher again. */
+    extern void voice_wakeword_force_dictation_stop(void);
+    voice_wakeword_force_dictation_stop();
+
+    /* TT #625 Wave A.1 (R2) — belt-and-braces: even with the wakeword
+     * reset above, ext_pcm pump can race for 1-2 frames before the
+     * matcher state propagates.  Pause the pump for 1.5 s so K144's
+     * streaming ASR drains the buffer that captured the TTS we just
+     * stopped, preventing self-wake from lingering "thinker" partials. */
+    voice_ext_pcm_stream_set_paused(true);
+    extern void voice_extpcm_pump_unpause_in(uint32_t ms);
+    voice_extpcm_pump_unpause_in(1500); /* schedule unpause */
+
+    tab5_debug_obs_event("voice.cancel", "done");
     return ESP_OK;
+}
+
+/* TT #625 Wave A.1 — esp_timer one-shot that re-enables the ext_pcm
+ * pump after voice_cancel's quiet window expires.  Kept as a typed
+ * wrapper so we don't UB-cast voice_ext_pcm_stream_set_paused's
+ * (bool) signature into an esp_timer_cb_t (void *) one. */
+static esp_timer_handle_t s_pump_unpause_timer = NULL;
+static void pump_unpause_cb(void *arg) {
+   (void)arg;
+   voice_ext_pcm_stream_set_paused(false);
+   tab5_debug_obs_event("voice.cancel", "pump_resumed");
+}
+void voice_extpcm_pump_unpause_in(uint32_t ms) {
+   if (!s_pump_unpause_timer) {
+      const esp_timer_create_args_t args = {
+          .callback = pump_unpause_cb,
+          .arg = NULL,
+          .name = "pump_unpause",
+      };
+      esp_timer_create(&args, &s_pump_unpause_timer);
+   }
+   if (s_pump_unpause_timer) {
+      esp_timer_stop(s_pump_unpause_timer);
+      esp_timer_start_once(s_pump_unpause_timer, (uint64_t)ms * 1000);
+   }
 }
 
 esp_err_t voice_disconnect(void)


### PR DESCRIPTION
## Summary

Wave A of the 5-wave stability + navigation overhaul.  Wave 0 (#624) shipped centralised nav.  This PR closes 3 user-visible voice bugs (R2, R6, R7) from the 14-journey stability audit.

- **R2 — Hey Tinker "can't stop the conversation" loop fixed.** voice_cancel now resets the wakeword state machine + pauses the ext_pcm pump for 1.5s.  Invisible DICTATION_FINAL re-trigger paths die.
- **R6 — vmode change mid-turn no longer orphans data.** Mode sheet auto-cancels the in-flight turn before sending config_update, with a "Switched mode — current turn stopped" toast.
- **R7 — Dictation tap during voice turn no longer corrupts mic.** voice_start_dictation refuses when mic is busy + Notes FAB shows a toast.

## Test plan
- [x] `idf.py build` clean (ESP-IDF v5.5.2)
- [x] `git-clang-format --diff origin/main` empty
- [x] `POST /voice/cancel` fires `voice.cancel done` + `voice.cancel pump_resumed` (1500ms later) — confirmed in /events ring
- [x] Heap stable post-test (15 KB internal largest free)
- [ ] Live "Hey Tinker → speak → tap X → confirm no DICTATION_FINAL in /events for 30s" — needs K144 on Tab5 USB-A
- [ ] Live "vmode change mid-turn shows toast + cancels" — needs Dragon active turn
- [ ] CI build + format + host-tests green

## Files changed (3)
- `main/voice.c` — A.1 (voice_cancel wakeword reset + pump pause + timer), A.3 (voice_start_dictation mic-busy refuse)
- `main/ui_mode_sheet.c` — A.2 (persist_and_notify_dragon auto-cancels in-flight turn + toast)
- `main/ui_notes.c` — A.3 (Notes FAB shows toast on dictation refusal)

Next: Wave B (R1/R3/R9 races — s_mic_running set order, wake re-arm grace 1000→1500ms + atomic suppression, USB replug auto-restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)