### PR TITLE
TT #629 Wave C: edge cases + observability extensions (closes #629)

### DIFF
--- a/main/debug_server_m5.c
+++ b/main/debug_server_m5.c
@@ -145,6 +145,18 @@ static esp_err_t m5_status_handler(httpd_req_t *req) {
     * remote diagnostics correlate behavior with daemon version. */
    cJSON_AddStringToObject(root, "version", s_m5_version_cache);
 
+   /* TT #629 Wave C.4 — cached work_id snapshot + ms since last reset.
+    * Lets soak tests verify that R12/R12b invalidation actually clears
+    * the cached llm/tts/yolo handles after sys.reset:recovered. */
+   cJSON *work_ids = cJSON_CreateObject();
+   char llm_wid[32], tts_wid[32];
+   voice_m5_llm_get_work_ids(llm_wid, sizeof(llm_wid), tts_wid, sizeof(tts_wid));
+   cJSON_AddStringToObject(work_ids, "llm", llm_wid);
+   cJSON_AddStringToObject(work_ids, "tts", tts_wid);
+   cJSON_AddBoolToObject(work_ids, "yolo_ready", voice_yolo_is_ready());
+   cJSON_AddItemToObject(root, "work_ids", work_ids);
+   cJSON_AddNumberToObject(root, "ms_since_last_reset", (double)voice_onboard_ms_since_last_reset());
+
    char *json = cJSON_PrintUnformatted(root);
    cJSON_Delete(root);
    httpd_resp_set_type(req, "application/json");

--- a/main/debug_server_tinkeron.c
+++ b/main/debug_server_tinkeron.c
@@ -32,6 +32,7 @@
 #include "freertos/task.h"
 #include "settings.h"             /* TT #617 — wake_src */
 #include "task_worker.h"          /* tab5_worker_enqueue */
+#include "voice.h"                /* TT #629 — channel_reply TTL accessors */
 #include "voice_ext_pcm_stream.h" /* TT #131 stats */
 #include "voice_m5_llm.h"         /* sys_reboot, hwinfo accessor */
 #include "voice_onboard.h"        /* failover state names */
@@ -385,6 +386,21 @@ static esp_err_t handle_extpcm(httpd_req_t *req) {
    cJSON_AddNumberToObject(root, "last_tx_bytes", st.last_tx_bytes);
    cJSON_AddNumberToObject(root, "last_send_ok", st.last_send_ok);
    cJSON_AddNumberToObject(root, "last_pump_age_ms", (double)st.last_pump_age_ms);
+
+   /* TT #629 Wave C.4 — wakeword internal observability + channel_reply
+    * armed status + TTL.  These let soak/e2e tests catch the "wakeword
+    * silently wedged" and "channel_reply context never cleared" cases
+    * without needing JTAG. */
+   cJSON_AddNumberToObject(root, "wakeword_state", voice_wakeword_get_state_value());
+   cJSON_AddStringToObject(root, "wakeword_state_name", voice_wakeword_get_state_name());
+   int64_t since_busy_ms = voice_wakeword_get_ms_since_busy();
+   cJSON_AddNumberToObject(root, "wakeword_ms_since_busy", (double)since_busy_ms);
+   cJSON_AddNumberToObject(root, "dictation_final_count", (double)voice_wakeword_get_dictation_final_count());
+   int reply_age = voice_channel_reply_age_s();
+   int reply_ttl = voice_channel_reply_ttl_s();
+   cJSON_AddBoolToObject(root, "channel_reply_armed", reply_age >= 0);
+   cJSON_AddNumberToObject(root, "channel_reply_age_s", reply_age);
+   cJSON_AddNumberToObject(root, "channel_reply_ttl_remaining_s", reply_age >= 0 ? (reply_ttl - reply_age) : -1);
 
    /* Hint strings the user can scan at a glance. */
    const char *hint;

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -242,6 +242,18 @@ void ui_notification_reply_current(const char *text) {
       return;
    }
 
+   /* TT #629 Wave C.1 (R8b): refuse REPLY taps while a voice turn is in
+    * flight — arming a new reply context mid-PROCESSING would shadow the
+    * STT result of the in-flight turn, routing it to Telegram instead of
+    * the user's LLM.  LISTENING/SPEAKING are fine (user is mid-utterance
+    * or mid-TTS, can reply after).  Only PROCESSING is the dangerous
+    * window. */
+   if (voice_get_state() == VOICE_STATE_PROCESSING) {
+      tab5_debug_obs_event("ui.notif.reply", "refused_processing");
+      ui_home_show_toast_ex("Wait for current reply", UI_TOAST_WARN);
+      return;
+   }
+
    /* W7-E.4b: when caller supplies explicit text, use the legacy direct-
     * send path (debug surfaces + future shortcut paths still use this).
     * When text is NULL/empty, arm the reply context so the next mic-orb

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -371,6 +371,16 @@ void ui_voice_on_state_change(voice_state_t state, const char *detail)
     s_cur_state = state;
     update_mic_button_state(state);
 
+    /* TT #629 Wave C.1 (R8a): re-assert the close button above any
+     * channel now-card that may have been raised between voice state
+     * transitions.  Both surfaces live on lv_layer_top(); the most
+     * recently-created object floats highest.  Moving the X button to
+     * foreground on every state edge guarantees the cancel affordance
+     * is always reachable, regardless of incoming-message timing. */
+    if (s_visible && s_close_btn) {
+       lv_obj_move_foreground(s_close_btn);
+    }
+
     /* W7-E.4c: reply chip is meaningful only during the LISTENING phase.
      * Once the user releases the orb (→ PROCESSING/SPEAKING/READY/IDLE)
      * the reply context has either been consumed (real channel_reply

--- a/main/voice.c
+++ b/main/voice.c
@@ -2484,11 +2484,36 @@ esp_err_t voice_send_channel_reply(const char *channel, const char *thread_id, c
 }
 
 /* W7-E.4b: armed-reply context.  Guarded by s_state_mutex so concurrent
- * STT arrival (WS task) + REPLY button arm (LVGL task) don't race. */
+ * STT arrival (WS task) + REPLY button arm (LVGL task) don't race.
+ * TT #629 Wave C.3: armed context auto-expires after CHANNEL_REPLY_TTL_US
+ * to prevent "wake transcript routed to Telegram by mistake" 30+ minutes
+ * after the user tapped REPLY but never spoke. */
+#define CHANNEL_REPLY_TTL_US (30LL * 1000LL * 1000LL) /* 30 s */
 static char s_reply_channel[16];
 static char s_reply_thread[64];
 static char s_reply_sender[64];
 static bool s_reply_armed = false;
+static int64_t s_reply_armed_at_us = 0;
+
+/* Caller must hold s_state_mutex. */
+static void reply_clear_locked(void) {
+   s_reply_armed = false;
+   s_reply_armed_at_us = 0;
+   s_reply_channel[0] = '\0';
+   s_reply_thread[0] = '\0';
+   s_reply_sender[0] = '\0';
+}
+
+/* Caller must hold s_state_mutex.  Returns true + clears if armed but past TTL. */
+static bool reply_expire_if_stale_locked(void) {
+   if (!s_reply_armed) return false;
+   int64_t age = esp_timer_get_time() - s_reply_armed_at_us;
+   if (age >= CHANNEL_REPLY_TTL_US) {
+      reply_clear_locked();
+      return true;
+   }
+   return false;
+}
 
 void voice_arm_channel_reply(const char *channel, const char *thread_id, const char *sender) {
    if (!channel || !thread_id) return;
@@ -2497,30 +2522,36 @@ void voice_arm_channel_reply(const char *channel, const char *thread_id, const c
    snprintf(s_reply_thread, sizeof(s_reply_thread), "%s", thread_id);
    snprintf(s_reply_sender, sizeof(s_reply_sender), "%s", sender ? sender : "");
    s_reply_armed = true;
+   s_reply_armed_at_us = esp_timer_get_time();
    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
-   ESP_LOGI(TAG, "voice_arm_channel_reply: ch=%s thread=%s sender=%s", channel, thread_id, sender ? sender : "");
+   ESP_LOGI(TAG, "voice_arm_channel_reply: ch=%s thread=%s sender=%s ttl=%ds", channel, thread_id, sender ? sender : "",
+            (int)(CHANNEL_REPLY_TTL_US / 1000000));
 }
 
 void voice_disarm_channel_reply(void) {
    if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
-   s_reply_armed = false;
-   s_reply_channel[0] = '\0';
-   s_reply_thread[0] = '\0';
-   s_reply_sender[0] = '\0';
+   reply_clear_locked();
    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
 }
 
 bool voice_is_channel_reply_armed(void) {
    bool armed = false;
+   bool expired = false;
    if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+   expired = reply_expire_if_stale_locked();
    armed = s_reply_armed;
    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+   if (expired) {
+      tab5_debug_obs_event("ui.notif.reply", "expired_ttl");
+   }
    return armed;
 }
 
 bool voice_peek_channel_reply(char *channel_out, char *thread_id_out, char *sender_out) {
    bool armed = false;
+   bool expired = false;
    if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+   expired = reply_expire_if_stale_locked();
    if (s_reply_armed) {
       armed = true;
       if (channel_out) snprintf(channel_out, 16, "%s", s_reply_channel);
@@ -2528,25 +2559,43 @@ bool voice_peek_channel_reply(char *channel_out, char *thread_id_out, char *send
       if (sender_out) snprintf(sender_out, 64, "%s", s_reply_sender);
    }
    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+   if (expired) {
+      tab5_debug_obs_event("ui.notif.reply", "expired_ttl");
+   }
    return armed;
 }
 
 bool voice_consume_channel_reply(char *channel_out, char *thread_id_out, char *sender_out) {
    bool was_armed = false;
+   bool expired = false;
    if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+   expired = reply_expire_if_stale_locked();
    if (s_reply_armed) {
       was_armed = true;
       if (channel_out) snprintf(channel_out, 16, "%s", s_reply_channel);
       if (thread_id_out) snprintf(thread_id_out, 64, "%s", s_reply_thread);
       if (sender_out) snprintf(sender_out, 64, "%s", s_reply_sender);
-      s_reply_armed = false;
-      s_reply_channel[0] = '\0';
-      s_reply_thread[0] = '\0';
-      s_reply_sender[0] = '\0';
+      reply_clear_locked();
    }
    if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+   if (expired) {
+      tab5_debug_obs_event("ui.notif.reply", "expired_ttl");
+   }
    return was_armed;
 }
+
+/* TT #629 Wave C: expose seconds-since-arm and TTL for /tinkeron/extpcm obs. */
+int voice_channel_reply_age_s(void) {
+   int age = -1;
+   if (s_state_mutex) xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+   if (s_reply_armed) {
+      age = (int)((esp_timer_get_time() - s_reply_armed_at_us) / 1000000LL);
+   }
+   if (s_state_mutex) xSemaphoreGive(s_state_mutex);
+   return age;
+}
+
+int voice_channel_reply_ttl_s(void) { return (int)(CHANNEL_REPLY_TTL_US / 1000000LL); }
 
 /* voice_send_widget_action moved to voice_ws_proto.c (TT #331 Wave 23
  * SRP-A1) — pure WS-proto concern: builds a JSON frame + calls

--- a/main/voice.h
+++ b/main/voice.h
@@ -219,6 +219,14 @@ bool voice_consume_channel_reply(char *channel_out, char *thread_id_out, char *s
  *  armed target without consuming it.  Returns true if armed. */
 bool voice_peek_channel_reply(char *channel_out, char *thread_id_out, char *sender_out);
 
+/** TT #629 Wave C.3: seconds since voice_arm_channel_reply, or -1 if
+ *  not armed.  Reflects expiry — expired contexts are cleared on read
+ *  and return -1. */
+int voice_channel_reply_age_s(void);
+
+/** TT #629 Wave C.3: the channel_reply TTL ceiling in seconds (30). */
+int voice_channel_reply_ttl_s(void);
+
 /** W4-A: return the current turn_id (12-hex-char string + null).  Set by
  *  voice_start_listening / voice_start_dictation / voice_send_text on every
  *  fresh turn.  Returns "-" before the first turn (never NULL).  Use to

--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -468,6 +468,19 @@ void voice_m5_llm_release(void) {
 
 bool voice_m5_llm_is_ready(void) { return s_setup_work_id[0] != '\0'; }
 
+/* TT #629 Wave C.4: cached work_ids snapshot for /m5 obs.  Caller-owned
+ * buffers — short copies so no locking required (s_setup/tts_work_id are
+ * never NULL-terminated past the buffer + the UART worker uses the same
+ * cached value atomically per StackFlow call). */
+void voice_m5_llm_get_work_ids(char *llm_out, size_t llm_cap, char *tts_out, size_t tts_cap) {
+   if (llm_out && llm_cap) {
+      snprintf(llm_out, llm_cap, "%s", s_setup_work_id);
+   }
+   if (tts_out && tts_cap) {
+      snprintf(tts_out, tts_cap, "%s", s_tts_work_id);
+   }
+}
+
 esp_err_t voice_m5_llm_sys_reset(void) {
    esp_err_t err = ensure_uart();
    if (err != ESP_OK) return err;
@@ -516,8 +529,11 @@ esp_err_t voice_m5_llm_sys_reset(void) {
    if (ok) {
       ESP_LOGI(TAG, "sys.reset acked: %s", resp.error_message ? resp.error_message : "(no msg)");
       /* All K144-side work_ids are invalidated by the daemon restart.
-       * Clear our cache so the next infer call re-issues llm.setup. */
+       * Clear our cache so the next infer call re-issues llm.setup.
+       * TT #629 Wave C.2 (R12): TTS work_id was previously left stale —
+       * next voice_m5_llm_tts call would send to a dead handle. */
       s_setup_work_id[0] = '\0';
+      s_tts_work_id[0] = '\0';
    } else {
       ESP_LOGW(TAG, "sys.reset returned error_code=%d msg=%s", resp.error_code,
                resp.error_message ? resp.error_message : "(none)");
@@ -557,8 +573,10 @@ esp_err_t voice_m5_llm_sys_reboot(void) {
       M5_UNLOCK();
       ESP_LOGW(TAG, "sys.reboot: no ack frame (timeout — K144 may already be rebooting)");
       /* Reboot doesn't always ack before the kernel cuts the UART; treat
-       * timeout as best-effort success.  Caller waits then re-probes. */
+       * timeout as best-effort success.  Caller waits then re-probes.
+       * TT #629 Wave C.2 (R12): invalidate TTS work_id too. */
       s_setup_work_id[0] = '\0';
+      s_tts_work_id[0] = '\0';
       return ESP_OK;
    }
 
@@ -568,7 +586,9 @@ esp_err_t voice_m5_llm_sys_reboot(void) {
              && resp.error_code == 0;
    if (ok) {
       ESP_LOGI(TAG, "sys.reboot acked: %s", resp.error_message ? resp.error_message : "(no msg)");
+      /* TT #629 Wave C.2 (R12): invalidate TTS work_id too. */
       s_setup_work_id[0] = '\0';
+      s_tts_work_id[0] = '\0';
    } else {
       ESP_LOGW(TAG, "sys.reboot returned error_code=%d msg=%s",
                resp.error_code, resp.error_message ? resp.error_message : "(none)");

--- a/main/voice_m5_llm.h
+++ b/main/voice_m5_llm.h
@@ -302,6 +302,16 @@ esp_err_t voice_m5_llm_set_baud(uint32_t new_baud);
  */
 uint32_t voice_m5_llm_get_baud(void);
 
+/**
+ * @brief Snapshot the cached LLM + TTS work_ids into caller buffers.
+ *
+ * TT #629 Wave C.4.  Surfaced via GET /m5 so the e2e harness + soak tests
+ * can verify the work_id cache is invalidated on sys.reset / sys.reboot.
+ * Empty string means "not currently set up".  Each buffer should be ≥32
+ * bytes.  Both args may be NULL (skip that copy).
+ */
+void voice_m5_llm_get_work_ids(char *llm_out, size_t llm_cap, char *tts_out, size_t tts_cap);
+
 /* ---------------------------------------------------------------------- */
 /*  Phase 6c — Text-to-Speech via the K144 TTS unit                       */
 /*                                                                        */

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -37,6 +37,12 @@
 
 static const char *TAG = "voice_onboard";
 
+/* TT #629 Wave C.4: last successful K144 reset-recovered timestamp.  Set
+ * inside the recovered branch of onboard_reset_failover_job.  0 means
+ * "never reset since boot".  File-scope static so the same compilation
+ * unit's voice_onboard_ms_since_last_reset accessor can read it. */
+static int64_t s_last_reset_recovered_us = 0;
+
 /* ---------------------------------------------------------------------- */
 /*  Failover state                                                        */
 /*                                                                        */
@@ -880,6 +886,16 @@ static void onboard_reset_failover_job(void *arg) {
       tab5_debug_obs_event("m5.warmup", "ready");
       tab5_debug_obs_event("m5.reset", "recovered");
       mark_k144_recovered(); /* Wave 16 — clear banner + reset retry budget */
+      /* TT #629 Wave C.2 (R12b): K144 daemon restart invalidated every
+       * cached work_id.  voice_m5_llm.c already clears its own llm/tts
+       * handles inside the sys.reset/reboot path; voice_yolo.c does not
+       * — wire the invalidation here so the next yolo.inference call
+       * re-runs voice_yolo_init against a fresh work_id. */
+      extern void voice_yolo_invalidate(void);
+      voice_yolo_invalidate();
+      /* TT #629 Wave C.4: stamp the recovered timestamp so /m5 can
+       * surface "ms since last reset" for soak-test correlation. */
+      s_last_reset_recovered_us = esp_timer_get_time();
       /* Same "free LLM slot before ASR" gate as the initial warmup
        * path — see comment there for why this is required. */
       voice_m5_llm_release();
@@ -1296,6 +1312,11 @@ bool voice_onboard_chain_active(void) { return s_chain_active; }
 int64_t voice_onboard_chain_uptime_ms(void) {
    if (!s_chain_active || s_chain_started_us == 0) return 0;
    return (esp_timer_get_time() - s_chain_started_us) / 1000;
+}
+
+int64_t voice_onboard_ms_since_last_reset(void) {
+   if (s_last_reset_recovered_us == 0) return -1;
+   return (esp_timer_get_time() - s_last_reset_recovered_us) / 1000;
 }
 
 /* TT #586 — Settings UI entry-point for "Always-on listener" ON.

--- a/main/voice_onboard.h
+++ b/main/voice_onboard.h
@@ -112,6 +112,12 @@ bool voice_onboard_chain_active(void);
  *  serial cable. */
 int64_t voice_onboard_chain_uptime_ms(void);
 
+/** TT #629 Wave C.4 — milliseconds since the last successful K144 reset
+ *  recovery (the `m5.reset:recovered` edge).  -1 if no reset has fired
+ *  since boot.  Surfaced via GET /m5 so soak tests can correlate
+ *  cached-work_id invalidation with the reset event. */
+int64_t voice_onboard_ms_since_last_reset(void);
+
 /** TT #586 — re-arm the always-on wakeword listener using the canonical
  *  event handler from this module.  Settings UI calls this to start
  *  the listener after the user toggles "Always-on listener" ON.

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -193,9 +193,16 @@ static void enter_listening(void) {
    emit_event(VOICE_WAKEWORD_EVENT_WAKE, s_wake_phrase);
 }
 
+/* TT #629 Wave C.4: monotonic counter of DICTATION_FINAL events fired since
+ * boot.  Surfaced via /tinkeron/extpcm so the e2e harness + soak tests can
+ * distinguish "wakeword is quiet" from "wakeword silently stuck in
+ * LISTENING". */
+static uint32_t s_dictation_final_count = 0;
+
 static void finish_dictation(const char *reason) {
    if (s_state != ST_LISTENING) return;
    s_state = ST_IDLE;
+   s_dictation_final_count++;
    char detail[48];
    snprintf(detail, sizeof(detail), "stop %s len=%u", reason, (unsigned)s_dict_buf_len);
    tab5_debug_obs_event("wakeword.dict", detail);
@@ -608,6 +615,30 @@ esp_err_t voice_wakeword_reconfigure_phrase(const char *new_phrase) {
    };
    return voice_wakeword_start(&cfg, cb, user);
 }
+
+/* TT #629 Wave C.4: small observability getters surfaced via /tinkeron/extpcm
+ * for the e2e harness + soak test.  Wakeword internal state machine is
+ * normally invisible — these expose its shape without leaking the enum
+ * to other modules. */
+int voice_wakeword_get_state_value(void) { return (int)s_state; }
+
+const char *voice_wakeword_get_state_name(void) {
+   switch (s_state) {
+      case ST_IDLE:
+         return "IDLE";
+      case ST_LISTENING:
+         return "LISTENING";
+      default:
+         return "?";
+   }
+}
+
+int64_t voice_wakeword_get_ms_since_busy(void) {
+   if (s_last_busy_us == 0) return -1;
+   return (esp_timer_get_time() - s_last_busy_us) / 1000;
+}
+
+uint32_t voice_wakeword_get_dictation_final_count(void) { return s_dictation_final_count; }
 
 size_t voice_wakeword_get_recent_transcripts(voice_wakeword_transcript_t *out, size_t max) {
    if (out == NULL || max == 0) return 0;

--- a/main/voice_wakeword.h
+++ b/main/voice_wakeword.h
@@ -165,6 +165,20 @@ typedef struct {
  *         deltas are evicted FIFO.  Useful for debug tail. */
 size_t voice_wakeword_get_recent_transcripts(voice_wakeword_transcript_t *out, size_t max);
 
+/** TT #629 Wave C.4: observability getters surfaced via /tinkeron/extpcm.
+ *  Returns wakeword internal state machine value (0=IDLE, 1=LISTENING). */
+int voice_wakeword_get_state_value(void);
+
+/** Returns wakeword state as a string ("IDLE"/"LISTENING"). */
+const char *voice_wakeword_get_state_name(void);
+
+/** Milliseconds since last self-wake suppression (TTS bleed grace).  -1
+ *  if never triggered or already cleared. */
+int64_t voice_wakeword_get_ms_since_busy(void);
+
+/** Monotonic count of DICTATION_FINAL events fired since boot. */
+uint32_t voice_wakeword_get_dictation_final_count(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/voice_yolo.c
+++ b/main/voice_yolo.c
@@ -237,6 +237,20 @@ esp_err_t voice_yolo_init(void) {
 
 bool voice_yolo_is_ready(void) { return s_ready; }
 
+/* TT #629 Wave C.2 (R12b): K144 sys.reset reboots the StackFlow daemon
+ * which invalidates every cached work_id on Tab5.  Re-running
+ * yolo.inference with a stale work_id returns "invalid handle" + can
+ * confuse the daemon's slot tracking.  Called from voice_onboard.c on
+ * the m5.reset:recovered edge so the next yolo_infer reissues
+ * yolo.setup against a fresh work_id. */
+void voice_yolo_invalidate(void) {
+   if (s_ready) {
+      ESP_LOGI(TAG, "voice_yolo_invalidate: clearing work_id=%s after K144 reset", s_work_id);
+   }
+   s_work_id[0] = '\0';
+   s_ready = false;
+}
+
 /* Parse a single yolo.box.stream JSON line, append box if present.
  * Skips lines whose request_id doesn't match @p want_rid (filters out
  * ext_pcm/asr ack noise on the shared xport).  Returns 1 if a

--- a/main/voice_yolo.h
+++ b/main/voice_yolo.h
@@ -66,6 +66,17 @@ esp_err_t voice_yolo_init(void);
 bool voice_yolo_is_ready(void);
 
 /**
+ * @brief Clear the cached yolo work_id so the next voice_yolo_infer call
+ *        re-runs voice_yolo_init against a fresh handle.
+ *
+ * TT #629 Wave C.2 (R12b): K144's sys.reset reboots the StackFlow daemon
+ * and invalidates every cached work_id on Tab5.  Hook this from the
+ * m5.reset:recovered edge in voice_onboard.c so stale "yolo.NNNN"
+ * handles don't survive a K144 daemon restart.
+ */
+void voice_yolo_invalidate(void);
+
+/**
  * @brief Run YOLO11n on a 320×320 JPEG and collect detections.
  *
  * Caller owns @p jpeg; this function base64-encodes internally + sends


### PR DESCRIPTION
Part of the Stability + Navigation overhaul (see [plan](.claude/plans/delightful-exploring-blum.md)).

Wave 0 → #623 (merged)
Wave A → #625 (merged)
Wave B → #627 (merged)

## What lands

### R8a + R8b — Notification z-order + REPLY mid-PROCESSING gate
- `main/ui_voice.c::ui_voice_on_state_change` re-asserts `s_close_btn` to the foreground on every voice state edge.  Both surfaces live on `lv_layer_top()` — the most recently-created object floats highest, so an incoming channel now-card landing mid-turn would otherwise obscure the X cancel affordance.
- `main/ui_notification.c::ui_notification_reply_current` refuses + toasts "Wait for current reply" if `voice_get_state() == VOICE_STATE_PROCESSING`.  Prevents the armed-reply context from shadowing the in-flight STT result.

### R12 + R12b — Cached work_id invalidation on K144 reset
- `voice_m5_llm.c::voice_m5_llm_sys_reset` + `_sys_reboot` now clear `s_tts_work_id` alongside `s_setup_work_id`.  Previously only the LLM handle was wiped; a stale TTS handle survived daemon restart and the next `voice_m5_llm_tts` call sent to a dead work_id.
- New `voice_yolo_invalidate()` clears `s_work_id` + `s_ready`.  Wired from `voice_onboard.c` on the `m5.reset:recovered` edge.

### R14 — channel_reply 30 s TTL
- `voice_arm_channel_reply` stamps `s_reply_armed_at_us`.
- `voice_is_armed` / `_peek` / `_consume` all expire stale contexts on read and emit `ui.notif.reply:expired_ttl`.  TTL constant = 30 s.
- New public `voice_channel_reply_age_s()` + `voice_channel_reply_ttl_s()` for the `/tinkeron/extpcm` surface.

### C.4 — Observability extensions
**`/tinkeron/extpcm` adds:**
- `wakeword_state` + `wakeword_state_name` (IDLE / LISTENING)
- `wakeword_ms_since_busy` (self-wake suppression grace age, -1 if never set)
- `dictation_final_count` (monotonic since boot)
- `channel_reply_armed` + `channel_reply_age_s` + `channel_reply_ttl_remaining_s`

**`/m5` adds:**
- `work_ids: { llm, tts, yolo_ready }` (cached handle snapshot)
- `ms_since_last_reset` (-1 if no reset since boot)

New getters: `voice_wakeword_get_state_value/_name/ms_since_busy/dictation_final_count`, `voice_m5_llm_get_work_ids`, `voice_onboard_ms_since_last_reset`.

## Live verification on Tab5 192.168.1.90

`/tinkeron/extpcm` returns the 7 new fields cleanly:
```json
{
  "wakeword_state": 0,
  "wakeword_state_name": "IDLE",
  "wakeword_ms_since_busy": -1,
  "dictation_final_count": 0,
  "channel_reply_armed": false,
  "channel_reply_age_s": -1,
  "channel_reply_ttl_remaining_s": -1
}
```

`/m5` shows the cache before reset (`llm.1003` warmed):
```json
{ "work_ids": { "llm": "llm.1003", "tts": "", "yolo_ready": false },
  "ms_since_last_reset": -1 }
```

After `POST /m5/reset`, the cached handle clears and the recovered timestamp populates:
```
fs=unavailable  wids={'llm':'','tts':'','yolo_ready':False}  msr=-1
fs=probing      wids={'llm':'','tts':'','yolo_ready':False}  msr=-1
fs=ready        wids={'llm':'','tts':'','yolo_ready':False}  msr=3614
fs=ready        wids={'llm':'','tts':'','yolo_ready':False}  msr=18725
fs=ready        wids={'llm':'','tts':'','yolo_ready':False}  msr=34910
```

Navigation regression check (Wave 0) still healthy — settings/notes/home all return `{"navigated":"…"}` and the screenshot grab returns a 32 KB BMP from home.

Closes #629