### PR TITLE
TT #633: USB FFS stream buffers in PSRAM — fix heap_wd reboot loop (closes #633)

### DIFF
--- a/main/voice_usb_ffs.c
+++ b/main/voice_usb_ffs.c
@@ -30,6 +30,7 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
+#include "freertos/idf_additions.h" /* TT #633 — xStreamBufferCreateWithCaps */
 #include "freertos/semphr.h"
 #include "freertos/stream_buffer.h"
 #include "freertos/task.h"
@@ -489,8 +490,12 @@ esp_err_t voice_usb_ffs_init(void) {
 
    s_ch_ctrl.lock = xSemaphoreCreateRecursiveMutex();
    s_ch_video.lock = xSemaphoreCreateRecursiveMutex();
-   s_ch_ctrl.rx = xStreamBufferCreate(s_ch_ctrl.rx_ring_bytes, 1);
-   s_ch_video.rx = xStreamBufferCreate(s_ch_video.rx_ring_bytes, 1);
+   /* TT #633: stream buffers in PSRAM, not internal SRAM.  Defaults
+    * pulled 16 + 32 = 48 KB from the FreeRTOS heap (internal) → heap_wd
+    * reboot loop.  WithCaps uses the same backing as the rest of the
+    * USB DMA path (PSRAM via CONFIG_USB_HOST_DWC_DMA_CAP_MEMORY_IN_PSRAM). */
+   s_ch_ctrl.rx = xStreamBufferCreateWithCaps(s_ch_ctrl.rx_ring_bytes, 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   s_ch_video.rx = xStreamBufferCreateWithCaps(s_ch_video.rx_ring_bytes, 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    s_disconnect_sem = xSemaphoreCreateBinary();
    if (!s_ch_ctrl.lock || !s_ch_video.lock || !s_ch_ctrl.rx || !s_ch_video.rx || !s_disconnect_sem) {
       ESP_LOGE(TAG, "alloc fail");


### PR DESCRIPTION
## Bug
Tab5 in a heap_wd reboot loop.  Coredump confirms \`heap_wd: sram_exhausted\` at \`heap_watchdog.c:237\`.

## Root cause
\`main/voice_usb_ffs.c::voice_usb_ffs_init\` creates two FreeRTOS StreamBuffers for the USB ctrl + video RX rings via \`xStreamBufferCreate\`.  FreeRTOS default heap is internal SRAM on ESP32-P4.

| Ring | Size | Lands in |
|------|-----:|----------|
| ctrl RX | 16 KB | internal SRAM ⚠️ |
| video RX | 32 KB | internal SRAM ⚠️ |
| ctrl OUT xfer | 8 KB | PSRAM ✓ (host DMA config) |
| video OUT xfer | 48 KB | PSRAM ✓ (host DMA config) |

The 48 KB of stream buffers in internal SRAM was the regression magnitude matching what \`/heap/history\` showed: boot drops from 124 KB largest free → 9 KB largest free during USB host init.

## Fix
One-API swap: \`xStreamBufferCreate(size, 1)\` → \`xStreamBufferCreateWithCaps(size, 1, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)\` for both rings.  Available in ESP-IDF 5.5.2 via \`freertos/esp_additions/include/freertos/idf_additions.h\`.

## Live verification on Tab5 192.168.1.90

**Before fix** (heap_wd reboot loop):
\`\`\`
uptime  int_free  int_largest  psram_free
   13s    166 KB      124 KB   20,459 KB
   43s     17 KB        9 KB   13,946 KB  ← below 20 KB threshold
   73s     16 KB        9 KB   13,946 KB  ← reboot after 2 polls
\`\`\`

**After fix** (stable):
\`\`\`
uptime  int_free  int_largest  psram_free
   13s    169 KB      124 KB   20,459 KB
   43s     77 KB       72 KB   13,898 KB  ← 3.6× above threshold
   73s     76 KB       72 KB   13,898 KB
  103s     75 KB       72 KB   13,898 KB
\`\`\`

PSRAM cost: ~48 KB more used (14 MB still free — negligible).
Restores the 56-80 KB internal SRAM baseline noted in memory (\`project_ext_pcm_stability_fix_2026_05_20\`).

Closes #633