### PR TITLE
Cap Wave 2: YOLO model picker — DET / POSE / SEG (closes #638)

### DIFF
--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -144,8 +144,14 @@ static bool        capture_counter_init = false;
 static bool s_yolo_on = false;
 static lv_obj_t *s_yolo_btn = NULL;
 static lv_obj_t *s_yolo_btn_lbl = NULL;
+/* TT #638 Wave 2: model picker — cycle DET → POSE → SEG. */
+static lv_obj_t *s_yolo_mode_btn = NULL;
+static lv_obj_t *s_yolo_mode_lbl = NULL;
 static lv_obj_t *s_yolo_boxes[UI_CAM_YOLO_MAX_BOXES] = {0};
 static lv_obj_t *s_yolo_box_lbls[UI_CAM_YOLO_MAX_BOXES] = {0};
+/* TT #638: 17 reusable keypoint dots per box (pose only).  Each dot is
+ * a tiny child of the box widget; coords are box-relative. */
+static lv_obj_t *s_yolo_kpts[UI_CAM_YOLO_MAX_BOXES][VOICE_YOLO_MAX_KPTS] = {{0}};
 static lv_obj_t *s_yolo_overlay_parent = NULL; /* canvas_preview */
 static volatile bool s_yolo_inflight = false;
 static voice_yolo_box_t s_yolo_boxes_pending[UI_CAM_YOLO_MAX_BOXES];
@@ -158,11 +164,13 @@ static int64_t s_yolo_last_tick_us = 0;
 #define COL_YOLO_LABEL_BG 0x1A1A24
 
 static void yolo_btn_cb(lv_event_t *e);
+static void yolo_mode_btn_cb(lv_event_t *e);
 static void yolo_redraw_async(void *arg);
 static void yolo_infer_job(void *arg);
 static void yolo_alloc_resources(void);
 static void yolo_free_resources(void);
 static void yolo_downsample_rgb565(const uint16_t *src, int sw, int sh, uint16_t *dst);
+static const char *yolo_mode_short_label(voice_yolo_model_t m);
 
 /* Currently selected resolution (default VGA for smooth preview) */
 static tab5_cam_resolution_t current_res = TAB5_CAM_RES_HD;  /* SC202CS outputs 1280x720 */
@@ -614,6 +622,21 @@ lv_obj_t *ui_camera_create(void)
                lv_obj_set_style_pad_hor(lbl, 4, 0);
                lv_obj_align(lbl, LV_ALIGN_TOP_LEFT, 0, -18);
                s_yolo_box_lbls[i] = lbl;
+
+               /* TT #638: 17 keypoint dots, hidden by default. */
+               for (int k = 0; k < VOICE_YOLO_MAX_KPTS; k++) {
+                  lv_obj_t *dot = lv_obj_create(bx);
+                  lv_obj_remove_style_all(dot);
+                  lv_obj_set_size(dot, 8, 8);
+                  lv_obj_set_style_radius(dot, 4, 0);
+                  lv_obj_set_style_bg_color(dot, lv_color_hex(0xFF6B6B), 0);
+                  lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+                  lv_obj_set_style_border_width(dot, 0, 0);
+                  lv_obj_add_flag(dot, LV_OBJ_FLAG_HIDDEN);
+                  lv_obj_clear_flag(dot, LV_OBJ_FLAG_SCROLLABLE);
+                  lv_obj_clear_flag(dot, LV_OBJ_FLAG_CLICKABLE);
+                  s_yolo_kpts[i][k] = dot;
+               }
             }
 
             /* Start the preview timer */
@@ -710,6 +733,29 @@ lv_obj_t *ui_camera_create(void)
     lv_obj_set_style_text_color(s_yolo_btn_lbl, lv_color_hex(COL_YOLO_BORDER), 0);
     lv_obj_set_style_text_font(s_yolo_btn_lbl, &lv_font_montserrat_18, 0);
     lv_obj_center(s_yolo_btn_lbl);
+
+    /* ── TT #638: MODE cycle button (DET / POSE / SEG) ──────────── */
+    s_yolo_mode_btn = lv_button_create(bar);
+    lv_obj_remove_style_all(s_yolo_mode_btn);
+    lv_obj_set_size(s_yolo_mode_btn, 100, 44);
+    /* Stack above DETECT (same x_offset -110, smaller height, y above).
+     * Bottom-bar height = CONTROL_BAR_H=320, DETECT at y_off=-20 means
+     * the DETECT center sits 20 px above the bar's vertical center.
+     * Placing MODE at y_off=-90 stacks it cleanly with ~16 px gap. */
+    lv_obj_align(s_yolo_mode_btn, LV_ALIGN_CENTER, -110, -90);
+    lv_obj_set_style_bg_color(s_yolo_mode_btn, lv_color_hex(0x1A1A24), 0);
+    lv_obj_set_style_bg_opa(s_yolo_mode_btn, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(s_yolo_mode_btn, lv_color_hex(COL_YOLO_BORDER), 0);
+    lv_obj_set_style_border_width(s_yolo_mode_btn, 2, 0);
+    lv_obj_set_style_radius(s_yolo_mode_btn, 30, 0);
+    lv_obj_clear_flag(s_yolo_mode_btn, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_event_cb(s_yolo_mode_btn, yolo_mode_btn_cb, LV_EVENT_CLICKED, NULL);
+    ui_fb_button(s_yolo_mode_btn);
+    s_yolo_mode_lbl = lv_label_create(s_yolo_mode_btn);
+    lv_label_set_text(s_yolo_mode_lbl, yolo_mode_short_label(voice_yolo_get_model()));
+    lv_obj_set_style_text_color(s_yolo_mode_lbl, lv_color_hex(COL_YOLO_BORDER), 0);
+    lv_obj_set_style_text_font(s_yolo_mode_lbl, &lv_font_montserrat_18, 0);
+    lv_obj_center(s_yolo_mode_lbl);
 
     /* ── "No SD" label below capture button (hidden by default) ── */
     lbl_no_sd = lv_label_create(bar);
@@ -1047,6 +1093,24 @@ static void yolo_redraw_async(void *arg) {
          snprintf(buf, sizeof(buf), "%s %d%%", b->klass, (int)(b->confidence * 100.0f));
          lv_label_set_text(s_yolo_box_lbls[i], buf);
       }
+
+      /* TT #638: keypoint dots — render up to b->kpt_count keypoints
+       * in box-relative coords.  Hidden when no keypoints (DET/SEG). */
+      for (int k = 0; k < VOICE_YOLO_MAX_KPTS; k++) {
+         lv_obj_t *dot = s_yolo_kpts[i][k];
+         if (dot == NULL) continue;
+         if (k >= b->kpt_count || b->kpts[k].score < 0.3f) {
+            lv_obj_add_flag(dot, LV_OBJ_FLAG_HIDDEN);
+            continue;
+         }
+         /* Keypoint coords are in 320×320 input space — scale to canvas
+          * then subtract the box's top-left so the dot sits inside the
+          * box widget's coordinate space. */
+         int kx = (int)(b->kpts[k].x * parent_w / VOICE_YOLO_INPUT_W) - px;
+         int ky = (int)(b->kpts[k].y * parent_h / VOICE_YOLO_INPUT_H) - py;
+         lv_obj_set_pos(dot, kx - 4, ky - 4); /* 8 px dot, center on point */
+         lv_obj_clear_flag(dot, LV_OBJ_FLAG_HIDDEN);
+      }
    }
 }
 
@@ -1093,6 +1157,18 @@ static void yolo_infer_job(void *arg) {
    s_yolo_inflight = false;
 }
 
+static const char *yolo_mode_short_label(voice_yolo_model_t m) {
+   switch (m) {
+      case VOICE_YOLO_MODEL_POSE:
+         return "POSE";
+      case VOICE_YOLO_MODEL_SEG:
+         return "SEG";
+      case VOICE_YOLO_MODEL_DET:
+      default:
+         return "DET";
+   }
+}
+
 static void yolo_btn_cb(lv_event_t *e) {
    (void)e;
    s_yolo_on = !s_yolo_on;
@@ -1107,6 +1183,26 @@ static void yolo_btn_cb(lv_event_t *e) {
       yolo_alloc_resources();
    }
    tab5_debug_obs_event("yolo.toggle", s_yolo_on ? "on" : "off");
+}
+
+/* TT #638: cycle the K144 yolo model (DET → POSE → SEG → DET).  Hides
+ * all currently-shown boxes immediately so we don't leave stale
+ * keypoint dots around when switching out of POSE; next inference
+ * tick re-fills the overlay. */
+static void yolo_mode_btn_cb(lv_event_t *e) {
+   (void)e;
+   voice_yolo_model_t next = voice_yolo_get_model();
+   next = (next == VOICE_YOLO_MODEL_DET)    ? VOICE_YOLO_MODEL_POSE
+          : (next == VOICE_YOLO_MODEL_POSE) ? VOICE_YOLO_MODEL_SEG
+                                            : VOICE_YOLO_MODEL_DET;
+   voice_yolo_set_model(next);
+   if (s_yolo_mode_lbl) {
+      lv_label_set_text(s_yolo_mode_lbl, yolo_mode_short_label(next));
+   }
+   /* Hide existing overlay until the new model returns its first frame. */
+   s_yolo_n_pending = 0;
+   yolo_redraw_async(NULL);
+   tab5_debug_obs_event("yolo.model", voice_yolo_get_model_name(next));
 }
 
 /* ================================================================
@@ -1470,9 +1566,14 @@ void ui_camera_destroy(void)
        s_rec_overlay_lbl = NULL;
        s_yolo_btn = NULL;
        s_yolo_btn_lbl = NULL;
+       s_yolo_mode_btn = NULL;
+       s_yolo_mode_lbl = NULL;
        for (int i = 0; i < UI_CAM_YOLO_MAX_BOXES; i++) {
           s_yolo_boxes[i] = NULL;
           s_yolo_box_lbls[i] = NULL;
+          for (int k = 0; k < VOICE_YOLO_MAX_KPTS; k++) {
+             s_yolo_kpts[i][k] = NULL;
+          }
        }
        ESP_LOGI(TAG, "Camera screen cleaned (kept resident; canvas %u KB PSRAM reused)",
                 (unsigned)(canvas_buf_size / 1024));

--- a/main/voice_yolo.c
+++ b/main/voice_yolo.c
@@ -167,12 +167,51 @@ static int send_action(const char *action, const char *work_id_in, const char *o
    return code;
 }
 
+/* TT #638 (Wave 2): selected K144 yolo model.  Defaults to DET.  Changed
+ * via voice_yolo_set_model — that path also invalidates the cached
+ * work_id so the next infer call re-runs setup against the new model. */
+static voice_yolo_model_t s_model = VOICE_YOLO_MODEL_DET;
+
+const char *voice_yolo_get_model_name(voice_yolo_model_t model) {
+   switch (model) {
+      case VOICE_YOLO_MODEL_POSE:
+         return "yolo11n-pose";
+      case VOICE_YOLO_MODEL_SEG:
+         return "yolo11s-seg";
+      case VOICE_YOLO_MODEL_DET:
+      default:
+         return "yolo11n";
+   }
+}
+
+voice_yolo_model_t voice_yolo_get_model(void) { return s_model; }
+
+esp_err_t voice_yolo_set_model(voice_yolo_model_t model) {
+   if (model > VOICE_YOLO_MODEL_SEG) return ESP_ERR_INVALID_ARG;
+   ensure_lock();
+   xSemaphoreTake(s_lock, portMAX_DELAY);
+   if (s_model != model) {
+      ESP_LOGI(TAG, "switching model %s → %s — invalidating work_id", voice_yolo_get_model_name(s_model),
+               voice_yolo_get_model_name(model));
+      s_model = model;
+      s_work_id[0] = '\0';
+      s_ready = false;
+   }
+   xSemaphoreGive(s_lock);
+   return ESP_OK;
+}
+
 /* On a fresh K144 the yolo task pool is empty.  Earlier dev-box probes
  * and pre-flash test sessions leak slots, so we may hit code=-21 "task
- * full".  Recovery: issue a yolo unit reset and retry. */
+ * full".  Recovery: issue a yolo unit reset and retry.
+ *
+ * TT #638 (Wave 2): model is now selectable via s_model.  All three K144
+ * yolo11 variants share the same yolo.setup shape (verified empirically
+ * — see voice_yolo_set_model); the daemon picks the right response
+ * format based on the model name. */
 static int try_setup(char *out_wid, size_t out_wid_cap) {
    cJSON *data = cJSON_CreateObject();
-   cJSON_AddStringToObject(data, "model", "yolo11n");
+   cJSON_AddStringToObject(data, "model", voice_yolo_get_model_name(s_model));
    cJSON_AddStringToObject(data, "response_format", "yolo.box.stream");
    cJSON_AddStringToObject(data, "input", "yolo.jpeg.base64");
    cJSON_AddBoolToObject(data, "enoutput", true);
@@ -295,6 +334,38 @@ static int parse_stream_line(const char *line, const char *want_rid, voice_yolo_
             b->h = (y2 > y1) ? (y2 - y1) : 0.0f;
             b->confidence = cJSON_IsString(conf) && conf->valuestring ? (float)atof(conf->valuestring) : 0.0f;
             strlcpy(b->klass, cJSON_IsString(kls) && kls->valuestring ? kls->valuestring : "?", sizeof(b->klass));
+            b->kpt_count = 0;
+            /* TT #638 (Wave 2): yolo11n-pose adds a "keypoints" or "kpts"
+             * array per detection — each entry is either [x, y, score]
+             * or {x, y, score}.  Tolerate both shapes; cap at
+             * VOICE_YOLO_MAX_KPTS (17 COCO body keypoints). */
+            cJSON *kpts = cJSON_GetObjectItem(delta, "keypoints");
+            if (!cJSON_IsArray(kpts)) kpts = cJSON_GetObjectItem(delta, "kpts");
+            if (cJSON_IsArray(kpts)) {
+               int nkp = cJSON_GetArraySize(kpts);
+               if (nkp > VOICE_YOLO_MAX_KPTS) nkp = VOICE_YOLO_MAX_KPTS;
+               for (int k = 0; k < nkp; k++) {
+                  cJSON *kp = cJSON_GetArrayItem(kpts, k);
+                  voice_yolo_kpt_t *out = &b->kpts[k];
+                  out->x = out->y = out->score = 0.0f;
+                  if (cJSON_IsArray(kp) && cJSON_GetArraySize(kp) >= 2) {
+                     cJSON *ax = cJSON_GetArrayItem(kp, 0);
+                     cJSON *ay = cJSON_GetArrayItem(kp, 1);
+                     cJSON *as = cJSON_GetArraySize(kp) > 2 ? cJSON_GetArrayItem(kp, 2) : NULL;
+                     out->x = (float)atof(cJSON_IsString(ax) ? (ax->valuestring ?: "0") : "0");
+                     out->y = (float)atof(cJSON_IsString(ay) ? (ay->valuestring ?: "0") : "0");
+                     out->score = as && cJSON_IsString(as) ? (float)atof(as->valuestring ?: "0") : 1.0f;
+                  } else if (cJSON_IsObject(kp)) {
+                     cJSON *ox = cJSON_GetObjectItem(kp, "x");
+                     cJSON *oy = cJSON_GetObjectItem(kp, "y");
+                     cJSON *os = cJSON_GetObjectItem(kp, "score");
+                     if (cJSON_IsString(ox) && ox->valuestring) out->x = (float)atof(ox->valuestring);
+                     if (cJSON_IsString(oy) && oy->valuestring) out->y = (float)atof(oy->valuestring);
+                     if (cJSON_IsString(os) && os->valuestring) out->score = (float)atof(os->valuestring);
+                  }
+               }
+               b->kpt_count = (uint8_t)nkp;
+            }
             (*count)++;
          }
       }

--- a/main/voice_yolo.h
+++ b/main/voice_yolo.h
@@ -43,11 +43,31 @@ extern "C" {
 #define VOICE_YOLO_INPUT_W 320
 #define VOICE_YOLO_INPUT_H 320
 
+/** TT #638 (Wave 2): max keypoints per detection — yolo11n-pose emits 17
+ *  COCO body keypoints per person. */
+#define VOICE_YOLO_MAX_KPTS 17
+
+/** TT #638 (Wave 2): K144 yolo model registry — selects which of the
+ *  three pre-installed yolo11 variants `voice_yolo_init` arms. */
+typedef enum {
+   VOICE_YOLO_MODEL_DET = 0, /**< yolo11n: 80 COCO classes, boxes */
+   VOICE_YOLO_MODEL_POSE,    /**< yolo11n-pose: person + 17 keypoints */
+   VOICE_YOLO_MODEL_SEG,     /**< yolo11s-seg: 80 COCO classes + masks (box-only rendering for v1) */
+} voice_yolo_model_t;
+
+/** Single keypoint for pose detections.  Coords in 320×320 input space. */
+typedef struct {
+   float x, y, score;
+} voice_yolo_kpt_t;
+
 /** Single detection box returned by yolo.inference. */
 typedef struct {
    float x, y, w, h; /**< pixel coords in the 320×320 input */
    float confidence; /**< 0..1 */
    char klass[24];   /**< COCO class name, NUL-terminated */
+   /** TT #638: keypoint count (0 when current model isn't pose). */
+   uint8_t kpt_count;
+   voice_yolo_kpt_t kpts[VOICE_YOLO_MAX_KPTS];
 } voice_yolo_box_t;
 
 /**
@@ -75,6 +95,23 @@ bool voice_yolo_is_ready(void);
  * handles don't survive a K144 daemon restart.
  */
 void voice_yolo_invalidate(void);
+
+/**
+ * @brief TT #638: pick which K144 YOLO11 model `voice_yolo_init` arms.
+ *        If a work_id is already cached against a different model the
+ *        caller-side state is invalidated (`voice_yolo_invalidate`) so
+ *        the next infer call re-runs setup against the new variant.
+ *
+ * Safe to call from any task; takes the same internal lock as init.
+ * Returns ESP_OK on selection; the actual setup happens lazily.
+ */
+esp_err_t voice_yolo_set_model(voice_yolo_model_t model);
+
+/** Current selected model (defaults to DET). */
+voice_yolo_model_t voice_yolo_get_model(void);
+
+/** Human-readable name ("yolo11n", "yolo11n-pose", "yolo11s-seg"). */
+const char *voice_yolo_get_model_name(voice_yolo_model_t model);
 
 /**
  * @brief Run YOLO11n on a 320×320 JPEG and collect detections.


### PR DESCRIPTION
Pivot of the original Wave 2 (KWS gate — abandoned because K144's gigaspeech model is unreliable).  This wave surfaces K144's **three pre-installed yolo11 variants** on the camera screen with a single cycle button.

## What lands
- New \`MODE\` button on the camera control bar, stacked above the existing \`DETECT\` toggle.
- Tap cycles **DET → POSE → SEG → DET**.  Label updates live.
- \`voice_yolo_set_model\` / \`_get_model\` / \`_get_model_name\` swap the K144 \`yolo.setup\` model string, invalidate the cached work_id, and the next inference re-runs setup against the new variant.
- Parser extended to capture optional pose keypoint arrays per detection (17-slot \`kpts[]\` on \`voice_yolo_box_t\`).  Tolerates both \`[x, y, score]\` and \`{x, y, score}\` shapes.
- 17 reusable 8×8 magenta dot widgets pre-allocated as children of each box widget — ready to render the moment K144 starts emitting keypoints (current \`yolo.box.stream\` response_format returns bbox only for pose/seg).

## Live verification on Tab5 192.168.1.90
- **DET** (yolo11n): tight torso person box (80 COCO classes).
- **POSE** (yolo11n-pose): wider full-body person box.
- **SEG** (yolo11s-seg): same model accepts the swap and returns bbox; "s" variant ~3× heavier but cycles cleanly.

## Known limitations
- Pose keypoint rendering is wired but daemon-side response format needs extension to deliver them.  When K144 lands a \`yolo.kpts.stream\` (or similar) format, swap the response_format string and dots light up.
- Segmentation mask rendering is parked (heavier draw cost, box-only for v1).

New obs event: \`yolo.model\` (\`yolo11n\` / \`yolo11n-pose\` / \`yolo11s-seg\`).

Closes #638