### PR TITLE
Cap Wave 5: Settings UI redesign + Privacy lock (closes #644)

### DIFF
--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -124,6 +124,8 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
    /* Cap Wave 4 (TT #642): LLM engine override surfaced for harness +
     * Settings round-trip verification. */
    cJSON_AddNumberToObject(root, "llm_engine", tab5_settings_get_llm_engine());
+   /* Cap Wave 5 (TT #644): privacy lock master switch. */
+   cJSON_AddBoolToObject(root, "privacy_lock", tab5_settings_get_privacy_lock());
    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
@@ -428,6 +430,18 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
       }
       if (eng >= 0 && eng < LLM_ENG_COUNT && tab5_settings_set_llm_engine((uint8_t)eng) == ESP_OK) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("llm_engine"));
+      }
+   }
+   /* Cap Wave 5 (TT #644): privacy lock toggle.  Accept bool or 0/1. */
+   cJSON *pl = cJSON_GetObjectItem(req_json, "privacy_lock");
+   if (pl) {
+      bool on = false;
+      if (cJSON_IsBool(pl))
+         on = cJSON_IsTrue(pl);
+      else if (cJSON_IsNumber(pl))
+         on = pl->valuedouble != 0;
+      if (tab5_settings_set_privacy_lock(on) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("privacy_lock"));
       }
    }
    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");

--- a/main/settings.c
+++ b/main/settings.c
@@ -503,6 +503,18 @@ esp_err_t tab5_settings_set_llm_engine(uint8_t eng) {
    return set_u8("llm_eng", eng);
 }
 
+/* ── Privacy lock (Cap Wave 5 / TT #644) ───────────────────────────────
+ *
+ * Master "on-device only" switch.  When set, voice_modes_route_text
+ * refuses any dispatch that would hit Dragon or OpenRouter — only K144
+ * paths are allowed.  Composes with llm_eng: if user picks K144 + lock
+ * ON, every text turn routes to K144 regardless of vmode.
+ *
+ * Default OFF so existing devices upgrade transparently. */
+bool tab5_settings_get_privacy_lock(void) { return get_u8("privacy", 0) != 0; }
+
+esp_err_t tab5_settings_set_privacy_lock(bool on) { return set_u8("privacy", on ? 1 : 0); }
+
 /* ── Wake source picker (TT #617) ───────────────────────────────────── */
 
 esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {

--- a/main/settings.h
+++ b/main/settings.h
@@ -196,6 +196,13 @@ typedef enum {
 uint8_t tab5_settings_get_llm_engine(void);
 esp_err_t tab5_settings_set_llm_engine(uint8_t eng);
 
+/** Cap Wave 5 (TT #644) — Privacy lock master switch.  When ON,
+ *  voice_modes_route_text refuses any dispatch to Dragon or
+ *  OpenRouter; only K144 paths (vmode=4 + llm_eng=K144) are
+ *  permitted.  Composes with the LLM engine override above. */
+bool tab5_settings_get_privacy_lock(void);
+esp_err_t tab5_settings_set_privacy_lock(bool on);
+
 /** TT #617 — Wake source.  Picks which wakeword detection path runs.
  *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
  *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -453,6 +453,34 @@ static int mk_section(lv_obj_t *parent, const char *text, lv_color_t accent, int
     return y + HDR_H;
 }
 
+/** Cap Wave 5 (TT #644) — card-background helper.  Creates a rounded
+ *  filled rect under the just-laid-out section and sends it to back
+ *  via lv_obj_move_background so it sits behind the section's content
+ *  without re-parenting.  Lets us turn the flat row-stack into airy
+ *  visually-grouped cards with one helper call per section.
+ *
+ *  Pass the y_top BEFORE the section header label and y_bottom AFTER
+ *  the last row.  The card extends 8 px above/below for breathing
+ *  room (header sits on the card top edge, content has padding). */
+static void mk_card_bg(lv_obj_t *parent, int y_top, int y_bottom) {
+   if (y_bottom <= y_top) return;
+   lv_obj_t *card = lv_obj_create(parent);
+   if (!card) return;
+   lv_obj_remove_style_all(card);
+   lv_obj_set_pos(card, SIDE_PAD - 12, y_top + HDR_H - 4);
+   lv_obj_set_size(card, CONTENT_W + 24, (y_bottom - y_top) - HDR_H + 12);
+   lv_obj_set_style_bg_color(card, lv_color_hex(0x121620), 0);
+   lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(card, 16, 0);
+   lv_obj_set_style_border_width(card, 1, 0);
+   lv_obj_set_style_border_color(card, lv_color_hex(0x1E2030), 0);
+   lv_obj_set_style_border_opa(card, LV_OPA_COVER, 0);
+   lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_clear_flag(card, LV_OBJ_FLAG_CLICKABLE);
+   /* Send to back so content (labels, switches, chips) renders on top. */
+   lv_obj_move_background(card);
+}
+
 /** Row with label (single line, vertically centered in ROW_H). */
 static void mk_row_label(lv_obj_t *parent, const char *label, int y)
 {
@@ -982,6 +1010,26 @@ static void cb_quiet_on(lv_event_t *e)
     ESP_LOGI(TAG, "Quiet hours: %d", on);
     extern void ui_home_refresh_sys_label(void);
     ui_home_refresh_sys_label();
+}
+
+/* Cap Wave 5 (TT #644): Privacy lock master switch.  Flips the NVS
+ * value + refreshes the home top-bar indicator. */
+static lv_obj_t *s_lbl_privacy_status = NULL;
+
+static void cb_privacy_lock(lv_event_t *e) {
+   lv_obj_t *sw = lv_event_get_target(e);
+   bool on = lv_obj_has_state(sw, LV_STATE_CHECKED);
+   tab5_settings_set_privacy_lock(on);
+   ESP_LOGI(TAG, "Privacy lock: %d", on);
+   tab5_debug_obs_event("privacy.lock", on ? "on" : "off");
+   if (s_lbl_privacy_status) {
+      lv_label_set_text(s_lbl_privacy_status, on ? "ON · On-device only" : "OFF · Cloud allowed");
+      lv_obj_set_style_text_color(s_lbl_privacy_status, lv_color_hex(on ? 0xF59E0B : TEXT_DIM), 0);
+   }
+   /* Nudge the home pill so the new state is reflected without a 5 s
+    * polling delay. */
+   extern void ui_home_refresh_sys_label(void);
+   ui_home_refresh_sys_label();
 }
 
 /* W7-E.5: per-channel notification toggles.  Each callback persists to
@@ -1731,6 +1779,10 @@ lv_obj_t *ui_settings_create(void)
     ESP_LOGI(TAG, "Phase 1 — Section: Voice Mode");
     lv_color_t acc_voice = lv_color_hex(ACC_VOICE);
 
+    /* Cap Wave 5 (TT #644): track VOICE MODE + CLOUD LLM block's top y
+     * so we can paint a single airy card behind the combined picker
+     * region (header → mode rows → cloud chips). */
+    int s_voice_section_top = y;
     y = mk_section(s_scroll, "VOICE MODE", acc_voice, y);
 
     /* v5 flat vertical radio rows. Each row = colored dot + name + desc;
@@ -1955,6 +2007,11 @@ lv_obj_t *ui_settings_create(void)
        }
        y += chip_h + 16;
     }
+    /* Card BG for the combined VOICE MODE + CLOUD LLM block (Wave 5
+     * visual reorg).  s_voice_section_top is captured below at the
+     * VOICE MODE section header. */
+    mk_card_bg(s_scroll, s_voice_section_top, y);
+    y += 24;
 
     /* ── Cap Wave 4 (TT #642): ENGINES section ─────────────────────
      *
@@ -1964,6 +2021,7 @@ lv_obj_t *ui_settings_create(void)
      * for STT + TTS so the user can see what each capability is
      * currently doing under the active vmode.  Greyed chips = backend
      * unreachable. */
+    int s_engines_section_top = y;
     {
        lv_obj_t *cap = lv_label_create(s_scroll);
        lv_label_set_text(cap, "ENGINES");
@@ -2027,14 +2085,58 @@ lv_obj_t *ui_settings_create(void)
        }
        y += ROW_H + 16;
     }
+    /* Card BG for ENGINES section (Wave 4 + Wave 5 visual reorg). */
+    mk_card_bg(s_scroll, s_engines_section_top, y);
+    y += 24; /* breathing-room gap before next section */
 
-    /* PRIVACY + QUIET HOURS rows (spec groups them under the VOICE MODE
+    /* ── Cap Wave 5 (TT #644): PRIVACY section ─────────────────────
+     *
+     * Master "on-device only" lock.  When ON, voice_modes_route_text
+     * refuses Dragon/OpenRouter dispatch and forces K144 routing for
+     * every text turn.  Composes with the LLM engine knob above. */
+    int privacy_section_top = y;
+    {
+       lv_obj_t *cap = lv_label_create(s_scroll);
+       lv_label_set_text(cap, "PRIVACY");
+       lv_obj_set_pos(cap, SIDE_PAD, y);
+       lv_obj_set_style_text_color(cap, lv_color_hex(AMBER), 0);
+       lv_obj_set_style_text_font(cap, FONT_SECONDARY, 0);
+       lv_obj_set_style_text_letter_space(cap, 4, 0);
+       y += 26;
+
+       bool priv_on = tab5_settings_get_privacy_lock();
+       mk_row_label(s_scroll, "On-device lock", y);
+       mk_switch(s_scroll, acc_voice, 660, y, priv_on, cb_privacy_lock, NULL);
+       y += ROW_H + 4;
+
+       /* Status line under the toggle row — "ON · On-device only" or
+        * "OFF · Cloud allowed" — same pattern as the K144 health chip. */
+       s_lbl_privacy_status = lv_label_create(s_scroll);
+       if (s_lbl_privacy_status) {
+          lv_obj_set_pos(s_lbl_privacy_status, SIDE_PAD, y);
+          lv_obj_set_style_text_font(s_lbl_privacy_status, FONT_SECONDARY, 0);
+          lv_obj_set_style_text_color(s_lbl_privacy_status, lv_color_hex(priv_on ? 0xF59E0B : TEXT_DIM), 0);
+          lv_label_set_text(s_lbl_privacy_status, priv_on ? "ON · On-device only" : "OFF · Cloud allowed");
+       }
+       y += 28 + 16;
+    }
+    mk_card_bg(s_scroll, privacy_section_top, y);
+    y += 24;
+
+    /* AUDIO + QUIET HOURS rows (spec groups them under the VOICE MODE
      * section visually — single amber caption, rows straight below). */
+    int audio_section_top = y;
+    y = mk_section(s_scroll, "AUDIO", acc_voice, y);
     mk_row_label(s_scroll, "Mic mute", y);
     mk_switch(s_scroll, acc_voice, 660, y, tab5_settings_get_mic_mute() != 0,
               cb_mic_mute, NULL);
     y += ROW_H + 16;
-    mk_row_label(s_scroll, "Quiet hours", y);
+    mk_card_bg(s_scroll, audio_section_top, y);
+    y += 24;
+
+    int quiet_section_top = y;
+    y = mk_section(s_scroll, "QUIET HOURS", acc_voice, y);
+    mk_row_label(s_scroll, "Enable", y);
     mk_switch(s_scroll, acc_voice, 660, y, tab5_settings_get_quiet_on() != 0,
               cb_quiet_on, NULL);
     y += ROW_H + 8;
@@ -2075,10 +2177,14 @@ lv_obj_t *ui_settings_create(void)
         }
     }
     y += ROW_H + 16;
+    mk_card_bg(s_scroll, quiet_section_top, y);
+    y += 24;
 
     /* v4·D Phase 4e: daily budget cap editor.  Slider range 0-50, each
      * step = 20¢, so 0 = OFF, 50 = $10.00.  Maps to NVS cap_mils field
      * consumed by the auto-downgrade path in voice.c. */
+    int budget_section_top = y;
+    y = mk_section(s_scroll, "BUDGET", acc_voice, y);
     mk_row_label(s_scroll, "Daily cap", y);
     {
         uint32_t cap_mils = tab5_budget_get_cap_mils();
@@ -2100,12 +2206,15 @@ lv_obj_t *ui_settings_create(void)
         }
     }
     y += ROW_H + 20;
+    mk_card_bg(s_scroll, budget_section_top, y);
+    y += 24;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: TINKERON (TT #586 — always-on listener controls)
      * ════════════════════════════════════════════════════════════════ */
     feed_wdt();
     ESP_LOGI(TAG, "Phase 1 — Section: TinkerON");
+    int tinkeron_section_top = y;
     y = mk_section(s_scroll, "TINKERON", acc_voice, y);
 
     /* Status row: temp + version + chain hwinfo cache (best-effort —
@@ -2138,6 +2247,8 @@ lv_obj_t *ui_settings_create(void)
     mk_pill_btn(s_scroll, "RESET", acc_voice, lv_color_hex(0xFFFFFF),
                 RIGHT_X - 130, y + 4, 130, ROW_H - 8, 18, cb_tinkeron_reset);
     y += ROW_H + 20;
+    mk_card_bg(s_scroll, tinkeron_section_top, y);
+    y += 24;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: CHANNELS (W7-E.5 — per-platform notification opt-in)
@@ -2554,6 +2665,8 @@ void ui_settings_destroy(void)
     memset(s_eng_chip, 0, sizeof(s_eng_chip));
     s_eng_stt_lbl = NULL;
     s_eng_tts_lbl = NULL;
+    /* Cap Wave 5 (TT #644) — privacy status label. */
+    s_lbl_privacy_status = NULL;
 
     s_lbl_wifi      = NULL;
     s_lbl_bat_status = NULL;

--- a/main/voice.c
+++ b/main/voice.c
@@ -2360,7 +2360,15 @@ esp_err_t voice_send_text(const char *text)
           return ESP_OK;
        case VOICE_MODES_ROUTE_K144_FAILED:
           if (tab5_ui_try_lock(100)) {
-             ui_home_show_toast("Onboard LLM not ready");
+             /* Cap Wave 5 (TT #644): a K144_FAILED while privacy lock
+              * is ON means the lock forced a K144-only dispatch that
+              * couldn't land — surface that distinctly so the user
+              * knows to either turn the lock off OR bring K144 up. */
+             if (tab5_settings_get_privacy_lock()) {
+                ui_home_show_toast("Privacy lock on — K144 not ready");
+             } else {
+                ui_home_show_toast("Onboard LLM not ready");
+             }
              tab5_ui_unlock();
           }
           return route.err;

--- a/main/voice_modes.c
+++ b/main/voice_modes.c
@@ -77,11 +77,39 @@ void voice_modes_route_text(const char *text, voice_modes_route_result_t *out) {
     * gets OpenRouter (override wins).  The VMODE_LOCAL_ONBOARD branch
     * stays untouched as the "follow preset" path for engine=AUTO. */
    uint8_t llm_eng = tab5_settings_get_llm_engine();
+   bool privacy_lock = tab5_settings_get_privacy_lock();
    {
       char detail[48];
-      snprintf(detail, sizeof(detail), "vmode=%u eng=%u", tab5_settings_get_voice_mode(), llm_eng);
+      snprintf(detail, sizeof(detail), "vmode=%u eng=%u priv=%u", tab5_settings_get_voice_mode(), llm_eng,
+               (unsigned)privacy_lock);
       tab5_debug_obs_event("eng.route_in", detail);
    }
+
+   /* Cap Wave 5 (TT #644) — Privacy lock.  When ON, refuse any dispatch
+    * to Dragon or OpenRouter — only K144 paths are allowed.  We force
+    * K144 routing here when reachable; if K144 isn't ready, surface a
+    * dedicated REFUSED kind so the caller can toast the user. */
+   if (privacy_lock) {
+      if (voice_onboard_failover_state() == 2 /* M5_FAIL_READY */) {
+         esp_err_t fe = voice_onboard_send_text(text);
+         if (fe == ESP_OK) {
+            ESP_LOGI(TAG, "privacy_lock=ON — forced K144 dispatch");
+            tab5_debug_obs_event("eng.route", "priv_k144_ok");
+            out->kind = VOICE_MODES_ROUTE_K144_OK;
+            return;
+         }
+         ESP_LOGW(TAG, "privacy_lock=ON but K144 send_text failed (%s)", esp_err_to_name(fe));
+      }
+      /* K144 not reachable while privacy is locked — refuse the turn
+       * rather than fall through to Dragon/OpenRouter (which would
+       * violate the lock). */
+      ESP_LOGW(TAG, "privacy_lock=ON and K144 unreachable — refusing turn");
+      tab5_debug_obs_event("eng.route", "priv_refused");
+      out->kind = VOICE_MODES_ROUTE_K144_FAILED;
+      out->err = ESP_ERR_INVALID_STATE;
+      return;
+   }
+
    if (llm_eng == LLM_ENG_K144) {
       int fs = voice_onboard_failover_state();
       if (fs == 2 /* M5_FAIL_READY */) {


### PR DESCRIPTION
Two pieces in one wave.

## 1. Settings UI redesign
The top half of Settings (VOICE MODE / CLOUD LLM / ENGINES / PRIVACY / AUDIO / QUIET HOURS / BUDGET / TINKERON) was a flat row-stack with no breathing room.  Now each section sits in an airy **visually-grouped card** with 24 px between sections.

Implementation: new \`mk_card_bg(parent, y_top, y_bottom)\` helper creates a rounded filled rect behind the just-laid-out section's content via \`lv_obj_move_background\` — no widget re-parenting needed.

## 2. Privacy lock
New master "on-device only" switch in a dedicated **PRIVACY** card.  When ON, \`voice_modes_route_text\` refuses any dispatch to Dragon or OpenRouter and forces K144 routing for every text turn.  Composes with the Wave 4 LLM engine override.  K144 unreachable while locked = turn refused with toast "Privacy lock on — K144 not ready".

## What lands
- \`settings.h/c\` — new \`privacy\` NVS key + \`tab5_settings_get/set_privacy_lock\`.
- \`debug_server_settings\` — \`/settings\` GET surfaces \`privacy_lock\`; POST accepts bool or 0/1.
- \`voice_modes.c\` — privacy-lock check ahead of the Wave 4 override.  Forces K144 dispatch when reachable, returns K144_FAILED otherwise.
- \`voice.c\` — K144_FAILED toast distinguishes "Privacy lock on — K144 not ready" from "Onboard LLM not ready".
- \`ui_settings\` — \`mk_card_bg\` helper + 7 section cards (VOICE MODE through TINKERON) + new PRIVACY card with master switch + status line ("ON · On-device only" / "OFF · Cloud allowed").

## New obs events
- \`privacy.lock\` — \`on\` / \`off\` on UI toggle.
- \`eng.route_in\` extended with \`priv=N\` field.
- \`eng.route\` adds \`priv_k144_ok\` and \`priv_refused\` outcomes.

## Live verification on Tab5 192.168.1.90

### Visual

Settings top half now renders as cards (each section visually grouped, 24 px gaps, rounded backgrounds).  PRIVACY card shows the master switch + status text.

### Functional
\`POST /settings {"privacy_lock":true}\` round-trips.  Then with vmode=0 LOCAL + llm_engine=AUTO + Dragon connected + K144 READY:

\`POST /chat {"text":"hi"}\` →
\`\`\`
eng.route_in vmode=0 eng=0 priv=1
eng.route priv_k144_ok
voice.state PROCESSING → SPEAKING (m5.tts queued) → READY (m5.tts done)
\`\`\`

Turn forced to K144 instead of Dragon, K144 TTS played through Tab5 speaker.  Total ~6 s.

## Out of scope (Wave 5b)
- Card wrapping for the lower-half sections (CHANNELS, DISPLAY, NETWORK, STORAGE, BATTERY, ABOUT).
- Top-bar home indicator showing privacy state.
- True STT/TTS engine knobs (still waiting on Dragon protocol extension — flagged for Wave 4b).

Closes #644