### PR TITLE
Cap Wave 5b: Settings lower-half cards + home privacy chip (closes #646)

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -119,6 +119,9 @@ static lv_obj_t *s_sys_label       = NULL;  /* left: "ONLINE" / "OFFLINE" / etc 
 static lv_obj_t *s_tinkeron_dot    = NULL;
 static lv_obj_t *s_tinkeron_label  = NULL;
 static lv_obj_t *s_time_label      = NULL;  /* right: "Thursday · 9:42" */
+/* Cap Wave 5b (TT #646): privacy lock pill, pinned right of the time label.
+ * Visible only when tab5_settings_get_privacy_lock() is true. */
+static lv_obj_t *s_privacy_chip = NULL;
 
 /* F1/F2 full-screen OFFLINE hero (audit 2026-04-20). Shown when NO_WIFI
  * or DRAGON_DOWN persists past 8 s. Auto-dismisses on recovery. */
@@ -608,6 +611,33 @@ lv_obj_t *ui_home_create(void)
     lv_obj_set_style_text_color(s_time_label, lv_color_hex(TH_TEXT_BODY), 0);
     lv_obj_set_style_text_align(s_time_label, LV_TEXT_ALIGN_RIGHT, 0);
     lv_obj_set_style_text_letter_space(s_time_label, 1, 0);
+
+    /* Cap Wave 5b (TT #646): privacy lock indicator.  Small amber pill
+     * with a lock glyph + "PRIVACY" caption pinned right of the time
+     * label.  Hidden by default; shown when tab5_settings_get_privacy_lock()
+     * returns true.  Refreshed by ui_home_refresh_sys_label so toggling
+     * the switch in Settings updates the indicator without a 5 s tick. */
+    s_privacy_chip = lv_obj_create(s_screen);
+    if (s_privacy_chip) {
+       lv_obj_remove_style_all(s_privacy_chip);
+       lv_obj_set_size(s_privacy_chip, 152, 36);
+       lv_obj_set_pos(s_privacy_chip, SW - SIDE_PAD - 152, 56);
+       lv_obj_set_style_bg_color(s_privacy_chip, lv_color_hex(0x1A1A24), 0);
+       lv_obj_set_style_bg_opa(s_privacy_chip, LV_OPA_COVER, 0);
+       lv_obj_set_style_radius(s_privacy_chip, 18, 0);
+       lv_obj_set_style_border_width(s_privacy_chip, 1, 0);
+       lv_obj_set_style_border_color(s_privacy_chip, lv_color_hex(0xF59E0B), 0);
+       lv_obj_set_style_border_opa(s_privacy_chip, LV_OPA_COVER, 0);
+       lv_obj_clear_flag(s_privacy_chip, LV_OBJ_FLAG_SCROLLABLE);
+       lv_obj_add_flag(s_privacy_chip, LV_OBJ_FLAG_HIDDEN);
+
+       lv_obj_t *lbl = lv_label_create(s_privacy_chip);
+       lv_label_set_text(lbl, LV_SYMBOL_EYE_CLOSE "  PRIVACY");
+       lv_obj_set_style_text_font(lbl, FONT_SMALL, 0);
+       lv_obj_set_style_text_color(lbl, lv_color_hex(0xF59E0B), 0);
+       lv_obj_set_style_text_letter_space(lbl, 2, 0);
+       lv_obj_center(lbl);
+    }
 
     /* ── Orb stage ──────────────────────────────────────────────
      * TT #511 wave-1: halos REMOVED.  The 520 px / 340 px amber discs
@@ -2557,6 +2587,7 @@ void ui_home_destroy(void)
     if (s_screen) { lv_obj_del(s_screen); s_screen = NULL; }
     ui_orb_destroy(); /* TT #511: clear ui_orb's handles + state machine. */
     s_sys_dot = s_sys_label = s_time_label = NULL;
+    s_privacy_chip = NULL;
     s_halo_outer = s_halo_inner = NULL;
     s_ring_outer = s_ring_mid = s_ring_inner = NULL;
     s_orb = NULL;
@@ -3439,6 +3470,14 @@ static void sys_label_refresh_async_cb(void *arg)
     (void)arg;
     ui_home_update_status();
     ui_home_orb_aliveness_sync();
+    /* Cap Wave 5b (TT #646): refresh privacy chip visibility. */
+    if (s_privacy_chip) {
+       if (tab5_settings_get_privacy_lock()) {
+          lv_obj_clear_flag(s_privacy_chip, LV_OBJ_FLAG_HIDDEN);
+       } else {
+          lv_obj_add_flag(s_privacy_chip, LV_OBJ_FLAG_HIDDEN);
+       }
+    }
 }
 
 void ui_home_refresh_sys_label(void)

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -1488,6 +1488,7 @@ static void phase2_timer_cb(lv_timer_t *t)
     ESP_LOGI(TAG, "Section: Storage");
     lv_color_t acc_storage = lv_color_hex(ACC_STORAGE);
 
+    int storage_section_top = y;
     y = mk_section(s_scroll, "STORAGE", acc_storage, y);
 
     /* SD info shown directly under section header */
@@ -1497,6 +1498,8 @@ static void phase2_timer_cb(lv_timer_t *t)
     lv_obj_set_style_text_font(s_lbl_sd_info, FONT_BODY, 0);
     lv_obj_set_pos(s_lbl_sd_info, SIDE_PAD, y + (ROW_H - 18) / 2);
     y += ROW_H + 16;
+    mk_card_bg(s_scroll, storage_section_top, y);
+    y += 24;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: BATTERY (red #EF4444)
@@ -1505,6 +1508,7 @@ static void phase2_timer_cb(lv_timer_t *t)
     ESP_LOGI(TAG, "Section: Battery");
     lv_color_t acc_battery = lv_color_hex(ACC_BATTERY);
 
+    int battery_section_top = y;
     y = mk_section(s_scroll, "BATTERY", acc_battery, y);
 
     /* Primary battery status: "XX% . Charging" or "USB Powered" */
@@ -1539,6 +1543,8 @@ static void phase2_timer_cb(lv_timer_t *t)
     lv_obj_set_style_text_font(s_lbl_bat_volt, FONT_SMALL, 0);
     lv_obj_set_pos(s_lbl_bat_volt, SIDE_PAD, y);
     y += 20 + 16;
+    mk_card_bg(s_scroll, battery_section_top, y);
+    y += 24;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: ABOUT (violet #8B5CF6)
@@ -1547,6 +1553,7 @@ static void phase2_timer_cb(lv_timer_t *t)
     ESP_LOGI(TAG, "Section: About");
     lv_color_t acc_about = lv_color_hex(ACC_ABOUT);
 
+    int about_section_top = y;
     y = mk_section(s_scroll, "ABOUT", acc_about, y);
 
     /* Device info -- Line 1: product name + version (prominent) */
@@ -1615,6 +1622,8 @@ static void phase2_timer_cb(lv_timer_t *t)
     lv_obj_set_style_text_font(s_lbl_heap, FONT_SMALL, 0);
     lv_obj_set_pos(s_lbl_heap, SIDE_PAD, y + (ROW_H - 14) / 2);
     y += ROW_H;
+    mk_card_bg(s_scroll, about_section_top, y);
+    y += 24;
 
     /* ── Bottom padding ──────────────────────────────────────────────── */
     y += 40;
@@ -2257,6 +2266,7 @@ lv_obj_t *ui_settings_create(void)
     ESP_LOGI(TAG, "Phase 1 — Section: Channels");
     lv_color_t acc_channels = lv_color_hex(ACC_VOICE); /* shares amber w/ Voice */
 
+    int channels_section_top = y;
     y = mk_section(s_scroll, "CHANNELS", acc_channels, y);
 
     struct {
@@ -2274,7 +2284,9 @@ lv_obj_t *ui_settings_create(void)
        mk_switch(s_scroll, acc_channels, 660, y, ch_rows[i].getter() != 0, ch_rows[i].cb, NULL);
        y += ROW_H + 8;
     }
-    y += 20;
+    y += 12;
+    mk_card_bg(s_scroll, channels_section_top, y);
+    y += 24;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: DISPLAY (amber #F5A623)
@@ -2283,6 +2295,7 @@ lv_obj_t *ui_settings_create(void)
     ESP_LOGI(TAG, "Phase 1 — Section: Display");
     lv_color_t acc_display = lv_color_hex(ACC_DISPLAY);
 
+    int display_section_top = y;
     y = mk_section(s_scroll, "DISPLAY", acc_display, y);
 
     /* Brightness */
@@ -2359,6 +2372,8 @@ lv_obj_t *ui_settings_create(void)
         lv_obj_add_event_cb(dd, cb_cam_rotation, LV_EVENT_VALUE_CHANGED, NULL);
     }
     y += ROW_H + 16;
+    mk_card_bg(s_scroll, display_section_top, y);
+    y += 24;
 
     /* ════════════════════════════════════════════════════════════════
      *  SECTION: NETWORK (cyan #00E5FF)
@@ -2367,6 +2382,7 @@ lv_obj_t *ui_settings_create(void)
     ESP_LOGI(TAG, "Phase 1 — Section: Network");
     lv_color_t acc_network = lv_color_hex(ACC_NETWORK);
 
+    int network_section_top = y;
     y = mk_section(s_scroll, "NETWORK", acc_network, y);
 
     /* WiFi status */
@@ -2456,6 +2472,8 @@ lv_obj_t *ui_settings_create(void)
         lv_obj_add_event_cb(s_conn_dd, cb_conn_mode, LV_EVENT_VALUE_CHANGED, NULL);
     }
     y += ROW_H + 16;
+    mk_card_bg(s_scroll, network_section_top, y);
+    y += 24;
 
     /* ═══════════════════════════════════════════════════════════════════
      *  END PHASE 1 — Screen is visible now with Display + Network.


### PR DESCRIPTION
Polish closer for the capabilities sprint.

## What lands
- **Settings lower-half cards.**  STORAGE / BATTERY / ABOUT (Phase 2) and CHANNELS / DISPLAY / NETWORK (Phase 1) now use \`mk_card_bg\` to match the top-half look from #645.  Whole Settings screen reads as a consistent card-grouped layout, 24 px breathing room between sections.
- **Home privacy lock indicator.**  Amber pill (\`⊘  PRIVACY\`) pinned right of the time label on home.  Hidden by default; shown via \`ui_home_refresh_sys_label\` when \`tab5_settings_get_privacy_lock()\` is true.  Reuses the existing sys-label refresh hook so the indicator updates the moment the user toggles the Settings switch.

## Live verification on Tab5 192.168.1.90
- \`POST /settings {"privacy_lock":true}\` → home top-right shows the amber PRIVACY pill next to "Friday · 2:33".
- Settings scrolls cleanly through 14 cards: VOICE MODE / ENGINES / PRIVACY / AUDIO / QUIET HOURS / BUDGET / TINKERON / CHANNELS / DISPLAY / NETWORK / STORAGE / BATTERY / ABOUT.

Closes #646