### PR TITLE
Polish P1: ui_components atom library + Notes airy-card refit (closes #648)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(UI_SRCS
     "ui_theme.c"
+    "ui_components.c"
     "ui_splash.c" "ui_home.c" "ui_orb.c" "ui_settings.c"
     "ui_camera.c" "ui_files.c" "ui_audio.c" "ui_keyboard.c" "ui_voice.c" "ui_wifi.c"
     "ui_video_pane.c"

--- a/main/ui_components.c
+++ b/main/ui_components.c
@@ -1,0 +1,465 @@
+/**
+ * @file ui_components.c
+ * @brief Shared UI atoms — Polish Wave P1 (TT #648).
+ *
+ * Implementations are intentionally short.  Each atom is one LVGL
+ * widget tree built from `ui_theme.h` tokens + `ui_feedback.h`
+ * press-state helpers.  No persistent state, no allocator calls,
+ * no PSRAM use — atoms are pure widget factories.
+ */
+
+#include "ui_components.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "config.h"
+#include "lvgl.h"
+#include "ui_core.h"
+#include "ui_feedback.h"
+#include "ui_theme.h"
+
+/* ── Layout constants — shared by every atom ───────────────────── */
+#define UI_TOPBAR_H 48
+#define UI_LIST_ROW_H 64
+#define UI_PILL_H 36
+#define UI_ACTION_BTN_H 44
+#define UI_CHIP_H 28
+
+/* ── Tone → color resolver ──────────────────────────────────────── */
+static uint32_t tone_to_accent(ui_tone_t tone) {
+   switch (tone) {
+      case UI_TONE_ACCENT:
+         return TH_AMBER;
+      case UI_TONE_SUCCESS:
+         return 0x22C55E; /* TT #328 success-green */
+      case UI_TONE_DANGER:
+         return 0xEF4444;
+      case UI_TONE_INFO:
+         return 0x3B82F6;
+      case UI_TONE_DIM:
+         return TH_TEXT_DIM;
+      case UI_TONE_NEUTRAL:
+      default:
+         return TH_TEXT_BODY;
+   }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Top-bar
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_topbar(lv_obj_t *parent, const char *title, ui_topbar_cb_t back_cb, lv_obj_t **out_right_slot) {
+   lv_obj_t *bar = lv_obj_create(parent);
+   if (!bar) return NULL;
+   lv_obj_remove_style_all(bar);
+   lv_obj_set_size(bar, lv_obj_get_width(parent), UI_TOPBAR_H);
+   lv_obj_set_pos(bar, 0, 0);
+   lv_obj_set_style_bg_color(bar, lv_color_hex(TH_BG), 0);
+   lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
+   lv_obj_set_style_pad_all(bar, 0, 0);
+   lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+
+   /* Back arrow (only when caller supplies a handler — explicit is
+    * better than implicit; no caller wants a phantom back button). */
+   if (back_cb) {
+      lv_obj_t *back = lv_obj_create(bar);
+      lv_obj_remove_style_all(back);
+      lv_obj_set_size(back, 60, UI_TOPBAR_H);
+      lv_obj_set_pos(back, 0, 0);
+      lv_obj_set_style_bg_opa(back, LV_OPA_TRANSP, 0);
+      lv_obj_add_flag(back, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_clear_flag(back, LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_add_event_cb(back, back_cb, LV_EVENT_CLICKED, NULL);
+      ui_fb_button(back);
+      lv_obj_t *icon = lv_label_create(back);
+      lv_label_set_text(icon, LV_SYMBOL_LEFT);
+      lv_obj_set_style_text_color(icon, lv_color_hex(TH_TEXT_PRIMARY), 0);
+      lv_obj_set_style_text_font(icon, FONT_HEADING, 0);
+      lv_obj_center(icon);
+   }
+
+   /* Title — centered horizontally in the bar.  FONT_HEADING for
+    * scannability.  Caller passes empty string to suppress. */
+   if (title && title[0]) {
+      lv_obj_t *lbl = lv_label_create(bar);
+      lv_label_set_text(lbl, title);
+      lv_obj_set_style_text_font(lbl, FONT_HEADING, 0);
+      lv_obj_set_style_text_color(lbl, lv_color_hex(TH_TEXT_PRIMARY), 0);
+      lv_obj_align(lbl, LV_ALIGN_CENTER, 0, 0);
+   }
+
+   /* Right-slot — caller stashes pointer; can lv_obj_set_parent
+    * children to it later.  Useful for action buttons or live status
+    * chips (privacy lock, k144 health). */
+   if (out_right_slot) {
+      lv_obj_t *slot = lv_obj_create(bar);
+      lv_obj_remove_style_all(slot);
+      lv_obj_set_size(slot, 120, UI_TOPBAR_H);
+      lv_obj_align(slot, LV_ALIGN_RIGHT_MID, 0, 0);
+      lv_obj_set_style_bg_opa(slot, LV_OPA_TRANSP, 0);
+      lv_obj_set_style_pad_all(slot, 0, 0);
+      lv_obj_clear_flag(slot, LV_OBJ_FLAG_SCROLLABLE);
+      *out_right_slot = slot;
+   }
+
+   return bar;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Card
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_card(lv_obj_t *parent, int x, int y, int w, int h) {
+   lv_obj_t *card = lv_obj_create(parent);
+   if (!card) return NULL;
+   lv_obj_remove_style_all(card);
+   lv_obj_set_pos(card, x, y);
+   lv_obj_set_size(card, w, h);
+   lv_obj_set_style_bg_color(card, lv_color_hex(TH_CARD), 0);
+   lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(card, 16, 0);
+   lv_obj_set_style_border_width(card, 1, 0);
+   lv_obj_set_style_border_color(card, lv_color_hex(0x1E2030), 0);
+   lv_obj_set_style_border_opa(card, LV_OPA_COVER, 0);
+   lv_obj_set_style_pad_all(card, 14, 0);
+   lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+   return card;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  List row
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_list_row(lv_obj_t *parent, int y, const char *label, const char *secondary, ui_tone_t tone) {
+   int parent_w = lv_obj_get_width(parent);
+   if (parent_w <= 0) parent_w = 680;
+   lv_obj_t *row = lv_obj_create(parent);
+   if (!row) return NULL;
+   lv_obj_remove_style_all(row);
+   lv_obj_set_size(row, parent_w, UI_LIST_ROW_H);
+   lv_obj_set_pos(row, 0, y);
+   lv_obj_set_style_bg_color(row, lv_color_hex(TH_CARD), 0);
+   lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(row, 14, 0);
+   lv_obj_set_style_pad_all(row, 14, 0);
+   lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+
+   /* Accent bar on the left edge for selected / focused rows. */
+   if (tone == UI_TONE_ACCENT) {
+      lv_obj_t *bar = lv_obj_create(row);
+      lv_obj_remove_style_all(bar);
+      lv_obj_set_size(bar, 3, UI_LIST_ROW_H - 8);
+      lv_obj_align(bar, LV_ALIGN_LEFT_MID, -10, 0);
+      lv_obj_set_style_bg_color(bar, lv_color_hex(TH_AMBER), 0);
+      lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
+      lv_obj_set_style_radius(bar, 2, 0);
+   }
+
+   if (label && label[0]) {
+      lv_obj_t *lbl = lv_label_create(row);
+      lv_label_set_text(lbl, label);
+      lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
+      lv_obj_set_style_text_color(lbl, lv_color_hex(TH_TEXT_PRIMARY), 0);
+      lv_obj_align(lbl, LV_ALIGN_LEFT_MID, 0, 0);
+   }
+
+   if (secondary && secondary[0]) {
+      lv_obj_t *sec = lv_label_create(row);
+      lv_label_set_text(sec, secondary);
+      lv_obj_set_style_text_font(sec, FONT_SECONDARY, 0);
+      lv_obj_set_style_text_color(sec, lv_color_hex(TH_TEXT_DIM), 0);
+      lv_obj_align(sec, LV_ALIGN_RIGHT_MID, 0, 0);
+   }
+
+   return row;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Filter pills — selected-index state lives on the container via
+ *  user_data; each pill's tap handler updates it and repaints siblings.
+ * ───────────────────────────────────────────────────────────────── */
+
+typedef struct {
+   int n;
+   int selected;
+   ui_filter_cb_t cb;
+} filter_state_t;
+
+static void filter_pill_cb(lv_event_t *e) {
+   lv_obj_t *pill = lv_event_get_target(e);
+   lv_obj_t *container = lv_obj_get_parent(pill);
+   filter_state_t *state = (filter_state_t *)lv_obj_get_user_data(container);
+   if (!state) return;
+   /* Index = position of pill among siblings. */
+   int idx = -1;
+   int n = lv_obj_get_child_count(container);
+   for (int i = 0; i < n; i++) {
+      if (lv_obj_get_child(container, i) == pill) {
+         idx = i;
+         break;
+      }
+   }
+   if (idx < 0 || idx == state->selected) return;
+   /* Repaint old + new pills. */
+   for (int i = 0; i < n; i++) {
+      lv_obj_t *p = lv_obj_get_child(container, i);
+      bool sel = (i == idx);
+      lv_obj_set_style_bg_color(p, lv_color_hex(sel ? TH_AMBER : TH_CARD), 0);
+      lv_obj_set_style_bg_opa(p, sel ? LV_OPA_COVER : LV_OPA_COVER, 0);
+      lv_obj_set_style_border_color(p, lv_color_hex(sel ? TH_AMBER : 0x1E2030), 0);
+      /* Set text color on the first child label. */
+      if (lv_obj_get_child_count(p) > 0) {
+         lv_obj_t *lbl = lv_obj_get_child(p, 0);
+         lv_obj_set_style_text_color(lbl, lv_color_hex(sel ? 0x111119 : TH_TEXT_BODY), 0);
+      }
+   }
+   state->selected = idx;
+   if (state->cb) state->cb(idx);
+}
+
+lv_obj_t *ui_filter_pills(lv_obj_t *parent, int y, int w, const char *const *labels, int n_labels, int selected,
+                          ui_filter_cb_t cb) {
+   if (n_labels <= 0) return NULL;
+   lv_obj_t *container = lv_obj_create(parent);
+   if (!container) return NULL;
+   lv_obj_remove_style_all(container);
+   lv_obj_set_size(container, w, UI_PILL_H + 8);
+   lv_obj_set_pos(container, 0, y);
+   lv_obj_set_style_bg_opa(container, LV_OPA_TRANSP, 0);
+   lv_obj_set_style_pad_all(container, 0, 0);
+   lv_obj_clear_flag(container, LV_OBJ_FLAG_SCROLLABLE);
+
+   /* Persist state on the container via user_data.  static_alloc so
+    * we don't malloc per pill row — each filter row owns one. */
+   static filter_state_t s_states[4]; /* up to 4 filter rows in app */
+   static int s_states_n = 0;
+   filter_state_t *st = NULL;
+   if (s_states_n < (int)(sizeof(s_states) / sizeof(s_states[0]))) {
+      st = &s_states[s_states_n++];
+      st->n = n_labels;
+      st->selected = selected;
+      st->cb = cb;
+      lv_obj_set_user_data(container, st);
+   }
+
+   int gap = 8;
+   int total_gap = gap * (n_labels - 1);
+   int pill_w = (w - total_gap) / n_labels;
+   for (int i = 0; i < n_labels; i++) {
+      lv_obj_t *p = lv_obj_create(container);
+      lv_obj_remove_style_all(p);
+      lv_obj_set_size(p, pill_w, UI_PILL_H);
+      lv_obj_set_pos(p, i * (pill_w + gap), 4);
+      bool sel = (i == selected);
+      lv_obj_set_style_bg_color(p, lv_color_hex(sel ? TH_AMBER : TH_CARD), 0);
+      lv_obj_set_style_bg_opa(p, LV_OPA_COVER, 0);
+      lv_obj_set_style_radius(p, UI_PILL_H / 2, 0);
+      lv_obj_set_style_border_width(p, 1, 0);
+      lv_obj_set_style_border_color(p, lv_color_hex(sel ? TH_AMBER : 0x1E2030), 0);
+      lv_obj_add_flag(p, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_clear_flag(p, LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_add_event_cb(p, filter_pill_cb, LV_EVENT_CLICKED, NULL);
+      ui_fb_button(p);
+      lv_obj_t *lbl = lv_label_create(p);
+      lv_label_set_text(lbl, labels[i]);
+      lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
+      lv_obj_set_style_text_color(lbl, lv_color_hex(sel ? 0x111119 : TH_TEXT_BODY), 0);
+      lv_obj_center(lbl);
+   }
+   return container;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Action button
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_action_btn(lv_obj_t *parent, const char *icon, const char *label, ui_tone_t tone, ui_topbar_cb_t cb,
+                        void *user_data) {
+   lv_obj_t *btn = lv_obj_create(parent);
+   if (!btn) return NULL;
+   lv_obj_remove_style_all(btn);
+   int w = (icon && label) ? 140 : 56;
+   lv_obj_set_size(btn, w, UI_ACTION_BTN_H);
+   uint32_t accent = tone_to_accent(tone);
+   lv_obj_set_style_bg_color(btn, lv_color_hex(TH_CARD), 0);
+   lv_obj_set_style_bg_opa(btn, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(btn, UI_ACTION_BTN_H / 2, 0);
+   lv_obj_set_style_border_width(btn, 1, 0);
+   lv_obj_set_style_border_color(btn, lv_color_hex(accent), 0);
+   lv_obj_set_style_border_opa(btn, LV_OPA_COVER, 0);
+   lv_obj_add_flag(btn, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_clear_flag(btn, LV_OBJ_FLAG_SCROLLABLE);
+   if (cb) lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, user_data);
+   ui_fb_button(btn);
+
+   /* Compose label string: "icon  label" when both supplied. */
+   char text[64];
+   if (icon && label)
+      snprintf(text, sizeof(text), "%s  %s", icon, label);
+   else if (icon)
+      snprintf(text, sizeof(text), "%s", icon);
+   else if (label)
+      snprintf(text, sizeof(text), "%s", label);
+   else
+      text[0] = '\0';
+   lv_obj_t *lbl = lv_label_create(btn);
+   lv_label_set_text(lbl, text);
+   lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
+   lv_obj_set_style_text_color(lbl, lv_color_hex(accent), 0);
+   lv_obj_center(lbl);
+   return btn;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Chip
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_chip(lv_obj_t *parent, int x, int y, const char *label, ui_tone_t tone) {
+   if (!label) label = "";
+   uint32_t accent = tone_to_accent(tone);
+   /* Estimate chip width from label length (FONT_SECONDARY is ~10 px/char). */
+   int label_len = strlen(label);
+   int chip_w = label_len * 10 + 24;
+   if (chip_w < 60) chip_w = 60;
+
+   lv_obj_t *chip = lv_obj_create(parent);
+   if (!chip) return NULL;
+   lv_obj_remove_style_all(chip);
+   lv_obj_set_size(chip, chip_w, UI_CHIP_H);
+   lv_obj_set_pos(chip, x, y);
+   lv_obj_set_style_bg_color(chip, lv_color_hex(TH_CARD), 0);
+   lv_obj_set_style_bg_opa(chip, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(chip, UI_CHIP_H / 2, 0);
+   lv_obj_set_style_border_width(chip, 1, 0);
+   lv_obj_set_style_border_color(chip, lv_color_hex(accent), 0);
+   lv_obj_set_style_border_opa(chip, LV_OPA_COVER, 0);
+   lv_obj_clear_flag(chip, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_clear_flag(chip, LV_OBJ_FLAG_CLICKABLE);
+
+   lv_obj_t *lbl = lv_label_create(chip);
+   lv_label_set_text(lbl, label);
+   lv_obj_set_style_text_font(lbl, FONT_SECONDARY, 0);
+   lv_obj_set_style_text_color(lbl, lv_color_hex(accent), 0);
+   lv_obj_set_style_text_letter_space(lbl, 2, 0);
+   lv_obj_center(lbl);
+   return chip;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Empty state
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_empty_state(lv_obj_t *parent, const char *icon_text, const char *title, const char *hint) {
+   lv_obj_t *box = lv_obj_create(parent);
+   if (!box) return NULL;
+   lv_obj_remove_style_all(box);
+   lv_obj_set_size(box, lv_obj_get_width(parent), 240);
+   lv_obj_center(box);
+   lv_obj_set_style_bg_opa(box, LV_OPA_TRANSP, 0);
+   lv_obj_clear_flag(box, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_clear_flag(box, LV_OBJ_FLAG_CLICKABLE);
+
+   int y = 0;
+   if (icon_text && icon_text[0]) {
+      lv_obj_t *icon = lv_label_create(box);
+      lv_label_set_text(icon, icon_text);
+      lv_obj_set_style_text_font(icon, FONT_TITLE, 0);
+      lv_obj_set_style_text_color(icon, lv_color_hex(TH_TEXT_DIM), 0);
+      lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, y);
+      y += 56;
+   }
+   if (title && title[0]) {
+      lv_obj_t *lbl = lv_label_create(box);
+      lv_label_set_text(lbl, title);
+      lv_obj_set_style_text_font(lbl, FONT_HEADING, 0);
+      lv_obj_set_style_text_color(lbl, lv_color_hex(TH_TEXT_BODY), 0);
+      lv_obj_align(lbl, LV_ALIGN_TOP_MID, 0, y);
+      y += 36;
+   }
+   if (hint && hint[0]) {
+      lv_obj_t *lbl = lv_label_create(box);
+      lv_label_set_text(lbl, hint);
+      lv_obj_set_style_text_font(lbl, FONT_SECONDARY, 0);
+      lv_obj_set_style_text_color(lbl, lv_color_hex(TH_TEXT_DIM), 0);
+      lv_label_set_long_mode(lbl, LV_LABEL_LONG_WRAP);
+      lv_obj_set_width(lbl, lv_obj_get_width(parent) - 80);
+      lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, 0);
+      lv_obj_align(lbl, LV_ALIGN_TOP_MID, 0, y);
+   }
+   return box;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Time formatter
+ * ───────────────────────────────────────────────────────────────── */
+
+void ui_fmt_time(char *buf, size_t cap, int64_t ts, ui_time_style_t style) {
+   if (!buf || cap < 8) return;
+   time_t now = time(NULL);
+   time_t when = (time_t)ts;
+   struct tm tm_now = {0}, tm_when = {0};
+   localtime_r(&now, &tm_now);
+   localtime_r(&when, &tm_when);
+
+   if (style == UI_TIME_SHORT) {
+      snprintf(buf, cap, "%02d:%02d", tm_when.tm_hour, tm_when.tm_min);
+      return;
+   }
+   if (style == UI_TIME_ABSOLUTE) {
+      static const char *mons[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+      int m = tm_when.tm_mon;
+      if (m < 0 || m > 11) m = 0;
+      snprintf(buf, cap, "%s %d %02d:%02d", mons[m], tm_when.tm_mday, tm_when.tm_hour, tm_when.tm_min);
+      return;
+   }
+
+   /* RELATIVE: today / yesterday / day-of-week (≤7 days) / absolute. */
+   long diff_days = ((long)now - (long)when) / 86400;
+   if (now <= 0 || when <= 0 || diff_days < 0) {
+      /* Clock not set or future ts — fall back to absolute. */
+      ui_fmt_time(buf, cap, ts, UI_TIME_ABSOLUTE);
+      return;
+   }
+   if (tm_now.tm_year == tm_when.tm_year && tm_now.tm_yday == tm_when.tm_yday) {
+      snprintf(buf, cap, "Today %02d:%02d", tm_when.tm_hour, tm_when.tm_min);
+   } else if (diff_days == 1) {
+      snprintf(buf, cap, "Yest %02d:%02d", tm_when.tm_hour, tm_when.tm_min);
+   } else if (diff_days < 7) {
+      static const char *dows[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+      int d = tm_when.tm_wday;
+      if (d < 0 || d > 6) d = 0;
+      snprintf(buf, cap, "%s %02d:%02d", dows[d], tm_when.tm_hour, tm_when.tm_min);
+   } else {
+      ui_fmt_time(buf, cap, ts, UI_TIME_ABSOLUTE);
+   }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Byte / count formatters
+ * ───────────────────────────────────────────────────────────────── */
+
+void ui_fmt_bytes(char *buf, size_t cap, uint64_t n) {
+   if (!buf || cap < 8) return;
+   if (n < 1024) {
+      snprintf(buf, cap, "%llu B", (unsigned long long)n);
+   } else if (n < 1024 * 1024) {
+      snprintf(buf, cap, "%.1f KB", (double)n / 1024.0);
+   } else if (n < 1024ULL * 1024 * 1024) {
+      snprintf(buf, cap, "%.1f MB", (double)n / (1024.0 * 1024.0));
+   } else {
+      snprintf(buf, cap, "%.1f GB", (double)n / (1024.0 * 1024.0 * 1024.0));
+   }
+}
+
+void ui_fmt_count(char *buf, size_t cap, uint64_t n) {
+   if (!buf || cap < 8) return;
+   if (n < 1000) {
+      snprintf(buf, cap, "%llu", (unsigned long long)n);
+   } else if (n < 1000 * 1000) {
+      snprintf(buf, cap, "%.1fK", (double)n / 1000.0);
+   } else {
+      snprintf(buf, cap, "%.1fM", (double)n / 1000000.0);
+   }
+}

--- a/main/ui_components.h
+++ b/main/ui_components.h
@@ -1,0 +1,129 @@
+/**
+ * @file ui_components.h
+ * @brief Shared UI atom library — the design-system foundation.
+ *
+ * Polish Wave P1 (TT #648): every screen now uses the same vocabulary
+ * for top-bars, cards, list rows, filter pills, action buttons, chips,
+ * empty states, and value formatting.  Atoms are intentionally small
+ * + composable so consumers don't fight the helper's opinions.
+ *
+ * All atoms read from `ui_theme.h` tokens — never hard-code colors,
+ * radii, or padding in callers.  When a token needs to change app-wide,
+ * the theme file is the single source of truth.
+ *
+ * Memory: all atoms allocate LVGL widgets only (children of the parent
+ * passed in), so caller owns lifecycle via `lv_obj_delete(parent)` /
+ * `lv_obj_clean(parent)`.  No persistent allocations; safe to call
+ * repeatedly during screen rebuild.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lvgl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Tone tokens (passed to atoms that vary by semantic role) ────── */
+typedef enum {
+   UI_TONE_NEUTRAL = 0, /**< default — card / chip with no semantic */
+   UI_TONE_ACCENT,      /**< amber — primary action / selected state */
+   UI_TONE_SUCCESS,     /**< green — positive state */
+   UI_TONE_DANGER,      /**< red — destructive / error */
+   UI_TONE_INFO,        /**< blue — informational / link */
+   UI_TONE_DIM,         /**< gray — passive / disabled */
+} ui_tone_t;
+
+/* ── Top-bar ────────────────────────────────────────────────────────
+ *
+ * 48 px header at the top of every full-screen UI: back arrow (when
+ * back_cb != NULL), centered title, optional right-chip (status pill
+ * or action).  Matches the Settings + Files + Chat header rhythm.
+ *
+ * Returns the topbar container so callers can stash a pointer for
+ * later updates.  Children of the topbar use box-relative positioning. */
+typedef void (*ui_topbar_cb_t)(lv_event_t *e);
+lv_obj_t *ui_topbar(lv_obj_t *parent, const char *title, ui_topbar_cb_t back_cb, lv_obj_t **out_right_slot);
+
+/* ── Card ───────────────────────────────────────────────────────────
+ *
+ * Rounded `TH_CARD` background with 1 px `TH_CARD_BORDER` outline.
+ * Drop-in replacement for the previous `mk_card_bg` retroactive
+ * helper — `ui_card` is for new layouts that compose children inside
+ * the card directly.
+ *
+ * Caller positions the card via lv_obj_set_pos / lv_obj_set_size on
+ * the returned handle; children parent to the returned object. */
+lv_obj_t *ui_card(lv_obj_t *parent, int x, int y, int w, int h);
+
+/* ── List row ───────────────────────────────────────────────────────
+ *
+ * 64 px row with FONT_BODY label on the left and an optional
+ * right-aligned secondary text (size, count, status).  When tone is
+ * UI_TONE_ACCENT a 3 px amber bar is drawn on the row's left edge
+ * (for selected-state highlighting). */
+lv_obj_t *ui_list_row(lv_obj_t *parent, int y, const char *label, const char *secondary, ui_tone_t tone);
+
+/* ── Filter pills ───────────────────────────────────────────────────
+ *
+ * Horizontal flex row of pill buttons.  Selected pill renders with
+ * TH_AMBER fill, others with TH_CARD.  The selected index updates
+ * automatically when a pill is tapped, and cb is invoked with the
+ * newly-selected index.  Used by Notes / Sessions filter rows. */
+typedef void (*ui_filter_cb_t)(int new_index);
+lv_obj_t *ui_filter_pills(lv_obj_t *parent, int y, int w, const char *const *labels, int n_labels, int selected,
+                          ui_filter_cb_t cb);
+
+/* ── Action button ──────────────────────────────────────────────────
+ *
+ * Pill button with optional icon + label.  Tone selects border + label
+ * color (UI_TONE_DANGER = red, UI_TONE_ACCENT = amber, etc).  Built-in
+ * pressed-state feedback via `ui_fb_button`.  Icon string can be any
+ * LV_SYMBOL_* or NULL. */
+lv_obj_t *ui_action_btn(lv_obj_t *parent, const char *icon, const char *label, ui_tone_t tone, ui_topbar_cb_t cb,
+                        void *user_data);
+
+/* ── Chip ──────────────────────────────────────────────────────────
+ *
+ * Passive status chip: rounded pill with single-line label.  No tap
+ * affordance.  Used for status badges (LOCAL / CLAW / OFFLINE), mode
+ * indicators, and label tags. */
+lv_obj_t *ui_chip(lv_obj_t *parent, int x, int y, const char *label, ui_tone_t tone);
+
+/* ── Empty state ───────────────────────────────────────────────────
+ *
+ * Centered icon + dim title + secondary hint.  Used inside empty
+ * lists (Notes, Files, Sessions) when there's nothing to render.
+ * Caller is responsible for sizing the parent to give the helper room. */
+lv_obj_t *ui_empty_state(lv_obj_t *parent, const char *icon_text, const char *title, const char *hint);
+
+/* ── Time formatter ────────────────────────────────────────────────
+ *
+ * Unified date/time formatting across the app.  STYLE picks the
+ * display granularity:
+ *   UI_TIME_RELATIVE — "Today 22:33", "Yesterday 17:42", "Mon 09:15",
+ *                       "May 17 16:07" for >7 days
+ *   UI_TIME_ABSOLUTE — always "MMM DD HH:MM" (e.g. "May 17 16:07")
+ *   UI_TIME_SHORT    — just "HH:MM"
+ *
+ * @p ts is a Unix timestamp (seconds).  Buffer must be ≥24 bytes. */
+typedef enum {
+   UI_TIME_RELATIVE = 0,
+   UI_TIME_ABSOLUTE,
+   UI_TIME_SHORT,
+} ui_time_style_t;
+void ui_fmt_time(char *buf, size_t cap, int64_t ts, ui_time_style_t style);
+
+/* ── Byte/count formatters ─────────────────────────────────────────
+ *
+ * Consistent K / M / G suffix for sizes and counts.  Buffer ≥16 bytes. */
+void ui_fmt_bytes(char *buf, size_t cap, uint64_t n);
+void ui_fmt_count(char *buf, size_t cap, uint64_t n);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -32,10 +32,12 @@
 #include "nvs_flash.h"
 #include "settings.h"
 #include "tab5_rtc.h"
+#include "ui_components.h" /* Polish P1 (TT #648) — design-system atoms */
 #include "ui_core.h"
 #include "ui_home.h"
 #include "ui_keyboard.h"
-#include "ui_nav.h" /* TT #623 — tab5_nav_to */
+#include "ui_nav.h"   /* TT #623 — tab5_nav_to */
+#include "ui_theme.h" /* Polish P1: TH_* tokens replace local COL_* */
 #include "ui_voice.h"
 #include "voice.h"
 #include "voice_dictation.h"
@@ -2653,14 +2655,16 @@ static void add_note_card_sectioned(lv_obj_t *parent, const note_entry_t *note, 
     * the preview so the chip isn't clipped. */
    bool has_chip = (note->pending.kind != PENDING_NONE && note->pending.confidence >= PENDING_CONFIDENCE_FLOOR);
    lv_obj_set_style_max_height(card, has_chip ? 230 : 160, 0);
-   /* v5: flat row, hairline rule underneath — no rounded bubble. */
-   lv_obj_set_style_bg_color(card, lv_color_hex(0x08080E), 0); /* TH_BG */
+   /* Polish P1 (TT #648): airy rounded cards — matches Settings rhythm.
+    * Was: flat row + bottom hairline on TH_BG, blending into the screen.
+    * Now: TH_CARD bg + 14 px radius + 1 px subtle border for depth. */
+   lv_obj_set_style_bg_color(card, lv_color_hex(TH_CARD), 0);
    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
-   lv_obj_set_style_radius(card, 0, 0);
+   lv_obj_set_style_radius(card, 14, 0);
    lv_obj_set_style_border_width(card, 1, 0);
-   lv_obj_set_style_border_color(card, lv_color_hex(0x1C1C28), 0); /* TH_HAIRLINE */
-   lv_obj_set_style_border_side(card, LV_BORDER_SIDE_BOTTOM, 0);
-   lv_obj_set_style_pad_all(card, 12, 0);
+   lv_obj_set_style_border_color(card, lv_color_hex(0x1E2030), 0);
+   lv_obj_set_style_border_side(card, LV_BORDER_SIDE_FULL, 0);
+   lv_obj_set_style_pad_all(card, 14, 0);
    lv_obj_set_style_pad_row(card, 6, 0);
    lv_obj_set_flex_flow(card, LV_FLEX_FLOW_COLUMN); /* Stack header + preview vertically */
    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);


### PR DESCRIPTION
Kicks off the UI/UX polish program.  Builds the shared atom library every screen will adopt, then re-fits Notes to close the visual jolt against Settings.

## What lands
- **New** \`main/ui_components.{c,h}\` — eight atoms (\`ui_topbar\`, \`ui_card\`, \`ui_list_row\`, \`ui_filter_pills\`, \`ui_action_btn\`, \`ui_chip\`, \`ui_empty_state\`) + two formatters (\`ui_fmt_time\`, \`ui_fmt_bytes\`/\`ui_fmt_count\`).  All read from \`ui_theme.h\` tokens.  Pure widget factories — no persistent state, no malloc, no PSRAM allocs.
- **Notes refit** — card BG switched from \`TH_BG\` (invisible) to \`TH_CARD\` (0x111119) with 14 px radius + 1 px subtle border; each note now reads as a grouped card matching the Settings rhythm.  \`ui_theme.h\` + \`ui_components.h\` includes wired in for the P2-5 atom migrations.

## Live verification on Tab5 192.168.1.90

**Before** (flat hairline rows blending with screen background) → **After** (rounded cards, clear groupings).  Filter pills above + "Yesterday"/"This week" section headers all read cleanly.

**Heap behaviour:**
\`\`\`
Boot (clean):          internal 75 / 72 KB largest free, PSRAM 13.8 MB free
Notes rendered (full): internal 55 / 54 KB largest free, PSRAM 13.8 MB free
\`\`\`
~20 KB internal for ~10 visible card containers — in line with the previous flat-row count.  Well above the 20 KB \`heap_wd\` EXHAUST floor (the regression boundary fixed in #634).  PSRAM unchanged.

## What stays for P2-5
- Notes timestamp migration to \`ui_fmt_time\` — needs note schema refactor (today stores discrete h/m/mo/d, not unix ts).
- Filter-pills migration to \`ui_filter_pills\` — visually fine today, swap-over in P2 alongside Files/Sessions.
- Action-button migration to \`ui_action_btn\` — play/delete/retry buttons.  P2.
- \`ui_empty_state\` adoption — never triggers in normal Notes use; P4 sweep covers all lists.

Closes #648