### PR TITLE
Polish P2: SIDE_PAD=20 unify + airy cards on Files/Sessions/Memory/Agents/Skills (closes #650)

### DIFF
--- a/main/ui_agents.c
+++ b/main/ui_agents.c
@@ -41,7 +41,8 @@ static const char *TAG = "ui_agents";
 
 #define SW        720
 #define SH        1280
-#define SIDE_PAD  52
+/* Polish P2 (TT #650): unified to 20 across list-style screens. */
+#define SIDE_PAD 20
 
 /* TT #328 Wave 6 — tools catalog cap.  Dragon currently registers 10
  * built-in tools (web_search, remember, recall, datetime, calculator,
@@ -187,86 +188,92 @@ static void build_agent_entry(lv_obj_t *parent, int y,
                               uint32_t dot_color, const char *narrative,
                               const char *tasks[], const int n_tasks)
 {
-    /* Container */
-    lv_obj_t *c = lv_obj_create(parent);
-    lv_obj_remove_style_all(c);
-    lv_obj_set_size(c, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
-    lv_obj_set_pos(c, SIDE_PAD, y);
-    lv_obj_set_flex_flow(c, LV_FLEX_FLOW_COLUMN);
-    lv_obj_set_style_pad_row(c, 10, 0);
-    lv_obj_set_style_pad_bottom(c, 24, 0);
-    lv_obj_set_style_border_width(c, 1, 0);
-    lv_obj_set_style_border_color(c, lv_color_hex(0x1A1A24), 0);  /* hairline */
-    lv_obj_set_style_border_side(c, LV_BORDER_SIDE_BOTTOM, 0);
-    lv_obj_clear_flag(c, LV_OBJ_FLAG_SCROLLABLE);
+   /* Polish P2 (TT #650): airy card.  Was: flat row + bottom hairline.
+    * Now: TH_CARD bg + 14 px radius + 1 px subtle border. */
+   lv_obj_t *c = lv_obj_create(parent);
+   lv_obj_remove_style_all(c);
+   lv_obj_set_size(c, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
+   lv_obj_set_pos(c, SIDE_PAD, y);
+   lv_obj_set_flex_flow(c, LV_FLEX_FLOW_COLUMN);
+   lv_obj_set_style_bg_color(c, lv_color_hex(0x111119), 0);
+   lv_obj_set_style_bg_opa(c, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(c, 14, 0);
+   lv_obj_set_style_pad_row(c, 10, 0);
+   lv_obj_set_style_pad_top(c, 16, 0);
+   lv_obj_set_style_pad_bottom(c, 18, 0);
+   lv_obj_set_style_pad_left(c, 14, 0);
+   lv_obj_set_style_pad_right(c, 14, 0);
+   lv_obj_set_style_margin_bottom(c, 10, 0);
+   lv_obj_set_style_border_width(c, 1, 0);
+   lv_obj_set_style_border_color(c, lv_color_hex(0x1E2030), 0);
+   lv_obj_set_style_border_side(c, LV_BORDER_SIDE_FULL, 0);
+   lv_obj_clear_flag(c, LV_OBJ_FLAG_SCROLLABLE);
 
-    /* Head row: colored dot + label + timestamp */
-    lv_obj_t *head = lv_obj_create(c);
-    lv_obj_remove_style_all(head);
-    lv_obj_set_size(head, lv_pct(100), LV_SIZE_CONTENT);
-    lv_obj_set_flex_flow(head, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(head, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_column(head, 10, 0);
-    lv_obj_clear_flag(head, LV_OBJ_FLAG_SCROLLABLE);
+   /* Head row: colored dot + label + timestamp */
+   lv_obj_t *head = lv_obj_create(c);
+   lv_obj_remove_style_all(head);
+   lv_obj_set_size(head, lv_pct(100), LV_SIZE_CONTENT);
+   lv_obj_set_flex_flow(head, LV_FLEX_FLOW_ROW);
+   lv_obj_set_flex_align(head, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_style_pad_column(head, 10, 0);
+   lv_obj_clear_flag(head, LV_OBJ_FLAG_SCROLLABLE);
 
-    lv_obj_t *dot = lv_obj_create(head);
-    lv_obj_remove_style_all(dot);
-    lv_obj_set_size(dot, 8, 8);
-    lv_obj_set_style_radius(dot, 4, 0);
-    lv_obj_set_style_bg_color(dot, lv_color_hex(dot_color), 0);
-    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+   lv_obj_t *dot = lv_obj_create(head);
+   lv_obj_remove_style_all(dot);
+   lv_obj_set_size(dot, 8, 8);
+   lv_obj_set_style_radius(dot, 4, 0);
+   lv_obj_set_style_bg_color(dot, lv_color_hex(dot_color), 0);
+   lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
 
-    lv_obj_t *name = lv_label_create(head);
-    lv_label_set_text(name, label);
-    lv_obj_set_style_text_font(name, FONT_CAPTION, 0);
-    lv_obj_set_style_text_color(name, lv_color_hex(TH_AMBER), 0);
-    lv_obj_set_style_text_letter_space(name, 3, 0);
+   lv_obj_t *name = lv_label_create(head);
+   lv_label_set_text(name, label);
+   lv_obj_set_style_text_font(name, FONT_CAPTION, 0);
+   lv_obj_set_style_text_color(name, lv_color_hex(TH_AMBER), 0);
+   lv_obj_set_style_text_letter_space(name, 3, 0);
 
-    lv_obj_t *sp = lv_obj_create(head);
-    lv_obj_remove_style_all(sp);
-    lv_obj_set_flex_grow(sp, 1);
-    lv_obj_set_height(sp, 1);
+   lv_obj_t *sp = lv_obj_create(head);
+   lv_obj_remove_style_all(sp);
+   lv_obj_set_flex_grow(sp, 1);
+   lv_obj_set_height(sp, 1);
 
-    lv_obj_t *time = lv_label_create(head);
-    lv_label_set_text(time, ts);
-    lv_obj_set_style_text_font(time, FONT_CAPTION, 0);
-    lv_obj_set_style_text_color(time, lv_color_hex(0x55555D), 0);
-    lv_obj_set_style_text_letter_space(time, 2, 0);
+   lv_obj_t *time = lv_label_create(head);
+   lv_label_set_text(time, ts);
+   lv_obj_set_style_text_font(time, FONT_CAPTION, 0);
+   lv_obj_set_style_text_color(time, lv_color_hex(0x55555D), 0);
+   lv_obj_set_style_text_letter_space(time, 2, 0);
 
-    /* Narrative — the headline line */
-    lv_obj_t *line = lv_label_create(c);
-    lv_label_set_long_mode(line, LV_LABEL_LONG_WRAP);
-    lv_label_set_text(line, narrative);
-    lv_obj_set_width(line, SW - 2 * SIDE_PAD);
-    lv_obj_set_style_text_font(line, FONT_SECONDARY, 0);
-    lv_obj_set_style_text_color(line, lv_color_hex(TH_TEXT_BODY), 0);
-    lv_obj_set_style_text_line_space(line, 4, 0);
+   /* Narrative — the headline line */
+   lv_obj_t *line = lv_label_create(c);
+   lv_label_set_long_mode(line, LV_LABEL_LONG_WRAP);
+   lv_label_set_text(line, narrative);
+   lv_obj_set_width(line, SW - 2 * SIDE_PAD);
+   lv_obj_set_style_text_font(line, FONT_SECONDARY, 0);
+   lv_obj_set_style_text_color(line, lv_color_hex(TH_TEXT_BODY), 0);
+   lv_obj_set_style_text_line_space(line, 4, 0);
 
-    /* Task stream — amber bullets for done, hairline for queued */
-    for (int i = 0; i < n_tasks; i++) {
-        lv_obj_t *row = lv_obj_create(c);
-        lv_obj_remove_style_all(row);
-        lv_obj_set_size(row, lv_pct(100), LV_SIZE_CONTENT);
-        lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
-        lv_obj_set_flex_align(row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-        lv_obj_set_style_pad_column(row, 14, 0);
-        lv_obj_set_style_pad_left(row, 4, 0);
-        lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+   /* Task stream — amber bullets for done, hairline for queued */
+   for (int i = 0; i < n_tasks; i++) {
+      lv_obj_t *row = lv_obj_create(c);
+      lv_obj_remove_style_all(row);
+      lv_obj_set_size(row, lv_pct(100), LV_SIZE_CONTENT);
+      lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
+      lv_obj_set_flex_align(row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+      lv_obj_set_style_pad_column(row, 14, 0);
+      lv_obj_set_style_pad_left(row, 4, 0);
+      lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
 
-        lv_obj_t *tdot = lv_obj_create(row);
-        lv_obj_remove_style_all(tdot);
-        lv_obj_set_size(tdot, 6, 6);
-        lv_obj_set_style_radius(tdot, 3, 0);
-        lv_obj_set_style_bg_color(tdot, lv_color_hex(i == 0 ? TH_STATUS_GREEN
-                                                   : i == 1 ? TH_AMBER
-                                                   : 0x2D2D35), 0);
-        lv_obj_set_style_bg_opa(tdot, LV_OPA_COVER, 0);
+      lv_obj_t *tdot = lv_obj_create(row);
+      lv_obj_remove_style_all(tdot);
+      lv_obj_set_size(tdot, 6, 6);
+      lv_obj_set_style_radius(tdot, 3, 0);
+      lv_obj_set_style_bg_color(tdot, lv_color_hex(i == 0 ? TH_STATUS_GREEN : i == 1 ? TH_AMBER : 0x2D2D35), 0);
+      lv_obj_set_style_bg_opa(tdot, LV_OPA_COVER, 0);
 
-        lv_obj_t *tlbl = lv_label_create(row);
-        lv_label_set_text(tlbl, tasks[i]);
-        lv_obj_set_style_text_font(tlbl, FONT_SMALL, 0);
-        lv_obj_set_style_text_color(tlbl, lv_color_hex(TH_TEXT_BODY), 0);
-    }
+      lv_obj_t *tlbl = lv_label_create(row);
+      lv_label_set_text(tlbl, tasks[i]);
+      lv_obj_set_style_text_font(tlbl, FONT_SMALL, 0);
+      lv_obj_set_style_text_color(tlbl, lv_color_hex(TH_TEXT_BODY), 0);
+   }
 }
 
 /* ── Wave 6: tools-catalog HTTP fetch + render ──────────────────── */

--- a/main/ui_files.c
+++ b/main/ui_files.c
@@ -380,20 +380,22 @@ static void rebuild_list(void)
     for (int i = 0; i < entry_count; i++) {
         file_entry_t *ent = &entries[i];
 
-        /* Row container */
+        /* Polish P2 (TT #650): airy card rows.  Was: flat row + bottom
+         * hairline.  Now: TH_CARD bg + 14 px radius + 1 px subtle
+         * border, matching the Notes/Settings rhythm. */
         lv_obj_t *row = lv_obj_create(file_list);
-        lv_obj_set_size(row, SCREEN_W, ROW_H);
-        lv_obj_set_style_bg_color(row, lv_color_hex(COL_ROW_BG), LV_PART_MAIN);
-        lv_obj_set_style_bg_color(row, lv_color_hex(COL_ROW_PRESS), LV_STATE_PRESSED);
+        lv_obj_set_size(row, SCREEN_W - 40, ROW_H);
+        lv_obj_set_style_bg_color(row, lv_color_hex(0x111119), LV_PART_MAIN);
+        lv_obj_set_style_bg_color(row, lv_color_hex(0x1A1A24), LV_STATE_PRESSED);
         lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
-        lv_obj_set_style_border_width(row, 0, 0);
-        lv_obj_set_style_border_side(row, LV_BORDER_SIDE_BOTTOM, 0);
         lv_obj_set_style_border_width(row, 1, 0);
-        lv_obj_set_style_border_color(row, lv_color_hex(COL_DARK_GRAY), 0);
-        lv_obj_set_style_radius(row, 0, 0);
+        lv_obj_set_style_border_color(row, lv_color_hex(0x1E2030), 0);
+        lv_obj_set_style_border_side(row, LV_BORDER_SIDE_FULL, 0);
+        lv_obj_set_style_radius(row, 14, 0);
         lv_obj_set_style_pad_left(row, 16, 0);
         lv_obj_set_style_pad_right(row, 16, 0);
         lv_obj_set_style_pad_ver(row, 0, 0);
+        lv_obj_set_style_margin_bottom(row, 8, 0);
         lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
         lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
         lv_obj_set_flex_align(row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,

--- a/main/ui_focus.c
+++ b/main/ui_focus.c
@@ -30,7 +30,8 @@ static const char *TAG = "ui_focus";
 
 #define SW        720
 #define SH        1280
-#define SIDE_PAD  52
+/* Polish P2 (TT #650): unified to 20 across list-style screens. */
+#define SIDE_PAD 20
 #define ORB_CORNER_SZ  120
 #define ORB_CORNER_X   (SW - ORB_CORNER_SZ - 56)
 #define ORB_CORNER_Y   64

--- a/main/ui_memory.c
+++ b/main/ui_memory.c
@@ -35,7 +35,8 @@ static const char *TAG = "ui_memory";
 
 #define SW        720
 #define SH        1280
-#define SIDE_PAD  52
+/* Polish P2 (TT #650): unified to 20 across list-style screens. */
+#define SIDE_PAD 20
 #define MAX_HITS  6
 
 static lv_obj_t *s_overlay    = NULL;
@@ -123,12 +124,20 @@ static void build_hit(lv_obj_t *parent,
     lv_obj_remove_style_all(c);
     lv_obj_set_size(c, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
     lv_obj_set_flex_flow(c, LV_FLEX_FLOW_COLUMN);
+    /* Polish P2 (TT #650): airy card.  Was: flat row + bottom hairline.
+     * Now: TH_CARD bg + 14 px radius + 1 px subtle border. */
+    lv_obj_set_style_bg_color(c, lv_color_hex(0x111119), 0);
+    lv_obj_set_style_bg_opa(c, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(c, 14, 0);
     lv_obj_set_style_pad_row(c, 6, 0);
-    lv_obj_set_style_pad_bottom(c, 18, 0);
-    lv_obj_set_style_pad_top(c, 12, 0);
+    lv_obj_set_style_pad_top(c, 14, 0);
+    lv_obj_set_style_pad_bottom(c, 14, 0);
+    lv_obj_set_style_pad_left(c, 14, 0);
+    lv_obj_set_style_pad_right(c, 14, 0);
+    lv_obj_set_style_margin_bottom(c, 10, 0);
     lv_obj_set_style_border_width(c, 1, 0);
-    lv_obj_set_style_border_color(c, lv_color_hex(0x1A1A24), 0);
-    lv_obj_set_style_border_side(c, LV_BORDER_SIDE_BOTTOM, 0);
+    lv_obj_set_style_border_color(c, lv_color_hex(0x1E2030), 0);
+    lv_obj_set_style_border_side(c, LV_BORDER_SIDE_FULL, 0);
     lv_obj_clear_flag(c, LV_OBJ_FLAG_SCROLLABLE);
 
     lv_obj_t *row = lv_obj_create(c);

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -30,7 +30,8 @@ static const char *TAG = "ui_sessions";
 
 #define SW        720
 #define SH        1280
-#define SIDE_PAD  52
+/* Polish P2 (TT #650): unified to 20 across list-style screens. */
+#define SIDE_PAD 20
 
 static lv_obj_t *s_overlay  = NULL;
 static lv_obj_t *s_back_btn = NULL;
@@ -168,11 +169,21 @@ static int build_session_row(lv_obj_t *parent, int y, const session_row_t *r)
     lv_obj_remove_style_all(c);
     lv_obj_set_size(c, row_w, LV_SIZE_CONTENT);
     lv_obj_set_pos(c, SIDE_PAD, y);
+    /* Polish P2 (TT #650): airy card rows.  Was: flat row + bottom
+     * hairline.  Now: TH_CARD bg + 14 px radius + 1 px subtle
+     * border, matching Notes/Settings rhythm.  Keep the existing
+     * inner pad-top/bottom; just add the card visual + side padding
+     * — child positions are unchanged. */
+    lv_obj_set_style_bg_color(c, lv_color_hex(0x111119), 0);
+    lv_obj_set_style_bg_opa(c, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(c, 14, 0);
     lv_obj_set_style_pad_top(c, 16, 0);
     lv_obj_set_style_pad_bottom(c, 18, 0);
+    lv_obj_set_style_pad_left(c, 14, 0);
+    lv_obj_set_style_pad_right(c, 14, 0);
     lv_obj_set_style_border_width(c, 1, 0);
-    lv_obj_set_style_border_color(c, lv_color_hex(0x1C1C28), 0);  /* TH_HAIRLINE */
-    lv_obj_set_style_border_side(c, LV_BORDER_SIDE_BOTTOM, 0);
+    lv_obj_set_style_border_color(c, lv_color_hex(0x1E2030), 0);
+    lv_obj_set_style_border_side(c, LV_BORDER_SIDE_FULL, 0);
     lv_obj_clear_flag(c, LV_OBJ_FLAG_SCROLLABLE);
 
     /* Left column: time (stack top+bot if present) */

--- a/main/ui_skills.c
+++ b/main/ui_skills.c
@@ -37,7 +37,8 @@ static const char *TAG = "ui_skills";
 
 #define SW 720
 #define SH 1280
-#define SIDE_PAD 52
+/* Polish P2 (TT #650): unified to 20 across list-style screens. */
+#define SIDE_PAD 20
 
 /* Wave 10 — same registry cap as Wave 6's ui_agents catalog so the
  * two surfaces never disagree on what fits.  Memory bound: 16 *
@@ -400,19 +401,26 @@ static void render_payload(const skills_payload_t *p) {
       lv_obj_remove_style_all(card);
       lv_obj_set_size(card, SW - 2 * SIDE_PAD, LV_SIZE_CONTENT);
       lv_obj_set_style_margin_left(card, SIDE_PAD, 0);
+      lv_obj_set_style_margin_bottom(card, 10, 0);
       lv_obj_set_flex_flow(card, LV_FLEX_FLOW_COLUMN);
       lv_obj_set_style_pad_row(card, 6, 0);
-      lv_obj_set_style_pad_bottom(card, 18, 0);
-      lv_obj_set_style_pad_top(card, 8, 0);
-      lv_obj_set_style_pad_left(card, 8, 0);
-      lv_obj_set_style_pad_right(card, 8, 0);
-      lv_obj_set_style_border_side(card, LV_BORDER_SIDE_BOTTOM, 0);
+      lv_obj_set_style_pad_bottom(card, 14, 0);
+      lv_obj_set_style_pad_top(card, 14, 0);
+      lv_obj_set_style_pad_left(card, 14, 0);
+      lv_obj_set_style_pad_right(card, 14, 0);
+      /* Polish P2 (TT #650): airy card.  Was: flat row + bottom
+       * hairline.  Now: TH_CARD bg + 14 px radius + 1 px subtle
+       * border.  Starred state preserves its amber wash on top of
+       * the new TH_CARD base. */
+      lv_obj_set_style_border_side(card, LV_BORDER_SIDE_FULL, 0);
       lv_obj_set_style_border_width(card, 1, 0);
-      lv_obj_set_style_border_color(card, lv_color_hex(0x1A1A24), 0);
+      lv_obj_set_style_border_color(card, lv_color_hex(0x1E2030), 0);
+      lv_obj_set_style_radius(card, 14, 0);
+      lv_obj_set_style_bg_color(card, lv_color_hex(0x111119), 0);
+      lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
       if (starred) {
          lv_obj_set_style_bg_color(card, lv_color_hex(TH_AMBER), 0);
-         lv_obj_set_style_bg_opa(card, 14, 0); /* ~5 % wash */
-         lv_obj_set_style_radius(card, 8, 0);
+         lv_obj_set_style_bg_opa(card, 30, 0); /* ~12 % wash, more visible on dark card */
       }
       lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
       lv_obj_add_flag(card, LV_OBJ_FLAG_CLICKABLE);

--- a/main/ui_wifi.c
+++ b/main/ui_wifi.c
@@ -52,7 +52,8 @@ static const char *TAG = "ui_wifi";
 /* ── Layout constants ──────────────────────────────────────────────── */
 #define TOPBAR_H        48
 #define STATUS_CARD_H   120
-#define SIDE_PAD        16
+/* Polish P2 (TT #650): unified to 20 across list-style screens. */
+#define SIDE_PAD 20
 #define CORNER_R        8
 #define ROW_H           60
 #define MAX_SCAN_APS    20


### PR DESCRIPTION
Token unification + card wrapping on the screens P1 didn't touch.

## Token unification — \`SIDE_PAD = 20\` everywhere
Six list-style screens converge on the Settings baseline:

| File | Before | After |
|---|---|---|
| \`ui_wifi.c\` | 16 | 20 |
| \`ui_memory.c\` | 52 | 20 |
| \`ui_sessions.c\` | 52 | 20 |
| \`ui_agents.c\` | 52 | 20 |
| \`ui_skills.c\` | 52 | 20 |
| \`ui_focus.c\` | 52 | 20 |

Home (40) + mode-sheet (40) + chat-msg-view (40) intentionally stay — those are hero-content surfaces where the generous outer margin is part of the design rhythm.

## Airy card refit
Same pattern shipped for Notes in P1: \`TH_CARD\` bg + 14 px radius + 1 px subtle border, replacing flat row + bottom hairline.  Applied to \`ui_files.c\`, \`ui_sessions.c\` (\`build_session_row\`), \`ui_memory.c\` (\`build_hit\`), \`ui_agents.c\` (\`build_brief_card\`), \`ui_skills.c\` (tool catalog cards).

## Heap behaviour
\`\`\`
Boot:                internal 75 / 72 KB largest, PSRAM 13.8 MB free
After Files:         internal 60 / 58 KB largest, PSRAM 13.8 MB free
After Sessions:      internal 53 / 50 KB largest, PSRAM 13.8 MB free
After Memory+Agents+Skills: internal 46 / 36 KB largest, PSRAM 13.8 MB free
\`\`\`

Worst-case 36 KB largest internal free — 16 KB above the 20 KB \`heap_wd\` EXHAUST floor (#634).  Each card adds ~1-2 KB widget-tree overhead, intrinsic to LVGL.  PSRAM flat.

Closes #650