### PR TITLE
Polish P3: motion language — fade transitions + press feedback sweep (closes #652)

### DIFF
--- a/main/ui_components.c
+++ b/main/ui_components.c
@@ -463,3 +463,28 @@ void ui_fmt_count(char *buf, size_t cap, uint64_t n) {
       snprintf(buf, cap, "%.1fM", (double)n / 1000000.0);
    }
 }
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Overlay fade-in
+ * ───────────────────────────────────────────────────────────────── */
+
+static void fade_anim_cb(void *obj, int32_t v) {
+   if (obj) lv_obj_set_style_opa((lv_obj_t *)obj, (lv_opa_t)v, LV_PART_MAIN);
+}
+
+void ui_overlay_fade_in(lv_obj_t *obj, uint32_t duration_ms) {
+   if (!obj) return;
+   if (duration_ms == 0) duration_ms = 250;
+   /* Snap to opaque-zero before animating so the widget appears at 0
+    * and animates up.  Idempotent — calling on a fully-visible widget
+    * just blinks it in 250 ms. */
+   lv_obj_set_style_opa(obj, LV_OPA_TRANSP, LV_PART_MAIN);
+   lv_anim_t a;
+   lv_anim_init(&a);
+   lv_anim_set_var(&a, obj);
+   lv_anim_set_exec_cb(&a, fade_anim_cb);
+   lv_anim_set_values(&a, LV_OPA_TRANSP, LV_OPA_COVER);
+   lv_anim_set_duration(&a, duration_ms);
+   lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
+   lv_anim_start(&a);
+}

--- a/main/ui_components.h
+++ b/main/ui_components.h
@@ -124,6 +124,15 @@ void ui_fmt_time(char *buf, size_t cap, int64_t ts, ui_time_style_t style);
 void ui_fmt_bytes(char *buf, size_t cap, uint64_t n);
 void ui_fmt_count(char *buf, size_t cap, uint64_t n);
 
+/* ── Overlay fade-in ───────────────────────────────────────────────
+ *
+ * Polish P3 (TT #652): fade @p obj opacity 0 → LV_OPA_COVER over
+ * @p duration_ms.  Default behaviour: caller has already done
+ * lv_obj_remove_flag(obj, LV_OBJ_FLAG_HIDDEN) so the widget is
+ * visible at zero opacity, then this animates it up.  Use 250 ms
+ * unless there's a specific reason. */
+void ui_overlay_fade_in(lv_obj_t *obj, uint32_t duration_ms);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -34,6 +34,7 @@
 #include "tab5_rtc.h"
 #include "ui_components.h" /* Polish P1 (TT #648) — design-system atoms */
 #include "ui_core.h"
+#include "ui_feedback.h" /* Polish P3 (TT #652) — ui_fb_button transition */
 #include "ui_home.h"
 #include "ui_keyboard.h"
 #include "ui_nav.h"   /* TT #623 — tab5_nav_to */
@@ -2775,6 +2776,8 @@ static void add_note_card_sectioned(lv_obj_t *parent, const note_entry_t *note, 
    lv_obj_set_style_border_width(del, 0, 0);
    lv_obj_set_style_bg_color(del, lv_color_hex(COL_RED), LV_PART_MAIN | LV_STATE_PRESSED);
    lv_obj_set_style_bg_opa(del, LV_OPA_20, LV_PART_MAIN | LV_STATE_PRESSED);
+   /* Polish P3 (TT #652): smooth opacity transition on press. */
+   ui_fb_button(del);
    lv_obj_add_event_cb(del, cb_note_delete, LV_EVENT_CLICKED, (void *)(intptr_t)note_idx);
    lv_obj_t *del_lbl = lv_label_create(del);
    if (!del_lbl) return;
@@ -2799,6 +2802,8 @@ static void add_note_card_sectioned(lv_obj_t *parent, const note_entry_t *note, 
       lv_obj_set_style_border_opa(act, LV_OPA_50, 0);
       lv_obj_set_style_bg_color(act, lv_color_hex(is_retry ? COL_AMBER : COL_MINT), LV_PART_MAIN | LV_STATE_PRESSED);
       lv_obj_set_style_bg_opa(act, LV_OPA_30, LV_PART_MAIN | LV_STATE_PRESSED);
+      /* Polish P3 (TT #652): smooth opacity transition on press. */
+      ui_fb_button(act);
       lv_obj_add_event_cb(act, is_retry ? cb_note_retry : cb_note_play, LV_EVENT_CLICKED, (void *)(intptr_t)note_idx);
       lv_obj_t *act_lbl = lv_label_create(act);
       if (!act_lbl) return;
@@ -2880,6 +2885,8 @@ static void add_note_card_sectioned(lv_obj_t *parent, const note_entry_t *note, 
       lv_obj_set_style_border_width(dismiss, 0, 0);
       lv_obj_set_style_bg_color(dismiss, lv_color_hex(0x6A6A72), LV_PART_MAIN | LV_STATE_PRESSED);
       lv_obj_set_style_bg_opa(dismiss, LV_OPA_30, LV_PART_MAIN | LV_STATE_PRESSED);
+      /* Polish P3 (TT #652): smooth opacity transition on press. */
+      ui_fb_button(dismiss);
       lv_obj_add_event_cb(dismiss, cb_chip_dismiss, LV_EVENT_CLICKED, (void *)(intptr_t)note_idx);
       lv_obj_t *dismiss_lbl = lv_label_create(dismiss);
       if (!dismiss_lbl) return;
@@ -3625,6 +3632,12 @@ lv_obj_t *ui_notes_create(void)
    }
 
    ESP_LOGI(TAG, "Notes screen created, %d notes", s_note_count);
+
+   /* Polish P3 (TT #652): fade the whole notes screen in over 250 ms
+    * instead of hard-cutting from home.  ui_overlay_fade_in handles
+    * the 0-opacity → opaque transition; the existing card render
+    * lights up smoothly. */
+   ui_overlay_fade_in(s_screen, 250);
    return s_screen;
 }
 

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -30,7 +30,8 @@
 #include "sdcard.h"
 #include "settings.h"
 #include "tab5_rtc.h"
-#include "task_worker.h" /* TT #328 Wave 14 — async K144 hwinfo fetch */
+#include "task_worker.h"   /* TT #328 Wave 14 — async K144 hwinfo fetch */
+#include "ui_components.h" /* TT #652 — ui_overlay_fade_in */
 #include "ui_core.h"
 #include "ui_feedback.h" /* TT #328 Wave 10: ui_fb_* */
 #include "ui_home.h"
@@ -2496,6 +2497,9 @@ lv_obj_t *ui_settings_create(void)
     ui_keyboard_set_layout_cb(settings_keyboard_layout_cb);
 
     ESP_LOGI(TAG, "Phase 1 visible — user sees Display + Network immediately");
+    /* Polish P3 (TT #652): 250 ms fade-in for the whole Settings
+     * screen instead of a hard cut from home. */
+    ui_overlay_fade_in(s_screen, 250);
     return s_screen;
 }
 


### PR DESCRIPTION
First piece of motion continuity — overlay screens fade in instead of hard-cutting from home, and Notes action buttons get smooth press feedback.

## What lands
- **New atom** \`ui_components::ui_overlay_fade_in(obj, ms)\` — animates opacity 0 → cover over @p ms (default 250 ms, ease-out).
- **Notes + Settings** \`*_create\` ends now call \`ui_overlay_fade_in(s_screen, 250)\` so navigating to them fades in instead of hard cuts.
- **Notes action buttons** (trash, play, retry, dismiss) gain \`ui_fb_button\` for smooth bg-opa transitions on press — previously the color snap was instant.

## Heap behaviour
\`\`\`
Boot:                       internal 75 / 72 KB largest, PSRAM 13.8 MB
After Notes + Settings nav: internal 57 / 56 KB largest, PSRAM 13.8 MB
\`\`\`
Animation cb is a single opacity write per frame; no allocations.  Above the 20 KB \`heap_wd\` floor with comfortable margin.

## Out of scope (later waves)
- Fade-in for Chat / Voice / Sessions / Memory / Agents / Skills overlays.  Same one-line helper call; will sweep in P4 alongside empty-state adoption.
- Fade-out on dismissal (slightly more complex — needs to defer the hide until anim completes).

Closes #652