### PR TITLE
Polish P4: state-communication helpers — empty / loading / error (closes #654)

### DIFF
--- a/main/ui_components.c
+++ b/main/ui_components.c
@@ -488,3 +488,107 @@ void ui_overlay_fade_in(lv_obj_t *obj, uint32_t duration_ms) {
    lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
    lv_anim_start(&a);
 }
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Skeleton row — static dim-gray placeholder bars
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_skeleton_row(lv_obj_t *parent, int y, int w, int lines) {
+   if (lines < 1) lines = 1;
+   if (lines > 4) lines = 4;
+   /* Row container.  Card-shaped to match real list rows so the
+    * placeholder reads as "row coming" rather than "broken UI". */
+   const int line_h = 14;
+   const int line_gap = 8;
+   const int pad = 14;
+   const int h = pad * 2 + lines * line_h + (lines - 1) * line_gap;
+   lv_obj_t *box = lv_obj_create(parent);
+   if (!box) return NULL;
+   lv_obj_remove_style_all(box);
+   lv_obj_set_pos(box, 0, y);
+   lv_obj_set_size(box, w, h);
+   lv_obj_set_style_bg_color(box, lv_color_hex(TH_CARD), 0);
+   lv_obj_set_style_bg_opa(box, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(box, 14, 0);
+   lv_obj_set_style_border_width(box, 1, 0);
+   lv_obj_set_style_border_color(box, lv_color_hex(0x1E2030), 0);
+   lv_obj_set_style_pad_all(box, pad, 0);
+   lv_obj_clear_flag(box, LV_OBJ_FLAG_SCROLLABLE);
+   for (int i = 0; i < lines; i++) {
+      lv_obj_t *bar = lv_obj_create(box);
+      lv_obj_remove_style_all(bar);
+      /* First bar full width, rest taper for natural variation. */
+      int bar_w = (i == 0) ? (w - pad * 2) : ((w - pad * 2) * (75 - i * 12) / 100);
+      if (bar_w < 80) bar_w = 80;
+      lv_obj_set_size(bar, bar_w, line_h);
+      lv_obj_set_pos(bar, 0, i * (line_h + line_gap));
+      lv_obj_set_style_bg_color(bar, lv_color_hex(0x222230), 0);
+      lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
+      lv_obj_set_style_radius(bar, 4, 0);
+      lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+   }
+   return box;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Error chip
+ * ───────────────────────────────────────────────────────────────── */
+
+lv_obj_t *ui_error_chip(lv_obj_t *parent, int x, int y, int w, const char *message, ui_topbar_cb_t retry_cb) {
+   if (!message) message = "Error";
+   lv_obj_t *chip = lv_obj_create(parent);
+   if (!chip) return NULL;
+   lv_obj_remove_style_all(chip);
+   const int chip_h = 64;
+   lv_obj_set_pos(chip, x, y);
+   lv_obj_set_size(chip, w, chip_h);
+   lv_obj_set_style_bg_color(chip, lv_color_hex(0x2A1A1A), 0);
+   lv_obj_set_style_bg_opa(chip, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(chip, 14, 0);
+   lv_obj_set_style_border_width(chip, 1, 0);
+   lv_obj_set_style_border_color(chip, lv_color_hex(0xEF4444), 0);
+   lv_obj_set_style_border_opa(chip, LV_OPA_COVER, 0);
+   lv_obj_set_style_pad_left(chip, 16, 0);
+   lv_obj_set_style_pad_right(chip, 12, 0);
+   lv_obj_clear_flag(chip, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_clear_flag(chip, LV_OBJ_FLAG_CLICKABLE);
+
+   /* Danger icon — single warning glyph. */
+   lv_obj_t *icon = lv_label_create(chip);
+   lv_label_set_text(icon, LV_SYMBOL_WARNING);
+   lv_obj_set_style_text_color(icon, lv_color_hex(0xEF4444), 0);
+   lv_obj_set_style_text_font(icon, FONT_HEADING, 0);
+   lv_obj_align(icon, LV_ALIGN_LEFT_MID, 0, 0);
+
+   /* Message label — body weight, primary text color (red would be
+    * shouting on red border; primary reads as info). */
+   lv_obj_t *lbl = lv_label_create(chip);
+   lv_label_set_text(lbl, message);
+   lv_label_set_long_mode(lbl, LV_LABEL_LONG_DOT);
+   lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
+   lv_obj_set_style_text_color(lbl, lv_color_hex(TH_TEXT_PRIMARY), 0);
+   lv_obj_set_width(lbl, w - 48 - (retry_cb ? 100 : 0));
+   lv_obj_align(lbl, LV_ALIGN_LEFT_MID, 36, 0);
+
+   /* Optional inline retry pill — fires retry_cb on tap. */
+   if (retry_cb) {
+      lv_obj_t *retry = lv_obj_create(chip);
+      lv_obj_remove_style_all(retry);
+      lv_obj_set_size(retry, 84, 36);
+      lv_obj_align(retry, LV_ALIGN_RIGHT_MID, 0, 0);
+      lv_obj_set_style_bg_color(retry, lv_color_hex(0xEF4444), 0);
+      lv_obj_set_style_bg_opa(retry, LV_OPA_COVER, 0);
+      lv_obj_set_style_radius(retry, 18, 0);
+      lv_obj_add_flag(retry, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_clear_flag(retry, LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_add_event_cb(retry, retry_cb, LV_EVENT_CLICKED, NULL);
+      ui_fb_button(retry);
+      lv_obj_t *rlbl = lv_label_create(retry);
+      lv_label_set_text(rlbl, "RETRY");
+      lv_obj_set_style_text_font(rlbl, FONT_BODY, 0);
+      lv_obj_set_style_text_color(rlbl, lv_color_hex(0xFFFFFF), 0);
+      lv_obj_center(rlbl);
+   }
+
+   return chip;
+}

--- a/main/ui_components.h
+++ b/main/ui_components.h
@@ -133,6 +133,25 @@ void ui_fmt_count(char *buf, size_t cap, uint64_t n);
  * unless there's a specific reason. */
 void ui_overlay_fade_in(lv_obj_t *obj, uint32_t duration_ms);
 
+/* ── Skeleton row ──────────────────────────────────────────────────
+ *
+ * Polish P4 (TT #654): placeholder rows for async fetches.  Renders
+ * @p lines (1-4) dim gray bars stacked vertically in a card-shaped
+ * container at (0, y) with width @p w.  Static — animated shimmer is
+ * P7.  Returns the container so callers can lv_obj_delete it when
+ * real content arrives. */
+lv_obj_t *ui_skeleton_row(lv_obj_t *parent, int y, int w, int lines);
+
+/* ── Error chip ────────────────────────────────────────────────────
+ *
+ * Polish P4 (TT #654): unified error-state widget.  Rounded card
+ * with danger-toned (red) border, a danger icon, a single-line
+ * message label, and an optional inline RETRY pill that fires
+ * @p retry_cb when tapped.  If retry_cb is NULL, the chip is
+ * passive (read-only error indicator).  Returns the chip handle
+ * so callers can delete it later. */
+lv_obj_t *ui_error_chip(lv_obj_t *parent, int x, int y, int w, const char *message, ui_topbar_cb_t retry_cb);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/ui_files.c
+++ b/main/ui_files.c
@@ -22,6 +22,7 @@
 #include "esp_log.h"
 #include "sdcard.h"
 #include "ui_audio.h"
+#include "ui_components.h" /* P4 (TT #654) — ui_empty_state */
 #include "ui_core.h"
 #include "ui_feedback.h" /* TT #328 Wave 10: ui_fb_* */
 #include "ui_home.h"
@@ -368,12 +369,9 @@ static void rebuild_list(void)
     read_directory();
 
     if (entry_count == 0) {
-        lv_obj_t *lbl_empty = lv_label_create(file_list);
-        lv_label_set_text(lbl_empty, "Empty folder");
-        lv_obj_set_style_text_color(lbl_empty, lv_color_hex(COL_GRAY), 0);
-        lv_obj_set_style_text_font(lbl_empty, &lv_font_montserrat_18, 0);
-        lv_obj_align(lbl_empty, LV_ALIGN_CENTER, 0, 0);
-        return;
+       /* Polish P4 (TT #654): shared empty-state atom. */
+       ui_empty_state(file_list, LV_SYMBOL_DIRECTORY, "Empty folder", "Photos and recordings will land here.");
+       return;
     }
 
     /* Create rows */

--- a/main/ui_notes.c
+++ b/main/ui_notes.c
@@ -3272,27 +3272,12 @@ static void refresh_list(void)
                 break;
           }
        }
-       lv_obj_t *empty = lv_obj_create(s_list);
-       lv_obj_remove_style_all(empty);
-       lv_obj_set_size(empty, SW, 220);
-       lv_obj_set_style_bg_opa(empty, LV_OPA_TRANSP, 0);
-       lv_obj_clear_flag(empty, LV_OBJ_FLAG_SCROLLABLE);
-       lv_obj_set_flex_flow(empty, LV_FLEX_FLOW_COLUMN);
-       lv_obj_set_flex_align(empty, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-       lv_obj_set_style_pad_top(empty, 80, 0);
-       lv_obj_set_style_pad_row(empty, 10, 0);
-
-       lv_obj_t *h = lv_label_create(empty);
-       lv_label_set_text(h, head);
-       lv_obj_set_style_text_color(h, lv_color_hex(0xC8C8D2), 0);
-       lv_obj_set_style_text_font(h, FONT_HEADING, 0);
-       lv_obj_set_style_text_align(h, LV_TEXT_ALIGN_CENTER, 0);
-
-       lv_obj_t *b = lv_label_create(empty);
-       lv_label_set_text(b, body);
-       lv_obj_set_style_text_color(b, lv_color_hex(0x6A6A72), 0);
-       lv_obj_set_style_text_font(b, FONT_BODY, 0);
-       lv_obj_set_style_text_align(b, LV_TEXT_ALIGN_CENTER, 0);
+       /* Polish P4 (TT #654): adopt shared ui_empty_state helper.
+        * Previously open-coded a flex container with two labels;
+        * now reads from the same design-system atom every other
+        * screen uses for empties.  Visual rhythm matches Sessions /
+        * Files / Memory consistently. */
+       ui_empty_state(s_list, LV_SYMBOL_EDIT, head, body);
     }
 }
 

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -21,6 +21,7 @@
 #include "freertos/task.h"
 #include "settings.h"
 #include "task_worker.h"
+#include "ui_components.h" /* P4 (TT #654) — ui_empty_state, ui_error_chip */
 #include "ui_core.h"
 #include "ui_home.h"
 #include "ui_nav.h" /* TT #623 — tab5_nav_to */
@@ -257,20 +258,17 @@ static void render_rows_cb(void *arg)
     /* Wipe previous rows. */
     lv_obj_clean(s_rows_root);
 
-    if (s_status) {
-        if (!s_fetch->ok) {
-            lv_label_set_text(s_status,
-                "Dragon unreachable. Check Settings \xe2\x80\xa2 Network.");
-            lv_obj_set_style_text_color(s_status, lv_color_hex(0xFF6464), 0);
-            lv_obj_remove_flag(s_status, LV_OBJ_FLAG_HIDDEN);
-        } else if (s_fetch->count == 0) {
-            lv_label_set_text(s_status, "No conversations yet.");
-            lv_obj_set_style_text_color(s_status,
-                lv_color_hex(TH_TEXT_DIM), 0);
-            lv_obj_remove_flag(s_status, LV_OBJ_FLAG_HIDDEN);
-        } else {
-            lv_obj_add_flag(s_status, LV_OBJ_FLAG_HIDDEN);
-        }
+    /* Polish P4 (TT #654): replace the plain status label with shared
+     * ui_error_chip / ui_empty_state atoms.  Both render into
+     * s_rows_root so they share the scroll viewport with the (absent)
+     * row cards.  Hide the legacy s_status label in those cases. */
+    if (s_status) lv_obj_add_flag(s_status, LV_OBJ_FLAG_HIDDEN);
+    if (!s_fetch->ok) {
+       ui_error_chip(s_rows_root, SIDE_PAD, 12, SW - 2 * SIDE_PAD, "Dragon unreachable. Check Network in Settings.",
+                     NULL);
+    } else if (s_fetch->count == 0) {
+       ui_empty_state(s_rows_root, LV_SYMBOL_DIRECTORY, "No conversations yet",
+                      "Talk to Tinker and they'll appear here.");
     }
 
     if (s_count_lbl) {


### PR DESCRIPTION
Unify how each screen tells the user what's happening across loading / error / empty states.

## New atoms in \`ui_components\`
- \`ui_skeleton_row(parent, y, w, lines)\` — card-shaped placeholder with 1-4 dim-gray bars where rows would land.  Static (animated shimmer is P7).
- \`ui_error_chip(parent, x, y, w, message, retry_cb)\` — rounded card with red-tinted border, danger icon, message, and optional RETRY pill.  Built-in \`ui_fb_button\` feedback on the retry.

## Adoption
- **Notes** empty branch → \`ui_empty_state\` (was: open-coded flex + 2 labels).
- **Sessions** unified the dual-mode status label.  When \`!ok\` → \`ui_error_chip("Dragon unreachable...")\`.  When \`count==0\` → \`ui_empty_state("No conversations yet", ...)\`.  Both render into \`s_rows_root\`.
- **Files** empty branch → \`ui_empty_state(LV_SYMBOL_DIRECTORY, "Empty folder", "Photos and recordings will land here.")\`.

## Heap behaviour
\`\`\`
Boot:                       internal 75 / 72 KB largest, PSRAM 13.8 MB
After Notes + Sessions nav: internal 44 / 40 KB largest, PSRAM 13.8 MB
\`\`\`
New atoms are pure widget factories — no malloc / no PSRAM allocs.  20 KB above the \`heap_wd\` floor.

Closes #654