### PR TITLE
Polish P6: gesture helper + first-launch swipe hint (closes #658)

### DIFF
--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -126,6 +126,10 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
    cJSON_AddNumberToObject(root, "llm_engine", tab5_settings_get_llm_engine());
    /* Cap Wave 5 (TT #644): privacy lock master switch. */
    cJSON_AddBoolToObject(root, "privacy_lock", tab5_settings_get_privacy_lock());
+   /* Polish P6 (TT #658): one-shot gesture hint guard.  Lets harness
+    * reset the flag via POST to re-test the hint UX without an NVS
+    * erase. */
+   cJSON_AddBoolToObject(root, "gesture_hint_seen", tab5_settings_get_gesture_hint_seen());
    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
@@ -442,6 +446,19 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
          on = pl->valuedouble != 0;
       if (tab5_settings_set_privacy_lock(on) == ESP_OK) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("privacy_lock"));
+      }
+   }
+   /* Polish P6 (TT #658): gesture-hint single-shot guard.  Accept
+    * bool or 0/1 for symmetry with the privacy lock. */
+   cJSON *gh = cJSON_GetObjectItem(req_json, "gesture_hint_seen");
+   if (gh) {
+      bool on = false;
+      if (cJSON_IsBool(gh))
+         on = cJSON_IsTrue(gh);
+      else if (cJSON_IsNumber(gh))
+         on = gh->valuedouble != 0;
+      if (tab5_settings_set_gesture_hint_seen(on) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("gesture_hint_seen"));
       }
    }
    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");

--- a/main/settings.c
+++ b/main/settings.c
@@ -515,6 +515,15 @@ bool tab5_settings_get_privacy_lock(void) { return get_u8("privacy", 0) != 0; }
 
 esp_err_t tab5_settings_set_privacy_lock(bool on) { return set_u8("privacy", on ? 1 : 0); }
 
+/* ── Gesture hint seen (Polish P6 / TT #658) ──────────────────────
+ *
+ * Single-shot guard for the "Tip: swipe right to go back" toast that
+ * fires on the first overlay nav after fresh install / NVS erase.
+ * Returning users (with the hint dismissed) skip the toast. */
+bool tab5_settings_get_gesture_hint_seen(void) { return get_u8("gest_hint", 0) != 0; }
+
+esp_err_t tab5_settings_set_gesture_hint_seen(bool seen) { return set_u8("gest_hint", seen ? 1 : 0); }
+
 /* ── Wake source picker (TT #617) ───────────────────────────────────── */
 
 esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {

--- a/main/settings.h
+++ b/main/settings.h
@@ -203,6 +203,12 @@ esp_err_t tab5_settings_set_llm_engine(uint8_t eng);
 bool tab5_settings_get_privacy_lock(void);
 esp_err_t tab5_settings_set_privacy_lock(bool on);
 
+/** Polish P6 (TT #658) — single-shot guard for the gesture hint
+ *  toast.  False on fresh install; tab5_nav_to surfaces "Tip: swipe
+ *  right to go back" on first overlay nav and flips this to true. */
+bool tab5_settings_get_gesture_hint_seen(void);
+esp_err_t tab5_settings_set_gesture_hint_seen(bool seen);
+
 /** TT #617 — Wake source.  Picks which wakeword detection path runs.
  *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
  *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future

--- a/main/ui_components.c
+++ b/main/ui_components.c
@@ -592,3 +592,31 @@ lv_obj_t *ui_error_chip(lv_obj_t *parent, int x, int y, int w, const char *messa
 
    return chip;
 }
+
+/* ─────────────────────────────────────────────────────────────────
+ *  Swipe-back gesture
+ * ───────────────────────────────────────────────────────────────── */
+
+typedef struct {
+   ui_topbar_cb_t dismiss_cb;
+} gesture_state_t;
+
+static void gesture_back_cb(lv_event_t *e) {
+   lv_dir_t dir = lv_indev_get_gesture_dir(lv_indev_active());
+   if (dir != LV_DIR_RIGHT && dir != LV_DIR_BOTTOM) return;
+   gesture_state_t *st = (gesture_state_t *)lv_event_get_user_data(e);
+   if (st && st->dismiss_cb) st->dismiss_cb(e);
+}
+
+void ui_gesture_register_back(lv_obj_t *obj, ui_topbar_cb_t dismiss_cb) {
+   if (!obj || !dismiss_cb) return;
+   /* Small per-screen state slab — at most ~8 screens register one
+    * gesture each, so a 16-slot static pool covers all cases without
+    * malloc churn. */
+   static gesture_state_t s_states[16];
+   static int s_n = 0;
+   if (s_n >= (int)(sizeof(s_states) / sizeof(s_states[0]))) return;
+   gesture_state_t *st = &s_states[s_n++];
+   st->dismiss_cb = dismiss_cb;
+   lv_obj_add_event_cb(obj, gesture_back_cb, LV_EVENT_GESTURE, st);
+}

--- a/main/ui_components.h
+++ b/main/ui_components.h
@@ -152,6 +152,17 @@ lv_obj_t *ui_skeleton_row(lv_obj_t *parent, int y, int w, int lines);
  * so callers can delete it later. */
 lv_obj_t *ui_error_chip(lv_obj_t *parent, int x, int y, int w, const char *message, ui_topbar_cb_t retry_cb);
 
+/* ── Swipe-back gesture registration ───────────────────────────────
+ *
+ * Polish P6 (TT #658): standard "swipe right or down → dismiss"
+ * gesture binding.  Registers an LV_EVENT_GESTURE callback on @p obj
+ * that fires @p dismiss_cb when the indev gesture direction is
+ * LV_DIR_RIGHT or LV_DIR_BOTTOM.  Other directions are ignored.
+ * Future screens use this instead of open-coding the gesture-cb +
+ * direction check.  The helper does not consume the gesture for
+ * other directions, so vertical scroll still works. */
+void ui_gesture_register_back(lv_obj_t *obj, ui_topbar_cb_t dismiss_cb);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/ui_nav.c
+++ b/main/ui_nav.c
@@ -20,8 +20,10 @@
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "ui_core.h" /* ui_tap_gate */
-#include "voice.h"   /* voice_get_state, voice_cancel, voice_state_t */
+#include "settings.h" /* TT #658 — gesture-hint NVS guard */
+#include "ui_core.h"  /* ui_tap_gate */
+#include "ui_home.h"  /* TT #658 — ui_home_show_toast for the hint */
+#include "voice.h"    /* voice_get_state, voice_cancel, voice_state_t */
 
 static const char *TAG = "ui_nav";
 
@@ -88,6 +90,19 @@ esp_err_t tab5_nav_to(tab5_nav_target_t target, tab5_nav_flags_t flags) {
 
    /* Step 3: emit obs event so the e2e harness can wait on it. */
    tab5_debug_obs_event("nav.go", name);
+
+   /* Polish P6 (TT #658): single-shot gesture hint.  On first
+    * overlay nav from home, surface a toast telling the user about
+    * the swipe-right-to-go-back gesture.  Gated on NVS `gest_hint`
+    * so it never fires twice.  Skipped on nav-to-home (would be
+    * unhelpful — user is going home, not landing on a new overlay). */
+   if (target != NAV_HOME && !tab5_settings_get_gesture_hint_seen()) {
+      tab5_settings_set_gesture_hint_seen(true);
+      /* Fire the toast — ui_home_show_toast already async-routes to
+       * the LVGL thread, so calling from any context is safe. */
+      ui_home_show_toast("Tip: swipe right to go back");
+      tab5_debug_obs_event("gest.hint", "fired");
+   }
 
    /* Step 4: hand off to the LVGL-thread dispatcher.  This sets the
     * cached nav-target name (so /screen returns the new value) and


### PR DESCRIPTION
All 11 main UI screens already had swipe-back handlers — this wave consolidates the pattern as a shared helper for future screens and adds a discoverability hint so users learn the gesture exists.

## What lands
- **\`ui_components::ui_gesture_register_back(obj, dismiss_cb)\`** — wraps the \`LV_EVENT_GESTURE + LV_DIR_RIGHT/BOTTOM\` check pattern.  Future screens import this instead of open-coding the cb.
- **First-launch hint** — single-shot toast "Tip: swipe right to go back" fires on first non-home overlay nav.  Gated on new NVS \`gest_hint\` key.  Harness can POST \`{"gesture_hint_seen":false}\` to re-arm.
- **Settings round-trip** for the new field in GET + POST.

## Existing gesture coverage stays untouched
agents / camera / chat / files / focus / home / memory / notes / sessions / settings / skills all already hold \`LV_EVENT_GESTURE\` cbs.  Migrating those to \`ui_gesture_register_back\` is mechanical churn we can defer.

## Live verification on Tab5 192.168.1.90
- Boot heap: internal 74/72 KB largest, PSRAM 13.9 MB.
- First nav (fresh NVS) → \`gest.hint fired\` obs event + toast displayed.
- Second nav → no \`gest.hint\` event (single-shot working).
- POST \`{"gesture_hint_seen":false}\` re-arms; next nav fires the hint again.

Closes #658