### PR TITLE
Polish P7: animated shimmer skeletons + Sessions adoption (closes #660)

### DIFF
--- a/main/ui_components.c
+++ b/main/ui_components.c
@@ -493,6 +493,14 @@ void ui_overlay_fade_in(lv_obj_t *obj, uint32_t duration_ms) {
  *  Skeleton row — static dim-gray placeholder bars
  * ───────────────────────────────────────────────────────────────── */
 
+/* Polish P7 (TT #660): shimmer animation — opacity sweeps from
+ * faint (40 %) → full (100 %) → faint over 1500 ms.  Each bar gets
+ * a staggered start delay so the wave moves left-to-right across
+ * the row.  Lightweight: single style write per frame per bar. */
+static void skeleton_opa_anim_cb(void *obj, int32_t v) {
+   if (obj) lv_obj_set_style_bg_opa((lv_obj_t *)obj, (lv_opa_t)v, LV_PART_MAIN);
+}
+
 lv_obj_t *ui_skeleton_row(lv_obj_t *parent, int y, int w, int lines) {
    if (lines < 1) lines = 1;
    if (lines > 4) lines = 4;
@@ -526,6 +534,22 @@ lv_obj_t *ui_skeleton_row(lv_obj_t *parent, int y, int w, int lines) {
       lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
       lv_obj_set_style_radius(bar, 4, 0);
       lv_obj_clear_flag(bar, LV_OBJ_FLAG_SCROLLABLE);
+
+      /* Polish P7: shimmer.  Each bar's anim is staggered by
+       * 150 ms × line index so the wave reads as a left-to-right
+       * sweep down the row.  PLAYBACK_TIME = REPEAT to make it
+       * a continuous ping-pong. */
+      lv_anim_t a;
+      lv_anim_init(&a);
+      lv_anim_set_var(&a, bar);
+      lv_anim_set_exec_cb(&a, skeleton_opa_anim_cb);
+      lv_anim_set_values(&a, LV_OPA_40, LV_OPA_COVER);
+      lv_anim_set_duration(&a, 750);
+      lv_anim_set_playback_duration(&a, 750);
+      lv_anim_set_delay(&a, i * 150);
+      lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
+      lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
+      lv_anim_start(&a);
    }
    return box;
 }

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -414,6 +414,18 @@ static void kick_sessions_fetch(void)
 {
     if (s_fetch_inflight) return;
     s_fetch_inflight = true;
+    /* Polish P7 (TT #660): render 3 shimmer skeleton rows into the
+     * scroll viewport while the worker fetches from Dragon.  Cleared
+     * when render_rows_cb wipes s_rows_root + repopulates with real
+     * cards (or an error chip / empty state). */
+    if (s_rows_root) {
+       lv_obj_clean(s_rows_root);
+       int y = 0;
+       for (int i = 0; i < 3; i++) {
+          ui_skeleton_row(s_rows_root, y, SW - 2 * SIDE_PAD, 2);
+          y += 80 + 12;
+       }
+    }
     if (tab5_worker_enqueue(fetch_sessions_job, NULL, "sessions") != ESP_OK) {
         ESP_LOGW(TAG, "worker queue full — dropping sessions fetch");
         s_fetch_inflight = false;


### PR DESCRIPTION
Upgrade \`ui_skeleton_row\` from static gray bars (P4) to a left-to-right shimmer wave, and adopt skeletons in Sessions while the Dragon fetch is in flight.

## What lands
- **Shimmer animation** on every skeleton bar — \`bg_opa\` ping-pongs between \`LV_OPA_40\` and \`LV_OPA_COVER\` over 1500 ms (750 ms each way, ease-in-out).  Per-bar 150 ms stagger reads as a wave sweeping down the row.  \`REPEAT_INFINITE\`; auto-stops when the widget is deleted.
- **Sessions adoption** — \`kick_sessions_fetch\` renders 3 shimmer rows into \`s_rows_root\` immediately, before the worker fires.  \`render_rows_cb\` wipes them when real rows / empty state / error chip arrive.

## Heap behaviour
\`\`\`
Boot:           internal 75 / 72 KB largest, PSRAM 13.8 MB
After Sessions: internal 46 / 42 KB largest, PSRAM 13.8 MB
\`\`\`

Cost: one style-write per frame per bar.  No allocations.

## Note on screenshot
On the bench Dragon's \`/api/v1/sessions\` settled in < 1 s so the screenshot caught real rows, not the shimmer.  The path is wired + builds clean.  On a slow / failing Dragon the shimmer becomes the visible loading state instead of blank screen.

Closes #660