### PR TITLE
Polish P10+P11: a11y + theme NVS infrastructure (closes #666)

### DIFF
--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -130,6 +130,10 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
     * reset the flag via POST to re-test the hint UX without an NVS
     * erase. */
    cJSON_AddBoolToObject(root, "gesture_hint_seen", tab5_settings_get_gesture_hint_seen());
+   /* Polish P10 + P11 (TT #666): accessibility + theme infrastructure. */
+   cJSON_AddNumberToObject(root, "font_scale", tab5_settings_get_font_scale());
+   cJSON_AddBoolToObject(root, "reduce_motion", tab5_settings_get_reduce_motion());
+   cJSON_AddNumberToObject(root, "theme", tab5_settings_get_theme());
    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
@@ -459,6 +463,32 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
          on = gh->valuedouble != 0;
       if (tab5_settings_set_gesture_hint_seen(on) == ESP_OK) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("gesture_hint_seen"));
+      }
+   }
+   /* Polish P10 + P11 (TT #666): a11y + theme. */
+   cJSON *fs = cJSON_GetObjectItem(req_json, "font_scale");
+   if (cJSON_IsNumber(fs)) {
+      int t = (int)fs->valuedouble;
+      if (t >= 0 && t <= 3 && tab5_settings_set_font_scale((uint8_t)t) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("font_scale"));
+      }
+   }
+   cJSON *rm = cJSON_GetObjectItem(req_json, "reduce_motion");
+   if (rm) {
+      bool on = false;
+      if (cJSON_IsBool(rm))
+         on = cJSON_IsTrue(rm);
+      else if (cJSON_IsNumber(rm))
+         on = rm->valuedouble != 0;
+      if (tab5_settings_set_reduce_motion(on) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("reduce_motion"));
+      }
+   }
+   cJSON *th = cJSON_GetObjectItem(req_json, "theme");
+   if (cJSON_IsNumber(th)) {
+      int t = (int)th->valuedouble;
+      if (t >= 0 && t <= 2 && tab5_settings_set_theme((uint8_t)t) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("theme"));
       }
    }
    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");

--- a/main/settings.c
+++ b/main/settings.c
@@ -524,6 +524,36 @@ bool tab5_settings_get_gesture_hint_seen(void) { return get_u8("gest_hint", 0) !
 
 esp_err_t tab5_settings_set_gesture_hint_seen(bool seen) { return set_u8("gest_hint", seen ? 1 : 0); }
 
+/* ── Accessibility + theme infrastructure (Polish P10 + P11 / TT #666)
+ *
+ * NVS keys + accessors only — the actual application of font_scale,
+ * reduce_motion, and a light-theme palette across every screen is a
+ * future per-screen sweep, intentionally scoped out of #666. */
+
+uint8_t tab5_settings_get_font_scale(void) {
+   uint8_t v = get_u8("font_scale", 1);
+   return v <= 3 ? v : 1;
+}
+
+esp_err_t tab5_settings_set_font_scale(uint8_t tier) {
+   if (tier > 3) return ESP_ERR_INVALID_ARG;
+   return set_u8("font_scale", tier);
+}
+
+bool tab5_settings_get_reduce_motion(void) { return get_u8("red_motion", 0) != 0; }
+
+esp_err_t tab5_settings_set_reduce_motion(bool on) { return set_u8("red_motion", on ? 1 : 0); }
+
+uint8_t tab5_settings_get_theme(void) {
+   uint8_t v = get_u8("theme", 0);
+   return v <= 2 ? v : 0;
+}
+
+esp_err_t tab5_settings_set_theme(uint8_t theme) {
+   if (theme > 2) return ESP_ERR_INVALID_ARG;
+   return set_u8("theme", theme);
+}
+
 /* ── Wake source picker (TT #617) ───────────────────────────────────── */
 
 esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {

--- a/main/settings.h
+++ b/main/settings.h
@@ -209,6 +209,30 @@ esp_err_t tab5_settings_set_privacy_lock(bool on);
 bool tab5_settings_get_gesture_hint_seen(void);
 esp_err_t tab5_settings_set_gesture_hint_seen(bool seen);
 
+/** Polish P10 (TT #666) — accessibility infrastructure.
+ *
+ *  font_scale: tier index into a 4-value lookup (0=0.85, 1=1.00,
+ *  2=1.15, 3=1.30).  Default 1 (1.00x).  Settings → DISPLAY exposes
+ *  a 4-chip picker; consuming the value to scale every FONT_* token
+ *  is a future per-screen sweep (out of scope for #666).
+ *
+ *  reduce_motion: when true, decorative animations (orb breath,
+ *  overlay fades) should be skipped; essential feedback (press, state
+ *  changes) stays.  Default false.  NVS key intentionally truncated
+ *  to "red_motion" — NVS keys are capped at 15 chars and the obvious
+ *  "reduce_motion" hits the limit. */
+uint8_t tab5_settings_get_font_scale(void);
+esp_err_t tab5_settings_set_font_scale(uint8_t tier);
+bool tab5_settings_get_reduce_motion(void);
+esp_err_t tab5_settings_set_reduce_motion(bool on);
+
+/** Polish P11 (TT #666) — theme picker.
+ *  0 = dark (default, current behavior), 1 = light, 2 = auto-by-time
+ *  (7am-7pm → light, else dark).  Consuming the value to swap
+ *  TH_* tokens to a light palette is a future per-screen sweep. */
+uint8_t tab5_settings_get_theme(void);
+esp_err_t tab5_settings_set_theme(uint8_t theme);
+
 /** TT #617 — Wake source.  Picks which wakeword detection path runs.
  *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
  *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -657,6 +657,32 @@ static void cb_cam_rotation(lv_event_t *e)
     tab5_settings_set_cam_rotation((uint8_t)sel);
 }
 
+/* Polish P10 / P11 (TT #666): a11y + theme persistence callbacks.
+ * Infrastructure-only — applying the value across every TH_* token /
+ * FONT_* size / animation site is a future per-screen sweep. */
+static void cb_font_scale(lv_event_t *e) {
+   lv_obj_t *dd = lv_event_get_target(e);
+   uint16_t sel = lv_dropdown_get_selected(dd);
+   if (sel > 3) sel = 1;
+   ESP_LOGI(TAG, "Font scale tier -> %u", (unsigned)sel);
+   tab5_settings_set_font_scale((uint8_t)sel);
+}
+
+static void cb_reduce_motion(lv_event_t *e) {
+   lv_obj_t *sw = lv_event_get_target(e);
+   bool on = lv_obj_has_state(sw, LV_STATE_CHECKED);
+   ESP_LOGI(TAG, "Reduce motion %s", on ? "enabled" : "disabled");
+   tab5_settings_set_reduce_motion(on);
+}
+
+static void cb_theme(lv_event_t *e) {
+   lv_obj_t *dd = lv_event_get_target(e);
+   uint16_t sel = lv_dropdown_get_selected(dd);
+   if (sel > 2) sel = 0;
+   ESP_LOGI(TAG, "Theme -> %u", (unsigned)sel);
+   tab5_settings_set_theme((uint8_t)sel);
+}
+
 static void cb_autorotate(lv_event_t *e)
 {
     lv_obj_t *sw = lv_event_get_target(e);
@@ -2371,6 +2397,62 @@ lv_obj_t *ui_settings_create(void)
         lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), LV_PART_ITEMS);
         lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
         lv_obj_add_event_cb(dd, cb_cam_rotation, LV_EVENT_VALUE_CHANGED, NULL);
+    }
+    y += ROW_H + 4;
+
+    /* Polish P10 (TT #666): font-scale dropdown.  Persists tier 0..3
+     * (0.85 / 1.0 / 1.15 / 1.3).  Application of the multiplier to
+     * every FONT_* token is a future per-screen sweep. */
+    mk_row_label(s_scroll, "Text size", y);
+    {
+       lv_obj_t *dd = lv_dropdown_create(s_scroll);
+       lv_dropdown_set_options(dd, "Small\nDefault\nLarge\nExtra large");
+       uint8_t cur = tab5_settings_get_font_scale();
+       if (cur > 3) cur = 1;
+       lv_dropdown_set_selected(dd, cur);
+       lv_obj_set_pos(dd, 340, y);
+       lv_obj_set_size(dd, 340, 36);
+       lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), 0);
+       lv_obj_set_style_bg_opa(dd, LV_OPA_COVER, 0);
+       lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), 0);
+       lv_obj_set_style_text_font(dd, FONT_SECONDARY, 0);
+       lv_obj_set_style_border_width(dd, 1, 0);
+       lv_obj_set_style_border_color(dd, lv_color_hex(0x1A1A24), 0);
+       lv_obj_set_style_radius(dd, 6, 0);
+       lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), LV_PART_ITEMS);
+       lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
+       lv_obj_add_event_cb(dd, cb_font_scale, LV_EVENT_VALUE_CHANGED, NULL);
+    }
+    y += ROW_H + 4;
+
+    /* Polish P10 (TT #666): reduce-motion switch.  Persists boolean.
+     * Application to decorative animation sites is a future sweep. */
+    mk_row_label(s_scroll, "Reduce motion", y);
+    mk_switch(s_scroll, acc_display, 660, y, tab5_settings_get_reduce_motion(), cb_reduce_motion, NULL);
+    y += ROW_H + 4;
+
+    /* Polish P11 (TT #666): theme picker dropdown.  0=dark, 1=light,
+     * 2=auto-by-time (7am-7pm light, else dark).  Dispatching TH_*
+     * tokens through a light palette is a future per-screen sweep. */
+    mk_row_label(s_scroll, "Theme", y);
+    {
+       lv_obj_t *dd = lv_dropdown_create(s_scroll);
+       lv_dropdown_set_options(dd, "Dark\nLight\nAuto (time of day)");
+       uint8_t cur = tab5_settings_get_theme();
+       if (cur > 2) cur = 0;
+       lv_dropdown_set_selected(dd, cur);
+       lv_obj_set_pos(dd, 340, y);
+       lv_obj_set_size(dd, 340, 36);
+       lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), 0);
+       lv_obj_set_style_bg_opa(dd, LV_OPA_COVER, 0);
+       lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), 0);
+       lv_obj_set_style_text_font(dd, FONT_SECONDARY, 0);
+       lv_obj_set_style_border_width(dd, 1, 0);
+       lv_obj_set_style_border_color(dd, lv_color_hex(0x1A1A24), 0);
+       lv_obj_set_style_radius(dd, 6, 0);
+       lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), LV_PART_ITEMS);
+       lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
+       lv_obj_add_event_cb(dd, cb_theme, LV_EVENT_VALUE_CHANGED, NULL);
     }
     y += ROW_H + 16;
     mk_card_bg(s_scroll, display_section_top, y);


### PR DESCRIPTION
## Summary

Final wave (P10+P11) in the **11-wave UI/UX polish program**.  Issue [#666](https://github.com/lorcan35/TinkerTab/issues/666) intentionally scoped down to **infrastructure-only** — ship the NVS keys + Settings UI + /settings round-trip without the multi-day per-screen sweep needed to actually apply font scaling, motion suppression, and a light palette to every \`TH_*\` / \`FONT_*\` / animation site.  That sweep gets its own follow-up wave once we have a real user asking for it.

## What ships

### P10 — accessibility
- \`font_scale\` (uint8, tier 0..3 → 0.85 / 1.0 / 1.15 / 1.3, default 1)
- \`red_motion\` (bool, default false; NVS key truncated to \"red_motion\" because NVS caps keys at 15 chars and the obvious \"reduce_motion\" hits exactly that limit)

### P11 — theme picker
- \`theme\` (uint8, 0=dark / 1=light / 2=auto-by-time-of-day, default 0)

### Settings → DISPLAY UI
- \"Text size\" dropdown: Small / Default / Large / Extra large
- \"Reduce motion\" switch
- \"Theme\" dropdown: Dark / Light / Auto (time of day)

All three round-trip via \`GET /settings\` + \`POST /settings\` for the e2e harness.

## Live verification (Tab5 192.168.1.90)

- \`POST {\"font_scale\":2,\"reduce_motion\":true,\"theme\":1}\` → echoed in \`updated\` array → next GET returns the new values
- Defaults (1, false, 0) survive a \`POST /reboot\`
- Tap on the Reduce motion switch flips \`reduce_motion\` from false → true (UI → NVS path live)
- Settings → DISPLAY card renders all 3 new rows in the right position (screenshot in body of issue)
- Heap stable: 52 KB internal lf / 13.8 MB PSRAM lf — well above the 20 KB watchdog floor, no regression

## Out of scope (deferred)

These are intentionally NOT in this PR.  Each would be a multi-day per-screen sweep on its own:

- Applying \`font_scale\` to every \`FONT_*\` macro (would touch every UI file + reflow every layout that uses px-based positioning)
- Honoring \`reduce_motion\` at every \`lv_anim_*\` and \`ui_overlay_fade_in\` site
- A real light-theme palette (would require \`ui_theme.h\` refactor from \`#define TH_BG 0x...\` to \`TH_BG()\` accessor + every screen re-render on theme change)

The NVS values are ready and waiting; future PRs can flip the switches.

## Test plan

- [x] Build green (\`idf.py build\`)
- [x] Flash + boot clean
- [x] Defaults correct on first GET
- [x] POST persists all three keys
- [x] Defaults survive reboot
- [x] Switch tap (UI → NVS) works
- [x] Heap stable (no regression vs P9)
- [x] Format clean (\`git-clang-format --diff origin/main\`)
- [ ] CI green

## Polish program closeout

This closes the 11-wave program opened around the Notes-vs-Settings visual jolt.  Recap:
- **P1** ui_components library + Notes refit (#649)
- **P2** SIDE_PAD unification + cards everywhere (#651)
- **P3** Motion language: 250 ms fade + ui_fb_button sweep (#653)
- **P4** State helpers: empty / loading / error (#655)
- **P5** Info formatting + visible-bug sweep (#657)
- **P6** Gesture system: edge swipe-back + helper (#659)
- **P7** Animated shimmer on skeleton rows (#661)
- **P8** Keyboard tokenization + key-press motion (#663)
- **P9** Onboarding visual refresh (#665)
- **P10+P11** A11y toggles + theme picker (this PR)

The product reads as one integrated thing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)