### PR TITLE
P10 follow-up: apply font_scale via typography accessor (closes #670)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(UI_SRCS
     "ui_theme.c"
+    "ui_typography.c"
     "ui_components.c"
     "ui_splash.c" "ui_home.c" "ui_orb.c" "ui_settings.c"
     "ui_camera.c" "ui_files.c" "ui_audio.c" "ui_keyboard.c" "ui_voice.c" "ui_wifi.c"

--- a/main/config.h
+++ b/main/config.h
@@ -82,16 +82,23 @@
 // ---------------------------------------------------------------------------
 // Global Typography Scale (720x1280 display @ arm's length)
 // ---------------------------------------------------------------------------
-#define FONT_TITLE       &lv_font_montserrat_28   /* Screen titles, big numbers */
-#define FONT_HEADING     &lv_font_montserrat_24   /* Section headers, card titles */
-#define FONT_BODY        &lv_font_montserrat_20   /* Primary body text, messages, labels */
-#define FONT_SECONDARY   &lv_font_montserrat_18   /* Secondary text, descriptions */
-#define FONT_CAPTION     &lv_font_montserrat_16   /* Timestamps, badges, metadata */
-#define FONT_SMALL       &lv_font_montserrat_14   /* Hints, placeholders, debug */
-#define FONT_CLOCK       &lv_font_montserrat_48   /* Home screen clock */
-#define FONT_DATE        &lv_font_montserrat_24   /* Home screen date */
-#define FONT_KEY         &lv_font_montserrat_20   /* Keyboard keys */
-#define FONT_NAV         &lv_font_montserrat_18   /* Nav bar labels */
+// Routes through ui_typography.h so font_scale (P10, TT #666) can
+// pick scaled tiers per role.  Defaults expand to the same physical
+// fonts as before (Montserrat 28/24/20/18/16/14/48/24/20/18) when
+// the user is on tier 1.  Verified no static initializers consume
+// FONT_* — all sites are runtime LVGL style calls, so a function-
+// call expansion is type-safe.
+#include "ui_typography.h"
+#define FONT_TITLE tab5_typography_get(FONT_ROLE_TITLE)
+#define FONT_HEADING tab5_typography_get(FONT_ROLE_HEADING)
+#define FONT_BODY tab5_typography_get(FONT_ROLE_BODY)
+#define FONT_SECONDARY tab5_typography_get(FONT_ROLE_SECONDARY)
+#define FONT_CAPTION tab5_typography_get(FONT_ROLE_CAPTION)
+#define FONT_SMALL tab5_typography_get(FONT_ROLE_SMALL)
+#define FONT_CLOCK tab5_typography_get(FONT_ROLE_CLOCK)
+#define FONT_DATE tab5_typography_get(FONT_ROLE_DATE)
+#define FONT_KEY tab5_typography_get(FONT_ROLE_KEY)
+#define FONT_NAV tab5_typography_get(FONT_ROLE_NAV)
 
 // ── v4·C chat fonts (Fraunces italic + JetBrains Mono) ───────────────
 #ifdef LV_FONT_DECLARE

--- a/main/main.c
+++ b/main/main.c
@@ -562,6 +562,11 @@ void app_main(void)
         tab5_ui_lock();
         ui_splash_destroy();
         ui_theme_init();  // must run before any screen that uses TH_* styles
+        /* P10 follow-up (TT #670): cache the scaled font pointers from the
+         * NVS font_scale tier.  Must run before any FONT_* macro expansion
+         * inside a UI create() — those macros now resolve via the cache. */
+        extern void tab5_typography_init(void);
+        tab5_typography_init();
         /* PR 2 / dictation pipeline: init the state machine + mutex BEFORE
          * any UI module that subscribes during create (ui_home_create →
          * ui_orb_create + the chip subscribe in ui_home).  Keeping init in

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -666,6 +666,11 @@ static void cb_font_scale(lv_event_t *e) {
    if (sel > 3) sel = 1;
    ESP_LOGI(TAG, "Font scale tier -> %u", (unsigned)sel);
    tab5_settings_set_font_scale((uint8_t)sel);
+   /* P10 follow-up (TT #670): apply-on-restart model — every widget
+    * already has its font baked at create-time, so a live tier change
+    * isn't visible until the next boot.  Toast prompts a restart. */
+   extern void ui_home_show_toast(const char *msg);
+   ui_home_show_toast("Text size — restart to apply");
 }
 
 static void cb_reduce_motion(lv_event_t *e) {

--- a/main/ui_typography.c
+++ b/main/ui_typography.c
@@ -1,0 +1,71 @@
+/**
+ * @file ui_typography.c
+ * @brief Implementation — see ui_typography.h.
+ */
+
+#include "ui_typography.h"
+
+#include "esp_log.h"
+#include "settings.h"
+
+static const char *TAG = "ui_typo";
+
+/* Lookup table: 10 roles × 4 tiers → font pointer.
+ *
+ * Picks below clamp at the nearest available compiled Montserrat
+ * size from sdkconfig (12/14/16/18/20/24/28/36/48).  Where a tier's
+ * mathematical scale lands between two compiled sizes, we round to
+ * the nearer one biased toward the larger so legibility wins.
+ *
+ * Per-role notes:
+ *   CLOCK 48px is already the largest compiled Montserrat — tiers 2/3
+ *   stay at 48 since there's no larger.  Tier 0 drops to 36 (next
+ *   available below 48).
+ *   SMALL 14px tier 0 drops to 12 (smallest sensible body size).
+ *   TITLE 28px upscale jumps to 36 (no 32 compiled). */
+static const lv_font_t *s_table[FONT_ROLE_COUNT][4] = {
+    [FONT_ROLE_TITLE] = {&lv_font_montserrat_24, &lv_font_montserrat_28, &lv_font_montserrat_36,
+                         &lv_font_montserrat_36},
+    [FONT_ROLE_HEADING] = {&lv_font_montserrat_20, &lv_font_montserrat_24, &lv_font_montserrat_28,
+                           &lv_font_montserrat_28},
+    [FONT_ROLE_BODY] = {&lv_font_montserrat_18, &lv_font_montserrat_20, &lv_font_montserrat_24, &lv_font_montserrat_28},
+    [FONT_ROLE_SECONDARY] = {&lv_font_montserrat_16, &lv_font_montserrat_18, &lv_font_montserrat_20,
+                             &lv_font_montserrat_24},
+    [FONT_ROLE_CAPTION] = {&lv_font_montserrat_14, &lv_font_montserrat_16, &lv_font_montserrat_18,
+                           &lv_font_montserrat_20},
+    [FONT_ROLE_SMALL] = {&lv_font_montserrat_12, &lv_font_montserrat_14, &lv_font_montserrat_16,
+                         &lv_font_montserrat_18},
+    [FONT_ROLE_CLOCK] = {&lv_font_montserrat_36, &lv_font_montserrat_48, &lv_font_montserrat_48,
+                         &lv_font_montserrat_48},
+    [FONT_ROLE_DATE] = {&lv_font_montserrat_20, &lv_font_montserrat_24, &lv_font_montserrat_28, &lv_font_montserrat_28},
+    [FONT_ROLE_KEY] = {&lv_font_montserrat_18, &lv_font_montserrat_20, &lv_font_montserrat_24, &lv_font_montserrat_28},
+    [FONT_ROLE_NAV] = {&lv_font_montserrat_16, &lv_font_montserrat_18, &lv_font_montserrat_20, &lv_font_montserrat_24},
+};
+
+/* Cached pointers for the session — one per role, picked at boot from
+ * the active font_scale tier.  Faster than indexing the table on
+ * every FONT_* macro expansion (~1500 hits during a full UI render). */
+static const lv_font_t *s_cache[FONT_ROLE_COUNT] = {0};
+static bool s_initialized = false;
+
+void tab5_typography_init(void) {
+   uint8_t tier = tab5_settings_get_font_scale();
+   if (tier > 3) tier = 1;
+   for (int r = 0; r < FONT_ROLE_COUNT; r++) {
+      s_cache[r] = s_table[r][tier];
+   }
+   s_initialized = true;
+   ESP_LOGI(TAG, "typography initialized — tier %u", (unsigned)tier);
+}
+
+const lv_font_t *tab5_typography_get(font_role_t role) {
+   if (role < 0 || role >= FONT_ROLE_COUNT) {
+      return &lv_font_montserrat_20;
+   }
+   /* Defensive: if a UI path runs before tab5_typography_init (boot
+    * order regression), fall back to the default-tier pointer. */
+   if (!s_initialized) {
+      return s_table[role][1];
+   }
+   return s_cache[role];
+}

--- a/main/ui_typography.h
+++ b/main/ui_typography.h
@@ -1,0 +1,42 @@
+/**
+ * @file ui_typography.h
+ * @brief Font-scale-aware typography accessors — Polish P10 follow-up (TT #670).
+ *
+ * Backs the user-facing "Text size" picker shipped in #667.  Reads the
+ * `font_scale` NVS tier (0=0.85x / 1=1.0x / 2=1.15x / 3=1.3x) once at
+ * boot and exposes a stable role → font pointer mapping that the
+ * existing `FONT_*` macros in config.h route through.
+ *
+ * Apply-on-restart model: the scaled font picks live for the whole
+ * session.  Changing the tier in Settings surfaces a toast asking the
+ * user to restart, then the next boot picks up the new tier.  Simpler
+ * + safer than live re-render (every widget would need re-styling, and
+ * LVGL's invalidation surface is large).
+ */
+#pragma once
+
+#include "lvgl.h"
+
+typedef enum {
+   FONT_ROLE_TITLE = 0, /* 28 default → 24/28/36/36 */
+   FONT_ROLE_HEADING,   /* 24 default → 20/24/28/28 */
+   FONT_ROLE_BODY,      /* 20 default → 18/20/24/28 */
+   FONT_ROLE_SECONDARY, /* 18 default → 16/18/20/24 */
+   FONT_ROLE_CAPTION,   /* 16 default → 14/16/18/20 */
+   FONT_ROLE_SMALL,     /* 14 default → 12/14/16/18 */
+   FONT_ROLE_CLOCK,     /* 48 default → 36/48/48/48 */
+   FONT_ROLE_DATE,      /* 24 default → 20/24/28/28 */
+   FONT_ROLE_KEY,       /* 20 default → 18/20/24/28 */
+   FONT_ROLE_NAV,       /* 18 default → 16/18/20/24 */
+   FONT_ROLE_COUNT,
+} font_role_t;
+
+/** Populate the session-cached font pointers from the NVS font_scale
+ *  tier.  Call once at boot, after settings init, before any UI
+ *  widget creation.  Safe to call repeatedly. */
+void tab5_typography_init(void);
+
+/** Return the cached scaled font pointer for the given role.  Always
+ *  returns a valid non-NULL pointer (falls back to montserrat_20 on
+ *  bad role / uninitialized state). */
+const lv_font_t *tab5_typography_get(font_role_t role);


### PR DESCRIPTION
## Summary

Wires the \`font_scale\` NVS tier (shipped in [#667](https://github.com/lorcan35/TinkerTab/pull/667)) into every \`FONT_*\` macro so the user-facing "Text size" picker actually scales the UI.

New module \`main/ui_typography.{c,h}\`: 10 role enum + 10×4 lookup table + cached pointer accessor.  \`config.h\` re-routes every \`FONT_*\` from \`&lv_font_montserrat_XX\` to \`tab5_typography_get(FONT_ROLE_*)\`.

## Apply-on-restart

Every widget bakes its font pointer at create-time; live re-style across every screen is too complex.  Change tier → toast "Text size — restart to apply" → user restarts → next boot picks up the new tier.  Matches iOS/Android a11y behavior.

## Scaling table (compiled Montserrat sizes 12/14/16/18/20/24/28/36/48)

| Role | tier 0 (0.85x) | tier 1 (1.0x) | tier 2 (1.15x) | tier 3 (1.30x) |
|------|----------------|---------------|----------------|----------------|
| TITLE 28 | 24 | **28** | 36 | 36 |
| HEADING 24 | 20 | **24** | 28 | 28 |
| BODY 20 | 18 | **20** | 24 | 28 |
| SECONDARY 18 | 16 | **18** | 20 | 24 |
| CAPTION 16 | 14 | **16** | 18 | 20 |
| SMALL 14 | 12 | **14** | 16 | 18 |
| CLOCK 48 | 36 | **48** | 48 | 48 |
| DATE 24 | 20 | **24** | 28 | 28 |
| KEY 20 | 18 | **20** | 24 | 28 |
| NAV 18 | 16 | **18** | 20 | 24 |

## Live verification (Tab5 192.168.1.90)

- POST \`font_scale=3\` → \`/reboot\` → home + settings render with visibly larger labels across every role
- Default tier (1) round-trips with no visual change vs pre-PR
- Heap 58 KB internal lf, 13.8 MB PSRAM lf — no regression
- Build: +7 KB flash (only the new module — Montserrat sizes already compiled in sdkconfig)

## Known limitation

Layouts were sized for tier 1.  At tier 3 some screens overflow horizontally (e.g. Settings model picker tabs).  Cost of the simplest possible a11y implementation; per-screen overflow fixes are a focused future wave.

## Out of scope

- Theme (light palette) application — separate refactor, separate wave.
- Per-screen overflow audit at higher tiers.
- Chat-specific fonts (Fraunces / JetBrains Mono) — keep their fixed sizes for layout-sensitive rich text.

## Test plan

- [x] Build green (+7 KB flash)
- [x] Flash + boot clean
- [x] Default tier renders identically to pre-PR
- [x] tier=3 visibly enlarges every \`FONT_*\` role after reboot
- [x] Settings → font dropdown shows toast on change
- [x] Heap stable
- [x] Format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)