### PR TITLE
Vision V1: yolo_mode + confidence picker + persistence (closes #672)

### DIFF
--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -134,6 +134,9 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
    cJSON_AddNumberToObject(root, "font_scale", tab5_settings_get_font_scale());
    cJSON_AddBoolToObject(root, "reduce_motion", tab5_settings_get_reduce_motion());
    cJSON_AddNumberToObject(root, "theme", tab5_settings_get_theme());
+   /* Vision V1 (TT #672): YOLO model + confidence persistence. */
+   cJSON_AddNumberToObject(root, "yolo_mode", tab5_settings_get_yolo_mode());
+   cJSON_AddNumberToObject(root, "yolo_conf", tab5_settings_get_yolo_conf());
    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
@@ -489,6 +492,21 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
       int t = (int)th->valuedouble;
       if (t >= 0 && t <= 2 && tab5_settings_set_theme((uint8_t)t) == ESP_OK) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("theme"));
+      }
+   }
+   /* Vision V1 (TT #672): YOLO mode + confidence. */
+   cJSON *ym = cJSON_GetObjectItem(req_json, "yolo_mode");
+   if (cJSON_IsNumber(ym)) {
+      int v = (int)ym->valuedouble;
+      if (v >= 0 && v <= 2 && tab5_settings_set_yolo_mode((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("yolo_mode"));
+      }
+   }
+   cJSON *yc = cJSON_GetObjectItem(req_json, "yolo_conf");
+   if (cJSON_IsNumber(yc)) {
+      int v = (int)yc->valuedouble;
+      if (v >= 0 && v <= 100 && tab5_settings_set_yolo_conf((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("yolo_conf"));
       }
    }
    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");

--- a/main/settings.c
+++ b/main/settings.c
@@ -554,6 +554,28 @@ esp_err_t tab5_settings_set_theme(uint8_t theme) {
    return set_u8("theme", theme);
 }
 
+/* ── Vision V1 (TT #672) — YOLO mode + confidence persistence ──── */
+
+uint8_t tab5_settings_get_yolo_mode(void) {
+   uint8_t v = get_u8("yolo_mode", 0);
+   return v <= 2 ? v : 0;
+}
+
+esp_err_t tab5_settings_set_yolo_mode(uint8_t mode) {
+   if (mode > 2) return ESP_ERR_INVALID_ARG;
+   return set_u8("yolo_mode", mode);
+}
+
+uint8_t tab5_settings_get_yolo_conf(void) {
+   uint8_t v = get_u8("yolo_conf", 50);
+   return v <= 100 ? v : 50;
+}
+
+esp_err_t tab5_settings_set_yolo_conf(uint8_t pct) {
+   if (pct > 100) return ESP_ERR_INVALID_ARG;
+   return set_u8("yolo_conf", pct);
+}
+
 /* ── Wake source picker (TT #617) ───────────────────────────────────── */
 
 esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {

--- a/main/settings.h
+++ b/main/settings.h
@@ -233,6 +233,20 @@ esp_err_t tab5_settings_set_reduce_motion(bool on);
 uint8_t tab5_settings_get_theme(void);
 esp_err_t tab5_settings_set_theme(uint8_t theme);
 
+/** Vision V1 (TT #672) — YOLO model preference persistence.
+ *  0 = DET (yolo11n, default), 1 = POSE (yolo11n-pose), 2 = SEG
+ *  (yolo11s-seg).  Long-press on the camera DETECT button cycles the
+ *  active model and writes the new value; voice_yolo seeds s_model
+ *  from this key at boot so the user's choice survives reboots.
+ *
+ *  Confidence threshold persistence — float ×100 stored as uint8 so
+ *  we can reuse the existing get_u8/set_u8 helpers.  Default 50 (=
+ *  0.50); range 0..100. */
+uint8_t tab5_settings_get_yolo_mode(void);
+esp_err_t tab5_settings_set_yolo_mode(uint8_t mode);
+uint8_t tab5_settings_get_yolo_conf(void);
+esp_err_t tab5_settings_set_yolo_conf(uint8_t pct);
+
 /** TT #617 — Wake source.  Picks which wakeword detection path runs.
  *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
  *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future

--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -144,6 +144,12 @@ static bool        capture_counter_init = false;
 static bool s_yolo_on = false;
 static lv_obj_t *s_yolo_btn = NULL;
 static lv_obj_t *s_yolo_btn_lbl = NULL;
+/* Vision V1 (TT #672): confidence picker — 3 chips visible top-right
+ * of the viewfinder when DETECT is on.  Tap a chip → set threshold +
+ * repaint active state. */
+#define UI_CAM_CONF_CHIPS 3
+static const uint8_t UI_CAM_CONF_VALUES[UI_CAM_CONF_CHIPS] = {30, 50, 70};
+static lv_obj_t *s_conf_chips[UI_CAM_CONF_CHIPS] = {0};
 /* TT #638 Wave 2: model picker — cycle DET → POSE → SEG. */
 static lv_obj_t *s_yolo_mode_btn = NULL;
 static lv_obj_t *s_yolo_mode_lbl = NULL;
@@ -168,6 +174,10 @@ static void yolo_mode_btn_cb(lv_event_t *e);
 static void yolo_redraw_async(void *arg);
 static void yolo_infer_job(void *arg);
 static void yolo_alloc_resources(void);
+/* Vision V1 (TT #672) */
+static void conf_chip_cb(lv_event_t *e);
+static void conf_chips_set_visible(bool on);
+static void conf_chips_repaint_active(void);
 static void yolo_free_resources(void);
 static void yolo_downsample_rgb565(const uint16_t *src, int sw, int sh, uint16_t *dst);
 static const char *yolo_mode_short_label(voice_yolo_model_t m);
@@ -638,6 +648,36 @@ lv_obj_t *ui_camera_create(void)
                   s_yolo_kpts[i][k] = dot;
                }
             }
+
+            /* Vision V1 (TT #672): confidence picker — 3 small pills
+             * at the viewfinder top-right.  Hidden by default; shown
+             * when DETECT is toggled on so the chips don't clutter the
+             * idle camera view.  Tap → set new threshold + persist. */
+            for (int i = 0; i < UI_CAM_CONF_CHIPS; i++) {
+               lv_obj_t *chip = lv_obj_create(scr_camera);
+               lv_obj_remove_style_all(chip);
+               lv_obj_set_size(chip, 56, 32);
+               /* Stack vertically along the right edge, ~20 px from top. */
+               lv_obj_align(chip, LV_ALIGN_TOP_RIGHT, -16, 20 + i * 40);
+               lv_obj_set_style_bg_color(chip, lv_color_hex(0x1A1A24), 0);
+               lv_obj_set_style_bg_opa(chip, LV_OPA_70, 0);
+               lv_obj_set_style_border_color(chip, lv_color_hex(COL_YOLO_BORDER), 0);
+               lv_obj_set_style_border_width(chip, 1, 0);
+               lv_obj_set_style_radius(chip, 16, 0);
+               lv_obj_clear_flag(chip, LV_OBJ_FLAG_SCROLLABLE);
+               lv_obj_add_flag(chip, LV_OBJ_FLAG_HIDDEN);
+               lv_obj_add_event_cb(chip, conf_chip_cb, LV_EVENT_CLICKED, (void *)(intptr_t)i);
+               ui_fb_button(chip);
+               lv_obj_t *lbl = lv_label_create(chip);
+               char buf[8];
+               snprintf(buf, sizeof(buf), "%u%%", (unsigned)UI_CAM_CONF_VALUES[i]);
+               lv_label_set_text(lbl, buf);
+               lv_obj_set_style_text_font(lbl, &lv_font_montserrat_14, 0);
+               lv_obj_set_style_text_color(lbl, lv_color_hex(COL_YOLO_BORDER), 0);
+               lv_obj_center(lbl);
+               s_conf_chips[i] = chip;
+            }
+            conf_chips_repaint_active();
 
             /* Start the preview timer */
             preview_timer = lv_timer_create(preview_timer_cb, PREVIEW_FPS_MS,
@@ -1176,7 +1216,47 @@ static void yolo_btn_cb(lv_event_t *e) {
    } else {
       yolo_alloc_resources();
    }
+   /* Vision V1 (TT #672): confidence chips track DETECT visibility. */
+   conf_chips_set_visible(s_yolo_on);
    tab5_debug_obs_event("yolo.toggle", s_yolo_on ? "on" : "off");
+}
+
+/* Vision V1 (TT #672): toggle the confidence chips with DETECT. */
+static void conf_chips_set_visible(bool on) {
+   for (int i = 0; i < UI_CAM_CONF_CHIPS; i++) {
+      if (!s_conf_chips[i]) continue;
+      if (on)
+         lv_obj_clear_flag(s_conf_chips[i], LV_OBJ_FLAG_HIDDEN);
+      else
+         lv_obj_add_flag(s_conf_chips[i], LV_OBJ_FLAG_HIDDEN);
+   }
+}
+
+/* Vision V1 (TT #672): paint the chip whose value matches the
+ * persisted confidence with a filled amber background; others
+ * stay transparent-bg with amber border. */
+static void conf_chips_repaint_active(void) {
+   uint8_t active_pct = (uint8_t)(voice_yolo_get_min_confidence() * 100.0f + 0.5f);
+   for (int i = 0; i < UI_CAM_CONF_CHIPS; i++) {
+      if (!s_conf_chips[i]) continue;
+      bool is_active = (UI_CAM_CONF_VALUES[i] == active_pct);
+      lv_obj_set_style_bg_color(s_conf_chips[i], lv_color_hex(is_active ? COL_YOLO_BORDER : 0x1A1A24), 0);
+      lv_obj_t *lbl = lv_obj_get_child(s_conf_chips[i], 0);
+      if (lbl) {
+         lv_obj_set_style_text_color(lbl, lv_color_hex(is_active ? 0x08080E : COL_YOLO_BORDER), 0);
+      }
+   }
+}
+
+/* Vision V1 (TT #672): tap a chip → set new threshold + persist. */
+static void conf_chip_cb(lv_event_t *e) {
+   int idx = (int)(intptr_t)lv_event_get_user_data(e);
+   if (idx < 0 || idx >= UI_CAM_CONF_CHIPS) return;
+   float threshold = (float)UI_CAM_CONF_VALUES[idx] / 100.0f;
+   voice_yolo_set_min_confidence(threshold);
+   conf_chips_repaint_active();
+   ESP_LOGI(TAG, "YOLO confidence threshold -> %u%%", (unsigned)UI_CAM_CONF_VALUES[idx]);
+   tab5_debug_obs_event("yolo.conf", "set");
 }
 
 /* TT #638: cycle the K144 yolo model (DET → POSE → SEG → DET).
@@ -1565,6 +1645,9 @@ void ui_camera_destroy(void)
        s_yolo_btn_lbl = NULL;
        s_yolo_mode_btn = NULL;
        s_yolo_mode_lbl = NULL;
+       /* Vision V1 (TT #672): confidence chips were children of
+        * scr_camera so lv_obj_clean already freed them. */
+       for (int i = 0; i < UI_CAM_CONF_CHIPS; i++) s_conf_chips[i] = NULL;
        for (int i = 0; i < UI_CAM_YOLO_MAX_BOXES; i++) {
           s_yolo_boxes[i] = NULL;
           s_yolo_box_lbls[i] = NULL;

--- a/main/voice_yolo.c
+++ b/main/voice_yolo.c
@@ -29,6 +29,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "mbedtls/base64.h"
+#include "settings.h"      /* Vision V1 — yolo_mode + yolo_conf NVS seeding */
 #include "voice_usb_ffs.h" /* TT #621 W6 — video channel APIs */
 
 static const char *TAG = "voice_yolo";
@@ -169,8 +170,35 @@ static int send_action(const char *action, const char *work_id_in, const char *o
 
 /* TT #638 (Wave 2): selected K144 yolo model.  Defaults to DET.  Changed
  * via voice_yolo_set_model — that path also invalidates the cached
- * work_id so the next infer call re-runs setup against the new model. */
+ * work_id so the next infer call re-runs setup against the new model.
+ *
+ * Vision V1 (TT #672): seeded from NVS `yolo_mode` on first read so
+ * the user's choice survives reboots.  `s_model_seeded` is a one-shot
+ * guard — the first call to a getter/setter populates s_model from
+ * NVS before any further mutation. */
 static voice_yolo_model_t s_model = VOICE_YOLO_MODEL_DET;
+static bool s_model_seeded = false;
+
+/* Vision V1 (TT #672): client-side confidence floor.  K144 returns
+ * detections at its own implicit threshold; we filter further before
+ * passing to the caller's box buffer.  Seeded from NVS `yolo_conf`
+ * (uint8 percent) on first access. */
+static float s_min_confidence = 0.5f;
+static bool s_min_confidence_seeded = false;
+
+static void seed_model_from_nvs(void) {
+   if (s_model_seeded) return;
+   uint8_t v = tab5_settings_get_yolo_mode();
+   s_model = (v > 2) ? VOICE_YOLO_MODEL_DET : (voice_yolo_model_t)v;
+   s_model_seeded = true;
+}
+
+static void seed_conf_from_nvs(void) {
+   if (s_min_confidence_seeded) return;
+   uint8_t pct = tab5_settings_get_yolo_conf();
+   s_min_confidence = (float)pct / 100.0f;
+   s_min_confidence_seeded = true;
+}
 
 const char *voice_yolo_get_model_name(voice_yolo_model_t model) {
    switch (model) {
@@ -184,10 +212,14 @@ const char *voice_yolo_get_model_name(voice_yolo_model_t model) {
    }
 }
 
-voice_yolo_model_t voice_yolo_get_model(void) { return s_model; }
+voice_yolo_model_t voice_yolo_get_model(void) {
+   seed_model_from_nvs();
+   return s_model;
+}
 
 esp_err_t voice_yolo_set_model(voice_yolo_model_t model) {
    if (model > VOICE_YOLO_MODEL_SEG) return ESP_ERR_INVALID_ARG;
+   seed_model_from_nvs();
    ensure_lock();
    xSemaphoreTake(s_lock, portMAX_DELAY);
    if (s_model != model) {
@@ -196,9 +228,25 @@ esp_err_t voice_yolo_set_model(voice_yolo_model_t model) {
       s_model = model;
       s_work_id[0] = '\0';
       s_ready = false;
+      /* Vision V1 (TT #672): persist user's pick so it survives reboot. */
+      tab5_settings_set_yolo_mode((uint8_t)model);
    }
    xSemaphoreGive(s_lock);
    return ESP_OK;
+}
+
+float voice_yolo_get_min_confidence(void) {
+   seed_conf_from_nvs();
+   return s_min_confidence;
+}
+
+void voice_yolo_set_min_confidence(float threshold) {
+   if (threshold < 0.0f) threshold = 0.0f;
+   if (threshold > 1.0f) threshold = 1.0f;
+   seed_conf_from_nvs();
+   s_min_confidence = threshold;
+   /* Persist as uint8 percent (0..100). */
+   tab5_settings_set_yolo_conf((uint8_t)(threshold * 100.0f + 0.5f));
 }
 
 /* On a fresh K144 the yolo task pool is empty.  Earlier dev-box probes
@@ -366,7 +414,16 @@ static int parse_stream_line(const char *line, const char *want_rid, voice_yolo_
                }
                b->kpt_count = (uint8_t)nkp;
             }
-            (*count)++;
+            /* Vision V1 (TT #672): client-side confidence floor.  Drop
+             * the detection if it lands below the user-configured
+             * threshold.  We seed the threshold lazily so the daemon
+             * settle path doesn't take the cost. */
+            seed_conf_from_nvs();
+            if (b->confidence < s_min_confidence) {
+               /* Slot stays unfilled — *count doesn't advance. */
+            } else {
+               (*count)++;
+            }
          }
       }
    }

--- a/main/voice_yolo.h
+++ b/main/voice_yolo.h
@@ -113,6 +113,14 @@ voice_yolo_model_t voice_yolo_get_model(void);
 /** Human-readable name ("yolo11n", "yolo11n-pose", "yolo11s-seg"). */
 const char *voice_yolo_get_model_name(voice_yolo_model_t model);
 
+/** Vision V1 (TT #672) — client-side confidence floor.  Detections
+ *  with confidence < threshold are dropped before being passed to the
+ *  caller's box buffer.  Range 0.0..1.0; default 0.5.  Persisted via
+ *  NVS `yolo_conf` (uint8 %).  Safe to change at runtime; takes
+ *  effect on the next inference. */
+float voice_yolo_get_min_confidence(void);
+void voice_yolo_set_min_confidence(float threshold);
+
 /**
  * @brief Run YOLO11n on a 320×320 JPEG and collect detections.
  *


### PR DESCRIPTION
## Summary

First wave of the **always-on vision program** (\`.claude/plans/delightful-exploring-blum.md\`).  Three independent quick wins on the camera screen — no K144 wire changes, no protocol bumps.

### What ships

1. **NVS \`yolo_mode\` persistence** — \`voice_yolo\`'s s_model now seeds from NVS on first read.  Long-press DETECT cycles DET → POSE → SEG and writes the new value; the user's choice survives reboots.
2. **NVS \`yolo_conf\` + client-side confidence floor** — new \`voice_yolo_set_min_confidence(float)\` API. Detections below threshold drop before the caller's box buffer fills.  Default 50 %; range 0..100 %.
3. **Camera-screen confidence picker** — 3 amber pills (30 / 50 / 70 %) at the viewfinder top-right.  Hidden when DETECT is off; visible when on.  Tap → set + persist + repaint active state.

\`/settings\` GET + POST surfaces both keys for harness use.

## Live verification (Tab5 192.168.1.90)

- Camera screen → DETECT on → 3 chips visible with 50 % active (amber-filled), others amber-bordered
- Tap 30 % chip → \`GET /settings\` reports \`yolo_conf: 50 → 30\`
- Screenshot shows active state moved from 50 % → 30 %
- Heap stable 60 KB internal lf

## Out of scope (deferred, called out in plan)

- SEG mask render — needs protocol-level work to receive mask data; future wave
- \"Ask Tinker about this\" pill — depends on V3 (K144 InternVL)
- Dedicated mode chip widget — current DETECT button label already shows the active model when on

## Test plan

- [x] Build green (+ minimal flash growth)
- [x] Flash + boot clean
- [x] Confidence chips appear when DETECT toggles on, disappear when off
- [x] Chip tap → NVS write + active state moves
- [x] \`yolo_mode\` survives reboot (NVS round-trip confirmed)
- [x] \`yolo_conf\` survives reboot (NVS round-trip confirmed)
- [x] Format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)