### PR TITLE
Vision V2-A.1: vision_service scaffold + Settings toggle (closes #674)

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UI_SRCS
     "ui_theme.c"
     "ui_typography.c"
     "ui_components.c"
+    "vision_service.c"
     "ui_splash.c" "ui_home.c" "ui_orb.c" "ui_settings.c"
     "ui_camera.c" "ui_files.c" "ui_audio.c" "ui_keyboard.c" "ui_voice.c" "ui_wifi.c"
     "ui_video_pane.c"

--- a/main/debug_server_camera.c
+++ b/main/debug_server_camera.c
@@ -39,8 +39,9 @@
 #include "freertos/atomic.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
-#include "task_worker.h" /* tab5_worker_enqueue */
-#include "ui_core.h"     /* tab5_ui_try_lock / tab5_ui_unlock */
+#include "task_worker.h"    /* tab5_worker_enqueue */
+#include "ui_core.h"        /* tab5_ui_try_lock / tab5_ui_unlock */
+#include "vision_service.h" /* V2-A.1 — /vision/state */
 
 static const char *TAG = "debug_camera";
 
@@ -325,6 +326,31 @@ static esp_err_t camera_handler(httpd_req_t *req) {
    return err;
 }
 
+/* Vision V2-A.1 (TT #674) — GET /vision/state */
+static esp_err_t vision_state_handler(httpd_req_t *req) {
+   if (!tab5_debug_check_auth(req)) return ESP_OK;
+   vision_service_state_t st;
+   vision_service_get_state(&st);
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddBoolToObject(root, "enabled", st.enabled);
+   cJSON_AddNumberToObject(root, "rate_hz", st.rate_hz);
+   cJSON_AddNumberToObject(root, "frames_processed", st.frames_processed);
+   cJSON_AddNumberToObject(root, "frames_yielded", st.frames_yielded);
+   cJSON_AddNumberToObject(root, "detections_total", st.detections_total);
+   cJSON_AddNumberToObject(root, "uptime_ms", (double)st.uptime_ms);
+   cJSON_AddStringToObject(root, "last_class", st.last_class);
+   cJSON_AddNumberToObject(root, "last_detection_ms", (double)st.last_detection_ms);
+   cJSON_AddNumberToObject(root, "last_confidence", st.last_confidence);
+   /* Surface upstream prereqs so the harness can correlate "frames=0
+    * after 6 s enabled" → either K144 USB isn't up, or yolo isn't
+    * armed, or the camera failed init. */
+   extern bool tab5_camera_initialized(void);
+   extern bool voice_yolo_is_ready(void);
+   cJSON_AddBoolToObject(root, "camera_ready", tab5_camera_initialized());
+   cJSON_AddBoolToObject(root, "yolo_ready", voice_yolo_is_ready());
+   return tab5_debug_send_json_resp(req, root);
+}
+
 void debug_server_camera_register(httpd_handle_t server) {
    if (!server) return;
 
@@ -335,8 +361,11 @@ void debug_server_camera_register(httpd_handle_t server) {
    static const httpd_uri_t uri_screenshot_jpg = {
        .uri = "/screenshot.jpg", .method = HTTP_GET, .handler = screenshot_handler};
    static const httpd_uri_t uri_camera = {.uri = "/camera", .method = HTTP_GET, .handler = camera_handler};
+   static const httpd_uri_t uri_vision_state = {
+       .uri = "/vision/state", .method = HTTP_GET, .handler = vision_state_handler};
 
    httpd_register_uri_handler(server, &uri_screenshot);
    httpd_register_uri_handler(server, &uri_screenshot_jpg);
    httpd_register_uri_handler(server, &uri_camera);
+   httpd_register_uri_handler(server, &uri_vision_state);
 }

--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -137,6 +137,9 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
    /* Vision V1 (TT #672): YOLO model + confidence persistence. */
    cJSON_AddNumberToObject(root, "yolo_mode", tab5_settings_get_yolo_mode());
    cJSON_AddNumberToObject(root, "yolo_conf", tab5_settings_get_yolo_conf());
+   /* Vision V2-A.1 (TT #674): always-on vision service. */
+   cJSON_AddBoolToObject(root, "vision_on", tab5_settings_get_vision_on());
+   cJSON_AddNumberToObject(root, "vision_rate", tab5_settings_get_vision_rate());
    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
@@ -507,6 +510,25 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
       int v = (int)yc->valuedouble;
       if (v >= 0 && v <= 100 && tab5_settings_set_yolo_conf((uint8_t)v) == ESP_OK) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("yolo_conf"));
+      }
+   }
+   /* Vision V2-A.1 (TT #674): always-on vision toggle + rate. */
+   cJSON *vo = cJSON_GetObjectItem(req_json, "vision_on");
+   if (vo) {
+      bool on = false;
+      if (cJSON_IsBool(vo))
+         on = cJSON_IsTrue(vo);
+      else if (cJSON_IsNumber(vo))
+         on = vo->valuedouble != 0;
+      if (tab5_settings_set_vision_on(on) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("vision_on"));
+      }
+   }
+   cJSON *vr = cJSON_GetObjectItem(req_json, "vision_rate");
+   if (cJSON_IsNumber(vr)) {
+      int v = (int)vr->valuedouble;
+      if (v >= 1 && v <= 3 && tab5_settings_set_vision_rate((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("vision_rate"));
       }
    }
    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");

--- a/main/main.c
+++ b/main/main.c
@@ -574,6 +574,12 @@ void app_main(void)
          * at the 100 ms timer tick.  Init is mutex-only here; no LVGL deps. */
         extern void voice_dictation_init(void);
         voice_dictation_init();
+        /* Vision V2-A.1 (TT #674): background YOLO service.  Idle
+         * until the user toggles vision_on via Settings or the
+         * runtime API.  Safe to init unconditionally — task just
+         * polls NVS in a sleep loop while disabled. */
+        extern esp_err_t vision_service_init(void);
+        vision_service_init();
         extern void widget_store_init(void);
         widget_store_init();  // widget platform — bounded PSRAM cache
         extern void chat_store_init(void);

--- a/main/settings.c
+++ b/main/settings.c
@@ -576,6 +576,24 @@ esp_err_t tab5_settings_set_yolo_conf(uint8_t pct) {
    return set_u8("yolo_conf", pct);
 }
 
+/* ── Vision V2-A.1 (TT #674) — always-on vision service ───────── */
+
+bool tab5_settings_get_vision_on(void) { return get_u8("vision_on", 0) != 0; }
+
+esp_err_t tab5_settings_set_vision_on(bool on) { return set_u8("vision_on", on ? 1 : 0); }
+
+uint8_t tab5_settings_get_vision_rate(void) {
+   uint8_t v = get_u8("vision_rate", 2);
+   if (v < 1) v = 1;
+   if (v > 3) v = 3;
+   return v;
+}
+
+esp_err_t tab5_settings_set_vision_rate(uint8_t hz) {
+   if (hz < 1 || hz > 3) return ESP_ERR_INVALID_ARG;
+   return set_u8("vision_rate", hz);
+}
+
 /* ── Wake source picker (TT #617) ───────────────────────────────────── */
 
 esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {

--- a/main/settings.h
+++ b/main/settings.h
@@ -247,6 +247,22 @@ esp_err_t tab5_settings_set_yolo_mode(uint8_t mode);
 uint8_t tab5_settings_get_yolo_conf(void);
 esp_err_t tab5_settings_set_yolo_conf(uint8_t pct);
 
+/** Vision V2-A.1 (TT #674) — always-on vision service.
+ *
+ *  vision_on: master toggle.  Default OFF for privacy posture
+ *  (matches the "Privacy lock" default and what the always-on UX
+ *  research recommended — opt-in per platform-level pattern).
+ *
+ *  vision_rate: inference rate when enabled.  Range 1..3 Hz.  Default
+ *  2 Hz — research compromise between Frigate's ≥5 fps tracking ideal
+ *  and our Wi-Fi DMA contention budget.  Stored as a Hz value
+ *  directly (no enum mapping) so future rate options don't bump the
+ *  schema. */
+bool tab5_settings_get_vision_on(void);
+esp_err_t tab5_settings_set_vision_on(bool on);
+uint8_t tab5_settings_get_vision_rate(void);
+esp_err_t tab5_settings_set_vision_rate(uint8_t hz);
+
 /** TT #617 — Wake source.  Picks which wakeword detection path runs.
  *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
  *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future

--- a/main/ui_camera.c
+++ b/main/ui_camera.c
@@ -182,6 +182,11 @@ static void yolo_free_resources(void);
 static void yolo_downsample_rgb565(const uint16_t *src, int sw, int sh, uint16_t *dst);
 static const char *yolo_mode_short_label(voice_yolo_model_t m);
 
+/* Vision V2-A.1 (TT #674): expose DETECT state to the background
+ * vision_service so it can yield when the foreground camera screen
+ * is already running YOLO. */
+bool ui_camera_yolo_active(void) { return s_yolo_on && scr_camera != NULL; }
+
 /* Currently selected resolution (default VGA for smooth preview) */
 static tab5_cam_resolution_t current_res = TAB5_CAM_RES_HD;  /* SC202CS outputs 1280x720 */
 

--- a/main/ui_camera.h
+++ b/main/ui_camera.h
@@ -20,3 +20,9 @@ void ui_camera_destroy(void);
  *  renders as a user image bubble.  Auto-clears after one capture so
  *  subsequent normal-camera captures don't accidentally upload. */
 void ui_camera_arm_chat_share(void);
+
+/** Vision V2-A.1 (TT #674): true when the camera screen is alive AND
+ *  the user has toggled DETECT on.  The background vision_service
+ *  yields when this is true so YOLO requests don't double up on the
+ *  K144 USB-FFS channel. */
+bool ui_camera_yolo_active(void);

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -688,6 +688,28 @@ static void cb_theme(lv_event_t *e) {
    tab5_settings_set_theme((uint8_t)sel);
 }
 
+/* Vision V2-A.1 (TT #674): always-on vision master toggle.  Persists
+ * to NVS via vision_service_set_enabled (which also fires the obs
+ * event for harness use). */
+static void cb_vision_on(lv_event_t *e) {
+   lv_obj_t *sw = lv_event_get_target(e);
+   bool on = lv_obj_has_state(sw, LV_STATE_CHECKED);
+   ESP_LOGI(TAG, "Always-on vision %s", on ? "enabled" : "disabled");
+   extern esp_err_t vision_service_set_enabled(bool enabled);
+   vision_service_set_enabled(on);
+}
+
+/* Vision V2-A.1 (TT #674): inference rate (1 / 2 / 3 Hz). */
+static void cb_vision_rate(lv_event_t *e) {
+   lv_obj_t *dd = lv_event_get_target(e);
+   uint16_t sel = lv_dropdown_get_selected(dd);
+   uint8_t hz = (uint8_t)(sel + 1);
+   if (hz < 1) hz = 1;
+   if (hz > 3) hz = 3;
+   ESP_LOGI(TAG, "Vision rate -> %u Hz", (unsigned)hz);
+   tab5_settings_set_vision_rate(hz);
+}
+
 static void cb_autorotate(lv_event_t *e)
 {
     lv_obj_t *sw = lv_event_get_target(e);
@@ -2458,6 +2480,37 @@ lv_obj_t *ui_settings_create(void)
        lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), LV_PART_ITEMS);
        lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
        lv_obj_add_event_cb(dd, cb_theme, LV_EVENT_VALUE_CHANGED, NULL);
+    }
+    y += ROW_H + 4;
+
+    /* Vision V2-A.1 (TT #674): Always-on vision master toggle.
+     * Privacy-by-default — default OFF.  Background YOLO service
+     * captures + classifies the camera feed when this is on. */
+    mk_row_label(s_scroll, "Always-on vision", y);
+    mk_switch(s_scroll, acc_display, 660, y, tab5_settings_get_vision_on(), cb_vision_on, NULL);
+    y += ROW_H + 4;
+
+    /* Vision V2-A.1 (TT #674): inference rate (1 / 2 / 3 Hz). */
+    mk_row_label(s_scroll, "Vision rate", y);
+    {
+       lv_obj_t *dd = lv_dropdown_create(s_scroll);
+       lv_dropdown_set_options(dd, "1 Hz\n2 Hz\n3 Hz");
+       uint8_t cur = tab5_settings_get_vision_rate();
+       if (cur < 1) cur = 2;
+       if (cur > 3) cur = 3;
+       lv_dropdown_set_selected(dd, cur - 1);
+       lv_obj_set_pos(dd, 340, y);
+       lv_obj_set_size(dd, 340, 36);
+       lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), 0);
+       lv_obj_set_style_bg_opa(dd, LV_OPA_COVER, 0);
+       lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), 0);
+       lv_obj_set_style_text_font(dd, FONT_SECONDARY, 0);
+       lv_obj_set_style_border_width(dd, 1, 0);
+       lv_obj_set_style_border_color(dd, lv_color_hex(0x1A1A24), 0);
+       lv_obj_set_style_radius(dd, 6, 0);
+       lv_obj_set_style_bg_color(dd, lv_color_hex(CARD_COLOR), LV_PART_ITEMS);
+       lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
+       lv_obj_add_event_cb(dd, cb_vision_rate, LV_EVENT_VALUE_CHANGED, NULL);
     }
     y += ROW_H + 16;
     mk_card_bg(s_scroll, display_section_top, y);

--- a/main/vision_service.c
+++ b/main/vision_service.c
@@ -1,0 +1,214 @@
+/**
+ * @file vision_service.c
+ * @brief Implementation — see vision_service.h.
+ *
+ * Vision V2-A.1 (TT #674).  Scaffolding-only — runs continuous YOLO
+ * but doesn't yet evaluate rules or fire notifications.  Layers
+ * (tracker → DSL → rules → notification) ship in V2-A.2 .. V2-A.4.
+ */
+
+#include "vision_service.h"
+
+#include <string.h>
+
+#include "camera.h"
+#include "debug_obs.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "settings.h"
+#include "ui_camera.h"
+#include "voice_video.h"
+#include "voice_yolo.h"
+
+static const char *TAG = "vision_svc";
+
+#define POLL_INTERVAL_MS 500u /* config re-read cadence when disabled */
+#define MIN_TICK_MS 333u      /* hard floor matches K144 USB-FFS budget */
+#define VS_MAX_BOXES 8
+#define VS_INPUT_W 320
+#define VS_INPUT_H 320
+#define VS_JPEG_CAP (24 * 1024)
+
+static TaskHandle_t s_task = NULL;
+static SemaphoreHandle_t s_lock = NULL;
+static vision_service_state_t s_state = {0};
+static uint64_t s_boot_ms = 0;
+static uint16_t *s_small_buf = NULL;
+static uint8_t *s_jpeg_buf = NULL;
+
+static uint64_t now_ms(void) { return (uint64_t)(esp_timer_get_time() / 1000); }
+
+/* RGB565 nearest-neighbour downsample.  Mirrors ui_camera's yolo
+ * downsampler but local-only so we don't need to expose it. */
+static void downsample_rgb565(const uint16_t *src, int sw, int sh, uint16_t *dst) {
+   const int dw = VS_INPUT_W;
+   const int dh = VS_INPUT_H;
+   for (int y = 0; y < dh; y++) {
+      int sy = (y * sh) / dh;
+      const uint16_t *srow = src + (size_t)sy * sw;
+      uint16_t *drow = dst + (size_t)y * dw;
+      for (int x = 0; x < dw; x++) {
+         int sx = (x * sw) / dw;
+         drow[x] = srow[sx];
+      }
+   }
+}
+
+static esp_err_t ensure_buffers(void) {
+   if (!s_small_buf) {
+      s_small_buf = heap_caps_malloc((size_t)VS_INPUT_W * VS_INPUT_H * 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (!s_small_buf) return ESP_ERR_NO_MEM;
+   }
+   if (!s_jpeg_buf) {
+      s_jpeg_buf = heap_caps_malloc(VS_JPEG_CAP, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      if (!s_jpeg_buf) return ESP_ERR_NO_MEM;
+   }
+   return ESP_OK;
+}
+
+static bool is_interesting_class(const char *klass) {
+   /* V2-A.1 surfaces only the 3 classes the built-in rules will care
+    * about in V2-A.2 (person / dog / cat).  Other COCO classes still
+    * count toward detections_total but don't fire obs.  Cheaper than
+    * a hash table and avoids surfacing noise. */
+   return klass && (strcmp(klass, "person") == 0 || strcmp(klass, "dog") == 0 || strcmp(klass, "cat") == 0);
+}
+
+static void process_one_frame(void) {
+   tab5_cam_frame_t frame;
+   esp_err_t err = tab5_camera_capture(&frame);
+   if (err != ESP_OK) {
+      /* NOT_FINISHED races against ui_camera's preview tick.  Treat
+       * as a yield — try again next tick. */
+      s_state.frames_yielded++;
+      return;
+   }
+   if (frame.format != TAB5_CAM_FMT_RGB565) {
+      ESP_LOGW(TAG, "frame format %d not RGB565 — skip", (int)frame.format);
+      return;
+   }
+   downsample_rgb565((const uint16_t *)frame.data, frame.width, frame.height, s_small_buf);
+
+   uint32_t jpeg_bytes = 0;
+   esp_err_t enc_err = voice_video_encode_rgb565((const uint8_t *)s_small_buf, VS_INPUT_W, VS_INPUT_H, 80, s_jpeg_buf,
+                                                 VS_JPEG_CAP, &jpeg_bytes);
+   if (enc_err != ESP_OK || jpeg_bytes == 0) {
+      ESP_LOGD(TAG, "JPEG encode failed (%d, bytes=%u)", (int)enc_err, (unsigned)jpeg_bytes);
+      return;
+   }
+
+   voice_yolo_box_t boxes[VS_MAX_BOXES];
+   size_t n = 0;
+   esp_err_t i_err = voice_yolo_infer(s_jpeg_buf, jpeg_bytes, boxes, VS_MAX_BOXES, &n, 1500);
+   s_state.frames_processed++;
+   if (i_err != ESP_OK) {
+      ESP_LOGD(TAG, "infer failed: %d", (int)i_err);
+      return;
+   }
+   s_state.detections_total += (uint32_t)n;
+   for (size_t i = 0; i < n; i++) {
+      if (!is_interesting_class(boxes[i].klass)) continue;
+      strlcpy(s_state.last_class, boxes[i].klass, sizeof(s_state.last_class));
+      s_state.last_detection_ms = now_ms();
+      s_state.last_confidence = boxes[i].confidence;
+      char detail[48];
+      snprintf(detail, sizeof(detail), "%s %.2f", boxes[i].klass, boxes[i].confidence);
+      tab5_debug_obs_event("vision.detect", detail);
+   }
+}
+
+static void vision_service_task(void *arg) {
+   (void)arg;
+   ESP_LOGI(TAG, "task started");
+   for (;;) {
+      bool enabled = tab5_settings_get_vision_on();
+      uint8_t rate = tab5_settings_get_vision_rate();
+      if (rate < 1) rate = 1;
+      if (rate > 3) rate = 3;
+
+      xSemaphoreTake(s_lock, portMAX_DELAY);
+      s_state.enabled = enabled;
+      s_state.rate_hz = rate;
+      s_state.uptime_ms = now_ms() - s_boot_ms;
+      xSemaphoreGive(s_lock);
+
+      if (!enabled) {
+         vTaskDelay(pdMS_TO_TICKS(POLL_INTERVAL_MS));
+         continue;
+      }
+
+      /* Yield to foreground YOLO loop on camera screen — avoids
+       * USB-FFS contention which Wi-Fi DMA can't tolerate. */
+      if (ui_camera_yolo_active()) {
+         s_state.frames_yielded++;
+         vTaskDelay(pdMS_TO_TICKS(POLL_INTERVAL_MS));
+         continue;
+      }
+
+      if (!tab5_camera_initialized()) {
+         vTaskDelay(pdMS_TO_TICKS(POLL_INTERVAL_MS));
+         continue;
+      }
+      /* Self-arm YOLO when the service is enabled.  voice_yolo_init is
+       * idempotent — fast no-op once armed.  Returns INVALID_STATE if
+       * K144 USB-FFS isn't connected yet; we just back off and retry. */
+      if (!voice_yolo_is_ready()) {
+         esp_err_t arm = voice_yolo_init();
+         if (arm != ESP_OK) {
+            vTaskDelay(pdMS_TO_TICKS(2000));
+            continue;
+         }
+      }
+
+      if (ensure_buffers() != ESP_OK) {
+         ESP_LOGW(TAG, "buffer alloc failed");
+         vTaskDelay(pdMS_TO_TICKS(2000));
+         continue;
+      }
+
+      process_one_frame();
+
+      uint32_t period_ms = 1000u / rate;
+      if (period_ms < MIN_TICK_MS) period_ms = MIN_TICK_MS;
+      vTaskDelay(pdMS_TO_TICKS(period_ms));
+   }
+}
+
+esp_err_t vision_service_init(void) {
+   if (s_task) return ESP_OK;
+   s_lock = xSemaphoreCreateMutex();
+   if (!s_lock) return ESP_ERR_NO_MEM;
+   s_boot_ms = now_ms();
+   /* PSRAM-backed task stack — keeps internal SRAM free for the
+    * Wi-Fi + LVGL hot paths. */
+   StaticTask_t *task_buf = heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+   StackType_t *stack_buf = heap_caps_malloc(8192 * sizeof(StackType_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+   if (!task_buf || !stack_buf) {
+      ESP_LOGE(TAG, "task alloc failed");
+      return ESP_ERR_NO_MEM;
+   }
+   s_task = xTaskCreateStatic(vision_service_task, "vision_svc", 8192, NULL, 5, stack_buf, task_buf);
+   if (!s_task) {
+      ESP_LOGE(TAG, "task create failed");
+      return ESP_FAIL;
+   }
+   tab5_debug_obs_event("vision.init", "ok");
+   return ESP_OK;
+}
+
+esp_err_t vision_service_set_enabled(bool enabled) {
+   esp_err_t err = tab5_settings_set_vision_on(enabled);
+   if (err == ESP_OK) tab5_debug_obs_event("vision.toggle", enabled ? "on" : "off");
+   return err;
+}
+
+void vision_service_get_state(vision_service_state_t *out) {
+   if (!out) return;
+   xSemaphoreTake(s_lock, portMAX_DELAY);
+   *out = s_state;
+   out->uptime_ms = now_ms() - s_boot_ms;
+   xSemaphoreGive(s_lock);
+}

--- a/main/vision_service.h
+++ b/main/vision_service.h
@@ -1,0 +1,53 @@
+/**
+ * @file vision_service.h
+ * @brief Background always-on vision service — Vision V2-A.1 (TT #674).
+ *
+ * Runs YOLO11n at a user-configurable rate when enabled.  Captures
+ * frames from the shared SC202CS sensor, downscales to 320×320,
+ * encodes via the HW JPEG engine, and dispatches to K144 over the
+ * existing voice_yolo + USB-FFS path.
+ *
+ * This first slice ships the scaffold + continuous detection only.
+ * The full plan (vision_service + object tracker + DSL evaluator +
+ * built-in rules + notification surface) lands across V2-A.2 .. V2-A.4.
+ *
+ * Architecture:
+ *   - Single FreeRTOS task with PSRAM-backed stack
+ *   - Wakes at NVS `vision_rate` Hz when NVS `vision_on` is true
+ *   - Yields when ui_camera has DETECT toggled on (avoid K144
+ *     USB-FFS contention with the foreground YOLO loop)
+ *   - Emits obs events ("vision.detect") for high-confidence
+ *     person / dog / cat detections
+ *   - Exposes service state for `GET /vision/state`
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+/** Initialize the background vision task.  Call once at boot, after
+ *  tab5_settings_init and voice_yolo_init (camera HW must already be
+ *  alive).  Task remains idle until vision_on is set true via NVS or
+ *  the runtime setter. */
+esp_err_t vision_service_init(void);
+
+/** Runtime enable/disable.  Persists to NVS `vision_on` so the state
+ *  survives reboot.  Safe to call from any task. */
+esp_err_t vision_service_set_enabled(bool enabled);
+
+/** Snapshot of the service state — populated for `GET /vision/state`. */
+typedef struct {
+   bool enabled;
+   uint8_t rate_hz;
+   uint32_t frames_processed;
+   uint32_t frames_yielded;    /* skipped because ui_camera was busy */
+   uint32_t detections_total;  /* boxes returned, summed across frames */
+   uint64_t uptime_ms;         /* ms since service init */
+   char last_class[24];        /* class name of most recent detection */
+   uint64_t last_detection_ms; /* uptime_ms at last detection */
+   float last_confidence;
+} vision_service_state_t;
+
+void vision_service_get_state(vision_service_state_t *out);


### PR DESCRIPTION
## Summary

First slice of the always-on vision program (V2).  Lands the **scaffold** without the tracker / DSL / notifications — those layer in V2-A.2 → V2-A.4.

### What ships

- New \`main/vision_service.{c,h}\` — PSRAM-backed background task that runs YOLO11n at the user-configured rate (1/2/3 Hz)
- NVS keys \`vision_on\` (default OFF for privacy posture) + \`vision_rate\` (default 2 Hz)
- Settings UI: \"Always-on vision\" switch + \"Vision rate\" dropdown under DISPLAY
- Debug endpoint \`GET /vision/state\` returns full service snapshot + prereq flags (\`camera_ready\`, \`yolo_ready\`) so failures are easy to root-cause
- Self-arms \`voice_yolo_init\` when enabled (idempotent — kicks off the moment K144 USB-FFS comes up)
- Yields to \`ui_camera\` foreground DETECT loop (avoid K144 USB-FFS contention)
- Emits \`vision.detect\` obs events for person/dog/cat — the 3 classes V2-A.2's built-in rules will care about

### Out of scope (next sub-waves)

- Object permanence tracker
- Trigger DSL evaluator
- Built-in rules (Welcome glance, Pet timeline)
- Notification surface integration + snooze chip
- Privacy indicator dot

These all depend on the scaffold landing first.

## Live verification (Tab5 192.168.1.90)

- Service initializes at boot, stays idle until enabled
- \`POST /settings -d '{\"vision_on\":true}'\` flips state to enabled
- When K144 USB-FFS not connected: \`yolo_ready=false\`, \`frames_processed=0\`, service polls every 2 s + retries voice_yolo_init (no panic, no leak)
- Settings screenshot shows new \"Always-on vision\" + \"Vision rate\" rows under DISPLAY card
- Heap stable 60 KB internal lf
- Build +4 KB flash

## Test plan

- [x] Build green
- [x] Boot clean — scaffold task created, idle
- [x] NVS round-trip via \`/settings\` GET + POST
- [x] \`/vision/state\` returns full snapshot
- [x] Self-arm path tries voice_yolo_init when enabled
- [x] Format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)