### PR TITLE
fix(vision): V2-A.1 JPEG alignment + voice_video self-init + skip-reason obs

### DIFF
--- a/main/vision_service.c
+++ b/main/vision_service.c
@@ -13,6 +13,7 @@
 
 #include "camera.h"
 #include "debug_obs.h"
+#include "driver/jpeg_encode.h" /* jpeg_alloc_encoder_mem for DMA-aligned output */
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_timer.h"
@@ -63,7 +64,14 @@ static esp_err_t ensure_buffers(void) {
       if (!s_small_buf) return ESP_ERR_NO_MEM;
    }
    if (!s_jpeg_buf) {
-      s_jpeg_buf = heap_caps_malloc(VS_JPEG_CAP, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+      /* HW JPEG engine needs a DMA-aligned output buffer.  Plain
+       * heap_caps_malloc on PSRAM doesn't guarantee the cache-line
+       * alignment the encoder expects — `jpeg_encoder_process` then
+       * fails with ESP_ERR_INVALID_ARG (=258) even for valid 320×320
+       * inputs.  ui_camera's yolo path does the same. */
+      jpeg_encode_memory_alloc_cfg_t mcfg = {.buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER};
+      size_t actual = 0;
+      s_jpeg_buf = (uint8_t *)jpeg_alloc_encoder_mem(VS_JPEG_CAP, &mcfg, &actual);
       if (!s_jpeg_buf) return ESP_ERR_NO_MEM;
    }
    return ESP_OK;
@@ -88,6 +96,9 @@ static void process_one_frame(void) {
    }
    if (frame.format != TAB5_CAM_FMT_RGB565) {
       ESP_LOGW(TAG, "frame format %d not RGB565 — skip", (int)frame.format);
+      char detail[24];
+      snprintf(detail, sizeof(detail), "fmt=%d", (int)frame.format);
+      tab5_debug_obs_event("vision.skip", detail);
       return;
    }
    downsample_rgb565((const uint16_t *)frame.data, frame.width, frame.height, s_small_buf);
@@ -97,6 +108,9 @@ static void process_one_frame(void) {
                                                  VS_JPEG_CAP, &jpeg_bytes);
    if (enc_err != ESP_OK || jpeg_bytes == 0) {
       ESP_LOGD(TAG, "JPEG encode failed (%d, bytes=%u)", (int)enc_err, (unsigned)jpeg_bytes);
+      char detail[32];
+      snprintf(detail, sizeof(detail), "enc=%d b=%u", (int)enc_err, (unsigned)jpeg_bytes);
+      tab5_debug_obs_event("vision.skip", detail);
       return;
    }
 
@@ -182,6 +196,12 @@ esp_err_t vision_service_init(void) {
    s_lock = xSemaphoreCreateMutex();
    if (!s_lock) return ESP_ERR_NO_MEM;
    s_boot_ms = now_ms();
+   /* voice_video_encode_rgb565 requires voice_video_init to have run
+    * for the HW JPEG encoder + mutex.  voice.c calls this at boot but
+    * we self-init here too — idempotent — to guard against init-order
+    * regressions. */
+   extern esp_err_t voice_video_init(void);
+   voice_video_init();
    /* PSRAM-backed task stack — keeps internal SRAM free for the
     * Wi-Fi + LVGL hot paths. */
    StaticTask_t *task_buf = heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);


### PR DESCRIPTION
## Summary

Live-testing V2-A.1 ([#675](https://github.com/lorcan35/TinkerTab/pull/675)) on Tab5 with K144 plugged in surfaced 3 quick fixes:

### 1. JPEG output buffer needs DMA-alignment

Plain \`heap_caps_malloc(MALLOC_CAP_SPIRAM|MALLOC_CAP_8BIT)\` returns memory that the HW JPEG encoder rejects with \`ESP_ERR_INVALID_ARG\` (=258) on every encode call.  \`ui_camera\`'s YOLO path already uses \`jpeg_alloc_encoder_mem\` for the output buffer — mirror that.

### 2. Self-init voice_video

\`voice_video_encode_rgb565\` requires \`voice_video_init()\` to have run.  \`voice.c\` already calls it at boot, but \`vision_service\` is loosely coupled — self-init in \`vision_service_init\` to guard against init-order regressions.  Idempotent.

### 3. Skip-reason obs events

Each early-return path now fires a \`vision.skip\` obs event with the failure detail (\`fmt=N\` or \`enc=N b=M\`).  Made root-causing the bug above trivial — the obs ring immediately showed \`enc=258 b=0\` repeating.

## Live verification (Tab5 192.168.1.90)

- **Before fix**: K144 plugged in, vision_on=true, frames_processed stuck at 0, vision.skip ring showed \`enc=258 b=0\` repeating
- **After fix**: frames_processed climbs 0 → 35 in ~45 s, 1 detection (camera was on a blank wall), heap stable 64 KB internal lf
- Background YOLO loop end-to-end verified

## Test plan

- [x] Build green
- [x] Flash + boot clean
- [x] frames_processed climbs when vision_on + K144 connected
- [x] vision.skip obs events fire when frame format != RGB565 or encode fails
- [x] Format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)