### PR TITLE
Vision V2-A.3: kill Pet timeline + LEAVE-gated Welcome + presence-aware brightness (closes #680)

### DIFF
--- a/main/debug_server_settings.c
+++ b/main/debug_server_settings.c
@@ -140,6 +140,9 @@ static esp_err_t settings_get_handler(httpd_req_t *req) {
    /* Vision V2-A.1 (TT #674): always-on vision service. */
    cJSON_AddBoolToObject(root, "vision_on", tab5_settings_get_vision_on());
    cJSON_AddNumberToObject(root, "vision_rate", tab5_settings_get_vision_rate());
+   /* Vision V2-A.3 (TT #680): presence-aware brightness. */
+   cJSON_AddBoolToObject(root, "away_dim", tab5_settings_get_away_dim());
+   cJSON_AddNumberToObject(root, "away_dim_pct", tab5_settings_get_away_dim_pct());
    cJSON_AddNumberToObject(root, "int_tier", tab5_settings_get_int_tier());
    cJSON_AddNumberToObject(root, "voi_tier", tab5_settings_get_voi_tier());
    cJSON_AddNumberToObject(root, "aut_tier", tab5_settings_get_aut_tier());
@@ -529,6 +532,25 @@ static esp_err_t settings_set_handler(httpd_req_t *req) {
       int v = (int)vr->valuedouble;
       if (v >= 1 && v <= 3 && tab5_settings_set_vision_rate((uint8_t)v) == ESP_OK) {
          cJSON_AddItemToArray(updated, cJSON_CreateString("vision_rate"));
+      }
+   }
+   /* Vision V2-A.3 (TT #680): presence-aware brightness. */
+   cJSON *ad = cJSON_GetObjectItem(req_json, "away_dim");
+   if (ad) {
+      bool on = false;
+      if (cJSON_IsBool(ad))
+         on = cJSON_IsTrue(ad);
+      else if (cJSON_IsNumber(ad))
+         on = ad->valuedouble != 0;
+      if (tab5_settings_set_away_dim(on) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("away_dim"));
+      }
+   }
+   cJSON *adp = cJSON_GetObjectItem(req_json, "away_dim_pct");
+   if (cJSON_IsNumber(adp)) {
+      int v = (int)adp->valuedouble;
+      if (v >= 0 && v <= 100 && tab5_settings_set_away_dim_pct((uint8_t)v) == ESP_OK) {
+         cJSON_AddItemToArray(updated, cJSON_CreateString("away_dim_pct"));
       }
    }
    cJSON *sid = cJSON_GetObjectItem(req_json, "session_id");

--- a/main/settings.c
+++ b/main/settings.c
@@ -594,6 +594,22 @@ esp_err_t tab5_settings_set_vision_rate(uint8_t hz) {
    return set_u8("vision_rate", hz);
 }
 
+/* ── Vision V2-A.3 (TT #680) — presence-aware brightness ────────── */
+
+bool tab5_settings_get_away_dim(void) { return get_u8("away_dim", 0) != 0; }
+
+esp_err_t tab5_settings_set_away_dim(bool on) { return set_u8("away_dim", on ? 1 : 0); }
+
+uint8_t tab5_settings_get_away_dim_pct(void) {
+   uint8_t v = get_u8("away_dim_pct", 20);
+   return v <= 100 ? v : 20;
+}
+
+esp_err_t tab5_settings_set_away_dim_pct(uint8_t pct) {
+   if (pct > 100) return ESP_ERR_INVALID_ARG;
+   return set_u8("away_dim_pct", pct);
+}
+
 /* ── Wake source picker (TT #617) ───────────────────────────────────── */
 
 esp_err_t tab5_settings_get_wake_src(char *buf, size_t len) {

--- a/main/settings.h
+++ b/main/settings.h
@@ -263,6 +263,19 @@ esp_err_t tab5_settings_set_vision_on(bool on);
 uint8_t tab5_settings_get_vision_rate(void);
 esp_err_t tab5_settings_set_vision_rate(uint8_t hz);
 
+/** Vision V2-A.3 (TT #680) — presence-aware brightness.
+ *
+ *  away_dim: when on, the display brightness drops to `away_dim_pct`
+ *  whenever the always-on vision service fires a person-LEAVE event,
+ *  and restores to the user's `brightness` pref on the next person-
+ *  ENTER.  Default OFF — opt-in like the master vision toggle.
+ *
+ *  away_dim_pct: target brightness while away (0..100 %).  Default 20. */
+bool tab5_settings_get_away_dim(void);
+esp_err_t tab5_settings_set_away_dim(bool on);
+uint8_t tab5_settings_get_away_dim_pct(void);
+esp_err_t tab5_settings_set_away_dim_pct(uint8_t pct);
+
 /** TT #617 — Wake source.  Picks which wakeword detection path runs.
  *  Values: "k144" (K144 onboard mic + sherpa-ncnn), "dragon" (Tab5 mic
  *  → Dragon whisper.cpp), "off" (mic-tap only via orb tap), or a future

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -710,6 +710,14 @@ static void cb_vision_rate(lv_event_t *e) {
    tab5_settings_set_vision_rate(hz);
 }
 
+/* Vision V2-A.3 (TT #680): auto-dim when away. */
+static void cb_away_dim(lv_event_t *e) {
+   lv_obj_t *sw = lv_event_get_target(e);
+   bool on = lv_obj_has_state(sw, LV_STATE_CHECKED);
+   ESP_LOGI(TAG, "Auto-dim when away %s", on ? "enabled" : "disabled");
+   tab5_settings_set_away_dim(on);
+}
+
 static void cb_autorotate(lv_event_t *e)
 {
     lv_obj_t *sw = lv_event_get_target(e);
@@ -2512,6 +2520,12 @@ lv_obj_t *ui_settings_create(void)
        lv_obj_set_style_text_color(dd, lv_color_hex(TEXT_PRIMARY), LV_PART_ITEMS);
        lv_obj_add_event_cb(dd, cb_vision_rate, LV_EVENT_VALUE_CHANGED, NULL);
     }
+    y += ROW_H + 4;
+
+    /* Vision V2-A.3 (TT #680): auto-dim screen when user walks away
+     * (person LEAVE confirmed) and restore on return (person ENTER). */
+    mk_row_label(s_scroll, "Auto-dim when away", y);
+    mk_switch(s_scroll, acc_display, 660, y, tab5_settings_get_away_dim(), cb_away_dim, NULL);
     y += ROW_H + 16;
     mk_card_bg(s_scroll, display_section_top, y);
     y += 24;

--- a/main/vision_service.c
+++ b/main/vision_service.c
@@ -39,7 +39,7 @@ static const char *TAG = "vision_svc";
 #define VS_TRACK_CONFIRM_HITS 3                 /* seen_count to fire ENTER */
 #define VS_TRACK_FORGET_MISSES 8                /* ~4 s @ 2 Hz to fire LEAVE */
 #define VS_WELCOME_COOLDOWN_MS (5 * 60 * 1000u) /* Nest Hub Max pattern — 5 min */
-#define VS_PET_COOLDOWN_MS (30 * 1000u)
+#define VS_ABSENCE_THRESHOLD_MS (120 * 1000u)   /* min absence before Welcome refires */
 
 typedef struct {
    bool in_use;
@@ -65,8 +65,8 @@ static uint32_t s_next_track_id = 1;
 
 /* Rule cooldown ring — last_fired_ms per built-in rule. */
 static uint64_t s_last_welcome_ms = 0;
-static uint64_t s_last_dog_ms = 0;
-static uint64_t s_last_cat_ms = 0;
+static uint64_t s_last_person_leave_ms = 0; /* set when a person track fires LEAVE */
+static bool s_user_present = false;         /* tracked across confirmed → leave */
 
 static uint64_t now_ms(void) { return (uint64_t)(esp_timer_get_time() / 1000); }
 
@@ -114,36 +114,12 @@ static esp_err_t ensure_buffers(void) {
 }
 
 static bool is_interesting_class(const char *klass) {
-   /* V2-A.1 surfaces only the 3 classes the built-in rules will care
-    * about in V2-A.2 (person / dog / cat).  Other COCO classes still
-    * count toward detections_total but don't fire obs.  Cheaper than
-    * a hash table and avoids surfacing noise. */
-   return klass && (strcmp(klass, "person") == 0 || strcmp(klass, "dog") == 0 || strcmp(klass, "cat") == 0);
-}
-
-/* V2-A.2 follow-up: per-class confidence floors.  yolo11n at 320×320
- * on indoor scenes routinely false-positives "dog"/"cat" on humans
- * with curly hair, beards, or partial occlusion.  Live test had the
- * model classify the user (on their own desk, clearly framed) as a
- * dog at 0.5 confidence.  Require animal detections at ≥ 0.65 (well
- * above the typical false-positive cluster).  Person stays at the
- * user-configured global threshold.  Suppresses ghost-pet events. */
-static float class_min_confidence(const char *klass) {
-   if (klass && (strcmp(klass, "dog") == 0 || strcmp(klass, "cat") == 0)) return 0.65f;
-   return 0.0f;
-}
-
-/* Suppress animal detections when a person is detected in the same
- * frame.  yolo11n COCO false-positive: when a human silhouette is in
- * frame, the model often double-fires both "person" and "dog"/"cat"
- * for the SAME pixels.  If both classes have boxes this frame, drop
- * the animal one.  Real-world false positives kept showing up as
- * vision.pet events even though no pet was in the scene. */
-static bool any_person_box(const voice_yolo_box_t *boxes, size_t n) {
-   for (size_t i = 0; i < n; i++) {
-      if (strcmp(boxes[i].klass, "person") == 0) return true;
-   }
-   return false;
+   /* V2-A.3: person-only.  The Pet timeline rule was dropped — yolo11n
+    * false-positives dog/cat on humans badly enough that the feature
+    * fired ghost-pet events in a single-user-at-desk scenario.  Real
+    * pet logging needs a different model (or face/animal-detection
+    * sub-program — V7 territory). */
+   return klass && strcmp(klass, "person") == 0;
 }
 
 /* ── V2-A.2 IoU tracker ──────────────────────────────────────────
@@ -166,6 +142,26 @@ static float iou(const vs_track_t *t, const voice_yolo_box_t *b) {
    return ua > 0.0f ? in / ua : 0.0f;
 }
 
+/* Restore display brightness from NVS user pref.  Called on confirmed
+ * person ENTER when away_dim was applied on a prior LEAVE. */
+static void restore_brightness(void) {
+   if (!tab5_settings_get_away_dim()) return;
+   uint8_t pct = tab5_settings_get_brightness();
+   extern esp_err_t tab5_display_set_brightness(int percent);
+   tab5_display_set_brightness((int)pct);
+   tab5_debug_obs_event("vision.presence", "wake");
+}
+
+/* Dim display to the away pref.  Called on confirmed person LEAVE.
+ * Idempotent — re-firing is harmless. */
+static void dim_brightness_for_away(void) {
+   if (!tab5_settings_get_away_dim()) return;
+   uint8_t pct = tab5_settings_get_away_dim_pct();
+   extern esp_err_t tab5_display_set_brightness(int percent);
+   tab5_display_set_brightness((int)pct);
+   tab5_debug_obs_event("vision.presence", "dim");
+}
+
 /* Rules fire on the ENTER edge (seen_count crossing CONFIRM_HITS). */
 static void fire_rules_on_enter(const vs_track_t *t) {
    uint64_t now = now_ms();
@@ -173,28 +169,40 @@ static void fire_rules_on_enter(const vs_track_t *t) {
    snprintf(detail, sizeof(detail), "%s id=%u conf=%.2f", t->klass, (unsigned)t->id, t->confidence);
    tab5_debug_obs_event("vision.enter", detail);
 
-   /* Welcome glance — person enters after 5 min cooldown.  Toast is
-    * the V2-A.2 surface; V2-A.3 promotes to ui_notification + TTS. */
+   /* Welcome glance — person enters after a REAL absence.
+    *
+    * V2-A.3 rule: gate on `s_last_person_leave_ms` so we don't fire
+    * Welcome when the user was already at their desk at boot.  First
+    * boot has no prior LEAVE recorded — don't fire.  After a real
+    * LEAVE → away_ms = now - s_last_person_leave_ms; only fire if
+    * that's at least VS_ABSENCE_THRESHOLD_MS (120 s). */
    if (strcmp(t->klass, "person") == 0) {
-      if (now - s_last_welcome_ms >= VS_WELCOME_COOLDOWN_MS) {
+      s_user_present = true;
+      restore_brightness(); /* presence-aware screen */
+
+      bool had_real_absence = (s_last_person_leave_ms != 0);
+      uint64_t away_ms = had_real_absence ? (now - s_last_person_leave_ms) : 0;
+      bool cooldown_ok = (now - s_last_welcome_ms >= VS_WELCOME_COOLDOWN_MS);
+      if (had_real_absence && away_ms >= VS_ABSENCE_THRESHOLD_MS && cooldown_ok) {
          s_last_welcome_ms = now;
          s_state.last_welcome_ms = now;
          s_state.welcome_fires_total++;
          extern void ui_home_show_toast(const char *msg);
          ui_home_show_toast("Welcome back");
-         tab5_debug_obs_event("vision.welcome", detail);
-      }
-   } else if (strcmp(t->klass, "dog") == 0) {
-      if (now - s_last_dog_ms >= VS_PET_COOLDOWN_MS) {
-         s_last_dog_ms = now;
-         tab5_debug_obs_event("vision.pet", detail);
-      }
-   } else if (strcmp(t->klass, "cat") == 0) {
-      if (now - s_last_cat_ms >= VS_PET_COOLDOWN_MS) {
-         s_last_cat_ms = now;
-         tab5_debug_obs_event("vision.pet", detail);
+         char wdetail[64];
+         snprintf(wdetail, sizeof(wdetail), "away_ms=%llu", (unsigned long long)away_ms);
+         tab5_debug_obs_event("vision.welcome", wdetail);
       }
    }
+}
+
+/* LEAVE edge — record the leave timestamp for absence gating + dim
+ * the display if presence-aware brightness is enabled. */
+static void fire_rules_on_leave(const vs_track_t *t) {
+   if (strcmp(t->klass, "person") != 0) return;
+   s_user_present = false;
+   s_last_person_leave_ms = now_ms();
+   dim_brightness_for_away();
 }
 
 static void tracker_update(const voice_yolo_box_t *boxes, size_t n) {
@@ -236,10 +244,11 @@ static void tracker_update(const voice_yolo_box_t *boxes, size_t n) {
          if (s_tracks[s].not_seen_count < 255) s_tracks[s].not_seen_count++;
          if (s_tracks[s].not_seen_count >= VS_TRACK_FORGET_MISSES) {
             if (s_tracks[s].confirmed) {
-               char detail[48];
+               char detail[64];
                snprintf(detail, sizeof(detail), "%s id=%u age_ms=%llu", s_tracks[s].klass, (unsigned)s_tracks[s].id,
                         (unsigned long long)(now - s_tracks[s].first_seen_ms));
                tab5_debug_obs_event("vision.leave", detail);
+               fire_rules_on_leave(&s_tracks[s]);
             }
             s_tracks[s].in_use = false;
          }
@@ -308,25 +317,14 @@ static void process_one_frame(void) {
       return;
    }
    s_state.detections_total += (uint32_t)n;
-   /* V2-A.2: only feed interesting classes to the tracker.  Saves
-    * tracker slots from being burned by the noisy "cell phone" /
-    * "bottle" detections that yolo11n surfaces from a desk shot.
-    *
-    * V2-A.2 follow-up — two false-positive suppressions for the
-    * desk-pointing-at-user case where yolo11n was firing "dog" on
-    * a human with curly hair + beard:
-    *  1. Per-class confidence floor (animals require 0.65+).
-    *  2. If any person box is in the frame, drop all animal boxes
-    *     from that same frame — the model double-fires both classes
-    *     on overlapping pixels; person wins. */
-   bool has_person = any_person_box(boxes, n);
+   /* V2-A.3: person-only filter.  Pet timeline was dropped after live
+    * testing showed yolo11n's animal false-positives on humans were
+    * the only thing the rule ever fired on.  All non-person boxes
+    * are silently dropped here so the tracker stays clean. */
    voice_yolo_box_t filtered[VS_MAX_BOXES];
    size_t fn = 0;
    for (size_t i = 0; i < n && fn < VS_MAX_BOXES; i++) {
       if (!is_interesting_class(boxes[i].klass)) continue;
-      if (boxes[i].confidence < class_min_confidence(boxes[i].klass)) continue;
-      bool is_animal = (strcmp(boxes[i].klass, "dog") == 0 || strcmp(boxes[i].klass, "cat") == 0);
-      if (is_animal && has_person) continue;
       filtered[fn++] = boxes[i];
       strlcpy(s_state.last_class, boxes[i].klass, sizeof(s_state.last_class));
       s_state.last_detection_ms = now_ms();


### PR DESCRIPTION
## Summary

Live test of V2-A.2 surfaced two real-world failures for the single-user-at-desk scenario:

1. **Pet timeline was useless** — no pet, yolo11n's animal false-positives on humans were the only thing the rule ever fired on
2. **Welcome back fired with no real absence** — booting with the user already at the desk produced a Welcome event

This wave fixes both AND adds the natural feature for a desk device: **presence-aware screen brightness**.

### Rip Pet timeline
- \`is_interesting_class\` narrowed to person-only (dog/cat never reach the tracker)
- All dog/cat rule branches removed; \`vision.pet\` obs event class retired
- Dead helpers (\`class_min_confidence\`, \`any_person_box\`) removed

### LEAVE-gated Welcome
- New \`s_last_person_leave_ms\` set when a confirmed person track fires LEAVE
- Welcome only fires if \`had_real_absence && away_ms >= 120 s && cooldown_ok\`
- First boot → no LEAVE recorded → no Welcome (even though person is detected) — fixes the false-fire-on-boot bug

### Presence-aware brightness
- NVS keys \`away_dim\` (default OFF) + \`away_dim_pct\` (default 20)
- On confirmed person LEAVE → \`tab5_display_set_brightness(away_dim_pct)\`
- On confirmed person ENTER → restore to NVS \`brightness\` user pref
- Settings UI: \"Auto-dim when away\" switch under DISPLAY

## Live verification

User sitting at desk, vision_on, 60 s elapsed:
- \`welcome_fires_total: 0\` (no false fire)
- No \`vision.pet\` events ever
- Heap stable

Next slice (V2-A.4) wires the proper notification surface with the Scrypted-style snooze chip, TTS playback for Welcome, and the privacy indicator green dot.

## Test plan

- [x] Build green
- [x] Flash + boot clean
- [x] No Welcome when user is already at desk at boot
- [x] No vision.pet events
- [x] /settings round-trips away_dim + away_dim_pct
- [x] Format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)