### PR TITLE
fix(ui): hide stale floating home button when returning to home

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -2660,6 +2660,14 @@ void ui_home_go_home(void)
      * it via ui_keyboard_set_trigger_visible(true). */
     extern void ui_keyboard_set_trigger_visible(bool);
     ui_keyboard_set_trigger_visible(false);
+    /* TT #687 follow-up: hide the floating home button.  ui_home_create
+     * hides it once at boot, but every other screen (camera, settings,
+     * notes, files, wifi) toggles it ON via ui_chrome_set_home_visible(true).
+     * Coming back to home via ui_home_go_home was leaving it stale —
+     * a ghost amber circle on bottom-right that did nothing (we're
+     * already on home). */
+    extern void ui_chrome_set_home_visible(bool visible);
+    ui_chrome_set_home_visible(false);
 }
 
 /* TT #328 Wave 7 — ui_home_get_tileview / ui_home_get_tile removed.


### PR DESCRIPTION
## Summary

User reported a ghost amber home button on the bottom-right of the home screen that did nothing when tapped — overlaying the 4-dot nav-menu chip.

## Root cause

\`ui_home_create()\` hides the floating home button once at boot (correctly — home doesn't need an escape hatch to itself).  Every other screen (camera, settings, notes, files, wifi) toggles it ON via \`ui_chrome_set_home_visible(true)\`.

But \`ui_home_go_home()\` — the function that runs every time the user navigates back to home — was missing the corresponding hide call.  So nav cycle camera → home left the button stale-visible.

## Fix

Add \`ui_chrome_set_home_visible(false)\` to \`ui_home_go_home()\`.  Now the button is hidden every time we land on home, not just at first boot.

## Live verification

Before: home → camera → home left the amber button overlapping the nav chip.
After: clean home screen with just the 4-dot nav-menu chip on bottom-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)