### PR TITLE
feat(home): quick-access mute button (closes #689)

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -124,6 +124,12 @@ static lv_obj_t *s_tinkeron_label  = NULL;
  * pattern — software-honest disclosure of an active camera sample
  * pipeline since Tab5 has no hardware kill switch. */
 static lv_obj_t *s_vision_dot = NULL;
+/* TT #689 — quick-access mic mute toggle.  Floating circular button
+ * under the top-right status bar.  Tap toggles NVS mic_mute (which
+ * voice_start_listening already honors).  Red bg + mute glyph when
+ * muted; dark bg + dim glyph when not. */
+static lv_obj_t *s_mute_btn = NULL;
+static lv_obj_t *s_mute_icon = NULL;
 static lv_obj_t *s_time_label      = NULL;  /* right: "Thursday · 9:42" */
 /* Cap Wave 5b (TT #646): privacy lock pill, pinned right of the time label.
  * Visible only when tab5_settings_get_privacy_lock() is true. */
@@ -623,6 +629,44 @@ lv_obj_t *ui_home_create(void)
     lv_obj_set_style_bg_color(s_vision_dot, lv_color_hex(TH_STATUS_GREEN), 0);
     lv_obj_set_style_bg_opa(s_vision_dot, LV_OPA_COVER, 0);
     lv_obj_add_flag(s_vision_dot, LV_OBJ_FLAG_HIDDEN);
+
+    /* TT #689 — quick-access mute button.  Floating circular toggle
+     * just under the top status bar at the right edge.  Always
+     * visible.  Tap toggles NVS mic_mute; voice_start_listening
+     * already refuses with a toast when the key is set. */
+    s_mute_btn = lv_obj_create(s_screen);
+    lv_obj_remove_style_all(s_mute_btn);
+    const int MUTE_SZ = 56;
+    lv_obj_set_size(s_mute_btn, MUTE_SZ, MUTE_SZ);
+    lv_obj_set_pos(s_mute_btn, SW - SIDE_PAD - MUTE_SZ, 72);
+    lv_obj_set_style_radius(s_mute_btn, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_bg_color(s_mute_btn, lv_color_hex(TH_CARD_ELEVATED), 0);
+    lv_obj_set_style_bg_opa(s_mute_btn, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(s_mute_btn, 1, 0);
+    lv_obj_set_style_border_color(s_mute_btn, lv_color_hex(0x1E1E2A), 0);
+    lv_obj_clear_flag(s_mute_btn, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_mute_btn, LV_OBJ_FLAG_CLICKABLE);
+    extern void mute_btn_click_cb(lv_event_t * e);
+    lv_obj_add_event_cb(s_mute_btn, mute_btn_click_cb, LV_EVENT_CLICKED, NULL);
+    ui_fb_card(s_mute_btn);
+    s_mute_icon = lv_label_create(s_mute_btn);
+    /* Initial state painted from NVS — survives reboot.  Inline so we
+     * don't need a forward decl of paint_mute_btn (defined further
+     * down). */
+    {
+       bool init_muted = tab5_settings_get_mic_mute() != 0;
+       if (init_muted) {
+          lv_obj_set_style_bg_color(s_mute_btn, lv_color_hex(TH_STATUS_RED), 0);
+          lv_obj_set_style_border_color(s_mute_btn, lv_color_hex(TH_STATUS_RED), 0);
+          lv_label_set_text(s_mute_icon, LV_SYMBOL_MUTE);
+          lv_obj_set_style_text_color(s_mute_icon, lv_color_hex(0xFFFFFF), 0);
+       } else {
+          lv_label_set_text(s_mute_icon, LV_SYMBOL_AUDIO);
+          lv_obj_set_style_text_color(s_mute_icon, lv_color_hex(TH_TEXT_DIM), 0);
+       }
+    }
+    lv_obj_set_style_text_font(s_mute_icon, FONT_HEADING, 0);
+    lv_obj_center(s_mute_icon);
 
     s_time_label = lv_label_create(s_screen);
     lv_label_set_text(s_time_label, "");
@@ -1861,6 +1905,36 @@ void menu_chip_click_cb(lv_event_t *e)
     if (any_overlay_visible()) return;
     extern void ui_nav_sheet_show(void);
     ui_nav_sheet_show();
+}
+
+/* TT #689 — quick-access mute button.  Toggle NVS mic_mute and
+ * repaint the button.  The voice path (voice_start_listening) reads
+ * the same key, so muting from here immediately prevents accidental
+ * dictation. */
+static void paint_mute_btn(bool muted) {
+   if (!s_mute_btn || !s_mute_icon) return;
+   if (muted) {
+      lv_obj_set_style_bg_color(s_mute_btn, lv_color_hex(TH_STATUS_RED), 0);
+      lv_obj_set_style_border_color(s_mute_btn, lv_color_hex(TH_STATUS_RED), 0);
+      lv_label_set_text(s_mute_icon, LV_SYMBOL_MUTE);
+      lv_obj_set_style_text_color(s_mute_icon, lv_color_hex(0xFFFFFF), 0);
+   } else {
+      lv_obj_set_style_bg_color(s_mute_btn, lv_color_hex(TH_CARD_ELEVATED), 0);
+      lv_obj_set_style_border_color(s_mute_btn, lv_color_hex(0x1E1E2A), 0);
+      lv_label_set_text(s_mute_icon, LV_SYMBOL_AUDIO);
+      lv_obj_set_style_text_color(s_mute_icon, lv_color_hex(TH_TEXT_DIM), 0);
+   }
+}
+
+void mute_btn_click_cb(lv_event_t *e) {
+   (void)e;
+   bool was_muted = tab5_settings_get_mic_mute() != 0;
+   bool now_muted = !was_muted;
+   tab5_settings_set_mic_mute(now_muted ? 1 : 0);
+   paint_mute_btn(now_muted);
+   /* Surface state — toast + obs for harness visibility. */
+   ui_home_show_toast(now_muted ? "Mic muted" : "Mic unmuted");
+   tab5_debug_obs_event("ui.mute", now_muted ? "on" : "off");
 }
 
 /* v4·D Phase 4g widget_prompt tap plumbing.


### PR DESCRIPTION
## Summary

User wanted 1-tap mic mute from home.  Settings → Voice → Mic mute existed but took 3 taps to reach.

## What ships

Floating 56×56 circular button at the top-right of home, just under the status bar.  Always visible, tap toggles the existing NVS \`mic_mute\` key.

**Visual state:**
- Unmuted: dark elevated bg + dim music glyph
- Muted: red bg + bright mute glyph
- Initial state painted from NVS at create — survives reboot

**Existing chrome already reacts** to mic_mute:
- Status bar \"ONLINE\" pip swaps to \"MUTED\"
- Orb's mic-off pip lights up red

So the new button gives a direct tap target while the rest of home gives confirmation.

## Live verification

- Tap → mic_mute 0→1, button turns red, \"Mic muted\" toast, status bar shows \"MUTED\", orb pip lights up
- Tap again → 1→0, button back to dark, \"Mic unmuted\" toast
- voice_start_listening already refuses with a toast when muted — verified path unchanged

## Test plan

- [x] Build green
- [x] Flash + boot clean
- [x] Tap toggles NVS mic_mute (verified via /settings round-trip)
- [x] Visual state updates correctly both directions
- [x] Initial state on fresh boot reads NVS
- [x] Format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)