### PR TITLE
fix(voice): X close + mute fully stop wakeword (closes #691)

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1932,6 +1932,18 @@ void mute_btn_click_cb(lv_event_t *e) {
    bool now_muted = !was_muted;
    tab5_settings_set_mic_mute(now_muted ? 1 : 0);
    paint_mute_btn(now_muted);
+   /* TT #691: true mute means BOTH push-to-talk + wakeword stop.
+    * Ambient noise was re-firing the wakeword and the device looped
+    * back into LISTENING even after the user pressed the X close. */
+   if (now_muted) {
+      extern void voice_wakeword_stop(void);
+      voice_wakeword_stop();
+   } else {
+      /* Re-arm wakeword on unmute — async, non-blocking; the K144
+       * warmup chain lazily picks it up. */
+      extern esp_err_t voice_onboard_arm_wakeword_async(void);
+      voice_onboard_arm_wakeword_async();
+   }
    /* Surface state — toast + obs for harness visibility. */
    ui_home_show_toast(now_muted ? "Mic muted" : "Mic unmuted");
    tab5_debug_obs_event("ui.mute", now_muted ? "on" : "off");

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -2111,9 +2111,19 @@ static void mic_long_press_cb(lv_event_t *e)
 static void close_click_cb(lv_event_t *e)
 {
     (void)e;
-    ESP_LOGI(TAG, "Close button tapped — cancelling");
+    ESP_LOGI(TAG, "Close button tapped — full stop");
+    /* TT #691: just calling voice_cancel() let the wakeword re-arm
+     * after ~1.5 s, and room ambient noise then re-triggered LISTENING
+     * — the user observed the X "didn't stop" and the device looped
+     * back into listening.  Hard stop now disarms the wakeword too;
+     * re-arm happens when the user explicitly taps the orb or
+     * un-mutes via the home mute button. */
     voice_cancel();
+    extern void voice_wakeword_stop(void);
+    voice_wakeword_stop();
     ui_voice_hide();
+    extern void ui_home_show_toast(const char *msg);
+    ui_home_show_toast("Voice stopped — tap orb to listen again");
 }
 
 static void send_click_cb(lv_event_t *e)


### PR DESCRIPTION
## Summary

User pressed X on the voice overlay but the device kept looping back into LISTENING.  The cycle:

\`\`\`
press X → voice_cancel → 1500 ms grace → room noise → wake fires
        → LISTENING → press X → ... (loop)
\`\`\`

Root cause: \`voice_cancel()\` sets state to READY + grants a 1500 ms wake suppression window (TT #625 Wave A.2 / R2), but after that grace ambient noise re-triggers the wakeword ASR matcher and a fresh turn starts.

## Two targeted fixes

### \`ui_voice.c::close_click_cb\`
Now also calls \`voice_wakeword_stop()\`.  User's explicit X press means \"stop listening until I ask again\" — wakeword shouldn't auto-rearm.  Toast: \"Voice stopped — tap orb to listen again\".

### \`ui_home.c::mute_btn_click_cb\`
Mute now \`voice_wakeword_stop()\`; unmute now \`voice_onboard_arm_wakeword_async()\`.  Previously the button only flipped NVS mic_mute, which the wakeword path didn't honor.  Now \"muted\" really means silent.

## Live verification

Post-reboot state on Tab5 192.168.1.90: wakeword IDLE, armed=true, voice READY.  X press is a full stop; no re-arm-then-refire cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)