### PR TITLE
fix(voice): post-cancel wake suppression + anchored matcher (closes #692)

### DIFF
--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1932,18 +1932,11 @@ void mute_btn_click_cb(lv_event_t *e) {
    bool now_muted = !was_muted;
    tab5_settings_set_mic_mute(now_muted ? 1 : 0);
    paint_mute_btn(now_muted);
-   /* TT #691: true mute means BOTH push-to-talk + wakeword stop.
-    * Ambient noise was re-firing the wakeword and the device looped
-    * back into LISTENING even after the user pressed the X close. */
-   if (now_muted) {
-      extern void voice_wakeword_stop(void);
-      voice_wakeword_stop();
-   } else {
-      /* Re-arm wakeword on unmute — async, non-blocking; the K144
-       * warmup chain lazily picks it up. */
-      extern esp_err_t voice_onboard_arm_wakeword_async(void);
-      voice_onboard_arm_wakeword_async();
-   }
+   /* TT #692 (revert of #691): mute = mic doesn't transmit; wakeword
+    * stays armed.  Matches consumer voice assistants where "mute"
+    * means "don't pick up my voice for the active turn" not "kill
+    * the always-on listener entirely".  voice_start_listening already
+    * honors mic_mute and refuses with a toast. */
    /* Surface state — toast + obs for harness visibility. */
    ui_home_show_toast(now_muted ? "Mic muted" : "Mic unmuted");
    tab5_debug_obs_event("ui.mute", now_muted ? "on" : "off");

--- a/main/ui_voice.c
+++ b/main/ui_voice.c
@@ -2111,19 +2111,15 @@ static void mic_long_press_cb(lv_event_t *e)
 static void close_click_cb(lv_event_t *e)
 {
     (void)e;
-    ESP_LOGI(TAG, "Close button tapped — full stop");
-    /* TT #691: just calling voice_cancel() let the wakeword re-arm
-     * after ~1.5 s, and room ambient noise then re-triggered LISTENING
-     * — the user observed the X "didn't stop" and the device looped
-     * back into listening.  Hard stop now disarms the wakeword too;
-     * re-arm happens when the user explicitly taps the orb or
-     * un-mutes via the home mute button. */
+    ESP_LOGI(TAG, "Close button tapped — cancelling current turn");
+    /* TT #692 (revert of #691): just cancel.  voice_cancel now
+     * installs a 3 s wakeword suppression window so the matcher
+     * silently ignores any wake events that fire from buffered
+     * audio (TTS tail or user follow-up speech) during that
+     * window.  Wakeword stays armed — "Hey Tinker" works
+     * continuously throughout the day. */
     voice_cancel();
-    extern void voice_wakeword_stop(void);
-    voice_wakeword_stop();
     ui_voice_hide();
-    extern void ui_home_show_toast(const char *msg);
-    ui_home_show_toast("Voice stopped — tap orb to listen again");
 }
 
 static void send_click_cb(lv_event_t *e)

--- a/main/voice.c
+++ b/main/voice.c
@@ -2164,14 +2164,24 @@ esp_err_t voice_cancel(void)
     extern void voice_wakeword_force_dictation_stop(void);
     voice_wakeword_force_dictation_stop();
 
-    /* TT #625 Wave A.1 (R2) — belt-and-braces: even with the wakeword
-     * reset above, ext_pcm pump can race for 1-2 frames before the
-     * matcher state propagates.  Pause the pump for 1.5 s so K144's
-     * streaming ASR drains the buffer that captured the TTS we just
-     * stopped, preventing self-wake from lingering "thinker" partials. */
+    /* TT #692 — install a 3 s wakeword-matcher suppression window.
+     * K144's sherpa-ncnn streaming-zipformer can keep emitting ASR
+     * partials sourced from buffered audio (TTS tail or user follow-up
+     * speech) for 1-2 s after we stop the mic.  Those partials would
+     * substring-match the wake set ("thinker", "tinker", …) and re-
+     * open the mic invisibly — the "X-button-doesn't-stop" loop.
+     * The listener task stays armed throughout; only matcher fires
+     * are dropped during the window.  Wakeword resumes automatically. */
+    extern void voice_wakeword_post_cancel_suppress_ms(uint32_t ms);
+    voice_wakeword_post_cancel_suppress_ms(3000);
+
+    /* TT #625 Wave A.1 (R2) + TT #692 — pause ext_pcm pump for the same
+     * 3 s window so K144's streaming ASR drains buffered audio entirely.
+     * Pump resumes automatically via esp_timer one-shot.  Length now
+     * matches the matcher suppression window above. */
     voice_ext_pcm_stream_set_paused(true);
     extern void voice_extpcm_pump_unpause_in(uint32_t ms);
-    voice_extpcm_pump_unpause_in(1500); /* schedule unpause */
+    voice_extpcm_pump_unpause_in(3000); /* schedule unpause */
 
     tab5_debug_obs_event("voice.cancel", "done");
     return ESP_OK;

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -234,6 +234,13 @@ static void finish_dictation(const char *reason) {
  * false-fire.  500-1000 ms is enough for the ASR engine's streaming
  * context to flush + Tab5's wake_window to settle on truly-new audio. */
 static int64_t s_last_busy_us = 0;
+
+/* TT #692 — post-cancel suppression deadline.  voice_cancel installs
+ * a 3 s window after explicit user cancels so the matcher silently
+ * drops wake events fired from K144 ASR partials that came out of
+ * buffered audio (TTS tail or user follow-up speech).  Wakeword task
+ * stays alive + armed throughout — no stop/restart cycle. */
+static int64_t s_post_cancel_until_us = 0;
 /* TT #627 Wave B.2 (R3) — bumped 1000 → 1500 ms.  Audit found that
  * K144's streaming-zipformer ASR can take 1.5-2 s to flush a long TTS
  * reply context after SPEAKING→READY.  1000 ms expired before the
@@ -279,7 +286,29 @@ static bool wakeword_suppressed_by_voice_state(void) {
       }
       s_last_busy_us = 0; /* grace expired — re-armed */
    }
+   /* TT #692: explicit post-cancel suppression window.  voice_cancel
+    * sets this when the user (or any other cancel-class caller) ends
+    * a turn.  Even if state is already READY and the busy-grace has
+    * expired, drop wake hits until the deadline. */
+   if (s_post_cancel_until_us != 0) {
+      int64_t now = esp_timer_get_time();
+      if (now < s_post_cancel_until_us) return true;
+      s_post_cancel_until_us = 0; /* window expired */
+   }
    return false;
+}
+
+void voice_wakeword_post_cancel_suppress_ms(uint32_t ms) {
+   if (ms == 0) {
+      s_post_cancel_until_us = 0;
+      return;
+   }
+   s_post_cancel_until_us = esp_timer_get_time() + (int64_t)ms * 1000;
+   /* Also reset the wake window so any partial transcript currently
+    * buffered (potentially containing TTS-tail "thinker" fragments)
+    * can't match the moment the window expires. */
+   wake_window_clear();
+   tab5_debug_obs_event("wakeword.suppress", "post_cancel_arm");
 }
 
 /* TT #578: push every ASR delta into the debug ring buffer.  Cheap —
@@ -345,44 +374,68 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
           "hick",    /* heavily-contracted rendering, real session 2026-05-20 */
           "hanker",  /* observed in "any hanker thinker" rendering */
       };
+      /* TT #692 — anchored matching.  The wake substring must appear in
+       * the FRESHLY-ARRIVED delta (not somewhere deep in an accumulated
+       * sliding window), AND its position must be within the first half
+       * of the delta (allows leading filler like "uh hey tinker" but
+       * rejects long buffered partials whose tail happens to contain
+       * "thinker" from TTS bleed or background noise).  K144's sherpa-
+       * ncnn streaming-zipformer is a rolling decoder — each partial
+       * is the cumulative recognition of the current segment, so a real
+       * wake utterance lands at the start of the delta that contains
+       * its trailing audio. */
       const char *match = NULL;
-      if (s_wake_window_len > 0) {
-         if (istrstr(s_wake_window, s_wake_phrase) != NULL) {
+      const char *match_pos = NULL;
+      if (delta && delta[0]) {
+         const char *p;
+         if ((p = istrstr(delta, s_wake_phrase)) != NULL) {
             match = s_wake_phrase;
-         } else if (s_wake_phrase_alt[0] &&
-                    istrstr(s_wake_window, s_wake_phrase_alt) != NULL) {
+            match_pos = p;
+         } else if (s_wake_phrase_alt[0] && (p = istrstr(delta, s_wake_phrase_alt)) != NULL) {
             match = s_wake_phrase_alt;
+            match_pos = p;
          } else {
             for (size_t i = 0; i < sizeof(k_alt_patterns) / sizeof(k_alt_patterns[0]); i++) {
-               if (istrstr(s_wake_window, k_alt_patterns[i]) != NULL) {
+               if ((p = istrstr(delta, k_alt_patterns[i])) != NULL) {
                   match = k_alt_patterns[i];
+                  match_pos = p;
                   break;
                }
             }
          }
+         if (match != NULL && match_pos != NULL) {
+            size_t pos = (size_t)(match_pos - delta);
+            size_t delta_len = strlen(delta);
+            /* Position floor: match must be in the first half of the
+             * delta + a 4-char slack for short leading fillers.  Rejects
+             * cases where a long partial's tail contains the wake word
+             * (the TTS-bleed / buffered-noise failure mode). */
+            size_t pos_ceiling = delta_len / 2 + 4;
+            if (pos > pos_ceiling) {
+               ESP_LOGD(TAG, "wake suppressed by anchor: pos=%u of %u in \"%s\"", (unsigned)pos, (unsigned)delta_len,
+                        delta);
+               match = NULL;
+               match_pos = NULL;
+            }
+         }
       }
       if (match != NULL) {
-         /* TT #595 — VAD pre-gate v1: require the sliding window
-          * to be ≥8 chars before a substring match is allowed to fire
-          * wake.  K144's sherpa-ncnn streaming ASR confabulates short
-          * 1-2 word fragments from background noise during silence
-          * ("kincher", "ereb", "thinker") — those would substring-
-          * match "thinker" but contain only that noise.  A real
-          * "Hey Tinker" utterance produces a window with leading
-          * context ("hi there hey tinker"), so the 8-char floor
-          * filters hallucinations without losing real wakes.
-          *
-          * The cheapest VAD we can do without K144 daemon changes:
-          * if the user really spoke the wake phrase, the partial
-          * stream carries more than just the phrase itself.
-          * Hallucinations are typically 4-6 chars of single-word
-          * garbage. */
-         if (s_wake_window_len < 8) {
-            ESP_LOGD(TAG, "wake suppressed by VAD pregate: window=\"%s\" (%u chars)", s_wake_window,
-                     (unsigned)s_wake_window_len);
+         /* TT #595 + TT #692 — VAD pre-gate: require the partial
+          * delta to be ≥8 chars before a substring match is allowed
+          * to fire wake.  K144's sherpa-ncnn streaming ASR confabulates
+          * short 1-2 word fragments from background noise during silence
+          * ("kincher", "ereb", "thinker") — those would substring-match
+          * "thinker" but contain only that noise.  A real "Hey Tinker"
+          * utterance produces a partial with leading context, so the
+          * 8-char floor filters hallucinations without losing real wakes.
+          * Now applied to the freshly-arrived delta (anchored matcher). */
+         size_t delta_len = (delta && delta[0]) ? strlen(delta) : 0;
+         if (delta_len < 8) {
+            ESP_LOGD(TAG, "wake suppressed by VAD pregate: delta=\"%s\" (%u chars)", delta ? delta : "",
+                     (unsigned)delta_len);
             s_vad_skip_count++;
          } else {
-            ESP_LOGI(TAG, "wake matched \"%s\" in \"%s\"", match, s_wake_window);
+            ESP_LOGI(TAG, "wake matched \"%s\" in delta=\"%s\"", match, delta);
             tab5_debug_obs_event("wakeword.fire", match);
             /* TT #578: bookkeeping for /tinkeron/status. */
             s_fire_count++;

--- a/main/voice_wakeword.h
+++ b/main/voice_wakeword.h
@@ -114,6 +114,24 @@ const char *voice_wakeword_asr_id(void);
  *         with whatever has been accumulated so far. */
 void voice_wakeword_force_dictation_stop(void);
 
+/** @brief TT #692 — install a post-cancel suppression window.
+ *
+ *  After voice_cancel runs, K144's sherpa-ncnn streaming-zipformer
+ *  may still emit ASR partials containing buffered audio fragments
+ *  from the TTS tail or the user's follow-up speech.  The matcher
+ *  would catch these as wake hits and re-open the mic — the
+ *  "X-button-doesn't-stop" loop.
+ *
+ *  Calling this with @p ms sets a deadline `now + ms`.  Any wake
+ *  events that would fire before the deadline are silently dropped
+ *  (with an obs event for visibility).  The listener task stays
+ *  alive and armed throughout — no need to stop/restart.
+ *
+ *  3000 ms is a sane default — covers the typical TTS-tail drain
+ *  window plus a margin for user follow-up speech.  voice_cancel
+ *  calls this. */
+void voice_wakeword_post_cancel_suppress_ms(uint32_t ms);
+
 /* ── Status accessors (TT #578 — TinkerON debug surface) ──────────── */
 
 /** @brief Snapshot of the listener's runtime state.  All fields are


### PR DESCRIPTION
## Summary

Wave A of the 4-wave voice-loop UX fix.  Reverts PR #691's permanent wakeword-disarm on cancel — wrong tradeoff, wakeword's job is to stay alive all day — and replaces it with a precise 3 s post-cancel matcher suppression window plus anchored partial-matching.

- **`voice_wakeword_post_cancel_suppress_ms(ms)`** — new API; sets a deadline, matcher silently drops wake events before it.  Listener task stays armed throughout.
- **`voice_cancel()` calls the API with 3000 ms** — every cancel path inherits (X button, mic mid-turn, nav, mode-sheet, watchdog, `/voice/cancel`).
- **Pump pause 1500 → 3000 ms** so K144's rolling decoder fully drains its TTS-tail / follow-up buffer before partials route to the matcher.
- **Anchored matcher** — wake substring must now appear in the freshly-arrived ASR delta with position in the first half + 4-char slack.  Rejects buffered-noise tails containing "thinker"/"tinker" fragments while still accepting "hi hey tinker".
- **Reverts of PR #691** — `ui_voice::close_click_cb` and `ui_home::mute_btn_click_cb` no longer disarm wakeword.  Mute = mic doesn't transmit; wakeword stays armed (matches consumer voice assistants).

## Verification needed (live)

- [ ] Wakeword stays armed all day across multiple X-button presses
- [ ] Press X mid-conversation → conversation ends, no re-LISTEN from TTS tail or follow-up speech within 3 s
- [ ] After 3 s grace, "Hey Tinker" still works
- [ ] Conversational speech with substrings like "kicker", "stick her", "thinking" no longer false-fires wake
- [ ] Mute toggle does NOT silently break wakeword

## Out of scope (Wave B/C/D follow-ups, separate PRs)

- VAD silence-stop in ASK mode + conditional auto-relisten on question mark + visible "still listening" caption (Wave B)
- `voice_disarm_channel_reply` on cancel (Wave C)
- Mute icon visual cleanup (Wave D)

## Build + test plan

- [x] `idf.py build` green
- [x] `git-clang-format --diff origin/main` clean
- [x] Flashed to Tab5 192.168.70.128
- [ ] e2e harness `story_smoke` re-run after live verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)