### PR TITLE
fix(wakeword): dedup K144 ASR delta flood + drop log noise (closes #698)

### DIFF
--- a/main/voice_m5_llm.c
+++ b/main/voice_m5_llm.c
@@ -1862,11 +1862,14 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
          m5_stackflow_response_free(&resp);
          continue;
       }
-      /* DEBUG (TT wakeword bring-up 2026-05-18): log every frame we
-       * receive so we can see what K144 ASR actually emits when the
-       * matcher fails to fire.  Cheap (one INFO per partial). */
-      ESP_LOGI(TAG, "asr frame: work_id=%s obj=%s",
-               resp.work_id ? resp.work_id : "(null)",
+      /* TT wakeword bring-up 2026-05-18 — was ESP_LOGI for the matcher
+       * regression hunt.  TT #698: dropped to LOGD because K144 emits
+       * 5-20 frames/sec under speech (rolling decoder re-emits same
+       * partial).  At LOGI this flooded the log ring (256 entries =
+       * <1 min of useful tail) and serial UART (~5 KB/s of duplicate
+       * text).  LOGD is still available via menuconfig when bring-up
+       * needs it. */
+      ESP_LOGD(TAG, "asr frame: work_id=%s obj=%s", resp.work_id ? resp.work_id : "(null)",
                resp.object ? resp.object : "(null)");
       if (resp.work_id == NULL || strcmp(resp.work_id, handle->asr_id) != 0) {
          m5_stackflow_response_free(&resp);
@@ -1907,7 +1910,11 @@ esp_err_t voice_m5_llm_wakeword_run(voice_m5_wakeword_handle_t *handle, voice_m5
             delta_str = resp.data->valuestring ? resp.data->valuestring : "";
             finished = true;
          }
-         ESP_LOGI(TAG, "asr delta: finish=%d text=\"%.80s\"", finished, delta_str);
+         /* TT #698: LOGI → LOGD for the same flood-control reason as the
+          * asr frame line above.  GET /tinkeron/transcripts gives a
+          * 32-entry ring of recent deltas for debug; we don't need the
+          * serial flood. */
+         ESP_LOGD(TAG, "asr delta: finish=%d text=\"%.80s\"", finished, delta_str);
          if (cb != NULL) cb(delta_str, finished, user);
       }
       m5_stackflow_response_free(&resp);

--- a/main/voice_wakeword.c
+++ b/main/voice_wakeword.c
@@ -306,6 +306,28 @@ static void asr_partial_cb(const char *delta, bool finish, void *user) {
     * K144's llm-asr is alive and dispatching to us. */
    s_last_delta_us = esp_timer_get_time();
 
+   /* TT #698 — drop consecutive identical non-finish partials.  K144's
+    * sherpa-ncnn streaming-zipformer rolling decoder re-emits the SAME
+    * partial 5-20× per audio frame (live-observed 10 deltas/sec all
+    * carrying identical 80-char text).  Without this gate every
+    * duplicate runs the matcher (7× istrstr), pushes the transcript
+    * ring (taskENTER_CRITICAL + strncpy), and pushes the wake window
+    * (memcpy + bounds checks) for zero new signal.
+    *
+    * Gate intentionally lets finish=true through (boundary marker) and
+    * empty deltas through (silence/heartbeat).  Watchdog timestamp
+    * above still fires so K144-aliveness detection isn't affected. */
+   static char s_last_delta[96] = {0};
+   if (delta != NULL && delta[0] != '\0' && !finish && strncmp(s_last_delta, delta, sizeof(s_last_delta) - 1) == 0) {
+      return;
+   }
+   if (delta != NULL && delta[0] != '\0') {
+      strncpy(s_last_delta, delta, sizeof(s_last_delta) - 1);
+      s_last_delta[sizeof(s_last_delta) - 1] = '\0';
+   } else if (finish) {
+      s_last_delta[0] = '\0'; /* segment closed — next partial is fresh */
+   }
+
    /* TT #578: every delta into the debug ring before any state branching. */
    if (delta && delta[0]) transcript_ring_push(delta, finish);
 


### PR DESCRIPTION
## Summary

Live audit of the Tab5 ↔ K144 piping caught the rolling-decoder re-emitting the SAME partial 10×/sec (sample: 20 deltas in 1.8 s, all identical 80-char text).  Every duplicate ran the matcher, churned mutexes, and flooded logs for zero new signal.

## Fix

- \`voice_wakeword.c\`: front-of-callback gate drops consecutive identical non-finish partials.  \`finish=true\` and empty markers still flow.  K144 watchdog timestamp still fires above the gate (liveness detection unaffected).
- \`voice_m5_llm.c\`: \`ESP_LOGI\` → \`ESP_LOGD\` for the two ASR frame/delta lines left at LOGI during 2026-05-18 matcher bring-up.

## Live verification

Pre-fix: \`/logs/tail\` shows ~30 ASR delta lines per pull, all duplicates.  
Post-fix: \`/logs/tail\` shows zero asr-* lines under normal speech; \`/tinkeron/transcripts\` ring populates only when content changes.

## Test plan

- [x] \`idf.py build\` green
- [x] \`git-clang-format --diff origin/main\` clean
- [x] Flashed to Tab5 192.168.1.90; boot fps=56, ASR log volume = 0
- [ ] Say "Hey Tinker" → wake still fires (the dedup only drops duplicates, not first-arrivals)
- [ ] Long dictation → transcript ring grows monotonically without duplicate noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)