### PR TITLE
Voice W2: make muted-mic legible on wake + tap (#708)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -1689,7 +1689,7 @@ esp_err_t voice_start_listening(void)
 
    if (tab5_settings_get_mic_mute()) {
       ESP_LOGW(TAG, "voice_start_listening: mic is muted, refusing");
-      ui_home_show_toast("Mic is muted -- unmute in Settings");
+      ui_home_show_toast("Mic muted -- tap the mute button (top-right) to talk");
       return ESP_ERR_INVALID_STATE;
    }
 

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -192,6 +192,19 @@ static void wakeword_event_handler(voice_wakeword_event_t event, const char *tex
    (void)user;
    switch (event) {
       case VOICE_WAKEWORD_EVENT_WAKE: {
+         /* TT #708 — if the mic is muted, voice_start_listening downstream
+          * refuses with only a fleeting toast AFTER we've already chimed +
+          * shown "Tinker listening…" — the exact "I woke it and nothing
+          * happens" confusion.  Surface the muted state honestly (somber
+          * error cue + actionable prompt) and do NOT pretend to listen. */
+         if (tab5_settings_get_mic_mute()) {
+            ESP_LOGW(TAG, "wake while mic muted — surfacing muted prompt, not starting a turn");
+            tab5_debug_obs_event("wakeword.fire", "muted");
+            ui_audio_cue_play(UI_CUE_ERROR);
+            char *mm = strdup("Mic muted — tap the mute button to talk");
+            if (mm != NULL) tab5_lv_async_call(wakeword_toast_async, mm);
+            break;
+         }
          /* TT #131-opt2: audible wake chime — confirms KWS fired before
           * we start listening for the user's question. */
          ui_audio_cue_play(UI_CUE_INCOMING_HIGH);


### PR DESCRIPTION
Part of the conversation-UX wave plan (#705, W2). Targets the confirmed live pain: the mic was muted and woken/tapped turns silently refused after a misleading chime + "listening" toast.

**Change:** wake handler + orb-tap now surface the muted state honestly (error cue + "Mic muted — tap the mute button to talk"), and don't fake a listening turn.

**Verified live (192.168.1.90):** orb tap while muted held READY (no fake-listen) and showed the actionable toast; home shows MUTED + red mute glyph. Wake-path branch shares the same guard but the wake trigger needs a human speech test.

Closes #708. Anchor: #705.