### PR TITLE
Voice W2: response-timeout watchdog — never stuck forever (#709)

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -513,8 +513,19 @@ void voice_set_state(voice_state_t new_state, const char *detail) {
     * Deferred via tab5_worker_enqueue so it runs on the worker's 16 KB
     * PSRAM stack rather than the 6 KB playback drain stack — same
     * pattern as the #133 queue drain above. */
-   if (old == VOICE_STATE_SPEAKING && new_state == VOICE_STATE_READY && s_conv_active) {
-      ESP_LOGI(TAG, "conv: SPEAKING→READY edge with conv_active, queueing relisten");
+   /* TT #714 — relisten on any normal turn-completion edge, not just
+    * SPEAKING→READY.  A turn that produced a reply but no TTS (llm_done
+    * with empty/disabled audio) reaches READY straight from PROCESSING;
+    * the old SPEAKING-only condition silently ended the conversation
+    * there, so the user had to re-tap/re-wake.  The PROCESSING edge is
+    * guarded on a non-empty reply so error / empty-STT / cancelled turns
+    * (which carry no llm text, and cancel already clears s_conv_active)
+    * don't relisten and can't loop. */
+   const char *conv_reply = voice_get_llm_text();
+   bool conv_complete_edge =
+       (old == VOICE_STATE_SPEAKING) || (old == VOICE_STATE_PROCESSING && conv_reply != NULL && conv_reply[0] != '\0');
+   if (conv_complete_edge && new_state == VOICE_STATE_READY && s_conv_active) {
+      ESP_LOGI(TAG, "conv: turn-complete edge (old=%d) with conv_active, queueing relisten", old);
       tab5_debug_obs_event("voice.conv", "relisten_enqueue");
       if (tab5_worker_enqueue(_conv_relisten_job, NULL, "voice-conv-relisten") != ESP_OK) {
          ESP_LOGW(TAG, "conv: relisten enqueue failed; conversation ending");
@@ -2749,6 +2760,10 @@ static void response_wd_recover_job(void *arg) {
    if (ws_live) {
       voice_ws_send_text("{\"type\":\"cancel\"}");
    }
+   /* TT #714 — a timeout ends the conversation; clear conv_active before
+    * the READY transition so it doesn't auto-relisten into a possible
+    * hang loop (same contract as voice_cancel). */
+   s_conv_active = false;
    voice_set_state(ws_live ? VOICE_STATE_READY : VOICE_STATE_IDLE, "watchdog_timeout");
    ui_home_show_toast("Tinker timed out -- ready again");
    s_resp_wd_recovering = false;

--- a/main/voice.c
+++ b/main/voice.c
@@ -433,6 +433,10 @@ void voice_set_state(voice_state_t new_state, const char *detail) {
    }
 
    if (old != new_state || (detail != NULL && detail[0] != '\0')) {
+      /* TT #709 — a real state transition is progress; reset the activity
+       * clock so the response-timeout watchdog measures time stuck in the
+       * NEW state, not since some earlier (possibly stale) event. */
+      if (old != new_state) s_last_activity_us = esp_timer_get_time();
       ESP_LOGI(TAG, "State: %d -> %d (%s)", old, new_state, detail ? detail : "");
       if (s_state_cb) {
          if (tab5_ui_try_lock(200)) {
@@ -2696,21 +2700,106 @@ const char *voice_get_dictation_summary(void)
 }
 
 // ---------------------------------------------------------------------------
-// Reconnect watchdog — superseded by esp_websocket_client's built-in
-// auto-reconnect. Public API preserved as no-ops for backward compat so
-// callers in main.c / debug_server.c still link. See issue #76.
+// Response-timeout watchdog (TT #709) — closes the "spins forever" class.
+// The WS-level reconnect is handled by esp_websocket_client's built-in
+// auto-reconnect; this watchdog handles the orthogonal failure where the
+// socket is fine but a turn never completes (Dragon hangs / drops the final
+// frame / LLM wedge), leaving PROCESSING or SPEAKING stuck indefinitely
+// (cf. the #697 stuck-PROCESSING bug — fixed for one branch, this is the
+// general safety net).  s_last_activity_us is reset on every state entry
+// (voice_set_state) and every Dragon WS frame (voice_ws_proto WS_DATA), so
+// it measures "time since any progress"; a genuine hang lets it go stale.
 // ---------------------------------------------------------------------------
+static esp_timer_handle_t s_resp_wd_timer = NULL;
+static volatile bool s_resp_wd_recovering = false;
+
+/* Per-mode "no Dragon activity" budget.  Generous on purpose: any streamed
+ * frame resets the clock, so these only trip on a true stall.  Cheaper to
+ * recover a rare hang slowly than to kill a legitimately slow turn. */
+static int64_t response_wd_budget_ms(void) {
+   switch (tab5_settings_get_voice_mode()) {
+      case 1: /* hybrid  */
+      case 2: /* cloud   */
+      case 5: /* solo    */
+         return 30000;
+      case 3: /* tinkerclaw agent — tool loops can pause between steps */
+         return 120000;
+      case 4: /* onboard K144 */
+         return 60000;
+      case 0: /* local   */
+      default:
+         return 45000;
+   }
+}
+
+/* Runs on the shared worker (not the esp_timer task) so voice_set_state's
+ * UI callback + the toast have a normal stack + scheduling. */
+static void response_wd_recover_job(void *arg) {
+   (void)arg;
+   voice_state_t st = voice_get_state();
+   if (st != VOICE_STATE_PROCESSING && st != VOICE_STATE_SPEAKING) {
+      s_resp_wd_recovering = false; /* unstuck on its own between tick + job */
+      return;
+   }
+   ESP_LOGW(TAG, "response watchdog: stuck in state %d — recovering to READY", st);
+   tab5_debug_obs_event("error.timeout", "resp_watchdog");
+   voice_playback_buf_reset();
+   tab5_audio_speaker_enable(false);
+   bool ws_live = g_voice_ws && esp_websocket_client_is_connected(g_voice_ws);
+   if (ws_live) {
+      voice_ws_send_text("{\"type\":\"cancel\"}");
+   }
+   voice_set_state(ws_live ? VOICE_STATE_READY : VOICE_STATE_IDLE, "watchdog_timeout");
+   ui_home_show_toast("Tinker timed out -- ready again");
+   s_resp_wd_recovering = false;
+}
+
+/* Light periodic check (esp_timer task) — only reads state + a timestamp,
+ * then defers any real work to the worker. */
+static void response_wd_tick_cb(void *arg) {
+   (void)arg;
+   if (s_resp_wd_recovering) return;
+   voice_state_t st = voice_get_state();
+   /* Only the "waiting on Dragon" states.  LISTENING is user-paced (and
+    * capped separately); CONNECTING/RECONNECTING are the WS client's job. */
+   if (st != VOICE_STATE_PROCESSING && st != VOICE_STATE_SPEAKING) return;
+   int64_t idle_ms = (esp_timer_get_time() - s_last_activity_us) / 1000;
+   if (idle_ms > response_wd_budget_ms()) {
+      ESP_LOGW(TAG, "response watchdog: %lld ms idle in state %d (budget %lld) — recovering", (long long)idle_ms, st,
+               (long long)response_wd_budget_ms());
+      s_resp_wd_recovering = true;
+      if (tab5_worker_enqueue(response_wd_recover_job, NULL, "voice-resp-wd") != ESP_OK) {
+         s_resp_wd_recovering = false; /* worker full — retry next tick */
+      }
+   }
+}
+
 esp_err_t voice_start_reconnect_watchdog(void)
 {
     ESP_LOGI(TAG, "reconnect watchdog superseded by esp_websocket_client built-in auto-reconnect");
+    /* TT #709 — start the response-timeout watchdog (3 s cadence). */
+    if (!s_resp_wd_timer) {
+       const esp_timer_create_args_t args = {
+           .callback = response_wd_tick_cb,
+           .arg = NULL,
+           .name = "voice_resp_wd",
+       };
+       esp_timer_create(&args, &s_resp_wd_timer);
+    }
+    if (s_resp_wd_timer) {
+       esp_timer_stop(s_resp_wd_timer); /* idempotent if already running */
+       esp_timer_start_periodic(s_resp_wd_timer, 3000000 /* 3 s */);
+    }
     return ESP_OK;
 }
 
 void voice_stop_reconnect_watchdog(void)
 {
-    /* No-op — the managed client's auto-reconnect loop runs until
-     * esp_websocket_client_stop() is called, which voice_disconnect()
-     * handles on the teardown path. */
+   /* WS auto-reconnect is the managed client's job; just stop our
+    * response-timeout watchdog. */
+   if (s_resp_wd_timer) {
+      esp_timer_stop(s_resp_wd_timer);
+   }
 }
 
 void voice_force_reconnect(void)

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -563,6 +563,15 @@ void voice_ws_proto_handle_text(const char *data, int len) {
 
    const char *type_str = type->valuestring;
 
+   /* TT #709 — count this frame as turn "progress" for the response-timeout
+    * watchdog, EXCEPT keepalive ping/pong.  Tab5 sends {"type":"ping"} every
+    * 15 s during PROCESSING and Dragon answers "pong"; treating those as
+    * progress would keep s_last_activity_us fresh forever, so a genuinely
+    * hung-but-pinging Dragon would never trip the watchdog. */
+   if (strcmp(type_str, "pong") != 0 && strcmp(type_str, "ping") != 0) {
+      s_last_activity_us = esp_timer_get_time();
+   }
+
    if (strcmp(type_str, "stt_partial") == 0) {
       cJSON *text = cJSON_GetObjectItem(root, "text");
       /* U12 (#206): regardless of dictation mode, surface the partial
@@ -1805,12 +1814,17 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t even
 
       case WEBSOCKET_EVENT_DATA:
          if (!data) break;
-         s_last_activity_us = esp_timer_get_time();
          if (data->op_code == WS_TRANSPORT_OPCODES_TEXT && data->data_len > 0) {
             ESP_LOGI(TAG, "WS recv text (%d bytes): %.*s", data->data_len, data->data_len > 200 ? 200 : data->data_len,
                      data->data_ptr);
+            /* TT #709 — the response-timeout progress clock is reset inside
+             * handle_text, gated to skip keepalive ping/pong (which arrive
+             * as TEXT frames every ~15 s and would otherwise keep the clock
+             * fresh forever, defeating the hang watchdog). */
             voice_ws_proto_handle_text(data->data_ptr, data->data_len);
          } else if (data->op_code == WS_TRANSPORT_OPCODES_BINARY && data->data_len > 0) {
+            /* TT #709 — TTS audio counts as turn progress. */
+            s_last_activity_us = esp_timer_get_time();
             /* #268: large binary frames (e.g. Phase 3B video JPEGs >32 KB)
              * arrive in fragments — esp_websocket_client splits them at
              * WS_CLIENT_BUFFER_SIZE.  Reassemble using payload_len +


### PR DESCRIPTION
Part of the conversation-UX wave plan (#705, W2). Closes the "spins forever" class — the general case of the #697 stuck-PROCESSING bug.

## What
- 3s periodic watchdog: if PROCESSING/SPEAKING and no Dragon activity within a **mode-scaled budget** (Local 45s, cloud/hybrid/solo 30s, TinkerClaw 120s, onboard 60s), snap to READY/IDLE + cancel Dragon + toast.
- Reset the activity clock on **state entry** (so a text turn doesn't start stale) and on **real app frames only** — NOT keepalive ping/pong (Dragon WS-pings every 5s + answers Tab5's 15s ping with `pong`; counting those kept the clock fresh forever).

## Verified live (192.168.1.90)
- **Induced a real hang** (SIGSTOP llama-server): serial showed idle climb 1s→46s with `pong` frames NOT resetting it, watchdog fired at idle=46128ms → snapped to READY.
- **No false-fire**: normal turns (incl. a slow 21.5s one) complete via SPEAKING untouched.
- Build + clang-format clean.

Note: the test also re-confirmed the Dragon-side cancel gap (a resumed "cancelled" turn still streamed its reply) — tracked separately in TinkerBox#372.

Closes #709. Anchor: #705.