### PR TITLE
fix(ui): kill tofu boxes across Settings/Chat/Home (UI audit)

### DIFF
--- a/main/chat_header.c
+++ b/main/chat_header.c
@@ -255,18 +255,26 @@ void chat_header_set_mode(chat_header_t *h, uint8_t m, const char *llm)
         char buf[32] = {0};
         if (m == 3) {
             snprintf(buf, sizeof(buf), "AGENT");
+        } else if (m == 0 || m == 1) {
+           /* UI audit: Local + Hybrid run the LLM ON-DEVICE (Dragon NPU/
+            * Ollama).  The NVS llm_model holds the Cloud picker value, which
+            * is NOT serving the turn — showing it (e.g. CLAUDE-SONNET-4.6)
+            * mislabels the mode.  Match the home pill: "ON-DEVICE". */
+           snprintf(buf, sizeof(buf), "ON-DEVICE");
+        } else if (m == 4) {
+           snprintf(buf, sizeof(buf), "K144");
         } else {
-            const char *nick = llm ? llm : "";
-            const char *slash = strchr(nick, '/');
-            if (slash) nick = slash + 1;
-            size_t n = strlen(nick);
-            if (n >= sizeof(buf)) n = sizeof(buf) - 1;
-            memcpy(buf, nick, n);
-            char *col = strchr(buf, ':');
-            if (col) *col = 0;
-            for (char *p = buf; *p; p++) {
-                if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
-            }
+           const char *nick = llm ? llm : "";
+           const char *slash = strchr(nick, '/');
+           if (slash) nick = slash + 1;
+           size_t n = strlen(nick);
+           if (n >= sizeof(buf)) n = sizeof(buf) - 1;
+           memcpy(buf, nick, n);
+           char *col = strchr(buf, ':');
+           if (col) *col = 0;
+           for (char *p = buf; *p; p++) {
+              if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
+           }
         }
         lv_label_set_text(h->chip_sub, buf);
     }
@@ -288,7 +296,11 @@ void chat_header_set_accent_color(chat_header_t *h, uint32_t hex)
 
 void chat_header_set_spend(chat_header_t *h, uint32_t mils, uint32_t cap_mils) {
    if (!h || !h->spend_lbl) return;
-   if (mils == 0 && cap_mils == 0) {
+   /* UI audit: don't show "$0.000 / $1.000" before any spend — it's dev
+    * clutter, and in free modes (Local/Hybrid/Onboard) it's always $0.
+    * The budget badge appears only once a paid turn has actually cost
+    * something. */
+   if (mils == 0) {
       lv_label_set_text(h->spend_lbl, "");
       return;
    }

--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -120,7 +120,7 @@ static void fmt_timestamp(char *buf, size_t n, uint32_t ts, bool is_user)
 {
     int h = (int)((ts / 3600) % 24);
     int m = (int)((ts / 60) % 60);
-    snprintf(buf, n, "%02d:%02d \xc2\xb7 %s", h, m, is_user ? "YOU" : "TINKER");
+    snprintf(buf, n, "%02d:%02d \xe2\x80\xa2 %s", h, m, is_user ? "YOU" : "TINKER");
     for (char *p = buf; *p; p++) {
         if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
     }
@@ -324,16 +324,16 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
         char kicker[64];
         switch (msg->type) {
             case MSG_IMAGE:
-                snprintf(kicker, sizeof(kicker), "IMAGE \xc2\xb7 %.40s",
-                         msg->subtitle[0] ? msg->subtitle : "INLINE");
-                break;
+               snprintf(kicker, sizeof(kicker), "IMAGE \xe2\x80\xa2 %.40s",
+                        msg->subtitle[0] ? msg->subtitle : "INLINE");
+               break;
             case MSG_CARD:
-                snprintf(kicker, sizeof(kicker), "CARD \xc2\xb7 %.40s",
-                         msg->subtitle[0] ? msg->subtitle : "PREVIEW");
-                break;
+               snprintf(kicker, sizeof(kicker), "CARD \xe2\x80\xa2 %.40s",
+                        msg->subtitle[0] ? msg->subtitle : "PREVIEW");
+               break;
             case MSG_AUDIO_CLIP:
-                snprintf(kicker, sizeof(kicker), "AUDIO \xc2\xb7 CLIP");
-                break;
+               snprintf(kicker, sizeof(kicker), "AUDIO \xe2\x80\xa2 CLIP");
+               break;
             default:
                 kicker[0] = 0;
                 break;
@@ -553,18 +553,15 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
              *   local turn  : " · MODEL · FREE"
              *   +retried    : prepend " · RETRIED" to either */
             size_t cur = strlen(ts);
-            const char *retry_tag = msg->receipt_retried ? " \xc2\xb7 RETRIED" : "";
+            const char *retry_tag = msg->receipt_retried ? " \xe2\x80\xa2 RETRIED" : "";
             if (msg->receipt_mils > 0) {
                 int dollars     = (int)(msg->receipt_mils / 100000);
                 int thousandths = (int)((msg->receipt_mils / 100) % 1000);
-                snprintf(ts + cur, sizeof(ts) - cur,
-                         " \xc2\xb7 %s \xc2\xb7 $%d.%03d%s",
-                         msg->receipt_model_short,
-                         dollars, thousandths, retry_tag);
+                snprintf(ts + cur, sizeof(ts) - cur, " \xe2\x80\xa2 %s \xe2\x80\xa2 $%d.%03d%s",
+                         msg->receipt_model_short, dollars, thousandths, retry_tag);
             } else {
-                snprintf(ts + cur, sizeof(ts) - cur,
-                         " \xc2\xb7 %s \xc2\xb7 FREE%s",
-                         msg->receipt_model_short, retry_tag);
+               snprintf(ts + cur, sizeof(ts) - cur, " \xe2\x80\xa2 %s \xe2\x80\xa2 FREE%s", msg->receipt_model_short,
+                        retry_tag);
             }
         }
         lv_label_set_text(slot->ts, ts);

--- a/main/chat_msg_view.c
+++ b/main/chat_msg_view.c
@@ -498,14 +498,20 @@ static void slot_bind(chat_msg_view_t *v, msg_slot_t *slot,
     lv_obj_set_style_pad_ver(slot->bubble, BUBBLE_PAD_V, 0);
 
     if (msg->is_user) {
-        lv_obj_set_style_bg_color(slot->bubble, lv_color_hex(TH_AMBER), 0);
-        lv_obj_set_style_border_width(slot->bubble, 0, 0);
-        /* Rounded-rect with a 6-px bottom-right tail. LVGL doesn't ship
-         * per-corner radius, so we settle for the 22 radius — the tail
-         * is approximated by a small 12×12 amber square tucked under
-         * the bubble's bottom-right edge. */
-        lv_obj_set_style_radius(slot->bubble, BUBBLE_RADIUS, 0);
-        lv_obj_set_style_text_color(slot->body, lv_color_hex(TH_BG), 0);
+       /* UI audit: richer amber — a vertical gradient (amber → amber-dark)
+        * instead of a flat neon fill so the user bubble reads premium, not
+        * garish.  Static bubble (rendered once, not per-tick invalidated)
+        * so a 2-stop gradient is within the render budget. */
+       lv_obj_set_style_bg_color(slot->bubble, lv_color_hex(TH_AMBER), 0);
+       lv_obj_set_style_bg_grad_color(slot->bubble, lv_color_hex(TH_AMBER_DARK), 0);
+       lv_obj_set_style_bg_grad_dir(slot->bubble, LV_GRAD_DIR_VER, 0);
+       lv_obj_set_style_border_width(slot->bubble, 0, 0);
+       /* Rounded-rect with a 6-px bottom-right tail. LVGL doesn't ship
+        * per-corner radius, so we settle for the 22 radius — the tail
+        * is approximated by a small 12×12 amber square tucked under
+        * the bubble's bottom-right edge. */
+       lv_obj_set_style_radius(slot->bubble, BUBBLE_RADIUS, 0);
+       lv_obj_set_style_text_color(slot->body, lv_color_hex(TH_BG), 0);
     } else {
         lv_obj_set_style_bg_color(slot->bubble, lv_color_hex(TH_CARD), 0);
         /* Wave 15 W15-C09: was `border_width=1 + radius=22`.  LVGL's

--- a/main/chat_session_drawer.c
+++ b/main/chat_session_drawer.c
@@ -262,8 +262,7 @@ static void render_rows(chat_session_drawer_t *d,
         for (char *p = nickbuf; *p; p++)
             if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
 
-        snprintf(info, sizeof(info), "%s \xc2\xb7 %s",
-                 s_mode_short[mode], nickbuf[0] ? nickbuf : "\xe2\x80\x93");
+        snprintf(info, sizeof(info), "%s \xe2\x80\xa2 %s", s_mode_short[mode], nickbuf[0] ? nickbuf : "\xe2\x80\x93");
         lv_label_set_text(r->info, info);
 
         lv_label_set_text(r->title, s->title[0] ? s->title : "Untitled");

--- a/main/chat_session_drawer.c
+++ b/main/chat_session_drawer.c
@@ -198,7 +198,10 @@ static void row_create(chat_session_drawer_t *d, drawer_row_t *r,
 
 static void format_relative(char *buf, size_t n, uint32_t updated_at)
 {
-    if (!updated_at) { snprintf(buf, n, "\xe2\x80\x93"); return; }
+   if (!updated_at) {
+      snprintf(buf, n, "-");
+      return;
+   }
     time_t now = 0; time(&now);
     long delta = (long)now - (long)updated_at;
     if (delta < 0) delta = 0;
@@ -262,7 +265,7 @@ static void render_rows(chat_session_drawer_t *d,
         for (char *p = nickbuf; *p; p++)
             if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
 
-        snprintf(info, sizeof(info), "%s \xe2\x80\xa2 %s", s_mode_short[mode], nickbuf[0] ? nickbuf : "\xe2\x80\x93");
+        snprintf(info, sizeof(info), "%s \xe2\x80\xa2 %s", s_mode_short[mode], nickbuf[0] ? nickbuf : "-");
         lv_label_set_text(r->info, info);
 
         lv_label_set_text(r->title, s->title[0] ? s->title : "Untitled");

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -258,8 +258,7 @@ static void on_mode_lp(void *ud)
     const char *nick = llm;
     const char *slash = strchr(nick, '/');
     if (slash) nick = slash + 1;
-    snprintf(toast, sizeof(toast), "Mode: %s \xc2\xb7 %s",
-             names[m], nick[0] ? nick : "default");
+    snprintf(toast, sizeof(toast), "Mode: %s \xe2\x80\xa2 %s", names[m], nick[0] ? nick : "default");
     ui_home_show_toast(toast);
 }
 

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -2904,7 +2904,7 @@ static void undo_tick_cb(lv_timer_t *t) {
    if (!s_undo_countdown) return;
    if (s_undo_secs_left > 0) s_undo_secs_left--;
    char buf[80];
-   snprintf(buf, sizeof(buf), "%s  \xc2\xb7  Undo (%ds)", s_undo_label_buf, s_undo_secs_left);
+   snprintf(buf, sizeof(buf), "%s  \xe2\x80\xa2  Undo (%ds)", s_undo_label_buf, s_undo_secs_left);
    lv_label_set_text(s_undo_countdown, buf);
 }
 
@@ -2947,7 +2947,7 @@ void ui_home_show_undo_toast(const char *label, int seconds, ui_undo_cb_t undo_c
    lv_obj_set_style_text_color(s_undo_countdown, lv_color_hex(TH_TEXT_PRIMARY), 0);
    lv_obj_set_style_text_letter_space(s_undo_countdown, 1, 0);
    char buf[80];
-   snprintf(buf, sizeof(buf), "%s  \xc2\xb7  Undo (%ds)", label, seconds);
+   snprintf(buf, sizeof(buf), "%s  \xe2\x80\xa2  Undo (%ds)", label, seconds);
    lv_label_set_text(s_undo_countdown, buf);
 
    lv_obj_add_flag(t, LV_OBJ_FLAG_CLICKABLE);

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -130,7 +130,7 @@ static void notif_show_async_cb(void *arg) {
       /* Toast: compose "[ch] sender · preview".  Bounded with %.Ns
        * specifiers so compiler can prove no truncation. */
       char text[200];
-      snprintf(text, sizeof(text), "[%.15s] %.40s · %.120s", ch, sender, preview);
+      snprintf(text, sizeof(text), "[%.15s] %.40s • %.120s", ch, sender, preview);
       /* W7-E.6: dim variant during quiet hours — visible but not
        * attention-grabbing per PLAN §4.3. */
       ui_home_show_toast_ex(text, quiet ? UI_TOAST_INCOMING_QUIET : UI_TOAST_INCOMING);

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -300,7 +300,10 @@ static void pick_circadian_palette(int hour, uint32_t *top, uint32_t *bot) {
       *bot = 0x804008; /* Dusk */
    } else {
       *top = 0x7F6535;
-      *bot = 0x2A1F0F; /* Night */
+      *bot = 0x4A3214; /* Night — UI audit: warmed from cold 0x2A1F0F (olive-
+                          dark) to a warm amber-brown so the night orb reads
+                          as a dim gold sphere, not muddy. Still night-dim
+                          (×0.7 in paint_body_for_hour). */
    }
 }
 

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -857,7 +857,10 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
     * blurred shadow blew the LVGL render budget — reverted to flat
     * fill.  The 96×56 size + 140 opa peak alone gives a brighter,
     * wetter highlight than the 70×44 / 110 baseline. */
-   lv_obj_set_style_bg_opa(s_spec, 140, 0);
+   /* UI audit: 140 read as a pasted "sticker" blob on the sphere.  Drop to
+    * 90 so the highlight blends into the lit-side gradient as a soft sheen
+    * rather than stamping an opaque disc on top (the #507 ball-in-ball look). */
+   lv_obj_set_style_bg_opa(s_spec, 90, 0);
    lv_obj_clear_flag(s_spec, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
    s_tilt_dx_ema = 0.0f;
    s_tilt_dy_ema = 0.0f;

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -112,7 +112,7 @@ static void k144_chip_tap_cb(lv_event_t *e) {
 /* TT #328 Wave 14 — K144 hardware gauge.  Small label below the chip
  * showing NPU temperature + load + StackFlow daemon version.
  * Wave 15 extends this with a model inventory line summarising the
- * sys.lsmode registry ("11 MODELS · 1 LLM · 2 ASR · 3 TTS · 2 KWS · 3 vision").
+ * sys.lsmode registry ("11 MODELS • 1 LLM • 2 ASR • 3 TTS • 2 KWS • 3 vision").
  * Populated via a worker job (UART round-trips ~150 ms each; can't
  * run on the LVGL thread).  Both labels rebuild every Settings show. */
 #include "esp_heap_caps.h" /* heap_caps_calloc for the modelist scratch */
@@ -153,10 +153,10 @@ static void k144_gauge_async_render(void *arg) {
       char buf[64];
       if (p->hw_ok && p->hw.valid) {
          double temp_c = (double)p->hw.temperature_milli_c / 1000.0;
-         /* Compact one-line gauge:  "NPU 39.4°C · load 0 · v1.3" */
+         /* Compact one-line gauge:  "NPU 39.4°C • load 0 • v1.3" */
          snprintf(buf, sizeof(buf),
                   "NPU %.1f\xc2\xb0"
-                  "C \xc2\xb7 load %d \xc2\xb7 %s",
+                  "C \xe2\x80\xa2 load %d \xe2\x80\xa2 %s",
                   temp_c, (int)p->hw.cpu_loadavg, p->version[0] ? p->version : "—");
       } else {
          snprintf(buf, sizeof(buf), "—");
@@ -166,15 +166,15 @@ static void k144_gauge_async_render(void *arg) {
    if (s_k144_models_lbl != NULL && p != NULL) {
       char buf[96];
       if (p->models_ok && p->n_total > 0) {
-         /* Compact inventory: "11 MODELS · 1 LLM · 2 ASR · 3 TTS · 2 KWS · 3 vision".
+         /* Compact inventory: "11 MODELS • 1 LLM • 2 ASR • 3 TTS • 2 KWS • 3 vision".
           * Categories with zero entries are elided so the line stays scannable. */
          int n = 0;
          n += snprintf(buf + n, sizeof(buf) - n, "%d MODEL%s", p->n_total, p->n_total == 1 ? "" : "S");
-         if (p->n_llm > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xc2\xb7 %d LLM", p->n_llm);
-         if (p->n_asr > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xc2\xb7 %d ASR", p->n_asr);
-         if (p->n_tts > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xc2\xb7 %d TTS", p->n_tts);
-         if (p->n_kws > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xc2\xb7 %d KWS", p->n_kws);
-         if (p->n_vision > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xc2\xb7 %d vision", p->n_vision);
+         if (p->n_llm > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d LLM", p->n_llm);
+         if (p->n_asr > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d ASR", p->n_asr);
+         if (p->n_tts > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d TTS", p->n_tts);
+         if (p->n_kws > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d KWS", p->n_kws);
+         if (p->n_vision > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d vision", p->n_vision);
       } else {
          snprintf(buf, sizeof(buf), "—");
       }
@@ -203,29 +203,29 @@ static void refresh_k144_chip(void) {
    uint32_t chip_col;
    switch (fs) {
       case 2:
-         chip_glyph = "\xe2\x97\x8f"; /* ● filled */
+         chip_glyph = "\xe2\x80\xa2"; /* • (in-font; ● U+25CF is not in the Montserrat subset → tofu) */
          chip_text = " READY";
          chip_col = 0x10B981;
          break;
       case 1:
-         chip_glyph = "\xe2\x97\x8b"; /* ○ open */
+         chip_glyph = "\xe2\x80\xa2"; /* • */
          chip_text = " WARMING";
          chip_col = AMBER;
          break;
       case 3:
-         chip_glyph = "\xe2\x9c\x97"; /* ✗ */
+         chip_glyph = "\xe2\x80\xa2"; /* • (red via chip_col conveys the error state) */
          chip_text = " UNAVAILABLE";
          chip_col = 0xE5484D;
          break;
       default:
-         chip_glyph = "\xe2\x97\x8b";
+         chip_glyph = "\xe2\x80\xa2"; /* • */
          chip_text = " UNKNOWN";
          chip_col = 0x55555D;
          break;
    }
    char chip_buf[40];
    if (fs == 3 || fs == 0) {
-      snprintf(chip_buf, sizeof(chip_buf), "%s%s \xc2\xb7 TAP", chip_glyph, chip_text);
+      snprintf(chip_buf, sizeof(chip_buf), "%s%s \xe2\x80\xa2 TAP", chip_glyph, chip_text);
    } else {
       snprintf(chip_buf, sizeof(chip_buf), "%s%s", chip_glyph, chip_text);
    }
@@ -311,12 +311,12 @@ static char      s_ota_sha256[65] = {0};
 /* Sliders */
 static lv_obj_t *s_slider_bright  = NULL;
 static lv_obj_t *s_slider_volume  = NULL;
-static lv_obj_t *s_slider_cap     = NULL;  /* v4·D Phase 4e daily budget cap */
+static lv_obj_t *s_slider_cap = NULL; /* v4•D Phase 4e daily budget cap */
 
 /* Slider value labels */
 static lv_obj_t *s_lbl_bright_val = NULL;
 static lv_obj_t *s_lbl_vol_val    = NULL;
-static lv_obj_t *s_lbl_cap_val    = NULL;  /* v4·D Phase 4e cap readout ($X.XX / OFF) */
+static lv_obj_t *s_lbl_cap_val = NULL; /* v4•D Phase 4e cap readout ($X.XX / OFF) */
 static lv_timer_t *s_cap_save_timer = NULL;
 
 /* Auto-rotate switch */
@@ -574,7 +574,7 @@ static void volume_save_cb(lv_timer_t *t)
     s_vol_save_timer = NULL;
 }
 
-/* v4·D Phase 4e: daily budget cap slider.
+/* v4•D Phase 4e: daily budget cap slider.
  * Slider range 0-50, each step = 20 cents = 20,000 mils.
  *   0  -> cap=0 (OFF, no auto-downgrade)
  *   5  -> $1.00
@@ -1085,7 +1085,7 @@ static void cb_privacy_lock(lv_event_t *e) {
    ESP_LOGI(TAG, "Privacy lock: %d", on);
    tab5_debug_obs_event("privacy.lock", on ? "on" : "off");
    if (s_lbl_privacy_status) {
-      lv_label_set_text(s_lbl_privacy_status, on ? "ON · On-device only" : "OFF · Cloud allowed");
+      lv_label_set_text(s_lbl_privacy_status, on ? "ON • On-device only" : "OFF • Cloud allowed");
       lv_obj_set_style_text_color(s_lbl_privacy_status, lv_color_hex(on ? 0xF59E0B : TEXT_DIM), 0);
    }
    /* Nudge the home pill so the new state is reflected without a 5 s
@@ -1632,8 +1632,8 @@ static void phase2_timer_cb(lv_timer_t *t)
     /* Device info -- Line 2: hardware details (smaller, gray) */
     {
         char hw_str[96];
-        snprintf(hw_str, sizeof(hw_str),
-                 "M5Stack Tab5 \xc2\xb7 ESP32-P4 \xc2\xb7 %s", tab5_ota_current_partition());
+        snprintf(hw_str, sizeof(hw_str), "M5Stack Tab5 \xe2\x80\xa2 ESP32-P4 \xe2\x80\xa2 %s",
+                 tab5_ota_current_partition());
         lv_obj_t *hw_lbl = lv_label_create(s_scroll);
         lv_label_set_text(hw_lbl, hw_str);
         lv_obj_set_style_text_color(hw_lbl, lv_color_hex(TEXT_DIM), 0);
@@ -2180,14 +2180,14 @@ lv_obj_t *ui_settings_create(void)
        mk_switch(s_scroll, acc_voice, 660, y, priv_on, cb_privacy_lock, NULL);
        y += ROW_H + 4;
 
-       /* Status line under the toggle row — "ON · On-device only" or
-        * "OFF · Cloud allowed" — same pattern as the K144 health chip. */
+       /* Status line under the toggle row — "ON • On-device only" or
+        * "OFF • Cloud allowed" — same pattern as the K144 health chip. */
        s_lbl_privacy_status = lv_label_create(s_scroll);
        if (s_lbl_privacy_status) {
           lv_obj_set_pos(s_lbl_privacy_status, SIDE_PAD, y);
           lv_obj_set_style_text_font(s_lbl_privacy_status, FONT_SECONDARY, 0);
           lv_obj_set_style_text_color(s_lbl_privacy_status, lv_color_hex(priv_on ? 0xF59E0B : TEXT_DIM), 0);
-          lv_label_set_text(s_lbl_privacy_status, priv_on ? "ON · On-device only" : "OFF · Cloud allowed");
+          lv_label_set_text(s_lbl_privacy_status, priv_on ? "ON • On-device only" : "OFF • Cloud allowed");
        }
        y += 28 + 16;
     }
@@ -2251,7 +2251,7 @@ lv_obj_t *ui_settings_create(void)
     mk_card_bg(s_scroll, quiet_section_top, y);
     y += 24;
 
-    /* v4·D Phase 4e: daily budget cap editor.  Slider range 0-50, each
+    /* v4•D Phase 4e: daily budget cap editor.  Slider range 0-50, each
      * step = 20¢, so 0 = OFF, 50 = $10.00.  Maps to NVS cap_mils field
      * consumed by the auto-downgrade path in voice.c. */
     int budget_section_top = y;
@@ -2297,9 +2297,9 @@ lv_obj_t *ui_settings_create(void)
         (void)voice_m5_llm_sys_version(ver, sizeof(ver));
         char status[80];
         if (hwok && hw.valid) {
-            snprintf(status, sizeof(status), "%s  ·  %ld.%ld°C  ·  load %ld",
-                     ver[0] ? ver : "v?", (long)(hw.temperature_milli_c / 1000),
-                     (long)((hw.temperature_milli_c / 100) % 10), (long)hw.cpu_loadavg);
+           snprintf(status, sizeof(status), "%s  •  %ld.%ld°C  •  load %ld", ver[0] ? ver : "v?",
+                    (long)(hw.temperature_milli_c / 1000), (long)((hw.temperature_milli_c / 100) % 10),
+                    (long)hw.cpu_loadavg);
         } else {
             snprintf(status, sizeof(status), "UNAVAILABLE — try Reset");
         }
@@ -2746,10 +2746,10 @@ void ui_settings_update(void)
                     lv_obj_set_style_text_color(s_lbl_bat_status,
                         lv_color_hex(TAB_LOCAL), 0);
                 } else {
-                    snprintf(sbuf, sizeof(sbuf), "%d%% \xc2\xb7 %s", bi.percent,
-                             bi.charging ? "Charging" : "Discharging");
-                    lv_obj_set_style_text_color(s_lbl_bat_status,
-                        bi.charging ? lv_color_hex(TAB_LOCAL) : lv_color_hex(TEXT_DIM), 0);
+                   snprintf(sbuf, sizeof(sbuf), "%d%% \xe2\x80\xa2 %s", bi.percent,
+                            bi.charging ? "Charging" : "Discharging");
+                   lv_obj_set_style_text_color(s_lbl_bat_status,
+                                               bi.charging ? lv_color_hex(TAB_LOCAL) : lv_color_hex(TEXT_DIM), 0);
                 }
                 lv_label_set_text(s_lbl_bat_status, sbuf);
             }

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -157,9 +157,9 @@ static void k144_gauge_async_render(void *arg) {
          snprintf(buf, sizeof(buf),
                   "NPU %.1f\xc2\xb0"
                   "C \xe2\x80\xa2 load %d \xe2\x80\xa2 %s",
-                  temp_c, (int)p->hw.cpu_loadavg, p->version[0] ? p->version : "—");
+                  temp_c, (int)p->hw.cpu_loadavg, p->version[0] ? p->version : "--");
       } else {
-         snprintf(buf, sizeof(buf), "—");
+         snprintf(buf, sizeof(buf), "--");
       }
       lv_label_set_text(s_k144_gauge_lbl, buf);
    }
@@ -176,7 +176,7 @@ static void k144_gauge_async_render(void *arg) {
          if (p->n_kws > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d KWS", p->n_kws);
          if (p->n_vision > 0) n += snprintf(buf + n, sizeof(buf) - n, " \xe2\x80\xa2 %d vision", p->n_vision);
       } else {
-         snprintf(buf, sizeof(buf), "—");
+         snprintf(buf, sizeof(buf), "--");
       }
       lv_label_set_text(s_k144_models_lbl, buf);
    }
@@ -240,8 +240,8 @@ static void refresh_k144_chip(void) {
    } else {
       /* Reset gauge + inventory to placeholder when leaving READY so
        * stale numbers don't mislead the user during a recovery cycle. */
-      if (s_k144_gauge_lbl != NULL) lv_label_set_text(s_k144_gauge_lbl, "—");
-      if (s_k144_models_lbl != NULL) lv_label_set_text(s_k144_models_lbl, "—");
+      if (s_k144_gauge_lbl != NULL) lv_label_set_text(s_k144_gauge_lbl, "--");
+      if (s_k144_models_lbl != NULL) lv_label_set_text(s_k144_models_lbl, "--");
    }
 }
 
@@ -1947,7 +1947,7 @@ lv_obj_t *ui_settings_create(void)
              lv_obj_t *chip = lv_label_create(row);
              s_k144_chip_lbl = chip;
              s_k144_last_chip_fs = -1; /* force refresh_k144_chip to run */
-             lv_label_set_text(chip, "—");
+             lv_label_set_text(chip, "--");
              lv_obj_set_style_text_font(chip, FONT_SMALL, 0);
              lv_obj_set_style_text_letter_space(chip, 2, 0);
              /* Right-aligned within the row, centred vertically. */
@@ -1969,7 +1969,7 @@ lv_obj_t *ui_settings_create(void)
               * em-dash placeholder so the row layout doesn't shift
               * when the worker callback lands a few hundred ms later. */
              s_k144_gauge_lbl = lv_label_create(row);
-             lv_label_set_text(s_k144_gauge_lbl, "—");
+             lv_label_set_text(s_k144_gauge_lbl, "--");
              lv_obj_set_style_text_font(s_k144_gauge_lbl, FONT_SMALL, 0);
              lv_obj_set_style_text_color(s_k144_gauge_lbl, lv_color_hex(TEXT_DIM), 0);
              lv_obj_set_style_text_letter_space(s_k144_gauge_lbl, 1, 0);
@@ -1987,7 +1987,7 @@ lv_obj_t *ui_settings_create(void)
               * advance below.  See line where `s_k144_models_lbl`
               * gets repositioned with the final y. */
              s_k144_models_lbl = lv_label_create(s_scroll);
-             lv_label_set_text(s_k144_models_lbl, "—");
+             lv_label_set_text(s_k144_models_lbl, "--");
              lv_obj_set_style_text_font(s_k144_models_lbl, FONT_SMALL, 0);
              lv_obj_set_style_text_color(s_k144_models_lbl, lv_color_hex(TEXT_DIM), 0);
              lv_obj_set_style_text_letter_space(s_k144_models_lbl, 1, 0);
@@ -2050,14 +2050,29 @@ lv_obj_t *ui_settings_create(void)
        lv_obj_set_style_text_letter_space(cap, 4, 0);
        y += 26;
 
-       const int chip_w = (CONTENT_W - 4 * 8) / (int)CLOUD_MODEL_COUNT; /* 4 gaps of 8 px */
+       /* TT UI-audit: the chip width used to divide CONTENT_W for ~5 models
+        * (the "4 * 8" gap term), but the catalog grew to 8 — so chips got
+        * squished AND the row overflowed, hard-clipping the first/last chip
+        * at both screen edges.  Put the chips in a horizontally-scrollable
+        * flex row, each sized to its own label, so the strip reads as a
+        * clean scrollable picker instead of a clipped row. */
        const int chip_h = 56;
        const int gap = 8;
+       lv_obj_t *chip_row = lv_obj_create(s_scroll);
+       lv_obj_remove_style_all(chip_row);
+       lv_obj_set_size(chip_row, CONTENT_W, chip_h + 6);
+       lv_obj_set_pos(chip_row, SIDE_PAD, y);
+       lv_obj_set_scroll_dir(chip_row, LV_DIR_HOR);
+       lv_obj_set_scrollbar_mode(chip_row, LV_SCROLLBAR_MODE_OFF);
+       lv_obj_set_flex_flow(chip_row, LV_FLEX_FLOW_ROW);
+       lv_obj_set_flex_align(chip_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+       lv_obj_set_style_pad_column(chip_row, gap, 0);
        for (int i = 0; i < (int)CLOUD_MODEL_COUNT; i++) {
-          lv_obj_t *chip = lv_obj_create(s_scroll);
+          lv_obj_t *chip = lv_obj_create(chip_row);
           lv_obj_remove_style_all(chip);
-          lv_obj_set_size(chip, chip_w, chip_h);
-          lv_obj_set_pos(chip, SIDE_PAD + i * (chip_w + gap), y);
+          lv_obj_set_height(chip, chip_h);
+          lv_obj_set_width(chip, LV_SIZE_CONTENT);
+          lv_obj_set_style_pad_hor(chip, 18, 0);
           lv_obj_set_style_bg_color(chip, lv_color_hex(CARD_COLOR), 0);
           lv_obj_set_style_bg_opa(chip, LV_OPA_COVER, 0);
           lv_obj_set_style_radius(chip, 12, 0);


### PR DESCRIPTION
First fix from a screenshot-grounded UI audit. **The #1 'broken' look:** Settings (and chat timestamps, home undo, notifications) rendered **□ tofu boxes** because the compiled Montserrat subset lacks the middle-dot `·` (U+00B7) and the `●○✗` status glyphs.

## Fix
Replaced every non-font glyph with the in-font bullet `•` (U+2022, already used + rendering in ui_home). Caught **both** source forms — escape sequences (`\xc2\xb7`) and raw UTF-8 bytes (`·`) — across ui_settings, chat_msg_view, chat_session_drawer, ui_chat, ui_home, ui_notification. Status chip `●/○/✗` → `•` (color already conveys state).

## Verified (Tab5 192.168.1.90 screenshots)
Settings now clean: `• READY`, `NPU 47.4°C • load 3 • v1.6`, `12 MODELS • 2 LLM • 2 ASR • 3 TTS • 2 KWS • 3 vision`, `OFF • Cloud allowed` — all proper bullets, zero boxes.

## Audit findings NOT changed (validated as deliberate)
- Home greeting `--`: intentional ASCII em-dash substitute (em-dash is tofu too — documented in code).
- Lone green status dot: the (unlabeled) vision-on indicator.
- A small red-circled speaker near the orb: couldn't locate in source — needs a closer look before touching.