### PR TITLE
fix(skills,agents): load tool registry — 64KB buffer + honest errors (#722)

### DIFF
--- a/main/ui_agents.c
+++ b/main/ui_agents.c
@@ -304,10 +304,10 @@ static void fetch_tools_job(void *arg) {
    char url[160];
    snprintf(url, sizeof(url), "http://%s:%d/api/v1/tools", dragon_host, TAB5_VOICE_PORT);
 
-   /* PSRAM-backed response buffer.  Dragon's tools endpoint returns
-    * ~2-5 KB JSON; 16 KB is plenty headroom for the registry growing
-    * past current 10-12 tools. */
-   const size_t resp_cap = 16 * 1024;
+   /* PSRAM-backed response buffer.  The registry with full JSON schemas is
+    * ~16.5 KB for 25 tools and grows; the old 16 KB cap truncated it mid-JSON
+    * → bogus "JSON parse failed" (TT #722).  64 KB. */
+   const size_t resp_cap = 64 * 1024;
    char *resp_buf = heap_caps_malloc(resp_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    if (!resp_buf) {
       snprintf(p->err_msg, sizeof(p->err_msg), "PSRAM alloc failed");
@@ -471,7 +471,9 @@ static void fetch_agent_log_job(void *arg) {
    char url[160];
    snprintf(url, sizeof(url), "http://%s:%d/api/v1/agent_log?limit=%d", dragon_host, TAB5_VOICE_PORT, AGENT_LOG_MAX);
 
-   const size_t resp_cap = 16 * 1024;
+   /* TT #722: 64 KB — agent_log entries embed raw tool results and can be
+    * large; 16 KB risked truncating into a "JSON parse failed". */
+   const size_t resp_cap = 64 * 1024;
    char *resp_buf = heap_caps_malloc(resp_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    if (!resp_buf) {
       snprintf(p->err_msg, sizeof(p->err_msg), "PSRAM alloc failed");
@@ -679,7 +681,7 @@ static void fetch_agent_skills_job(void *arg) {
    char url[160];
    snprintf(url, sizeof(url), "http://%s:%d/api/v1/agent_skills", dragon_host, TAB5_VOICE_PORT);
 
-   const size_t resp_cap = 8 * 1024;
+   const size_t resp_cap = 32 * 1024; /* TT #722: headroom for the skills union */
    char *resp_buf = heap_caps_malloc(resp_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    if (!resp_buf) {
       tab5_debug_obs_event("agent_skills", "psram_alloc_fail");

--- a/main/ui_skills.c
+++ b/main/ui_skills.c
@@ -182,7 +182,11 @@ static void fetch_skills_job(void *arg) {
    char url[160];
    snprintf(url, sizeof(url), "http://%s:%d/api/v1/tools", dragon_host, TAB5_VOICE_PORT);
 
-   const size_t resp_cap = 16 * 1024;
+   /* TT #722: 64 KB (was 16 KB). The /api/v1/tools registry with full JSON
+    * schemas is ~16.5 KB for 25 tools and grows — the old 16 KB cap truncated
+    * it mid-JSON → cJSON_Parse failed → the bogus "JSON parse failed" error.
+    * PSRAM-backed, so the headroom is cheap. */
+   const size_t resp_cap = 64 * 1024;
    char *resp_buf = heap_caps_malloc(resp_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
    if (!resp_buf) {
       snprintf(p->err_msg, sizeof(p->err_msg), "PSRAM alloc failed");
@@ -249,6 +253,16 @@ static void fetch_skills_job(void *arg) {
    resp_buf[total] = '\0';
    esp_http_client_close(client);
    esp_http_client_cleanup(client);
+
+   /* TT #722: if we filled the buffer, the response was truncated — report it
+    * honestly instead of letting cJSON fail with a misleading "parse" error. */
+   if (total >= (int)resp_cap - 1) {
+      snprintf(p->err_msg, sizeof(p->err_msg), "tool list too large (>%dKB)", (int)(resp_cap / 1024));
+      p->fetch_ok = false;
+      heap_caps_free(resp_buf);
+      tab5_lv_async_call(async_render_cb, p);
+      return;
+   }
 
    cJSON *root = cJSON_Parse(resp_buf);
    heap_caps_free(resp_buf);
@@ -327,19 +341,30 @@ static void render_payload(const skills_payload_t *p) {
    if (!p->fetch_ok) {
       lv_obj_t *e = lv_label_create(s_list_root);
       lv_label_set_long_mode(e, LV_LABEL_LONG_WRAP);
+      /* TT #722: honest, state-aware copy. Old text always blamed a missing
+       * token in dev language ("POST /settings"), even when the token was set
+       * and Dragon was online. Branch on whether the token is actually set. */
+      char tok[8] = {0};
+      tab5_settings_get_dragon_api_token(tok, sizeof(tok));
       char buf[256];
-      snprintf(buf, sizeof(buf),
-               "Couldn't reach Dragon's tool registry (%s).\n\n"
-               "Set the Dragon API token under POST /settings "
-               "(dragon_api_token) and re-open this screen.",
-               p->err_msg[0] ? p->err_msg : "no detail");
+      if (tok[0] == '\0') {
+         snprintf(buf, sizeof(buf),
+                  "Tool registry unavailable.\n\n"
+                  "Add your Dragon API token in Settings, then reopen this screen.");
+      } else {
+         snprintf(buf, sizeof(buf),
+                  "Couldn't load the tool registry.\n\n"
+                  "Dragon is connected, but the tool list didn't come through. "
+                  "Reopen to retry. (%s)",
+                  p->err_msg[0] ? p->err_msg : "no detail");
+      }
       lv_label_set_text(e, buf);
       lv_obj_set_width(e, SW - 2 * SIDE_PAD);
       lv_obj_set_style_pad_left(e, SIDE_PAD, 0);
       lv_obj_set_style_text_font(e, FONT_BODY, 0);
       lv_obj_set_style_text_color(e, lv_color_hex(TH_TEXT_DIM), 0);
       lv_obj_set_style_text_line_space(e, 4, 0);
-      if (s_count_lbl) lv_label_set_text(s_count_lbl, "OFFLINE");
+      if (s_count_lbl) lv_label_set_text(s_count_lbl, "UNAVAILABLE");
       return;
    }
 


### PR DESCRIPTION
Wave 1 of epic #720. Fixes the real bug behind the "broken" Skills/Agents screens.

## Root cause (measured)
Skills + Agents showed "OFFLINE / Couldn't reach Dragon's tool registry (JSON parse failed)" even with the token set and Dragon online. `/api/v1/tools` is **16,563 B** (25 tools, full JSON schemas) but the fetch buffers were a fixed **16,384 B** read-until-EOF → truncated 179 B in, mid-JSON → `cJSON_Parse` fails → misleading "JSON parse failed". The code's separate "HTTP %d" path confirms it was a 200 (valid token), not an auth failure.

## Fix
- `ui_skills.c` + `ui_agents.c` (3 fetch sites): 16KB→64KB PSRAM buffers (agent_skills 8→32KB). Skills adds a truncation guard → honest "tool list too large" instead of a parse error if a future response overflows.
- Skills error copy is now state-aware: no longer tells the user to set a token (in dev "POST /settings" language) when the token IS set; subtitle "OFFLINE"→"UNAVAILABLE" (Dragon WS is up; only the REST fetch failed).

## Verified live (Tab5 192.168.1.90)
- Skills: lists **16 tools, 3 pinned** (was OFFLINE/parse-fail).
- Agents: tools-catalog populates (system_info, calendar_*, schedule_reminder, …).

## Corrected audit notes (re-grounded before fixing)
- **Sessions was NOT broken** — works, already has 4s timeout + empty/error fallback. The "infinite skeleton" was a transient (in-flight fetch / no-token moment).
- **The Skills key name was correct** — `dragon_api_token` is the `POST /settings` field (writes the `dragon_tok` NVS key). My earlier audit conflated the two.

## Remaining follow-ups (lower severity / partly Dragon-side)
- Agents header "0 LIVE · 0 DONE / No tool activity yet" contradicts the "DRAGON: 42" activity below (different buckets).
- Agents activity preview shows raw JSON (Dragon stores raw tool `result`).
- Untitled sessions; a tofu glyph in a Dragon-provided tool description (Wave 6 font-subset).

## Test plan
- [x] `idf.py build` clean off main
- [x] `git-clang-format --diff origin/main` clean
- [x] Live: Skills + Agents catalogs load on Tab5

🤖 Generated with [Claude Code](https://claude.com/claude-code)