### PR TITLE
fix(ui): mode-sheet RESOLVES-TO reads canonical names (#723/#724)

### DIFF
--- a/main/chat_header.c
+++ b/main/chat_header.c
@@ -34,7 +34,8 @@ static const char *TAG = "chat_hdr";
 static const uint32_t s_mode_tint[VOICE_MODE_COUNT] = {
     TH_MODE_LOCAL, TH_MODE_HYBRID, TH_MODE_CLOUD, TH_MODE_CLAW, TH_MODE_ONBOARD, TH_MODE_SOLO,
 };
-static const char *s_mode_short[VOICE_MODE_COUNT] = {"Local", "Hybrid", "Cloud", "Claw", "Onboard", "Solo"};
+/* TT #723: mode names come from th_mode_names (ui_theme.c) — the single
+ * source of truth.  Dropped the local s_mode_short copy that diverged ("Claw"). */
 
 struct chat_header {
     lv_obj_t *root;       /* 96-h bar */
@@ -244,7 +245,7 @@ void chat_header_set_mode(chat_header_t *h, uint8_t m, const char *llm)
     /* TT #328 Wave 6 — recolor through the shared widget so any future
      * change to mode-dot rendering (opacity, gradient) flows everywhere. */
     if (h->chip_dot) widget_mode_dot_set_mode(h->chip_dot, m);
-    if (h->chip_name) lv_label_set_text(h->chip_name, s_mode_short[m]);
+    if (h->chip_name) lv_label_set_text(h->chip_name, th_mode_names[m]);
     if (h->chip_sub) {
         /* v4·D connectivity polish: TinkerClaw mode talks to the openclaw
          * gateway via Dragon, so the NVS llm_model (which still holds the

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -253,13 +253,12 @@ static void on_mode_lp(void *ud)
     paint_header_and_view_for_mode(m);
     if (s_sugg) chat_suggestions_set_mode(s_sugg, m);
 
-    static const char *names[VOICE_MODE_COUNT] = {"Local", "Hybrid", "Cloud", "Claw", "Onboard", "Solo"};
     char toast[64];
     const char *nick = llm;
     const char *slash = strchr(nick, '/');
     if (slash) nick = slash + 1;
-    snprintf(toast, sizeof(toast), "Mode: %s \xc2\xb7 %s",
-             names[m], nick[0] ? nick : "default");
+    /* TT #723: th_mode_names (ui_theme) is the single source of truth. */
+    snprintf(toast, sizeof(toast), "Mode: %s \xc2\xb7 %s", th_mode_names[m], nick[0] ? nick : "default");
     ui_home_show_toast(toast);
 }
 

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -242,14 +242,13 @@ static lv_obj_t *s_say_label_sub   = NULL;
 static lv_obj_t   *s_toast         = NULL;
 static lv_timer_t *s_refresh_timer = NULL;
 
-/* TT #328 Wave 6: s_mode_tint removed — widget_mode_dot owns color
- * resolution against the canonical th_mode_colors[] in ui_theme.c.
- * Kept s_mode_short here because the home pill uses different short
- * labels ("Local") than the canonical ui_theme th_mode_names[]
- * ("Local") — actually identical, future cleanup TODO. */
-static const char *s_mode_short[VOICE_MODE_COUNT] = {"Local", "Hybrid", "Cloud", "Claw", "Onboard", "Solo"};
+/* TT #723: mode NAMES now come from the canonical th_mode_names[] (ui_theme.c)
+ * — single source of truth (drops the old divergent "Claw"/"Onboard" copy).
+ * Only the home-pill TAGLINE stays local.  Fixes: Local's old "ON-DEVICE"
+ * tagline was wrong (Local = Dragon on the LAN) and collided with TinkerON
+ * (the actual on-device addon); and the "K144" brand leak is gone. */
 static const char *s_mode_tagline[VOICE_MODE_COUNT] = {
-    "ON-DEVICE", "LOCAL + CLOUD", "CLOUD ONLY", "TINKERCLAW", "K144 ONBOARD", "OPENROUTER DIRECT",
+    "DRAGON", "LOCAL + CLOUD", "CLOUD ONLY", "TOOLS + MEMORY", "ON-DEVICE", "OPENROUTER DIRECT",
 };
 
 static uint8_t s_badge_mode = 0;
@@ -517,8 +516,14 @@ static void update_mode_ui(uint8_t mode)
     * still mutates size/radius directly for the pulse animation; that
     * stays open-coded since it's not shared. */
    if (s_mode_dot) widget_mode_dot_set_mode(s_mode_dot, mode);
-   if (s_mode_name) lv_label_set_text(s_mode_name, s_mode_short[mode]);
+   if (s_mode_name) lv_label_set_text(s_mode_name, th_mode_names[mode]);
    if (s_mode_sub) lv_label_set_text(s_mode_sub, s_mode_tagline[mode]);
+   /* TT #723: place the tagline after the (variable-length) canonical name so
+    * longer names like "TinkerAgent" don't overlap the fixed sub position. */
+   if (s_mode_name && s_mode_sub) {
+      lv_obj_update_layout(s_mode_name);
+      lv_obj_set_x(s_mode_sub, 44 + lv_obj_get_width(s_mode_name) + 14);
+   }
    ui_orb_paint_for_mode(mode);
 
    /* Phase 4 (#42): pulse the dot only on actual mode changes (not the
@@ -888,7 +893,7 @@ lv_obj_t *ui_home_create(void)
     if (s_mode_dot) lv_obj_set_pos(s_mode_dot, 24, 21);
 
     s_mode_name = lv_label_create(s_mode_chip);
-    lv_label_set_text(s_mode_name, s_mode_short[s_badge_mode]);
+    lv_label_set_text(s_mode_name, th_mode_names[s_badge_mode]);
     lv_obj_set_pos(s_mode_name, 44, 15);
     lv_obj_set_style_text_font(s_mode_name, FONT_HEADING, 0);
     lv_obj_set_style_text_color(s_mode_name, lv_color_hex(TH_TEXT_PRIMARY), 0);

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -306,7 +306,8 @@ void ui_mode_sheet_show(void)
         const int gap = 8;
         const int chip_count = 6;
         const int chip_w = ((MS_W - 2 * SIDE_PAD) - gap * (chip_count - 1)) / chip_count;
-        const char *labels[6] = {"Local", "Hybrid", "Cloud", "Agent", "Onboard", "Solo"};
+        /* TT #723: labels from th_mode_names (single source); preset c maps to
+         * vmode c (Local/Hybrid/Cloud/TinkerAgent/TinkerON/Solo). */
         extern void preset_click_cb(lv_event_t *e);
         for (int c = 0; c < chip_count; c++) {
             lv_obj_t *chip = lv_obj_create(row);
@@ -323,8 +324,10 @@ void ui_mode_sheet_show(void)
             lv_obj_add_event_cb(chip, preset_click_cb, LV_EVENT_CLICKED,
                                 (void *)(uintptr_t)c);
             lv_obj_t *lbl = lv_label_create(chip);
-            lv_label_set_text(lbl, labels[c]);
-            lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
+            lv_label_set_text(lbl, th_mode_names[c]);
+            /* TT #723: FONT_SMALL so the longer canonical names (TinkerAgent)
+             * fit the narrow preset chip without clipping. */
+            lv_obj_set_style_text_font(lbl, FONT_SMALL, 0);
             lv_obj_center(lbl);
         }
         y += ROW_H + ROW_GAP;

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -420,11 +420,11 @@ static void refresh_composite(void)
     if (!s_composite_head || !s_composite_sub || !s_composite_card) return;
 
     char model_out[64] = {0};
-    uint8_t resolved = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier,
-                                          model_out, sizeof(model_out));
-    const char *mode_name[] = { "Local", "Hybrid", "Full Cloud", "Agent \xe2\x80\xa2 TinkerClaw" };
+    uint8_t resolved = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier, model_out, sizeof(model_out));
     if (resolved > 3) resolved = 0;
-    lv_label_set_text(s_composite_head, mode_name[resolved]);
+    /* TT #723: canonical name from th_mode_names (was a divergent local copy
+     * "Full Cloud" / "Agent · TinkerClaw"). */
+    lv_label_set_text(s_composite_head, th_mode_names[resolved]);
 
     /* Sub-label is built live so it reflects the actual LLM the user picked
      * (gemini-3-flash-preview, gpt-4o-mini, etc) instead of hardcoding

--- a/main/ui_sessions.c
+++ b/main/ui_sessions.c
@@ -104,20 +104,18 @@ static void mode_to_tag(uint8_t vm, char *out, size_t n, uint32_t *color_out)
     * vmode=4 (Onboard) sessions rendered as grey before the mode arrays
     * grew to VOICE_MODE_COUNT.  Now read straight from the canonical
     * th_mode_names + th_mode_colors. */
-   static const char *s_tags[VOICE_MODE_COUNT] = {
-       "LOCAL", "HYBRID", "CLOUD", "CLAW", "ONBOARD", "SOLO",
-   };
-   const char *tag;
-   uint32_t col;
+   /* TT #723: uppercase the canonical th_mode_names (single source) rather
+    * than a local copy that diverged ("CLAW"). */
    if (vm < VOICE_MODE_COUNT) {
-      tag = s_tags[vm];
-      col = th_mode_colors[vm];
+      snprintf(out, n, "%s", th_mode_names[vm]);
+      for (char *p = out; *p; p++) {
+         if (*p >= 'a' && *p <= 'z') *p = (char)(*p - 32);
+      }
+      if (color_out) *color_out = th_mode_colors[vm];
    } else {
-      tag = "?";
-      col = 0x5C5C68;
+      snprintf(out, n, "?");
+      if (color_out) *color_out = 0x5C5C68;
    }
-    snprintf(out, n, "%s", tag);
-    if (color_out) *color_out = col;
 }
 
 /* U1 (#206): unix-epoch updated_at → time_top + optional time_bot.

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -42,6 +42,11 @@
 
 static const char *TAG = "ui_settings";
 
+/* TT #723: canonical mode names live in ui_theme.c. ui_settings.c mirrors the
+ * TH_* color tokens locally rather than including ui_theme.h, so declare just
+ * the one symbol we need here. */
+extern const char *th_mode_names[];
+
 static inline void feed_wdt(void) {
     esp_task_wdt_reset();
     /* Yield to let LWIP TCP/IP task process packets on Core 0.
@@ -1861,7 +1866,9 @@ lv_obj_t *ui_settings_create(void)
     s_active_tab = tab5_settings_get_voice_mode();
     if (s_active_tab > 4) s_active_tab = 0;
     {
-       static const char *mode_names[5] = {"Local", "Hybrid", "Cloud", "TinkerClaw", "Onboard"};
+       /* TT #723: names from th_mode_names (single source). Solo (vmode 5) is
+        * intentionally still omitted from this radio — it's added properly in
+        * the Wave 3 picker redesign. */
        /* Cloud description reflects the LIVE llm_model from NVS so the
         * row doesn't lie when the user has picked, say, gemini or gpt-4o
         * instead of the original Claude default.  Condensed to the short
@@ -1878,11 +1885,8 @@ lv_obj_t *ui_settings_create(void)
           }
        }
        const char *mode_descs[5] = {
-           "Moonshine \xe2\x80\xa2 NPU",
-           "Cloud STT/TTS",
-           cloud_desc,
-           "Agents \xe2\x80\xa2 Memory",
-           "K144 stacked LLM \xe2\x80\xa2 No Dragon",
+           "Moonshine \xe2\x80\xa2 NPU",           "Cloud STT/TTS", cloud_desc, "Agents \xe2\x80\xa2 Memory",
+           "On-device LLM \xe2\x80\xa2 No Dragon", /* TT #723: was "K144" (brand leak) */
        };
        static const uint32_t mode_dot_col[5] = {
            TAB_LOCAL, TAB_HYBRID, TAB_CLOUD, TAB_TINKERCLAW, TAB_ONBOARD,
@@ -1908,7 +1912,7 @@ lv_obj_t *ui_settings_create(void)
           lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
           lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
           lv_obj_t *nm = lv_label_create(row);
-          lv_label_set_text(nm, mode_names[i]);
+          lv_label_set_text(nm, th_mode_names[i]);
           lv_obj_set_style_text_font(nm, FONT_BODY, 0);
           lv_obj_set_style_text_color(nm, lv_color_hex(TEXT_PRIMARY), 0);
           lv_obj_set_pos(nm, 44, 12);

--- a/main/ui_theme.c
+++ b/main/ui_theme.c
@@ -14,8 +14,13 @@ static const char *TAG = "ui_theme";
 /* TT #328 Wave 1: bumped from [4] → [VOICE_MODE_COUNT].  Pre-Wave-1 the
  * vmode=4 (Onboard) row in Sessions/Drawer rendered as grey "?" because
  * callers indexed [4] arrays with vm=4. */
+/* TT #723: canonical mode names — the single source of truth. vmode 3 is
+ * TinkerAgent (the *mode*; TinkerClaw stays the platform/ecosystem name);
+ * vmode 4 is TinkerON (the on-device addon). chat_header / ui_chat /
+ * ui_sessions / ui_mode_sheet / ui_settings all read this array now instead
+ * of keeping their own divergent {Claw/TinkerClaw/Agent, Onboard/K144} copies. */
 const char *th_mode_names[VOICE_MODE_COUNT] = {
-    "Local", "Hybrid", "Cloud", "TinkerClaw", "Onboard", "Solo",
+    "Local", "Hybrid", "Cloud", "TinkerAgent", "TinkerON", "Solo",
 };
 const uint32_t th_mode_colors[VOICE_MODE_COUNT] = {
     TH_MODE_LOCAL, TH_MODE_HYBRID, TH_MODE_CLOUD, TH_MODE_CLAW, TH_MODE_ONBOARD, TH_MODE_SOLO,


### PR DESCRIPTION
Wave 3 slice 3.0. The composite RESOLVES-TO card kept a divergent local copy ("Full Cloud"/"Agent · TinkerClaw") — now reads canonical th_mode_names (Cloud/TinkerAgent), completing the Wave 2 unification. Build + format clean. Bigger Wave 3 slices decomposed on #724. 🤖 Generated with [Claude Code](https://claude.com/claude-code)