### PR TITLE
fix(ui): mode chips open the picker, never silently cycle (#724)

### DIFF
--- a/main/chat_header.c
+++ b/main/chat_header.c
@@ -190,6 +190,11 @@ chat_header_t *chat_header_create(lv_obj_t *parent, const char *title)
     lv_obj_clear_flag(h->chip, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(h->chip, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_set_ext_click_area(h->chip, 6);
+    /* TT #724 (Wave 3.1) entry-point discipline: open the mode picker on a
+     * plain TAP, not only long-press — a tappable-looking chip that ignored
+     * taps was a discoverability dead end.  Both routes call the same cb;
+     * ui_mode_sheet_show() is idempotent (no-ops if already visible). */
+    lv_obj_add_event_cb(h->chip, ev_chip_lp, LV_EVENT_CLICKED, h);
     lv_obj_add_event_cb(h->chip, ev_chip_lp, LV_EVENT_LONG_PRESSED, h);
 
     /* TT #328 Wave 6 — shared mode-dot widget. */

--- a/main/ui_chat.c
+++ b/main/ui_chat.c
@@ -242,24 +242,13 @@ static void on_plus(void *ud)
 static void on_mode_lp(void *ud)
 {
     (void)ud;
-    uint8_t m = tab5_settings_get_voice_mode();
-    m = (m + 1) % VOICE_MODE_COUNT;
-    tab5_settings_set_voice_mode(m);
-    char llm[CHAT_LLM_MODEL_LEN] = {0};
-    tab5_settings_get_llm_model(llm, sizeof(llm));
-    voice_send_config_update((int)m, llm);
-
-    chat_store_update_session_mode(m, llm);
-    paint_header_and_view_for_mode(m);
-    if (s_sugg) chat_suggestions_set_mode(s_sugg, m);
-
-    char toast[64];
-    const char *nick = llm;
-    const char *slash = strchr(nick, '/');
-    if (slash) nick = slash + 1;
-    /* TT #723: th_mode_names (ui_theme) is the single source of truth. */
-    snprintf(toast, sizeof(toast), "Mode: %s \xc2\xb7 %s", th_mode_names[m], nick[0] ? nick : "default");
-    ui_home_show_toast(toast);
+    /* TT #724 (Wave 3.1) entry-point discipline: open the one mode picker
+     * instead of blind-cycling.  The old handler did m = (m+1) % COUNT with
+     * only a toast, so a tap/long-press could silently land you on Cloud /
+     * Solo / etc. with no menu to see or undo the choice.  The sheet shows
+     * every mode + what it does; the user picks deliberately. */
+    extern void ui_mode_sheet_show(void);
+    ui_mode_sheet_show();
 }
 
 static void on_ball_tap(void *ud)
@@ -458,6 +447,17 @@ static void poll_voice(lv_timer_t *t)
 {
     (void)t;
     if (!s_active) return;
+
+    /* TT #724 (Wave 3.1): the chip now opens the mode sheet instead of cycling
+     * inline, so the live voice_mode can change under the open chat overlay
+     * (sheet commit) without the header knowing.  Sync the header when it does
+     * — mirrors the home screen's mode-badge resync. */
+    static uint8_t s_hdr_mode = 0xFF;
+    uint8_t cur_mode = tab5_settings_get_voice_mode();
+    if (cur_mode != s_hdr_mode) {
+       s_hdr_mode = cur_mode;
+       paint_header_and_view_for_mode(cur_mode);
+    }
 
     voice_state_t st = voice_get_state();
 

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -2252,15 +2252,10 @@ static void mode_chip_long_press_cb(lv_event_t *e)
 static void mode_chip_click_cb(lv_event_t *e) {
    (void)e;
    if (any_overlay_visible()) return;
-   uint8_t cur = tab5_settings_get_voice_mode();
-   if (cur == VMODE_LOCAL_ONBOARD || cur == VMODE_SOLO_DIRECT) {
-      uint8_t next = (cur == VMODE_LOCAL_ONBOARD) ? VMODE_SOLO_DIRECT : VMODE_LOCAL_ONBOARD;
-      tab5_settings_set_voice_mode(next);
-      update_mode_ui(next);
-      ESP_LOGI(TAG, "mode pill: cycled %u -> %u", cur, next);
-      return;
-   }
-   /* Default: open the 3-dial mode-sheet (was the long-press UX). */
+   /* TT #724 (Wave 3.1) entry-point discipline: a tap on the mode chip always
+    * opens the one mode picker.  Removed the silent TinkerON<->Solo cycle that
+    * fired when the current mode was one of those two — switching modes by
+    * tapping (with no menu) was a trap; you pick the mode in the sheet now. */
    tab5_settings_set_mode_hint_seen(true);
    extern void ui_mode_sheet_show(void);
    ui_mode_sheet_show();


### PR DESCRIPTION
Wave 3 slice 3.1 — entry-point discipline. Both mode chips changed mode by blind-cycling with no menu:
- **Home chip**: tapping in TinkerON/Solo silently flipped between them → now always opens the mode sheet.
- **Chat-header chip**: long-press did `m=(m+1)%COUNT` (blind advance through 6 modes) → rewritten to open the sheet; chip now also responds to a plain **tap** (was long-press-only — a tappable-looking chip that ignored taps).
- `poll_voice` resyncs the chat header when the live mode changes under the open overlay (sheet commit).

**Verified live**: tapping the home chip in TinkerON opens the picker instead of flipping to Solo. The chat chip uses the same `ui_mode_sheet_show` path, and `on_mode_lp` no longer contains *any* mode-change code → a tap cannot cycle by construction.

Build + git-clang-format clean. (Surfaced + filed a separate debug-only screenshot-busy-flag bug: #734.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)