### PR TITLE
Mode picker rebuild — mode-primary reason-row picker (Wave 3.2/3.3/3.4)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-mode-picker-rebuild.md
+++ b/docs/superpowers/plans/2026-05-26-mode-picker-rebuild.md
@@ -39,8 +39,8 @@ typedef struct {
 
 /* Indexed by vmode (0..5). Order matches th_mode_names / VOICE_MODE_*. */
 static const mode_meta_t s_mode_meta[VOICE_MODE_COUNT] = {
-    /* 0 Local       */ {"Private brain, on the Dragon box", "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",          "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",        REQ_NONE,   false},
-    /* 1 Hybrid      */ {"Private brain, fast voice",        "leaves: your voice (STT) \xc2\xb7 ~5s \xc2\xb7 ~2\xc2\xa2", "Private brain \xc2\xb7 fast voice \xc2\xb7 ~2\xc2\xa2", REQ_NONE,   false},
+    /* 0 Local       */ {"Private brain, on the Dragon box", "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",          "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",        REQ_NONE,   true},
+    /* 1 Hybrid      */ {"Private brain, fast voice",        "leaves: your voice (STT) \xc2\xb7 ~5s \xc2\xb7 ~2\xc2\xa2", "Private brain \xc2\xb7 fast voice \xc2\xb7 ~2\xc2\xa2", REQ_NONE,   true},
     /* 2 Cloud       */ {"Smartest, everything cloud",       "leaves: voice + text \xc2\xb7 ~5s \xc2\xb7 needs key", "Voice+text \xc2\xb7 smartest \xc2\xb7 needs key",   REQ_NONE,   false},
     /* 3 TinkerAgent */ {"Tools + memory, agentic",          "leaves: voice + text + tools \xc2\xb7 via gateway",   "Tools + memory \xc2\xb7 agentic",                REQ_NONE,   true},
     /* 4 TinkerON    */ {"Works offline, on-device addon",   "Nothing leaves \xc2\xb7 works offline",               "Nothing leaves \xc2\xb7 works offline",          REQ_ADDON,  true},
@@ -269,17 +269,37 @@ Fast/Balanced/Smart row above the mode list, persisted to `int_tier`; greyed for
 
 Add a `static lv_obj_t *s_smart_seg[3] = {0};` with the other statics, and:
 
+**VALIDATED CORRECTION:** `int_tier` is read by *nothing* in the routing path
+(only the soon-retired `tab5_mode_resolve`), and `config_update` only forwards
+`llm_model` for Cloud. So setting `int_tier` alone is **cosmetic**. Smartness must
+set the **actual model** for the only two modes where Tab5 picks it — **Cloud**
+(`llm_model`) and **Solo** (`or_mdl_llm`) — and send `config_update`. Local/Hybrid
+(Dragon picks), TinkerON, TinkerAgent are fixed-brain (greyed). Default tier→model
+map (overridable via Advanced exact-pick), models taken from the existing
+`s_cloud_models[]`:
+
 ```c
+/* Fast/Balanced/Smart -> a concrete model. Setting int_tier alone changes
+ * nothing (routing keys off vmode + llm_model, never int_tier — validated). */
+static const char *const s_smart_cloud[3] = {
+    "~anthropic/claude-haiku-latest",  /* Fast     */
+    "anthropic/claude-sonnet-4.6",     /* Balanced */
+    "anthropic/claude-opus-4.7",       /* Smart    */
+};
 static void smart_click_cb(lv_event_t *e)
 {
     uint8_t tier = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
-    if (s_mode_meta[s_sel_vmode].fixed_brain) return; /* no range */
-    tab5_settings_set_int_tier(tier);
+    if (tier > 2 || s_mode_meta[s_sel_vmode].fixed_brain) return;
+    tab5_settings_set_int_tier(tier); /* persisted for the segment's on-state */
+    const char *model = s_smart_cloud[tier];
+    if (s_sel_vmode == VOICE_MODE_SOLO) tab5_settings_set_or_mdl_llm(model);
+    else                                tab5_settings_set_llm_model(model); /* Cloud */
+    voice_send_config_update((int)s_sel_vmode, (char *)model);
     for (int i = 0; i < 3; i++) {
-        if (!s_smart_seg[i]) continue;
-        bool on = (i == tier);
-        lv_obj_set_style_bg_color(s_smart_seg[i], lv_color_hex(on ? TH_AMBER : 0x15151F), 0);
+        if (s_smart_seg[i]) lv_obj_set_style_bg_color(
+            s_smart_seg[i], lv_color_hex(i == tier ? TH_AMBER : 0x15151F), 0);
     }
+    ESP_LOGI(TAG, "smartness tier=%u -> model=%s (vmode=%u)", tier, model, s_sel_vmode);
 }
 
 static void build_smartness(void)   /* called from ui_mode_sheet_show after the headline */

--- a/docs/superpowers/plans/2026-05-26-mode-picker-rebuild.md
+++ b/docs/superpowers/plans/2026-05-26-mode-picker-rebuild.md
@@ -1,0 +1,405 @@
+# Mode Picker Rebuild — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the leaky 3-dial mode-sheet with a mode-primary reason-row picker (Layout B): pick a mode directly, see why you'd pick it, set Smartness within it, and tuck plumbing under Advanced.
+
+**Architecture:** `ui_mode_sheet.c` keeps its overlay/sheet/header/Done shell but its body changes from `Intelligence×Voice×Autonomy` dials + preset chips to **6 mode rows** that write `vmode` directly (routing already keys off `vmode`, so the resolver core is untouched). A per-mode metadata table drives the copy; the 3.5 availability check drives dimming. Smartness (Fast/Balanced/Smart) persists to the existing `int_tier` NVS key as a within-mode model selector. An Advanced drawer absorbs the model picker, engine pins, privacy lock, and spend cap (relocated out of Settings).
+
+**Tech Stack:** ESP-IDF 5.5.2, LVGL 9.x, ESP32-P4, C. Spec: `docs/superpowers/specs/2026-05-26-mode-picker-rebuild-design.md`.
+
+**Verification model (firmware — read this):** There is no LVGL unit-test harness. Each task's "test" is the project's real loop: `idf.py build` clean → `git-clang-format --diff origin/main` clean → `idf.py -p /dev/ttyACM0 flash` → on-device checks via the debug server (`TOK=05eed3b13bf62d92cfd8ac424438b9f2`, Tab5 `192.168.1.90:8080`): screenshot, `GET /voice`, `GET /m5`, `GET /events?since=N` (`eng.route`). Screenshots: pace + retry (busy-guard 429s mid-render). A clean reboot clears any stuck screenshot busy-flag (#734).
+
+**Branch:** `feat/mode-picker-rebuild` (off main). Commit after each task with `refs #724`.
+
+---
+
+### Task 1: Mode metadata table + availability helper
+
+Pure data + one helper. No UI change yet — just compiles and is callable.
+
+**Files:**
+- Modify: `main/ui_mode_sheet.c` (add near top, after the includes / `static const char *TAG`)
+
+- [ ] **Step 1: Add the metadata struct + table**
+
+Add after the `#include`s (the file already includes `voice_onboard.h`, `settings.h`, `ui_theme.h` from slice 3.5):
+
+```c
+/* TT #724 (3.2): per-mode display + availability metadata. Names come from
+ * th_mode_names (single source). `requires` drives the 3.5 dim/refuse gate. */
+typedef enum { REQ_NONE = 0, REQ_ADDON, REQ_OR_KEY } mode_req_t;
+typedef struct {
+    const char *reason;  /* one-line why-you'd-pick-it (selected row) */
+    const char *leaves;  /* what leaves the device + speed + cost (selected row) */
+    const char *oneline; /* compact meta for unselected rows */
+    mode_req_t  req;
+    bool        fixed_brain; /* true => Smartness has no range (grey it) */
+} mode_meta_t;
+
+/* Indexed by vmode (0..5). Order matches th_mode_names / VOICE_MODE_*. */
+static const mode_meta_t s_mode_meta[VOICE_MODE_COUNT] = {
+    /* 0 Local       */ {"Private brain, on the Dragon box", "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",          "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",        REQ_NONE,   false},
+    /* 1 Hybrid      */ {"Private brain, fast voice",        "leaves: your voice (STT) \xc2\xb7 ~5s \xc2\xb7 ~2\xc2\xa2", "Private brain \xc2\xb7 fast voice \xc2\xb7 ~2\xc2\xa2", REQ_NONE,   false},
+    /* 2 Cloud       */ {"Smartest, everything cloud",       "leaves: voice + text \xc2\xb7 ~5s \xc2\xb7 needs key", "Voice+text \xc2\xb7 smartest \xc2\xb7 needs key",   REQ_NONE,   false},
+    /* 3 TinkerAgent */ {"Tools + memory, agentic",          "leaves: voice + text + tools \xc2\xb7 via gateway",   "Tools + memory \xc2\xb7 agentic",                REQ_NONE,   true},
+    /* 4 TinkerON    */ {"Works offline, on-device addon",   "Nothing leaves \xc2\xb7 works offline",               "Nothing leaves \xc2\xb7 works offline",          REQ_ADDON,  true},
+    /* 5 Solo        */ {"Cloud quality, no Dragon needed",  "leaves: voice + text \xc2\xb7 direct to OpenRouter",  "No Dragon \xc2\xb7 voice+text leave",            REQ_OR_KEY, false},
+};
+```
+
+- [ ] **Step 2: Add the availability helper**
+
+Add below the table (reuses the exact 3.5 checks):
+
+```c
+/* TT #724 (3.5/3.2): can this mode run right now? */
+static bool mode_is_available(uint8_t vmode)
+{
+    if (vmode >= VOICE_MODE_COUNT) return false;
+    switch (s_mode_meta[vmode].req) {
+        case REQ_ADDON:  return voice_onboard_failover_state() == 2 /* M5_FAIL_READY */;
+        case REQ_OR_KEY: {
+            char k[128] = {0};
+            tab5_settings_get_or_key(k, sizeof k);
+            return k[0] != '\0';
+        }
+        default: return true;
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `. /home/rebelforce/esp/esp-idf/export.sh && idf.py build 2>&1 | grep -E "Project build complete|error:"`
+Expected: `Project build complete` (the table/helper are unused for now — `-Wno-error=unused-function` allows it; if `unused-variable` on the table errors, add `__attribute__((unused))` to `s_mode_meta`).
+
+- [ ] **Step 4: Format check**
+
+Run: `git-clang-format --binary clang-format-18 --diff origin/main main/ui_mode_sheet.c`
+Expected: empty / "did not modify". If not: `git add main/ui_mode_sheet.c && git-clang-format --binary clang-format-18 origin/main`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/ui_mode_sheet.c
+git commit -m "feat(ui): mode metadata table + availability helper (refs #724)"
+```
+
+---
+
+### Task 2: Reason-row picker body (replaces dials + preset chips)
+
+Replace the dial/preset rendering with 6 mode rows; selected row expands; tap commits `vmode` directly. This is the core of 3.2 + 3.3.
+
+**Files:**
+- Modify: `main/ui_mode_sheet.c` — the body-render section of `ui_mode_sheet_show()` (the `INTELLIGENCE/VOICE/AUTONOMY` dial blocks + the `PRESETS` chip loop, roughly the run between the headline and the composite card). Replace those with the row list. Keep: overlay/scrim, sheet container, grip, kicker+headline ("How should she think?"), Done button, and the composite "RESOLVES TO" card MAY be removed (the selected row now shows the same info) — remove it in this task.
+
+- [ ] **Step 1: Add the commit + row-tap callbacks**
+
+Add above `ui_mode_sheet_show()` (near `preset_click_cb`):
+
+```c
+static uint8_t s_sel_vmode = 0;          /* row currently shown expanded */
+static void rebuild_rows(void);          /* fwd: re-render rows on selection */
+
+/* Write the chosen mode + notify Dragon. Same calls the old preset-4/5 path
+ * made — proven. Does NOT touch tab5_mode_resolve / the dial tiers. */
+static void commit_mode(uint8_t vmode)
+{
+    tab5_settings_set_voice_mode(vmode);
+    char model[64] = {0};
+    tab5_settings_get_llm_model(model, sizeof(model));
+    voice_send_config_update((int)vmode, model);
+    ui_audio_cue_play(UI_CUE_MODE_SWITCH);
+    extern void ui_agents_on_mode_change(void);
+    ui_agents_on_mode_change();
+    ESP_LOGI(TAG, "picker: mode -> %u (%s)", vmode, th_mode_names[vmode]);
+}
+
+static void row_click_cb(lv_event_t *e)
+{
+    uint8_t vmode = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+    if (vmode >= VOICE_MODE_COUNT) return;
+    if (!mode_is_available(vmode)) {
+        if (tab5_ui_try_lock(150)) {
+            ui_home_show_toast(s_mode_meta[vmode].req == REQ_ADDON
+                                   ? "TinkerON not ready \xe2\x80\x94 check the module"
+                                   : "Add an OpenRouter key in Settings first");
+            tab5_ui_unlock();
+        }
+        return;
+    }
+    s_sel_vmode = vmode;
+    rebuild_rows();      /* expand the newly-selected row */
+    commit_mode(vmode);
+}
+```
+
+- [ ] **Step 2: Add the row-list builder**
+
+Add the `rebuild_rows()` definition. It owns a container `s_rows_root` (file-scope `static lv_obj_t *s_rows_root = NULL;` — add with the other statics). It clears + rebuilds 6 rows:
+
+```c
+static lv_obj_t *s_rows_root = NULL;
+
+static void rebuild_rows(void)
+{
+    if (!s_rows_root) return;
+    lv_obj_clean(s_rows_root);
+    int y = 0;
+    for (uint8_t m = 0; m < VOICE_MODE_COUNT; m++) {
+        bool avail = mode_is_available(m);
+        bool sel   = (m == s_sel_vmode);
+        int  rh    = sel ? 74 : 46;
+
+        lv_obj_t *row = lv_obj_create(s_rows_root);
+        lv_obj_remove_style_all(row);
+        lv_obj_set_pos(row, SIDE_PAD, y);
+        lv_obj_set_size(row, MS_W - 2 * SIDE_PAD, rh);
+        lv_obj_set_style_bg_color(row, lv_color_hex(sel ? 0x1A1509 : 0x13131C), 0);
+        lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
+        lv_obj_set_style_radius(row, 12, 0);
+        lv_obj_set_style_border_width(row, 1, 0);
+        lv_obj_set_style_border_color(row, lv_color_hex(sel ? TH_AMBER : 0x20202C), 0);
+        lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_add_event_cb(row, row_click_cb, LV_EVENT_CLICKED, (void *)(uintptr_t)m);
+        if (!avail) lv_obj_set_style_opa(row, LV_OPA_40, 0);
+
+        /* mode dot (shared widget, colored by mode) */
+        lv_obj_t *dot = widget_mode_dot_create(row, 8, m);
+        if (dot) lv_obj_set_pos(dot, 12, sel ? 14 : 18);
+
+        lv_obj_t *nm = lv_label_create(row);
+        lv_label_set_text(nm, th_mode_names[m]);
+        lv_obj_set_style_text_font(nm, FONT_BODY, 0);
+        lv_obj_set_style_text_color(nm, lv_color_hex(TH_TEXT_PRIMARY), 0);
+        lv_obj_set_pos(nm, 30, sel ? 10 : 13);
+
+        if (m == 1) { /* Hybrid "recommended" tag */
+            lv_obj_t *rec = lv_label_create(row);
+            lv_label_set_text(rec, "RECOMMENDED");
+            lv_obj_set_style_text_font(rec, FONT_TINY, 0);
+            lv_obj_set_style_text_color(rec, lv_color_hex(0x7A7A88), 0);
+            lv_obj_align(rec, LV_ALIGN_TOP_RIGHT, -14, sel ? 14 : 16);
+        }
+        if (m == 4 && !avail) { /* TinkerON addon hint */
+            lv_obj_t *w = lv_label_create(row);
+            lv_label_set_text(w, "\xe2\x9a\xa0 attach addon");
+            lv_obj_set_style_text_font(w, FONT_TINY, 0);
+            lv_obj_set_style_text_color(w, lv_color_hex(TH_AMBER), 0);
+            lv_obj_align(w, LV_ALIGN_TOP_RIGHT, -14, sel ? 14 : 16);
+        }
+
+        if (sel) {
+            lv_obj_t *reason = lv_label_create(row);
+            lv_label_set_text(reason, s_mode_meta[m].reason);
+            lv_obj_set_style_text_font(reason, FONT_SMALL, 0);
+            lv_obj_set_style_text_color(reason, lv_color_hex(0xC2C2CC), 0);
+            lv_obj_set_pos(reason, 30, 34);
+            lv_obj_t *meta = lv_label_create(row);
+            lv_label_set_text(meta, s_mode_meta[m].leaves);
+            lv_obj_set_style_text_font(meta, FONT_TINY, 0);
+            lv_obj_set_style_text_color(meta, lv_color_hex(0x6A6A78), 0);
+            lv_obj_set_pos(meta, 30, 53);
+        } else {
+            lv_obj_t *one = lv_label_create(row);
+            lv_label_set_text(one, s_mode_meta[m].oneline);
+            lv_obj_set_style_text_font(one, FONT_TINY, 0);
+            lv_obj_set_style_text_color(one, lv_color_hex(0x6A6A78), 0);
+            lv_obj_align(one, LV_ALIGN_RIGHT_MID, -14, 0);
+        }
+        y += rh + 8;
+    }
+}
+```
+
+- [ ] **Step 2b: In `ui_mode_sheet_show()`, set `s_sel_vmode` + create `s_rows_root` + call `rebuild_rows()`**
+
+After the headline/kicker block, where the dial blocks used to start, insert:
+
+```c
+    s_sel_vmode = tab5_settings_get_voice_mode();
+    if (s_sel_vmode >= VOICE_MODE_COUNT) s_sel_vmode = 0;
+    s_rows_root = lv_obj_create(s_sheet);
+    lv_obj_remove_style_all(s_rows_root);
+    lv_obj_set_pos(s_rows_root, 0, 150);             /* below SMARTNESS (Task 3) */
+    lv_obj_set_size(s_rows_root, MS_W, 470);
+    lv_obj_clear_flag(s_rows_root, LV_OBJ_FLAG_SCROLLABLE);
+    rebuild_rows();
+```
+
+- [ ] **Step 2c: Delete the dial blocks + preset loop + composite card**
+
+Remove from `ui_mode_sheet_show()`: the three `INTELLIGENCE/VOICE/AUTONOMY` segment-render blocks, the `PRESETS` chip loop (the `for (c = 0; c < chip_count...)` added in 3.0/3.5), and the composite "RESOLVES TO" card creation + its `refresh_composite()` call. Also delete now-dead helpers: `refresh_segments`, `refresh_composite`, `seg_click_cb`, `preset_click_cb`, the agent-consent modal (`show_agent_consent`/`hide_agent_consent`/`consent_*_cb`) IF the new picker drops the in-sheet agent consent — **KEEP** the agent-consent flow: instead, call it from `commit_mode` when `vmode==3` and `aut_tier` was 0 (preserves the memory-bypass warning). Simplest: in `row_click_cb`, before `commit_mode(3)`, if `tab5_settings_get_aut_tier()==0` call `show_agent_consent`-equivalent. (If this balloons, file a follow-up to restore consent and land the picker first — note in commit.)
+
+- [ ] **Step 3: Build + format** (as Task 1 steps 3-4).
+
+- [ ] **Step 4: Flash + verify on device**
+
+```bash
+. /home/rebelforce/esp/esp-idf/export.sh && idf.py -p /dev/ttyACM0 flash
+# wait for boot, then:
+TOK=05eed3b13bf62d92cfd8ac424438b9f2; H="Authorization: Bearer $TOK"; B=192.168.1.90:8080
+curl -s -m6 -H "$H" -X POST "http://$B/navigate?screen=home"; sleep 1
+curl -s -m6 -H "$H" -X POST "http://$B/touch" -d '{"x":360,"y":340,"action":"long_press","duration_ms":900}'; sleep 2
+# screenshot (retry on 429):
+for t in 1 2 3 4; do c=$(curl -s -m8 -H "$H" -o /tmp/t2.jpg -w "%{http_code}" "http://$B/screenshot.jpg"); [ "$c" = 200 ] && break; sleep 0.8; done
+```
+Expected (read /tmp/t2.jpg): 6 mode rows, the current mode expanded (reason + leaves line), TinkerON dimmed if cold. Tap an available row at its y → `GET /voice` reflects the new mode; tap TinkerON when cold → toast, no change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main/ui_mode_sheet.c
+git commit -m "feat(ui): reason-row mode picker — mode-primary, sets vmode directly (refs #724)"
+```
+
+---
+
+### Task 3: Smartness segment
+
+Fast/Balanced/Smart row above the mode list, persisted to `int_tier`; greyed for fixed-brain modes.
+
+**Files:**
+- Modify: `main/ui_mode_sheet.c`
+
+- [ ] **Step 1: Add the segment + callback**
+
+Add a `static lv_obj_t *s_smart_seg[3] = {0};` with the other statics, and:
+
+```c
+static void smart_click_cb(lv_event_t *e)
+{
+    uint8_t tier = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+    if (s_mode_meta[s_sel_vmode].fixed_brain) return; /* no range */
+    tab5_settings_set_int_tier(tier);
+    for (int i = 0; i < 3; i++) {
+        if (!s_smart_seg[i]) continue;
+        bool on = (i == tier);
+        lv_obj_set_style_bg_color(s_smart_seg[i], lv_color_hex(on ? TH_AMBER : 0x15151F), 0);
+    }
+}
+
+static void build_smartness(void)   /* called from ui_mode_sheet_show after the headline */
+{
+    lv_obj_t *lab = lv_label_create(s_sheet);
+    lv_label_set_text(lab, "SMARTNESS");
+    lv_obj_set_style_text_font(lab, FONT_TINY, 0);
+    lv_obj_set_style_text_color(lab, lv_color_hex(TH_AMBER), 0);
+    lv_obj_set_style_text_letter_space(lab, 2, 0);
+    lv_obj_set_pos(lab, SIDE_PAD, 108);
+
+    bool fixed = s_mode_meta[s_sel_vmode].fixed_brain;
+    uint8_t tier = tab5_settings_get_int_tier();
+    const char *names[3] = {"Fast", "Balanced", "Smart"};
+    int seg_w = (MS_W - 2 * SIDE_PAD - 2 * 6) / 3;
+    for (int i = 0; i < 3; i++) {
+        lv_obj_t *s = lv_obj_create(s_sheet);
+        lv_obj_remove_style_all(s);
+        lv_obj_set_pos(s, SIDE_PAD + i * (seg_w + 6), 126);
+        lv_obj_set_size(s, seg_w, 30);
+        lv_obj_set_style_radius(s, 10, 0);
+        lv_obj_set_style_bg_color(s, lv_color_hex((i == tier && !fixed) ? TH_AMBER : 0x15151F), 0);
+        lv_obj_set_style_bg_opa(s, LV_OPA_COVER, 0);
+        lv_obj_clear_flag(s, LV_OBJ_FLAG_SCROLLABLE);
+        if (!fixed) {
+            lv_obj_add_flag(s, LV_OBJ_FLAG_CLICKABLE);
+            lv_obj_add_event_cb(s, smart_click_cb, LV_EVENT_CLICKED, (void *)(uintptr_t)i);
+        } else {
+            lv_obj_set_style_opa(s, LV_OPA_40, 0);
+        }
+        lv_obj_t *t = lv_label_create(s);
+        lv_label_set_text(t, names[i]);
+        lv_obj_set_style_text_font(t, FONT_SMALL, 0);
+        lv_obj_center(t);
+        s_smart_seg[i] = s;
+    }
+}
+```
+
+- [ ] **Step 2: Call `build_smartness()` in `ui_mode_sheet_show()`** right before the `s_rows_root` block from Task 2. Reset `s_smart_seg[*]=NULL` in `ui_mode_sheet_hide()` alongside the other statics.
+
+- [ ] **Step 3: When a row is selected, refresh smartness enabled/disabled** — in `row_click_cb`, after `rebuild_rows()`, also rebuild smartness (a fixed-brain mode greys it). Simplest: clear + rebuild via a `refresh_smartness()` that re-runs the per-segment styling using `s_mode_meta[s_sel_vmode].fixed_brain`. (Keep `build_smartness` idempotent by deleting prior segs first, or guard.)
+
+- [ ] **Step 4: Build + format + flash + verify** — open picker: SMARTNESS segment shows; select TinkerON → segment greys; select Cloud → segment active, tapping Smart persists (`GET /settings` → `int_tier`). Commit `feat(ui): Smartness knob (within-mode model tier) (refs #724)`.
+
+---
+
+### Task 4: Advanced drawer
+
+Collapsed "Advanced ▸" row → expands to model pick + engine pins + privacy lock + spend cap, relocated from Settings.
+
+**Files:**
+- Modify: `main/ui_mode_sheet.c` (drawer UI + handlers)
+- Reference (source the controls): `main/ui_settings.c` ENGINES block (`mk_section "ENGINES"` near `:421` + `cb_engine_pick` at `:948`), CLOUD LLM chips (tracked from `:1858`), privacy `On-device lock` + `cap_mils`.
+
+- [ ] **Step 1:** Add a collapsed drawer row below `s_rows_root` (a 1-line "Advanced ▸ model · engine · privacy · cap" button). On tap, toggle `s_adv_open` and rebuild the drawer contents into a `s_adv_root` container (created in `ui_mode_sheet_show`, sized 0 when collapsed).
+
+- [ ] **Step 2: Engine pins** — port the AUTO/K144/OPENROUTER segmented from `ui_settings.c` (`cb_engine_pick`, `tab5_settings_get/set_llm_engine`). Reuse the same setter; render 3 chips in the drawer. Code mirrors the Task-3 segment pattern but calls `tab5_settings_set_llm_engine(idx)`.
+
+- [ ] **Step 3: Exact-model pick** — port the CLOUD LLM horizontal chip row from `ui_settings.c` (the model chips that call the `/mode?model=` / `tab5_settings_set_llm_model` path). Render as a horizontally-scrollable chip row in the drawer.
+
+- [ ] **Step 4: Privacy lock + spend cap** — a toggle (`tab5_settings_get/set_*` for on-device-lock) and a read/edit of `cap_mils`. Toggle reuses the Settings privacy setter.
+
+- [ ] **Step 5:** When any Advanced control is touched, set a flag so the home/chat chip can show "Mode · modified" (expose via a `bool ui_mode_sheet_is_modified(void)` or reuse engine-pin != AUTO as the "modified" signal). Minimal: treat `llm_engine != AUTO || on-device-lock || custom model` as modified; surface in `chat_header_set_mode` / `ui_home update_mode_ui` as a " · modified" suffix.
+
+- [ ] **Step 6: Build + format + flash + verify** — Advanced ▸ expands; engine pin persists (`GET /settings` llm_engine); model chip persists; privacy toggle persists. Commit `feat(ui): Advanced drawer (model/engine/privacy/cap) (refs #724)`.
+
+---
+
+### Task 5: Settings — collapse the duplicate VOICE-MODE picker
+
+The picker is now the single mode authority; Settings should not host a second one.
+
+**Files:**
+- Modify: `main/ui_settings.c` — VOICE MODE block (`:1862`+) and the ENGINES (`:421`/section) + CLOUD LLM blocks now relocated to the drawer.
+
+- [ ] **Step 1:** Replace the VOICE MODE radio rows (the `for (i<5)` loop that renders `th_mode_names[i]` rows) with a single **read-only "current mode" row**: shows `th_mode_names[get_voice_mode()]` + its tagline; on tap → `ui_mode_sheet_show()`.
+- [ ] **Step 2:** Remove the ENGINES section + CLOUD LLM chip block from Settings (now in the Advanced drawer). Keep STT/TTS *status* labels if desired (read-only).
+- [ ] **Step 3: Build + format + flash + verify** — Settings shows one "current mode → opens picker" row; no duplicate radio; no ENGINES/CLOUD-LLM blocks. Tapping the row opens the picker. Commit `refactor(settings): replace VOICE-MODE radio with read-only row → opens picker (refs #724)`.
+
+---
+
+### Task 6: Cleanup + routing verification
+
+Retire the dial machinery from the picker path and prove routing is unaffected.
+
+**Files:**
+- Modify: `main/ui_mode_sheet.c` (remove the tier-resync block in `ui_mode_sheet_show` lines ~107-143 that reverse-derives tiers; the picker no longer uses dials). Leave `tab5_mode_resolve` (settings.c) + the debug `/mode`-from-tiers path untouched.
+
+- [ ] **Step 1:** Delete the dial-tier resync block + any remaining `tab5_mode_resolve` calls inside `ui_mode_sheet.c`. Confirm `s_int_tier/s_voi_tier/s_aut_tier` statics are only read by Smartness now (int_tier) — remove voi/aut if dead.
+- [ ] **Step 2: Build + format.**
+- [ ] **Step 3: Flash + routing verification** — for each mode, select it in the picker then send a turn and confirm it routes to the expected backend:
+
+```bash
+TOK=05eed3b13bf62d92cfd8ac424438b9f2; H="Authorization: Bearer $TOK"; B=192.168.1.90:8080
+for m in 0 1 2 4 5; do
+  curl -s -H "$H" -X POST "http://$B/mode?m=$m" >/dev/null; sleep 1
+  curl -s -H "$H" -X POST "http://$B/chat" -d '{"text":"hi"}' >/dev/null
+  sleep 3; curl -s -H "$H" "http://$B/events?since=0" | grep -o 'eng.route[^}]*' | tail -1
+done
+```
+Expected: each mode's `eng.route` matches (priv/k144/solo/local). No regression vs pre-change.
+
+- [ ] **Step 4: `story_smoke` regression**
+
+Run: `cd ~/projects/TinkerTab && TAB5_TOKEN=$TOK python3 tests/e2e/runner.py story_smoke`
+Expected: nav/camera/settings/chat-send pass (the Local-LLM-done timeout is the known flake).
+
+- [ ] **Step 5: Commit** `refactor(ui): retire dial machinery from picker; routing verified (refs #724)`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** 3.2 picker → Tasks 2/3; mode-primary (3.3) → Task 2 (commit_mode sets vmode) + Task 6 (retire dials); 3.4 Advanced → Task 4; Settings dedup → Task 5; capability gating → Task 1/2 (reused). 3.6 effective-route → out of scope (spec-flagged). ✅
+- **Placeholder scan:** Task 4 steps 2-4 describe *relocating* existing Settings controls with exact file:line sources rather than re-pasting their full code — this is a "modify, sourcing from file:lines" instruction, not a placeholder; the implementer reads the cited Settings code. Task 2c flags the agent-consent decision explicitly with a fallback. No "TBD/handle edge cases" left.
+- **Type consistency:** `mode_meta_t`/`s_mode_meta`/`mode_is_available`/`commit_mode`/`rebuild_rows`/`s_sel_vmode`/`s_rows_root`/`s_smart_seg` are defined in Task 1-3 and used consistently. `th_mode_names`, `voice_onboard_failover_state`, `tab5_settings_get_or_key`, `ui_audio_cue_play`, `tab5_ui_try_lock` all already in scope (slice 3.5 includes).
+
+## Risk notes for the executor
+
+- **Agent-consent (vmode 3):** the current sheet shows a memory-bypass consent modal before committing TinkerAgent. Task 2c preserves it via `commit_mode`; if wiring it cleanly balloons, land the picker without it and file a follow-up to restore — do NOT silently drop the consent.
+- **Screenshot busy-flag (#734):** if screenshots 429 forever, reboot to clear; don't fight it.
+- **No `LV_USE_ASSERT`:** allocs return NULL silently. Keep the picker lightweight; it builds on `lv_layer_top` while home is underneath.

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -252,6 +252,7 @@ static const char *s_mode_tagline[VOICE_MODE_COUNT] = {
 };
 
 static uint8_t s_badge_mode = 0;
+static bool s_badge_modified = false; /* TT #724 (3.4): Advanced override active */
 
 /* v4·D Phase 4g widget_prompt tap → widget_action plumbing.
  * When a PROMPT widget claims the live slot, we cache its card_id +
@@ -517,7 +518,19 @@ static void update_mode_ui(uint8_t mode)
     * stays open-coded since it's not shared. */
    if (s_mode_dot) widget_mode_dot_set_mode(s_mode_dot, mode);
    if (s_mode_name) lv_label_set_text(s_mode_name, th_mode_names[mode]);
-   if (s_mode_sub) lv_label_set_text(s_mode_sub, s_mode_tagline[mode]);
+   if (s_mode_sub) {
+      /* TT #724 (3.4): an Advanced-drawer override (engine pin / privacy lock)
+       * makes the effective route differ from the plain mode — flag it. */
+      extern bool ui_mode_sheet_is_modified(void);
+      s_badge_modified = ui_mode_sheet_is_modified();
+      if (s_badge_modified) {
+         char buf[64];
+         snprintf(buf, sizeof(buf), "%s \xe2\x80\xa2 modified", s_mode_tagline[mode]);
+         lv_label_set_text(s_mode_sub, buf);
+      } else {
+         lv_label_set_text(s_mode_sub, s_mode_tagline[mode]);
+      }
+   }
    /* TT #723: place the tagline after the (variable-length) canonical name so
     * longer names like "TinkerAgent" don't overlap the fixed sub position. */
    if (s_mode_name && s_mode_sub) {
@@ -1835,7 +1848,8 @@ void ui_home_update_status(void)
 
     /* Mode chip (re-read from NVS) */
     uint8_t current_mode = tab5_settings_get_voice_mode();
-    if (current_mode != s_badge_mode) update_mode_ui(current_mode);
+    extern bool ui_mode_sheet_is_modified(void);
+    if (current_mode != s_badge_mode || ui_mode_sheet_is_modified() != s_badge_modified) update_mode_ui(current_mode);
 }
 
 static void refresh_timer_cb(lv_timer_t *t)

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -18,7 +18,8 @@
 #include "ui_home.h"       /* W8: ui_home_show_toast */
 #include "ui_theme.h"
 #include "voice.h"
-#include "voice_onboard.h" /* TT #724 (3.5) — voice_onboard_failover_state */
+#include "voice_onboard.h"   /* TT #724 (3.5) — voice_onboard_failover_state */
+#include "widget_mode_dot.h" /* TT #724 (3.2) — mode dot on each picker row */
 
 static const char *TAG = "ui_mode_sheet";
 
@@ -35,23 +36,23 @@ typedef struct {
 
 /* Indexed by vmode (0..5). Order matches th_mode_names / VOICE_MODE_*. */
 static const mode_meta_t s_mode_meta[VOICE_MODE_COUNT] = {
-    /* 0 Local       */ {"Private brain, on the Dragon box", "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",
-                         "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s", REQ_NONE, true},
+    /* 0 Local       */ {"Private brain, on the Dragon box", "Nothing leaves \xe2\x80\xa2 free \xe2\x80\xa2 ~60s",
+                         "Nothing leaves \xe2\x80\xa2 free \xe2\x80\xa2 ~60s", REQ_NONE, true},
     /* 1 Hybrid      */
-    {"Private brain, fast voice", "leaves: your voice (STT) \xc2\xb7 ~5s \xc2\xb7 ~2\xc2\xa2",
-     "Private brain \xc2\xb7 fast voice \xc2\xb7 ~2\xc2\xa2", REQ_NONE, true},
+    {"Private brain, fast voice", "leaves: your voice (STT) \xe2\x80\xa2 ~5s \xe2\x80\xa2 ~$0.02",
+     "Private brain \xe2\x80\xa2 fast voice \xe2\x80\xa2 ~$0.02", REQ_NONE, true},
     /* 2 Cloud       */
-    {"Smartest, everything cloud", "leaves: voice + text \xc2\xb7 ~5s \xc2\xb7 needs key",
-     "Voice+text \xc2\xb7 smartest \xc2\xb7 needs key", REQ_NONE, false},
+    {"Smartest, everything cloud", "leaves: voice + text \xe2\x80\xa2 ~5s \xe2\x80\xa2 needs key",
+     "Voice+text \xe2\x80\xa2 smartest \xe2\x80\xa2 needs key", REQ_NONE, false},
     /* 3 TinkerAgent */
-    {"Tools + memory, agentic", "leaves: voice + text + tools \xc2\xb7 via gateway", "Tools + memory \xc2\xb7 agentic",
-     REQ_NONE, true},
+    {"Tools + memory, agentic", "leaves: voice + text + tools \xe2\x80\xa2 via gateway",
+     "Tools + memory \xe2\x80\xa2 agentic", REQ_NONE, true},
     /* 4 TinkerON    */
-    {"Works offline, on-device addon", "Nothing leaves \xc2\xb7 works offline", "Nothing leaves \xc2\xb7 works offline",
-     REQ_ADDON, true},
+    {"Works offline, on-device addon", "Nothing leaves \xe2\x80\xa2 works offline",
+     "Nothing leaves \xe2\x80\xa2 works offline", REQ_ADDON, true},
     /* 5 Solo        */
-    {"Cloud quality, no Dragon needed", "leaves: voice + text \xc2\xb7 direct to OpenRouter",
-     "No Dragon \xc2\xb7 voice+text leave", REQ_OR_KEY, false},
+    {"Cloud quality, no Dragon needed", "leaves: voice + text \xe2\x80\xa2 direct to OpenRouter",
+     "No Dragon \xe2\x80\xa2 voice+text leave", REQ_OR_KEY, false},
 };
 
 /* TT #724 (3.5/3.2): can this mode run right now? */
@@ -80,13 +81,7 @@ static bool mode_is_available(uint8_t vmode) {
 
 /* ── State ───────────────────────────────────────────────────────────── */
 static lv_obj_t *s_overlay     = NULL;  /* scrim container on layer_top */
-static lv_obj_t *s_sheet       = NULL;  /* visible sheet inside overlay */
-static lv_obj_t *s_seg_btn[3][3] = {{0}};  /* [dial][segment] for redraw */
-static lv_obj_t *s_composite_head = NULL;
-static lv_obj_t *s_composite_sub  = NULL;
-static lv_obj_t *s_composite_card = NULL;  /* container — reborder on agent */
-static lv_obj_t *s_composite_accent = NULL; /* amber/violet bar top-left */
-static lv_obj_t *s_composite_kicker = NULL; /* "RESOLVES TO" / "AGENT MODE" */
+static lv_obj_t *s_sheet = NULL;        /* visible sheet inside overlay */
 
 /* Phase 2c Agent consent modal — own scrim, shown on top of the sheet. */
 static lv_obj_t *s_consent_overlay = NULL;
@@ -103,19 +98,22 @@ static uint8_t s_int_tier = 0;
 static uint8_t s_voi_tier = 0;
 static uint8_t s_aut_tier = 0;
 
+/* TT #724 (3.2): mode-row picker state. */
+static uint8_t s_sel_vmode = 0;      /* row currently shown expanded */
+static lv_obj_t *s_rows_root = NULL; /* container holding the 6 mode rows */
+
 /* ── Forward decls ───────────────────────────────────────────────────── */
-static void refresh_segments(void);
-static void refresh_composite(void);
-static void persist_and_notify_dragon(void);
-static void seg_click_cb(lv_event_t *e);
+static void commit_mode(uint8_t vmode);
+static void rebuild_rows(void);
+static void row_click_cb(lv_event_t *e);
 static void done_click_cb(lv_event_t *e);
 static void scrim_click_cb(lv_event_t *e);
 static void show_agent_consent(uint8_t prev_aut_tier);
-/* Wave 10 H5 Presets: forward decl — body below seg_click_cb. */
-void preset_click_cb(lv_event_t *e);
 static void hide_agent_consent(bool commit);
 static void consent_confirm_cb(lv_event_t *e);
 static void consent_cancel_cb(lv_event_t *e);
+static void agent_consent_confirm_cb(void *ctx);
+static void agent_consent_cancel_cb(void *ctx);
 
 /* ── Public API ──────────────────────────────────────────────────────── */
 
@@ -126,26 +124,22 @@ bool ui_mode_sheet_visible(void)
 
 void ui_mode_sheet_hide(void)
 {
-    /* If an Agent consent modal is still up when the sheet gets hidden
-     * (e.g. user backs out via nav), treat that as Cancel — do NOT commit. */
-    if (s_consent_overlay) {
-        lv_obj_del(s_consent_overlay);
-        s_consent_overlay = NULL;
-        s_aut_tier = s_pre_consent_aut;
-    }
+   /* If an Agent consent modal is still up when the sheet gets hidden
+    * (e.g. user backs out via nav), treat that as Cancel — drop the
+    * pending callbacks so nothing commits. */
+   if (s_consent_overlay) {
+      lv_obj_del(s_consent_overlay);
+      s_consent_overlay = NULL;
+      s_consent_confirm_cb = NULL;
+      s_consent_cancel_cb = NULL;
+      s_consent_cb_ctx = NULL;
+   }
     if (s_overlay) {
         lv_obj_del(s_overlay);
     }
     s_overlay = NULL;
-    s_sheet   = NULL;
-    s_composite_head = NULL;
-    s_composite_sub  = NULL;
-    s_composite_card = NULL;
-    s_composite_accent = NULL;
-    s_composite_kicker = NULL;
-    for (int r = 0; r < 3; r++) {
-        for (int c = 0; c < 3; c++) s_seg_btn[r][c] = NULL;
-    }
+    s_sheet = NULL;
+    s_rows_root = NULL;
 }
 
 void ui_mode_sheet_show(void)
@@ -230,7 +224,7 @@ void ui_mode_sheet_show(void)
 
     /* Kicker + headline */
     lv_obj_t *kicker = lv_label_create(s_sheet);
-    lv_label_set_text(kicker, "\xe2\x80\xa2 MODE DIALS");
+    lv_label_set_text(kicker, "\xe2\x80\xa2 MODE");
     lv_obj_set_style_text_font(kicker, FONT_SMALL, 0);
     lv_obj_set_style_text_color(kicker, lv_color_hex(TH_AMBER), 0);
     lv_obj_set_style_text_letter_space(kicker, 4, 0);
@@ -259,187 +253,18 @@ void ui_mode_sheet_show(void)
     lv_obj_set_style_text_color(done_lbl, lv_color_hex(TH_BG), 0);
     lv_obj_center(done_lbl);
 
-    /* Build three dial rows.
-     * Each row: kicker label (12 px above segments) + segmented control. */
-    struct {
-        const char *kicker;
-        const char *labels[3];
-        int count;
-    } rows[3] = {
-        { "\xe2\x80\xa2 INTELLIGENCE",
-          { "Fast", "Balanced", "Smart" }, 3 },
-        { "\xe2\x80\xa2 VOICE",
-          { "Local", "Neutral", "Studio" }, 3 },
-        { "\xe2\x80\xa2 AUTONOMY",
-          { "Ask", "Agent", NULL }, 2 },
-    };
-
-    int y = 170;
-    for (int r = 0; r < 3; r++) {
-        lv_obj_t *rk = lv_label_create(s_sheet);
-        lv_label_set_text(rk, rows[r].kicker);
-        lv_obj_set_style_text_font(rk, FONT_SMALL, 0);
-        lv_obj_set_style_text_color(rk, lv_color_hex(TH_AMBER), 0);
-        lv_obj_set_style_text_letter_space(rk, 4, 0);
-        lv_obj_set_pos(rk, SIDE_PAD, y);
-
-        /* Segment track — elevated card + padded row of buttons */
-        lv_obj_t *track = lv_obj_create(s_sheet);
-        lv_obj_remove_style_all(track);
-        lv_obj_set_pos(track, SIDE_PAD, y + 30);
-        lv_obj_set_size(track, MS_W - 2 * SIDE_PAD, SEG_H);
-        lv_obj_set_style_bg_color(track, lv_color_hex(TH_CARD_ELEVATED), 0);
-        lv_obj_set_style_bg_opa(track, LV_OPA_COVER, 0);
-        lv_obj_set_style_radius(track, SEG_H / 2, 0);
-        lv_obj_set_style_border_width(track, 1, 0);
-        lv_obj_set_style_border_color(track, lv_color_hex(0x1E1E2A), 0);
-        lv_obj_clear_flag(track, LV_OBJ_FLAG_SCROLLABLE);
-
-        const int track_pad  = 4;
-        const int seg_count  = rows[r].count;
-        const int track_w    = (MS_W - 2 * SIDE_PAD) - 2 * track_pad;
-        const int seg_w      = track_w / seg_count;
-
-        for (int c = 0; c < seg_count; c++) {
-            lv_obj_t *seg = lv_obj_create(track);
-            lv_obj_remove_style_all(seg);
-            lv_obj_set_pos(seg, track_pad + c * seg_w, track_pad);
-            lv_obj_set_size(seg, seg_w, SEG_H - 2 * track_pad);
-            lv_obj_set_style_radius(seg, (SEG_H - 2 * track_pad) / 2, 0);
-            lv_obj_clear_flag(seg, LV_OBJ_FLAG_SCROLLABLE);
-            lv_obj_add_flag(seg, LV_OBJ_FLAG_CLICKABLE);
-            /* user_data packs dial row (high nibble) + segment idx (low nibble) */
-            uintptr_t pack = (uintptr_t)((r << 4) | c);
-            lv_obj_add_event_cb(seg, seg_click_cb, LV_EVENT_CLICKED, (void*)pack);
-
-            lv_obj_t *lbl = lv_label_create(seg);
-            lv_label_set_text(lbl, rows[r].labels[c]);
-            lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
-            lv_obj_center(lbl);
-
-            s_seg_btn[r][c] = seg;
-        }
-        y += ROW_H + ROW_GAP;
-    }
-
-    /* Wave 10 H5: Presets row — four chips matching the legacy voice_mode
-     * values so users can one-tap a recipe instead of spinning each dial.
-     * Presets set (int/voi/aut) to the same mapping the reverse-derive
-     * uses at line ~115 above:
-     *   Local  -> (0,0,0)   Hybrid -> (1,2,0)
-     *   Cloud  -> (2,2,0)   Agent  -> keep int/voi, aut=1 (triggers consent)
-     * Tapping Agent routes through show_agent_consent just like the
-     * dial segment does at line 460 — no silent mode-3 switch. */
-    {
-        lv_obj_t *rk = lv_label_create(s_sheet);
-        lv_label_set_text(rk, "\xe2\x80\xa2 PRESETS");
-        lv_obj_set_style_text_font(rk, FONT_SMALL, 0);
-        lv_obj_set_style_text_color(rk, lv_color_hex(TH_AMBER), 0);
-        lv_obj_set_style_text_letter_space(rk, 4, 0);
-        lv_obj_set_pos(rk, SIDE_PAD, y);
-
-        lv_obj_t *row = lv_obj_create(s_sheet);
-        lv_obj_remove_style_all(row);
-        lv_obj_set_pos(row, SIDE_PAD, y + 30);
-        lv_obj_set_size(row, MS_W - 2 * SIDE_PAD, SEG_H);
-        lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
-
-        /* TT #328 Wave 9 follow-up — Onboard added as a 5th preset.
-         * W8 (cross-stack audit 2026-05-11) — Solo added as a 6th preset
-         * to close the "SOLO_DIRECT not discoverable from the mode sheet"
-         * UX gap.  Both vmode=4 (K144) and vmode=5 (SOLO_DIRECT) bypass
-         * the int/voi/aut dial taxonomy because they aren't shaped by
-         * Dragon-side capability tiers — each is its own runtime.
-         * preset_click_cb's case 4 / case 5 take direct-write paths
-         * that bypass tab5_mode_resolve. */
-        const int gap = 8;
-        const int chip_count = 6;
-        const int chip_w = ((MS_W - 2 * SIDE_PAD) - gap * (chip_count - 1)) / chip_count;
-        /* TT #723: labels from th_mode_names (single source); preset c maps to
-         * vmode c (Local/Hybrid/Cloud/TinkerAgent/TinkerON/Solo). */
-        extern void preset_click_cb(lv_event_t *e);
-        for (int c = 0; c < chip_count; c++) {
-            lv_obj_t *chip = lv_obj_create(row);
-            lv_obj_remove_style_all(chip);
-            lv_obj_set_pos(chip, c * (chip_w + gap), 0);
-            lv_obj_set_size(chip, chip_w, SEG_H);
-            lv_obj_set_style_bg_color(chip, lv_color_hex(TH_CARD_ELEVATED), 0);
-            lv_obj_set_style_bg_opa(chip, LV_OPA_COVER, 0);
-            lv_obj_set_style_radius(chip, SEG_H / 2, 0);
-            lv_obj_set_style_border_width(chip, 1, 0);
-            lv_obj_set_style_border_color(chip, lv_color_hex(0x1E1E2A), 0);
-            lv_obj_clear_flag(chip, LV_OBJ_FLAG_SCROLLABLE);
-            lv_obj_add_flag(chip, LV_OBJ_FLAG_CLICKABLE);
-            lv_obj_add_event_cb(chip, preset_click_cb, LV_EVENT_CLICKED,
-                                (void *)(uintptr_t)c);
-            /* TT #724 (3.5) capability gating: dim a mode that can't run right
-             * now — TinkerON (4) needs the addon warm, Solo (5) needs an
-             * OpenRouter key.  Left clickable so the tap explains why (the
-             * toast in preset_click_cb cases 4/5). */
-            bool avail = true;
-            if (c == 4) {
-               avail = (voice_onboard_failover_state() == 2 /* M5_FAIL_READY */);
-            } else if (c == 5) {
-               /* Buffer must fit the whole key — NVS get_str returns empty on
-                * an undersized buffer, which falsely greyed Solo (TT #724). */
-               char k[128] = {0};
-               tab5_settings_get_or_key(k, sizeof k);
-               avail = (k[0] != '\0');
-            }
-            if (!avail) lv_obj_set_style_opa(chip, LV_OPA_40, 0);
-            lv_obj_t *lbl = lv_label_create(chip);
-            lv_label_set_text(lbl, th_mode_names[c]);
-            /* TT #723: FONT_SMALL so the longer canonical names (TinkerAgent)
-             * fit the narrow preset chip without clipping. */
-            lv_obj_set_style_text_font(lbl, FONT_SMALL, 0);
-            lv_obj_center(lbl);
-        }
-        y += ROW_H + ROW_GAP;
-    }
-
-    /* Composite preview — lives below the three dials. Border / accent /
-     * kicker / text colours all swap to violet when aut_tier == 1 to
-     * signal the TinkerClaw memory-bypass (Phase 2c informed-consent). */
-    s_composite_card = lv_obj_create(s_sheet);
-    lv_obj_remove_style_all(s_composite_card);
-    lv_obj_set_pos(s_composite_card, SIDE_PAD, y + 20);
-    lv_obj_set_size(s_composite_card, MS_W - 2 * SIDE_PAD, 140);
-    lv_obj_set_style_bg_color(s_composite_card, lv_color_hex(TH_CARD_ELEVATED), 0);
-    lv_obj_set_style_bg_opa(s_composite_card, LV_OPA_COVER, 0);
-    lv_obj_set_style_radius(s_composite_card, 20, 0);
-    lv_obj_set_style_border_width(s_composite_card, 1, 0);
-    lv_obj_set_style_border_color(s_composite_card, lv_color_hex(0x1E1E2A), 0);
-    lv_obj_clear_flag(s_composite_card, LV_OBJ_FLAG_SCROLLABLE);
-
-    s_composite_accent = lv_obj_create(s_composite_card);
-    lv_obj_remove_style_all(s_composite_accent);
-    lv_obj_set_size(s_composite_accent, 140, 3);
-    lv_obj_set_pos(s_composite_accent, 0, 0);
-    lv_obj_set_style_bg_color(s_composite_accent, lv_color_hex(TH_AMBER), 0);
-    lv_obj_set_style_bg_opa(s_composite_accent, LV_OPA_COVER, 0);
-
-    s_composite_kicker = lv_label_create(s_composite_card);
-    lv_label_set_text(s_composite_kicker, "\xe2\x80\xa2 RESOLVES TO");
-    lv_obj_set_style_text_font(s_composite_kicker, FONT_SMALL, 0);
-    lv_obj_set_style_text_color(s_composite_kicker, lv_color_hex(TH_AMBER), 0);
-    lv_obj_set_style_text_letter_space(s_composite_kicker, 4, 0);
-    lv_obj_set_pos(s_composite_kicker, 24, 22);
-    lv_obj_t *comp = s_composite_card; /* alias for remaining label placement */
-
-    s_composite_head = lv_label_create(comp);
-    lv_obj_set_style_text_font(s_composite_head, FONT_HEADING, 0);
-    lv_obj_set_style_text_color(s_composite_head, lv_color_hex(TH_TEXT_PRIMARY), 0);
-    lv_obj_set_pos(s_composite_head, 24, 48);
-
-    s_composite_sub = lv_label_create(comp);
-    lv_obj_set_style_text_font(s_composite_sub, FONT_SMALL, 0);
-    lv_obj_set_style_text_color(s_composite_sub, lv_color_hex(TH_TEXT_DIM), 0);
-    lv_obj_set_style_text_letter_space(s_composite_sub, 3, 0);
-    lv_obj_set_pos(s_composite_sub, 24, 86);
-
-    /* Initial styling + composite text */
-    refresh_segments();
-    refresh_composite();
+    /* TT #724 (3.2/3.3): mode-row picker body. Replaces the int/voi/aut
+     * dials + preset chips + composite card. Each row writes vmode directly
+     * via commit_mode(); the selected row expands to show why-you'd-pick-it.
+     * Routing keys off vmode, so the resolver core is untouched. */
+    s_sel_vmode = tab5_settings_get_voice_mode();
+    if (s_sel_vmode >= VOICE_MODE_COUNT) s_sel_vmode = 0;
+    s_rows_root = lv_obj_create(s_sheet);
+    lv_obj_remove_style_all(s_rows_root);
+    lv_obj_set_pos(s_rows_root, 0, 150);
+    lv_obj_set_size(s_rows_root, MS_W, 470);
+    lv_obj_clear_flag(s_rows_root, LV_OBJ_FLAG_SCROLLABLE);
+    rebuild_rows();
 
     /* Force full-screen invalidate — same pattern as ui_home create
      * (PARTIAL render needs this to paint every strip on first show). */
@@ -449,283 +274,142 @@ void ui_mode_sheet_show(void)
 
 /* ── Internals ───────────────────────────────────────────────────────── */
 
-static void refresh_segments(void)
-{
-    /* Dial 0 = int_tier, 1 = voi_tier, 2 = aut_tier */
-    uint8_t sel[3] = { s_int_tier, s_voi_tier, s_aut_tier };
-    int counts[3]  = { 3, 3, 2 };
+/* TT #724 (3.3): write the chosen mode + notify Dragon. Mirrors the proven
+ * preset-4/5 calls but for all six modes. Does NOT touch tab5_mode_resolve /
+ * the dial tiers — routing keys off the persisted vmode. */
+static void commit_mode(uint8_t vmode) {
+   if (vmode >= VOICE_MODE_COUNT) return;
 
-    for (int r = 0; r < 3; r++) {
-        for (int c = 0; c < counts[r]; c++) {
-            lv_obj_t *seg = s_seg_btn[r][c];
-            if (!seg) continue;
-            bool on = (sel[r] == c);
-            if (on) {
-                lv_obj_set_style_bg_color(seg, lv_color_hex(TH_AMBER), 0);
-                lv_obj_set_style_bg_opa(seg, LV_OPA_COVER, 0);
-                /* Update label colour */
-                lv_obj_t *lbl = lv_obj_get_child(seg, 0);
-                if (lbl) {
-                    lv_obj_set_style_text_color(lbl, lv_color_hex(TH_BG), 0);
-                }
-            } else {
-                lv_obj_set_style_bg_opa(seg, LV_OPA_TRANSP, 0);
-                lv_obj_t *lbl = lv_obj_get_child(seg, 0);
-                if (lbl) {
-                    lv_obj_set_style_text_color(lbl, lv_color_hex(TH_TEXT_SECONDARY), 0);
-                }
-            }
-        }
-    }
-}
-
-static void refresh_composite(void)
-{
-    if (!s_composite_head || !s_composite_sub || !s_composite_card) return;
-
-    char model_out[64] = {0};
-    uint8_t resolved = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier, model_out, sizeof(model_out));
-    if (resolved > 3) resolved = 0;
-    /* TT #723: canonical name from th_mode_names (was a divergent local copy
-     * "Full Cloud" / "Agent · TinkerClaw"). */
-    lv_label_set_text(s_composite_head, th_mode_names[resolved]);
-
-    /* Sub-label is built live so it reflects the actual LLM the user picked
-     * (gemini-3-flash-preview, gpt-4o-mini, etc) instead of hardcoding
-     * Sonnet.  Shortens vendor/model to the tail after "/" and upper-cases
-     * it to match the kicker typography. */
-    char sub_buf[96] = {0};
-    char short_model[48] = {0};
-    {
-        char lm[64] = {0};
-        tab5_settings_get_llm_model(lm, sizeof(lm));
-        if (lm[0]) {
-            const char *slash = strchr(lm, '/');
-            const char *tail  = slash ? slash + 1 : lm;
-            snprintf(short_model, sizeof(short_model), "%.47s", tail);
-            for (int i = 0; short_model[i]; i++) {
-                if (short_model[i] >= 'a' && short_model[i] <= 'z')
-                    short_model[i] -= 32;
-            }
-        }
-    }
-    /* TT #328 Wave 5 (audit Hybrid story) — captions now stamp three
-     * decisive variables per mode: latency, privacy, cost.  Pre-Wave-5
-     * the composite read "STUDIO VOICE · LOCAL BRAIN · ~$0.02" — true,
-     * but the user couldn't see WHY they'd pick Hybrid over Local
-     * (60 s vs. 4-8 s is the load-bearing reason).  Now every mode
-     * surfaces its sweet-spot in the same shape so cross-comparison
-     * is a glance, not an analysis. */
-    switch (resolved) {
-        case 0:
-           snprintf(sub_buf, sizeof(sub_buf), "~60S \xe2\x80\xa2 100%% PRIVATE \xe2\x80\xa2 FREE");
-           break;
-        case 1:
-           snprintf(sub_buf, sizeof(sub_buf), "4-8S \xe2\x80\xa2 PRIVATE BRAIN \xe2\x80\xa2 ~$0.02");
-           break;
-        case 2:
-           snprintf(sub_buf, sizeof(sub_buf), "3-6S \xe2\x80\xa2 %s \xe2\x80\xa2 ~$0.04",
-                    short_model[0] ? short_model : "CLOUD");
-           break;
-        case 3:
-           snprintf(sub_buf, sizeof(sub_buf), "AGENT TOOLS \xe2\x80\xa2 MEMORY BYPASSED");
-           break;
-    }
-    lv_label_set_text(s_composite_sub, sub_buf);
-
-    /* v4·D Sovereign Halo Phase 2c: when aut_tier == 1 (Agent),
-     * recolor the composite card to violet to flag the memory-bypass
-     * boundary.  The user has already tapped Agent, so this isn't a
-     * revert-confirm modal -- just a tonally distinct "this mode runs
-     * differently" signal matching the Sovereign system-d-modes.html M5
-     * warning sheet concept. */
-    const bool agent = (s_aut_tier >= 1);
-    uint32_t accent_col = agent ? 0xA78BFA : TH_AMBER;
-    uint32_t border_col = agent ? 0xA78BFA : 0x1E1E2A;
-    const char *kicker  = agent ? "\xe2\x80\xa2 AGENT MODE" : "\xe2\x80\xa2 RESOLVES TO";
-
-    lv_obj_set_style_bg_color(s_composite_accent, lv_color_hex(accent_col), 0);
-    lv_obj_set_style_border_color(s_composite_card, lv_color_hex(border_col), 0);
-    lv_obj_set_style_border_opa(s_composite_card, agent ? 255 : 255, 0);
-    if (s_composite_kicker) {
-        lv_label_set_text(s_composite_kicker, kicker);
-        lv_obj_set_style_text_color(s_composite_kicker, lv_color_hex(accent_col), 0);
-    }
-}
-
-static void persist_and_notify_dragon(void)
-{
-   /* W8: confirmatory chirp.  Fired from EVERY user-driven mode-sheet
-    * commit (dial segment tap → persist_and_notify_dragon, plus every
-    * preset chip case 0..3 below).  Audit found the device mute on
-    * UI interactions; the cue closes that gap.  Worker-dispatched so
-    * the LVGL caller doesn't block. */
-   ui_audio_cue_play(UI_CUE_MODE_SWITCH);
-
-   /* TT #625 Wave A.2 (R6) — vmode change mid-turn used to orphan the
-    * in-flight Dragon STT/LLM/TTS.  Now: if voice is mid-turn, cancel
-    * it cleanly first (voice_cancel also resets wakeword + pauses pump
-    * via Wave A.1), then let the config_update fire so the NEXT turn
-    * uses the new mode.  Toast tells the user what happened. */
-   voice_state_t vs_at_switch = voice_get_state();
-   if (vs_at_switch != VOICE_STATE_IDLE && vs_at_switch != VOICE_STATE_READY) {
-      ESP_LOGI(TAG, "vmode change while voice in state %d — cancelling first", (int)vs_at_switch);
+   /* TT #625 Wave A.2 (R6) — a vmode change mid-turn used to orphan the
+    * in-flight Dragon turn. Cancel cleanly first; the config_update then
+    * applies to the NEXT turn. */
+   voice_state_t vs = voice_get_state();
+   if (vs != VOICE_STATE_IDLE && vs != VOICE_STATE_READY) {
+      ESP_LOGI(TAG, "vmode change while voice in state %d — cancelling first", (int)vs);
       tab5_debug_obs_event("mode.cancel_for_switch", "");
       voice_cancel();
-      extern void ui_home_show_toast(const char *);
       ui_home_show_toast("Switched mode — current turn stopped");
    }
 
-   /* Persist the three tiers + the derived voice_mode + (optional) llm_model. */
-   tab5_settings_set_int_tier(s_int_tier);
-   tab5_settings_set_voi_tier(s_voi_tier);
-   tab5_settings_set_aut_tier(s_aut_tier);
+   tab5_settings_set_voice_mode(vmode);
+   char model[64] = {0};
+   tab5_settings_get_llm_model(model, sizeof(model));
+   voice_send_config_update((int)vmode, model);
+   ui_audio_cue_play(UI_CUE_MODE_SWITCH);
+   extern void ui_agents_on_mode_change(void);
+   ui_agents_on_mode_change();
+   ESP_LOGI(TAG, "picker: mode -> %u (%s)", vmode, th_mode_names[vmode]);
+}
 
-   char model_out[64] = {0};
-   uint8_t new_mode = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier, model_out, sizeof(model_out));
-   tab5_settings_set_voice_mode(new_mode);
-   if (model_out[0]) {
-      tab5_settings_set_llm_model(model_out);
+/* TT #724 (3.2/3.3): rebuild the six mode rows. The selected row expands to
+ * show reason + what-leaves; the rest show a single dim meta line. Unavailable
+ * modes dim and refuse selection (3.5). */
+static void rebuild_rows(void) {
+   if (!s_rows_root) return;
+   lv_obj_clean(s_rows_root);
+   int y = 0;
+   for (uint8_t m = 0; m < VOICE_MODE_COUNT; m++) {
+      bool avail = mode_is_available(m);
+      bool sel = (m == s_sel_vmode);
+      int rh = sel ? 74 : 46;
+
+      lv_obj_t *row = lv_obj_create(s_rows_root);
+      lv_obj_remove_style_all(row);
+      lv_obj_set_pos(row, SIDE_PAD, y);
+      lv_obj_set_size(row, MS_W - 2 * SIDE_PAD, rh);
+      lv_obj_set_style_bg_color(row, lv_color_hex(sel ? 0x1A1509 : 0x13131C), 0);
+      lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
+      lv_obj_set_style_radius(row, 12, 0);
+      lv_obj_set_style_border_width(row, 1, 0);
+      lv_obj_set_style_border_color(row, lv_color_hex(sel ? TH_AMBER : 0x20202C), 0);
+      lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+      lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_add_event_cb(row, row_click_cb, LV_EVENT_CLICKED, (void *)(uintptr_t)m);
+      if (!avail) lv_obj_set_style_opa(row, LV_OPA_40, 0);
+
+      /* mode dot (shared widget, colored by mode) */
+      lv_obj_t *dot = widget_mode_dot_create(row, 8, m);
+      if (dot) lv_obj_set_pos(dot, 12, sel ? 14 : 18);
+
+      lv_obj_t *nm = lv_label_create(row);
+      lv_label_set_text(nm, th_mode_names[m]);
+      lv_obj_set_style_text_font(nm, FONT_BODY, 0);
+      lv_obj_set_style_text_color(nm, lv_color_hex(TH_TEXT_PRIMARY), 0);
+      lv_obj_set_pos(nm, 30, sel ? 10 : 13);
+
+      if (m == 1) { /* Hybrid "recommended" tag */
+         lv_obj_t *rec = lv_label_create(row);
+         lv_label_set_text(rec, "RECOMMENDED");
+         lv_obj_set_style_text_font(rec, FONT_SMALL, 0);
+         lv_obj_set_style_text_color(rec, lv_color_hex(0x7A7A88), 0);
+         lv_obj_align(rec, LV_ALIGN_TOP_RIGHT, -14, sel ? 14 : 16);
+      }
+      if (m == 4 && !avail) { /* TinkerON addon hint */
+         lv_obj_t *w = lv_label_create(row);
+         lv_label_set_text(w, "attach addon");
+         lv_obj_set_style_text_font(w, FONT_SMALL, 0);
+         lv_obj_set_style_text_color(w, lv_color_hex(TH_AMBER), 0);
+         lv_obj_align(w, LV_ALIGN_TOP_RIGHT, -14, sel ? 14 : 16);
+      }
+
+      if (sel) {
+         lv_obj_t *reason = lv_label_create(row);
+         lv_label_set_text(reason, s_mode_meta[m].reason);
+         lv_obj_set_style_text_font(reason, FONT_SMALL, 0);
+         lv_obj_set_style_text_color(reason, lv_color_hex(0xC2C2CC), 0);
+         lv_obj_set_pos(reason, 30, 34);
+         lv_obj_t *meta = lv_label_create(row);
+         lv_label_set_text(meta, s_mode_meta[m].leaves);
+         lv_obj_set_style_text_font(meta, FONT_SMALL, 0);
+         lv_obj_set_style_text_color(meta, lv_color_hex(0x6A6A78), 0);
+         lv_obj_set_pos(meta, 30, 53);
+      } else if (!(m == 1 || (m == 4 && !avail))) {
+         /* one-line meta; skipped for rows that already carry a right-side
+          * annotation (Hybrid RECOMMENDED / TinkerON attach-addon) so they
+          * don't collide on the narrow unselected row. */
+         lv_obj_t *one = lv_label_create(row);
+         lv_label_set_text(one, s_mode_meta[m].oneline);
+         lv_obj_set_style_text_font(one, FONT_SMALL, 0);
+         lv_obj_set_style_text_color(one, lv_color_hex(0x6A6A78), 0);
+         lv_obj_align(one, LV_ALIGN_RIGHT_MID, -14, 0);
+      }
+      y += rh + 8;
    }
-
-    /* Fire config_update to Dragon so it swaps backends on the next turn.
-     * Re-read llm_model from NVS to send what's actually stored (either
-     * the newly-written cloud model or the pre-existing one). */
-    char model_to_send[64] = {0};
-    tab5_settings_get_llm_model(model_to_send, sizeof(model_to_send));
-    voice_send_config_update(new_mode, model_to_send);
-
-    ESP_LOGI(TAG, "Tier change resolved -> voice_mode=%d model=%s",
-             new_mode, model_to_send);
-    /* W7-B follow-up (TT #467): refresh agent_skills catalog if Agents
-     * overlay is visible — its vmode=3 gate needs to update live when
-     * the user dials in/out of TinkerClaw. */
-    extern void ui_agents_on_mode_change(void);
-    ui_agents_on_mode_change();
 }
 
-/* Wave 10 H5 Presets: one-tap recipes that set all three dials to the
- * tier combination matching the legacy voice_mode (0=Local, 1=Hybrid,
- * 2=Cloud, 3=Agent). Agent preset routes through the same consent modal
- * that the AUTONOMY dial does so there's no silent bypass path. */
-void preset_click_cb(lv_event_t *e)
-{
-    int preset = (int)(uintptr_t)lv_event_get_user_data(e);
-    uint8_t prev_aut = s_aut_tier;
-    switch (preset) {
-        case 0: /* Local   */ s_int_tier = 0; s_voi_tier = 0; s_aut_tier = 0; break;
-        case 1: /* Hybrid  */ s_int_tier = 1; s_voi_tier = 2; s_aut_tier = 0; break;
-        case 2: /* Cloud   */ s_int_tier = 2; s_voi_tier = 2; s_aut_tier = 0; break;
-        case 3: /* Agent   */
-            /* Keep intelligence + voice tiers as-is — agent mode is only
-             * about autonomy/memory-bypass. If already on Agent, no-op.
-             * Otherwise gate behind the consent modal. */
-            if (s_aut_tier == 1) return;
-            s_aut_tier = 1;
-            refresh_segments();
-            refresh_composite();
-            show_agent_consent(prev_aut);
-            return;  /* do NOT persist yet — modal commits or reverts */
-        case 4:      /* Onboard — TT #328 Wave 9 follow-up.  Direct vmode=4
-                      * write that bypasses tab5_mode_resolve (which only
-                      * maps to 0..3).  K144 is its own runtime — the dial
-                      * taxonomy doesn't apply, so the dials' visual state
-                      * stays at whatever the user last picked.  Closes the
-                      * "K144 unreachable from sheet" half of audit P0 #10. */
-           /* TT #724 (3.5): don't switch to TinkerON when the addon isn't
-            * ready — that lands the user on a non-functional mode.  Mirror
-            * the Solo (case 5) no-key guard. */
-           if (voice_onboard_failover_state() != 2 /* M5_FAIL_READY */) {
-              if (tab5_ui_try_lock(150)) {
-                 ui_home_show_toast("TinkerON not ready — check the module");
-                 tab5_ui_unlock();
-              }
-              return;
-           }
-           tab5_settings_set_voice_mode(VOICE_MODE_ONBOARD);
-           ui_audio_cue_play(UI_CUE_MODE_SWITCH); /* W8: chirp on Onboard preset */
-           char model[64] = {0};
-           tab5_settings_get_llm_model(model, sizeof(model));
-           voice_send_config_update(VOICE_MODE_ONBOARD, model);
-           ESP_LOGI(TAG, "Onboard preset -> voice_mode=%d (K144)", VOICE_MODE_ONBOARD);
-           {
-              extern void ui_agents_on_mode_change(void);
-              ui_agents_on_mode_change();
-           }
-           ui_mode_sheet_hide();
-           return;
-        case 5: /* Solo — W8 (cross-stack audit 2026-05-11): closes the
-                 * "SOLO_DIRECT only reachable via /mode debug or chip
-                 * cycling" discoverability gap.  Direct vmode=5 write;
-                 * Dragon sees it as a real mode after W3-A/B but
-                 * idle-pipelines because Tab5 goes direct to OpenRouter
-                 * for the audio path.  If the OpenRouter key isn't
-                 * provisioned, surface a hint instead of silently
-                 * switching to a non-functional mode. */
-        {
-           char or_key[96] = {0};
-           tab5_settings_get_or_key(or_key, sizeof or_key);
-           if (or_key[0] == '\0') {
-              if (tab5_ui_try_lock(150)) {
-                 ui_home_show_toast("Scan QR to set OpenRouter key first");
-                 tab5_ui_unlock();
-              }
-              return;
-           }
-           tab5_settings_set_voice_mode(VOICE_MODE_SOLO);
-           char model2[64] = {0};
-           tab5_settings_get_llm_model(model2, sizeof(model2));
-           voice_send_config_update(VOICE_MODE_SOLO, model2);
-           ESP_LOGI(TAG, "Solo preset -> voice_mode=%d (OpenRouter direct)", VOICE_MODE_SOLO);
-           {
-              extern void ui_agents_on_mode_change(void);
-              ui_agents_on_mode_change();
-           }
-        }
-           ui_mode_sheet_hide();
-           return;
-        default: return;
-    }
-    refresh_segments();
-    refresh_composite();
-    persist_and_notify_dragon();
-    /* TT #328 Wave 10 follow-up — dismiss the sheet on every preset tap
-     * so the user immediately sees the change reflected on home + their
-     * next navigation isn't shadowed by a sheet that's still up.  Pre-
-     * fix only the Onboard preset (case 4) auto-dismissed; the other
-     * four required a manual "Done" tap. */
-    ui_mode_sheet_hide();
+static void row_click_cb(lv_event_t *e) {
+   uint8_t vmode = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+   if (vmode >= VOICE_MODE_COUNT) return;
+   if (!mode_is_available(vmode)) {
+      if (tab5_ui_try_lock(150)) {
+         ui_home_show_toast(s_mode_meta[vmode].req == REQ_ADDON ? "TinkerON not ready \xe2\x80\x94 check the module"
+                                                                : "Add an OpenRouter key in Settings first");
+         tab5_ui_unlock();
+      }
+      return;
+   }
+   /* TinkerAgent (3) bypasses on-device memory — preserve the consent modal
+    * when switching INTO agent from another mode (memory-bypass boundary). */
+   if (vmode == VOICE_MODE_TINKERCLAW && tab5_settings_get_voice_mode() != VOICE_MODE_TINKERCLAW) {
+      ui_agent_consent_show(agent_consent_confirm_cb, agent_consent_cancel_cb, NULL);
+      return;
+   }
+   s_sel_vmode = vmode;
+   rebuild_rows(); /* expand the newly-selected row */
+   commit_mode(vmode);
 }
 
-static void seg_click_cb(lv_event_t *e)
-{
-    uintptr_t pack = (uintptr_t)lv_event_get_user_data(e);
-    int row = (int)((pack >> 4) & 0x0F);
-    int col = (int)(pack & 0x0F);
+/* In-sheet TinkerAgent consent decisions (routed via ui_agent_consent_show). */
+static void agent_consent_confirm_cb(void *ctx) {
+   (void)ctx;
+   s_sel_vmode = VOICE_MODE_TINKERCLAW;
+   rebuild_rows();
+   commit_mode(VOICE_MODE_TINKERCLAW);
+}
 
-    /* Phase 2c gate: tapping AUTONOMY→Agent while not already on Agent
-     * must trigger the consent modal before we commit the mode switch.
-     * Memory bypass is the most sensitive boundary in the system and
-     * deserves an explicit acknowledge+back path, not a silent recolor. */
-    if (row == 2 && col == 1 && s_aut_tier != 1) {
-        uint8_t prev = s_aut_tier;
-        s_aut_tier = 1;
-        refresh_segments();
-        refresh_composite();
-        show_agent_consent(prev);
-        return;  /* do NOT persist yet — modal commits or reverts */
-    }
-
-    switch (row) {
-        case 0: s_int_tier = (uint8_t)col; break;
-        case 1: s_voi_tier = (uint8_t)col; break;
-        case 2: s_aut_tier = (uint8_t)col; break;
-        default: return;
-    }
-
-    refresh_segments();
-    refresh_composite();
-    persist_and_notify_dragon();
+static void agent_consent_cancel_cb(void *ctx) {
+   (void)ctx;
+   /* Keep the prior selection; nothing was committed. */
 }
 
 /* ── Agent consent modal ─────────────────────────────────────────────── */
@@ -756,26 +440,15 @@ static void hide_agent_consent(bool commit)
         lv_obj_del(s_consent_overlay);
         s_consent_overlay = NULL;
     }
-    /* Generic callback mode (E3) — invoke caller's decision handler and
-     * reset the callback slots. Does NOT touch s_aut_tier / persist. */
-    if (s_consent_confirm_cb || s_consent_cancel_cb) {
-        void (*cb)(void *) = commit ? s_consent_confirm_cb : s_consent_cancel_cb;
-        void  *ctx         = s_consent_cb_ctx;
-        s_consent_confirm_cb = NULL;
-        s_consent_cancel_cb  = NULL;
-        s_consent_cb_ctx     = NULL;
-        if (cb) cb(ctx);
-        return;
-    }
-    /* Legacy mode-sheet flow: commit persists tiers, cancel reverts. */
-    if (commit) {
-        persist_and_notify_dragon();
-    } else {
-        /* Revert to the pre-modal autonomy tier + rebuild segment UI. */
-        s_aut_tier = s_pre_consent_aut;
-        refresh_segments();
-        refresh_composite();
-    }
+    /* Invoke the caller's decision handler and reset the callback slots.
+     * Both the in-sheet TinkerAgent flow (TT #724) and the Settings
+     * TinkerClaw row (audit E3) route through this generic path. */
+    void (*cb)(void *) = commit ? s_consent_confirm_cb : s_consent_cancel_cb;
+    void *ctx = s_consent_cb_ctx;
+    s_consent_confirm_cb = NULL;
+    s_consent_cancel_cb = NULL;
+    s_consent_cb_ctx = NULL;
+    if (cb) cb(ctx);
 }
 
 void ui_agent_consent_show(void (*on_confirm)(void *ctx),

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -99,12 +99,25 @@ static uint8_t s_voi_tier = 0;
 static uint8_t s_aut_tier = 0;
 
 /* TT #724 (3.2): mode-row picker state. */
-static uint8_t s_sel_vmode = 0;      /* row currently shown expanded */
-static lv_obj_t *s_rows_root = NULL; /* container holding the 6 mode rows */
+static uint8_t s_sel_vmode = 0;       /* row currently shown expanded */
+static lv_obj_t *s_rows_root = NULL;  /* container holding the 6 mode rows */
+static lv_obj_t *s_smart_root = NULL; /* Smartness segment container */
+
+/* TT #724 (3.3): Fast/Balanced/Smart -> a concrete model. Setting int_tier
+ * alone changes nothing (routing keys off vmode + llm_model, never int_tier
+ * — validated). Live for Cloud + Solo only; other modes are fixed-brain.
+ * Model IDs match s_cloud_models[] in ui_settings.c. */
+static const char *const s_smart_cloud[3] = {
+    "~anthropic/claude-haiku-latest", /* Fast     */
+    "anthropic/claude-sonnet-4.6",    /* Balanced */
+    "anthropic/claude-opus-4.7",      /* Smart    */
+};
 
 /* ── Forward decls ───────────────────────────────────────────────────── */
 static void commit_mode(uint8_t vmode);
 static void rebuild_rows(void);
+static void build_smartness(void);
+static void smart_click_cb(lv_event_t *e);
 static void row_click_cb(lv_event_t *e);
 static void done_click_cb(lv_event_t *e);
 static void scrim_click_cb(lv_event_t *e);
@@ -140,6 +153,7 @@ void ui_mode_sheet_hide(void)
     s_overlay = NULL;
     s_sheet = NULL;
     s_rows_root = NULL;
+    s_smart_root = NULL;
 }
 
 void ui_mode_sheet_show(void)
@@ -259,9 +273,18 @@ void ui_mode_sheet_show(void)
      * Routing keys off vmode, so the resolver core is untouched. */
     s_sel_vmode = tab5_settings_get_voice_mode();
     if (s_sel_vmode >= VOICE_MODE_COUNT) s_sel_vmode = 0;
+
+    /* TT #724 (3.3): Smartness segment, above the mode rows. */
+    s_smart_root = lv_obj_create(s_sheet);
+    lv_obj_remove_style_all(s_smart_root);
+    lv_obj_set_pos(s_smart_root, 0, 116);
+    lv_obj_set_size(s_smart_root, MS_W, 56);
+    lv_obj_clear_flag(s_smart_root, LV_OBJ_FLAG_SCROLLABLE);
+    build_smartness();
+
     s_rows_root = lv_obj_create(s_sheet);
     lv_obj_remove_style_all(s_rows_root);
-    lv_obj_set_pos(s_rows_root, 0, 150);
+    lv_obj_set_pos(s_rows_root, 0, 182);
     lv_obj_set_size(s_rows_root, MS_W, 470);
     lv_obj_clear_flag(s_rows_root, LV_OBJ_FLAG_SCROLLABLE);
     rebuild_rows();
@@ -395,7 +418,8 @@ static void row_click_cb(lv_event_t *e) {
       return;
    }
    s_sel_vmode = vmode;
-   rebuild_rows(); /* expand the newly-selected row */
+   rebuild_rows();    /* expand the newly-selected row */
+   build_smartness(); /* fixed-brain modes grey the knob; Cloud/Solo enable it */
    commit_mode(vmode);
 }
 
@@ -404,12 +428,75 @@ static void agent_consent_confirm_cb(void *ctx) {
    (void)ctx;
    s_sel_vmode = VOICE_MODE_TINKERCLAW;
    rebuild_rows();
+   build_smartness(); /* TinkerAgent is fixed-brain -> grey the knob */
    commit_mode(VOICE_MODE_TINKERCLAW);
 }
 
 static void agent_consent_cancel_cb(void *ctx) {
    (void)ctx;
    /* Keep the prior selection; nothing was committed. */
+}
+
+/* TT #724 (3.3): Smartness tap — sets the *real* model for the only two modes
+ * where Tab5 picks it (Cloud -> llm_model, Solo -> or_mdl_llm), persists the
+ * tier for the segment's on-state, and notifies Dragon. No-op for fixed-brain
+ * modes (the segment is greyed + non-clickable there). */
+static void smart_click_cb(lv_event_t *e) {
+   uint8_t tier = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+   if (tier > 2 || s_mode_meta[s_sel_vmode].fixed_brain) return;
+   tab5_settings_set_int_tier(tier);
+   const char *model = s_smart_cloud[tier];
+   if (s_sel_vmode == VOICE_MODE_SOLO)
+      tab5_settings_set_or_mdl_llm(model);
+   else
+      tab5_settings_set_llm_model(model); /* Cloud */
+   voice_send_config_update((int)s_sel_vmode, (char *)model);
+   build_smartness(); /* re-render the on-state */
+   ESP_LOGI(TAG, "smartness tier=%u -> model=%s (vmode=%u)", tier, model, s_sel_vmode);
+}
+
+/* TT #724 (3.3): (re)build the Smartness segment for the current selection.
+ * Greyed + non-clickable for fixed-brain modes; the on-state reflects the
+ * persisted int_tier. Lives in its own container so it can be rebuilt cheaply
+ * when the selected mode changes. */
+static void build_smartness(void) {
+   if (!s_smart_root) return;
+   lv_obj_clean(s_smart_root);
+
+   lv_obj_t *lab = lv_label_create(s_smart_root);
+   lv_label_set_text(lab, "SMARTNESS");
+   lv_obj_set_style_text_font(lab, FONT_SMALL, 0);
+   lv_obj_set_style_text_color(lab, lv_color_hex(TH_AMBER), 0);
+   lv_obj_set_style_text_letter_space(lab, 2, 0);
+   lv_obj_set_pos(lab, SIDE_PAD, 0);
+
+   bool fixed = s_mode_meta[s_sel_vmode].fixed_brain;
+   uint8_t tier = tab5_settings_get_int_tier();
+   if (tier > 2) tier = 0;
+   const char *names[3] = {"Fast", "Balanced", "Smart"};
+   int seg_w = (MS_W - 2 * SIDE_PAD - 2 * 6) / 3;
+   for (int i = 0; i < 3; i++) {
+      bool on = (i == tier && !fixed);
+      lv_obj_t *s = lv_obj_create(s_smart_root);
+      lv_obj_remove_style_all(s);
+      lv_obj_set_pos(s, SIDE_PAD + i * (seg_w + 6), 22);
+      lv_obj_set_size(s, seg_w, 30);
+      lv_obj_set_style_radius(s, 10, 0);
+      lv_obj_set_style_bg_color(s, lv_color_hex(on ? TH_AMBER : 0x15151F), 0);
+      lv_obj_set_style_bg_opa(s, LV_OPA_COVER, 0);
+      lv_obj_clear_flag(s, LV_OBJ_FLAG_SCROLLABLE);
+      if (!fixed) {
+         lv_obj_add_flag(s, LV_OBJ_FLAG_CLICKABLE);
+         lv_obj_add_event_cb(s, smart_click_cb, LV_EVENT_CLICKED, (void *)(uintptr_t)i);
+      } else {
+         lv_obj_set_style_opa(s, LV_OPA_40, 0);
+      }
+      lv_obj_t *t = lv_label_create(s);
+      lv_label_set_text(t, names[i]);
+      lv_obj_set_style_text_font(t, FONT_SMALL, 0);
+      lv_obj_set_style_text_color(t, lv_color_hex(on ? TH_BG : TH_TEXT_PRIMARY), 0);
+      lv_obj_center(t);
+   }
 }
 
 /* ── Agent consent modal ─────────────────────────────────────────────── */

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -22,6 +22,54 @@
 
 static const char *TAG = "ui_mode_sheet";
 
+/* TT #724 (3.2): per-mode display + availability metadata. Names come from
+ * th_mode_names (single source). `requires` drives the 3.5 dim/refuse gate. */
+typedef enum { REQ_NONE = 0, REQ_ADDON, REQ_OR_KEY } mode_req_t;
+typedef struct {
+   const char *reason;  /* one-line why-you'd-pick-it (selected row) */
+   const char *leaves;  /* what leaves the device + speed + cost (selected row) */
+   const char *oneline; /* compact meta for unselected rows */
+   mode_req_t req;
+   bool fixed_brain; /* true => Smartness has no range (grey it) */
+} mode_meta_t;
+
+/* Indexed by vmode (0..5). Order matches th_mode_names / VOICE_MODE_*. */
+static const mode_meta_t s_mode_meta[VOICE_MODE_COUNT] = {
+    /* 0 Local       */ {"Private brain, on the Dragon box", "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s",
+                         "Nothing leaves \xc2\xb7 free \xc2\xb7 ~60s", REQ_NONE, true},
+    /* 1 Hybrid      */
+    {"Private brain, fast voice", "leaves: your voice (STT) \xc2\xb7 ~5s \xc2\xb7 ~2\xc2\xa2",
+     "Private brain \xc2\xb7 fast voice \xc2\xb7 ~2\xc2\xa2", REQ_NONE, true},
+    /* 2 Cloud       */
+    {"Smartest, everything cloud", "leaves: voice + text \xc2\xb7 ~5s \xc2\xb7 needs key",
+     "Voice+text \xc2\xb7 smartest \xc2\xb7 needs key", REQ_NONE, false},
+    /* 3 TinkerAgent */
+    {"Tools + memory, agentic", "leaves: voice + text + tools \xc2\xb7 via gateway", "Tools + memory \xc2\xb7 agentic",
+     REQ_NONE, true},
+    /* 4 TinkerON    */
+    {"Works offline, on-device addon", "Nothing leaves \xc2\xb7 works offline", "Nothing leaves \xc2\xb7 works offline",
+     REQ_ADDON, true},
+    /* 5 Solo        */
+    {"Cloud quality, no Dragon needed", "leaves: voice + text \xc2\xb7 direct to OpenRouter",
+     "No Dragon \xc2\xb7 voice+text leave", REQ_OR_KEY, false},
+};
+
+/* TT #724 (3.5/3.2): can this mode run right now? */
+static bool mode_is_available(uint8_t vmode) {
+   if (vmode >= VOICE_MODE_COUNT) return false;
+   switch (s_mode_meta[vmode].req) {
+      case REQ_ADDON:
+         return voice_onboard_failover_state() == 2 /* M5_FAIL_READY */;
+      case REQ_OR_KEY: {
+         char k[128] = {0};
+         tab5_settings_get_or_key(k, sizeof k);
+         return k[0] != '\0';
+      }
+      default:
+         return true;
+   }
+}
+
 /* ── Layout ──────────────────────────────────────────────────────────── */
 #define MS_W        720
 #define MS_H        1280

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -113,11 +113,39 @@ static const char *const s_smart_cloud[3] = {
     "anthropic/claude-opus-4.7",      /* Smart    */
 };
 
+/* TT #724 (3.4): Advanced drawer state. */
+static lv_obj_t *s_adv_root = NULL; /* drawer container below the rows */
+static bool s_adv_open = false;
+
+/* Exact-model list for the Advanced drawer (relocated from ui_settings.c
+ * CLOUD LLM block; Task 5 removes the Settings copy). model_id is what we
+ * send to Dragon as llm_model. */
+typedef struct {
+   const char *label;
+   const char *model_id;
+} adv_model_t;
+static const adv_model_t s_adv_models[] = {
+    {"Opus 4.7", "anthropic/claude-opus-4.7"},
+    {"Sonnet", "anthropic/claude-sonnet-4.6"},
+    {"Haiku", "~anthropic/claude-haiku-latest"},
+    {"GPT-5.5", "openai/gpt-5.5"},
+    {"GPT-5.4m", "openai/gpt-5.4-mini"},
+    {"Gemini Pro", "~google/gemini-pro-latest"},
+    {"Gemini 3.1", "google/gemini-3.1-flash-lite"},
+    {"Grok 4.3", "x-ai/grok-4.3"},
+};
+#define ADV_MODEL_COUNT (sizeof(s_adv_models) / sizeof(s_adv_models[0]))
+
+/* Daily-cap presets in mils (1 mil = 1/1000 cent): OFF / $1 / $5 / $10. */
+static const uint32_t s_adv_caps[4] = {0, 100000, 500000, 1000000};
+static const char *const s_adv_cap_lbl[4] = {"Off", "$1", "$5", "$10"};
+
 /* ── Forward decls ───────────────────────────────────────────────────── */
 static void commit_mode(uint8_t vmode);
 static void rebuild_rows(void);
 static void build_smartness(void);
 static void smart_click_cb(lv_event_t *e);
+static void build_advanced(void);
 static void row_click_cb(lv_event_t *e);
 static void done_click_cb(lv_event_t *e);
 static void scrim_click_cb(lv_event_t *e);
@@ -154,6 +182,7 @@ void ui_mode_sheet_hide(void)
     s_sheet = NULL;
     s_rows_root = NULL;
     s_smart_root = NULL;
+    s_adv_root = NULL;
 }
 
 void ui_mode_sheet_show(void)
@@ -285,9 +314,18 @@ void ui_mode_sheet_show(void)
     s_rows_root = lv_obj_create(s_sheet);
     lv_obj_remove_style_all(s_rows_root);
     lv_obj_set_pos(s_rows_root, 0, 182);
-    lv_obj_set_size(s_rows_root, MS_W, 470);
+    lv_obj_set_size(s_rows_root, MS_W, 352);
     lv_obj_clear_flag(s_rows_root, LV_OBJ_FLAG_SCROLLABLE);
     rebuild_rows();
+
+    /* TT #724 (3.4): Advanced drawer, collapsed by default, below the rows. */
+    s_adv_open = false;
+    s_adv_root = lv_obj_create(s_sheet);
+    lv_obj_remove_style_all(s_adv_root);
+    lv_obj_set_pos(s_adv_root, 0, 542);
+    lv_obj_set_size(s_adv_root, MS_W, 480);
+    lv_obj_clear_flag(s_adv_root, LV_OBJ_FLAG_SCROLLABLE);
+    build_advanced();
 
     /* Force full-screen invalidate — same pattern as ui_home create
      * (PARTIAL render needs this to paint every strip on first show). */
@@ -497,6 +535,162 @@ static void build_smartness(void) {
       lv_obj_set_style_text_color(t, lv_color_hex(on ? TH_BG : TH_TEXT_PRIMARY), 0);
       lv_obj_center(t);
    }
+}
+
+/* ── Advanced drawer (3.4) ───────────────────────────────────────────── */
+
+/* Pill chip used by every drawer control. */
+static lv_obj_t *adv_chip(lv_obj_t *parent, int x, int y, int w, int h, const char *text, bool sel, lv_event_cb_t cb,
+                          void *ud) {
+   lv_obj_t *c = lv_obj_create(parent);
+   lv_obj_remove_style_all(c);
+   lv_obj_set_pos(c, x, y);
+   lv_obj_set_size(c, w, h);
+   lv_obj_set_style_radius(c, h / 2, 0);
+   lv_obj_set_style_bg_color(c, lv_color_hex(sel ? TH_AMBER : 0x15151F), 0);
+   lv_obj_set_style_bg_opa(c, LV_OPA_COVER, 0);
+   lv_obj_set_style_border_width(c, 1, 0);
+   lv_obj_set_style_border_color(c, lv_color_hex(sel ? TH_AMBER : 0x20202C), 0);
+   lv_obj_clear_flag(c, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(c, LV_OBJ_FLAG_CLICKABLE);
+   if (cb) lv_obj_add_event_cb(c, cb, LV_EVENT_CLICKED, ud);
+   lv_obj_t *l = lv_label_create(c);
+   lv_label_set_text(l, text);
+   lv_obj_set_style_text_font(l, FONT_SMALL, 0);
+   lv_obj_set_style_text_color(l, lv_color_hex(sel ? TH_BG : TH_TEXT_PRIMARY), 0);
+   lv_obj_center(l);
+   return c;
+}
+
+static void adv_section_label(lv_obj_t *parent, int y, const char *text) {
+   lv_obj_t *l = lv_label_create(parent);
+   lv_label_set_text(l, text);
+   lv_obj_set_style_text_font(l, FONT_SMALL, 0);
+   lv_obj_set_style_text_color(l, lv_color_hex(TH_AMBER), 0);
+   lv_obj_set_style_text_letter_space(l, 2, 0);
+   lv_obj_set_pos(l, SIDE_PAD, y);
+}
+
+static void adv_toggle_cb(lv_event_t *e) {
+   (void)e;
+   s_adv_open = !s_adv_open;
+   build_advanced();
+}
+
+static void adv_engine_cb(lv_event_t *e) {
+   uint8_t idx = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+   if (idx >= LLM_ENG_COUNT) return;
+   tab5_settings_set_llm_engine(idx);
+   tab5_debug_obs_event("eng.llm", "picker");
+   build_advanced();
+}
+
+static void adv_model_cb(lv_event_t *e) {
+   uint8_t idx = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+   if (idx >= ADV_MODEL_COUNT) return;
+   tab5_settings_set_llm_model(s_adv_models[idx].model_id);
+   voice_send_config_update((int)s_sel_vmode, (char *)s_adv_models[idx].model_id);
+   build_advanced();
+}
+
+static void adv_privacy_cb(lv_event_t *e) {
+   (void)e;
+   tab5_settings_set_privacy_lock(!tab5_settings_get_privacy_lock());
+   build_advanced();
+}
+
+static void adv_cap_cb(lv_event_t *e) {
+   uint8_t idx = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
+   if (idx >= 4) return;
+   tab5_budget_set_cap_mils(s_adv_caps[idx]);
+   build_advanced();
+}
+
+/* (re)build the Advanced drawer. Collapsed = a single toggle row; expanded =
+ * engine pins + exact-model row + privacy lock + daily cap, relocated from
+ * Settings. K144 as a hardware label is acceptable on this advanced surface. */
+static void build_advanced(void) {
+   if (!s_adv_root) return;
+   lv_obj_clean(s_adv_root);
+
+   lv_obj_t *tog = lv_obj_create(s_adv_root);
+   lv_obj_remove_style_all(tog);
+   lv_obj_set_pos(tog, SIDE_PAD, 0);
+   lv_obj_set_size(tog, MS_W - 2 * SIDE_PAD, 38);
+   lv_obj_clear_flag(tog, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(tog, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_add_event_cb(tog, adv_toggle_cb, LV_EVENT_CLICKED, NULL);
+   lv_obj_t *tl = lv_label_create(tog);
+   lv_label_set_text(tl, s_adv_open ? "Advanced  -"
+                                    : "Advanced  +   model \xe2\x80\xa2 engine \xe2\x80\xa2 privacy \xe2\x80\xa2 cap");
+   lv_obj_set_style_text_font(tl, FONT_SMALL, 0);
+   lv_obj_set_style_text_color(tl, lv_color_hex(0x8A8A98), 0);
+   lv_obj_set_pos(tl, 0, 8);
+   if (!s_adv_open) return;
+
+   int y = 50;
+   const int avail_w = MS_W - 2 * SIDE_PAD;
+
+   /* Engine pins (AUTO follows vmode; K144 / OpenRouter explicitly override). */
+   adv_section_label(s_adv_root, y, "ENGINE");
+   y += 22;
+   {
+      uint8_t cur = tab5_settings_get_llm_engine();
+      int gap = 6;
+      int w = (avail_w - 2 * gap) / 3;
+      const char *names[3] = {"Auto", "K144", "OpenRouter"};
+      for (int i = 0; i < 3; i++)
+         adv_chip(s_adv_root, SIDE_PAD + i * (w + gap), y, w, 34, names[i], cur == i, adv_engine_cb,
+                  (void *)(uintptr_t)i);
+   }
+   y += 46;
+
+   /* Exact model — overrides the Smartness default. Horizontally scrollable. */
+   adv_section_label(s_adv_root, y, "EXACT MODEL");
+   y += 22;
+   {
+      lv_obj_t *scroll = lv_obj_create(s_adv_root);
+      lv_obj_remove_style_all(scroll);
+      lv_obj_set_pos(scroll, SIDE_PAD, y);
+      lv_obj_set_size(scroll, avail_w, 40);
+      lv_obj_set_scroll_dir(scroll, LV_DIR_HOR);
+      lv_obj_set_scrollbar_mode(scroll, LV_SCROLLBAR_MODE_OFF);
+      char cur_model[64] = {0};
+      tab5_settings_get_llm_model(cur_model, sizeof(cur_model));
+      int cx = 0;
+      for (uint32_t i = 0; i < ADV_MODEL_COUNT; i++) {
+         bool sel = (strcmp(cur_model, s_adv_models[i].model_id) == 0);
+         adv_chip(scroll, cx, 0, 116, 34, s_adv_models[i].label, sel, adv_model_cb, (void *)(uintptr_t)i);
+         cx += 116 + 8;
+      }
+   }
+   y += 50;
+
+   /* Privacy lock (on-device only). */
+   adv_section_label(s_adv_root, y, "ON-DEVICE LOCK");
+   y += 22;
+   {
+      bool on = tab5_settings_get_privacy_lock();
+      adv_chip(s_adv_root, SIDE_PAD, y, 220, 34, on ? "Locked: on-device" : "Off: cloud allowed", on, adv_privacy_cb,
+               NULL);
+   }
+   y += 46;
+
+   /* Daily spend cap. */
+   adv_section_label(s_adv_root, y, "DAILY CAP");
+   y += 22;
+   {
+      uint32_t cur = tab5_budget_get_cap_mils();
+      int gap = 6;
+      int w = (avail_w - 3 * gap) / 4;
+      for (int i = 0; i < 4; i++)
+         adv_chip(s_adv_root, SIDE_PAD + i * (w + gap), y, w, 34, s_adv_cap_lbl[i], cur == s_adv_caps[i], adv_cap_cb,
+                  (void *)(uintptr_t)i);
+   }
+}
+
+bool ui_mode_sheet_is_modified(void) {
+   return tab5_settings_get_llm_engine() != LLM_ENG_AUTO || tab5_settings_get_privacy_lock();
 }
 
 /* ── Agent consent modal ─────────────────────────────────────────────── */

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -72,20 +72,16 @@ static bool mode_is_available(uint8_t vmode) {
 }
 
 /* ── Layout ──────────────────────────────────────────────────────────── */
-#define MS_W        720
-#define MS_H        1280
-#define SIDE_PAD    40
-#define SEG_H       56
-#define ROW_H       144      /* header label + segments */
-#define ROW_GAP     14
+#define MS_W 720
+#define MS_H 1280
+#define SIDE_PAD 40
 
 /* ── State ───────────────────────────────────────────────────────────── */
 static lv_obj_t *s_overlay     = NULL;  /* scrim container on layer_top */
 static lv_obj_t *s_sheet = NULL;        /* visible sheet inside overlay */
 
-/* Phase 2c Agent consent modal — own scrim, shown on top of the sheet. */
+/* Agent consent modal — own scrim, shown on top of the sheet. */
 static lv_obj_t *s_consent_overlay = NULL;
-static uint8_t   s_pre_consent_aut = 0;  /* tier to revert to on Cancel */
 /* Generic callback mode (audit E3): when non-NULL, hide_agent_consent
  * invokes these instead of the tier-revert / persist logic. Used by the
  * Settings TinkerClaw row so the same UI can drive a different commit
@@ -93,10 +89,6 @@ static uint8_t   s_pre_consent_aut = 0;  /* tier to revert to on Cancel */
 static void (*s_consent_confirm_cb)(void *) = NULL;
 static void (*s_consent_cancel_cb)(void *)  = NULL;
 static void  *s_consent_cb_ctx              = NULL;
-
-static uint8_t s_int_tier = 0;
-static uint8_t s_voi_tier = 0;
-static uint8_t s_aut_tier = 0;
 
 /* TT #724 (3.2): mode-row picker state. */
 static uint8_t s_sel_vmode = 0;       /* row currently shown expanded */
@@ -149,7 +141,7 @@ static void build_advanced(void);
 static void row_click_cb(lv_event_t *e);
 static void done_click_cb(lv_event_t *e);
 static void scrim_click_cb(lv_event_t *e);
-static void show_agent_consent(uint8_t prev_aut_tier);
+static void show_agent_consent(void);
 static void hide_agent_consent(bool commit);
 static void consent_confirm_cb(lv_event_t *e);
 static void consent_cancel_cb(lv_event_t *e);
@@ -189,43 +181,9 @@ void ui_mode_sheet_show(void)
 {
     if (ui_mode_sheet_visible()) return;
 
-    /* Pick up current tier values -- so the segmented buttons draw with the
-     * correct on-state for whatever the user last persisted. */
-    s_int_tier = tab5_settings_get_int_tier();
-    s_voi_tier = tab5_settings_get_voi_tier();
-    s_aut_tier = tab5_settings_get_aut_tier();
-
-    /* If voice_mode was set via a path that bypassed the dial sheet
-     * (debug /mode, settings radio rows, orb long-press cycle), the
-     * tiers can drift out of sync with the live mode.  Reverse-derive
-     * the tiers from the current voice_mode so the dials open showing
-     * what the device is actually running on. */
-    uint8_t resolved = tab5_mode_resolve(s_int_tier, s_voi_tier, s_aut_tier,
-                                         NULL, 0);
-    uint8_t live_mode = tab5_settings_get_voice_mode();
-    if (resolved != live_mode) {
-        switch (live_mode) {
-            case 3: /* TinkerClaw / Agent */
-                s_aut_tier = 1;
-                /* leave int/voi alone -- agent wins */
-                break;
-            case 2: /* Full Cloud */
-                s_int_tier = 2; s_voi_tier = 2; s_aut_tier = 0;
-                break;
-            case 1: /* Hybrid */
-                s_int_tier = 1; s_voi_tier = 2; s_aut_tier = 0;
-                break;
-            case 0: /* Local */
-            default:
-                s_int_tier = 0; s_voi_tier = 0; s_aut_tier = 0;
-                break;
-        }
-        ESP_LOGI(TAG, "Dial sheet tiers resynced to live mode %d -> int=%d voi=%d aut=%d",
-                 live_mode, s_int_tier, s_voi_tier, s_aut_tier);
-    } else {
-        ESP_LOGI(TAG, "Opening dial sheet (int=%d voi=%d aut=%d)",
-                 s_int_tier, s_voi_tier, s_aut_tier);
-    }
+    /* TT #724 (3.3): the picker no longer uses the int/voi/aut dials — routing
+     * keys off the persisted vmode, and tab5_mode_resolve stays only for the
+     * debug /mode-from-tiers path. No tier resync needed here. */
 
     /* Overlay scrim — fills the screen, dim semi-transparent, tappable
      * to dismiss.  lv_layer_top() keeps it above home + any other screen. */
@@ -744,133 +702,129 @@ void ui_agent_consent_show(void (*on_confirm)(void *ctx),
     s_consent_confirm_cb = on_confirm;
     s_consent_cancel_cb  = on_cancel;
     s_consent_cb_ctx     = ctx;
-    s_pre_consent_aut    = s_aut_tier;  /* irrelevant in cb-mode, but safe */
-    show_agent_consent(s_aut_tier);
+    show_agent_consent();
 }
 
-static void show_agent_consent(uint8_t prev_aut_tier)
-{
-    s_pre_consent_aut = prev_aut_tier;
+static void show_agent_consent(void) {
+   /* Scrim over the whole screen (on top layer so it covers the sheet
+    * plus any transient chrome). */
+   s_consent_overlay = lv_obj_create(lv_layer_top());
+   lv_obj_remove_style_all(s_consent_overlay);
+   lv_obj_set_size(s_consent_overlay, MS_W, MS_H);
+   lv_obj_set_pos(s_consent_overlay, 0, 0);
+   lv_obj_set_style_bg_color(s_consent_overlay, lv_color_hex(0x000000), 0);
+   lv_obj_set_style_bg_opa(s_consent_overlay, 200, 0);
+   lv_obj_clear_flag(s_consent_overlay, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(s_consent_overlay, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_add_event_cb(s_consent_overlay, consent_scrim_cb, LV_EVENT_CLICKED, NULL);
 
-    /* Scrim over the whole screen (on top layer so it covers the sheet
-     * plus any transient chrome). */
-    s_consent_overlay = lv_obj_create(lv_layer_top());
-    lv_obj_remove_style_all(s_consent_overlay);
-    lv_obj_set_size(s_consent_overlay, MS_W, MS_H);
-    lv_obj_set_pos(s_consent_overlay, 0, 0);
-    lv_obj_set_style_bg_color(s_consent_overlay, lv_color_hex(0x000000), 0);
-    lv_obj_set_style_bg_opa(s_consent_overlay, 200, 0);
-    lv_obj_clear_flag(s_consent_overlay, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_add_flag(s_consent_overlay, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_add_event_cb(s_consent_overlay, consent_scrim_cb, LV_EVENT_CLICKED, NULL);
+   /* Card — centered, tall enough for 4 bullets + 2 buttons. */
+   lv_obj_t *card = lv_obj_create(s_consent_overlay);
+   lv_obj_remove_style_all(card);
+   lv_obj_set_size(card, 640, 780);
+   lv_obj_align(card, LV_ALIGN_CENTER, 0, 0);
+   lv_obj_set_style_bg_color(card, lv_color_hex(0x13131F), 0);
+   lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(card, 24, 0);
+   lv_obj_set_style_border_width(card, 2, 0);
+   lv_obj_set_style_border_color(card, lv_color_hex(0xA78BFA), 0);
+   lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
 
-    /* Card — centered, tall enough for 4 bullets + 2 buttons. */
-    lv_obj_t *card = lv_obj_create(s_consent_overlay);
-    lv_obj_remove_style_all(card);
-    lv_obj_set_size(card, 640, 780);
-    lv_obj_align(card, LV_ALIGN_CENTER, 0, 0);
-    lv_obj_set_style_bg_color(card, lv_color_hex(0x13131F), 0);
-    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
-    lv_obj_set_style_radius(card, 24, 0);
-    lv_obj_set_style_border_width(card, 2, 0);
-    lv_obj_set_style_border_color(card, lv_color_hex(0xA78BFA), 0);
-    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+   /* Violet accent bar top. */
+   lv_obj_t *bar = lv_obj_create(card);
+   lv_obj_remove_style_all(bar);
+   lv_obj_set_size(bar, 140, 4);
+   lv_obj_set_pos(bar, 36, 32);
+   lv_obj_set_style_bg_color(bar, lv_color_hex(0xA78BFA), 0);
+   lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(bar, 2, 0);
 
-    /* Violet accent bar top. */
-    lv_obj_t *bar = lv_obj_create(card);
-    lv_obj_remove_style_all(bar);
-    lv_obj_set_size(bar, 140, 4);
-    lv_obj_set_pos(bar, 36, 32);
-    lv_obj_set_style_bg_color(bar, lv_color_hex(0xA78BFA), 0);
-    lv_obj_set_style_bg_opa(bar, LV_OPA_COVER, 0);
-    lv_obj_set_style_radius(bar, 2, 0);
+   /* Kicker */
+   lv_obj_t *kicker = lv_label_create(card);
+   lv_label_set_text(kicker, "\xe2\x80\xa2 AGENT MODE");
+   lv_obj_set_style_text_font(kicker, FONT_SMALL, 0);
+   lv_obj_set_style_text_color(kicker, lv_color_hex(0xA78BFA), 0);
+   lv_obj_set_style_text_letter_space(kicker, 4, 0);
+   lv_obj_set_pos(kicker, 36, 52);
 
-    /* Kicker */
-    lv_obj_t *kicker = lv_label_create(card);
-    lv_label_set_text(kicker, "\xe2\x80\xa2 AGENT MODE");
-    lv_obj_set_style_text_font(kicker, FONT_SMALL, 0);
-    lv_obj_set_style_text_color(kicker, lv_color_hex(0xA78BFA), 0);
-    lv_obj_set_style_text_letter_space(kicker, 4, 0);
-    lv_obj_set_pos(kicker, 36, 52);
+   /* Title */
+   lv_obj_t *title = lv_label_create(card);
+   lv_label_set_text(title, "Switch to Agent?");
+   lv_obj_set_style_text_font(title, FONT_TITLE, 0);
+   lv_obj_set_style_text_color(title, lv_color_hex(TH_TEXT_PRIMARY), 0);
+   lv_obj_set_pos(title, 36, 80);
 
-    /* Title */
-    lv_obj_t *title = lv_label_create(card);
-    lv_label_set_text(title, "Switch to Agent?");
-    lv_obj_set_style_text_font(title, FONT_TITLE, 0);
-    lv_obj_set_style_text_color(title, lv_color_hex(TH_TEXT_PRIMARY), 0);
-    lv_obj_set_pos(title, 36, 80);
+   /* Subtitle */
+   lv_obj_t *sub = lv_label_create(card);
+   lv_label_set_text(sub, "This changes how she thinks about you.");
+   lv_obj_set_style_text_font(sub, FONT_BODY, 0);
+   lv_obj_set_style_text_color(sub, lv_color_hex(TH_TEXT_DIM), 0);
+   lv_obj_set_pos(sub, 36, 128);
 
-    /* Subtitle */
-    lv_obj_t *sub = lv_label_create(card);
-    lv_label_set_text(sub, "This changes how she thinks about you.");
-    lv_obj_set_style_text_font(sub, FONT_BODY, 0);
-    lv_obj_set_style_text_color(sub, lv_color_hex(TH_TEXT_DIM), 0);
-    lv_obj_set_pos(sub, 36, 128);
+   /* Bullets — 4 items, each a row with a violet dot + text label. */
+   const char *bullets[4] = {
+       "Your on-device memory is NOT injected.\nAgent runs from the gateway's own context.",
+       "Tools drive the turn - search, calendar,\ninbox, etc. - not your recall of facts.",
+       "All routed through the TinkerClaw gateway.\nLatency is higher; responses can run 30-60s.",
+       "Billing flows through the gateway tier,\nnot your daily cap here.",
+   };
+   int y = 180;
+   for (int i = 0; i < 4; i++) {
+      lv_obj_t *dot = lv_obj_create(card);
+      lv_obj_remove_style_all(dot);
+      lv_obj_set_size(dot, 8, 8);
+      lv_obj_set_pos(dot, 36, y + 8);
+      lv_obj_set_style_bg_color(dot, lv_color_hex(0xA78BFA), 0);
+      lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+      lv_obj_set_style_radius(dot, 4, 0);
 
-    /* Bullets — 4 items, each a row with a violet dot + text label. */
-    const char *bullets[4] = {
-        "Your on-device memory is NOT injected.\nAgent runs from the gateway's own context.",
-        "Tools drive the turn - search, calendar,\ninbox, etc. - not your recall of facts.",
-        "All routed through the TinkerClaw gateway.\nLatency is higher; responses can run 30-60s.",
-        "Billing flows through the gateway tier,\nnot your daily cap here.",
-    };
-    int y = 180;
-    for (int i = 0; i < 4; i++) {
-        lv_obj_t *dot = lv_obj_create(card);
-        lv_obj_remove_style_all(dot);
-        lv_obj_set_size(dot, 8, 8);
-        lv_obj_set_pos(dot, 36, y + 8);
-        lv_obj_set_style_bg_color(dot, lv_color_hex(0xA78BFA), 0);
-        lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
-        lv_obj_set_style_radius(dot, 4, 0);
+      lv_obj_t *txt = lv_label_create(card);
+      lv_label_set_text(txt, bullets[i]);
+      lv_obj_set_style_text_font(txt, FONT_BODY, 0);
+      lv_obj_set_style_text_color(txt, lv_color_hex(TH_TEXT_PRIMARY), 0);
+      lv_obj_set_style_text_line_space(txt, 4, 0);
+      lv_obj_set_width(txt, 540);
+      lv_obj_set_pos(txt, 60, y);
+      y += 100;
+   }
 
-        lv_obj_t *txt = lv_label_create(card);
-        lv_label_set_text(txt, bullets[i]);
-        lv_obj_set_style_text_font(txt, FONT_BODY, 0);
-        lv_obj_set_style_text_color(txt, lv_color_hex(TH_TEXT_PRIMARY), 0);
-        lv_obj_set_style_text_line_space(txt, 4, 0);
-        lv_obj_set_width(txt, 540);
-        lv_obj_set_pos(txt, 60, y);
-        y += 100;
-    }
+   /* Primary button: Switch to Agent (violet fill). */
+   lv_obj_t *confirm = lv_obj_create(card);
+   lv_obj_remove_style_all(confirm);
+   lv_obj_set_size(confirm, 568, 64);
+   lv_obj_set_pos(confirm, 36, 620);
+   lv_obj_set_style_bg_color(confirm, lv_color_hex(0xA78BFA), 0);
+   lv_obj_set_style_bg_opa(confirm, LV_OPA_COVER, 0);
+   lv_obj_set_style_radius(confirm, 32, 0);
+   lv_obj_set_style_border_width(confirm, 0, 0);
+   lv_obj_clear_flag(confirm, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(confirm, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_add_event_cb(confirm, consent_confirm_cb, LV_EVENT_CLICKED, NULL);
 
-    /* Primary button: Switch to Agent (violet fill). */
-    lv_obj_t *confirm = lv_obj_create(card);
-    lv_obj_remove_style_all(confirm);
-    lv_obj_set_size(confirm, 568, 64);
-    lv_obj_set_pos(confirm, 36, 620);
-    lv_obj_set_style_bg_color(confirm, lv_color_hex(0xA78BFA), 0);
-    lv_obj_set_style_bg_opa(confirm, LV_OPA_COVER, 0);
-    lv_obj_set_style_radius(confirm, 32, 0);
-    lv_obj_set_style_border_width(confirm, 0, 0);
-    lv_obj_clear_flag(confirm, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_add_flag(confirm, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_add_event_cb(confirm, consent_confirm_cb, LV_EVENT_CLICKED, NULL);
+   lv_obj_t *confirm_lbl = lv_label_create(confirm);
+   lv_label_set_text(confirm_lbl, "Switch to Agent");
+   lv_obj_set_style_text_font(confirm_lbl, FONT_HEADING, 0);
+   lv_obj_set_style_text_color(confirm_lbl, lv_color_hex(0x08080E), 0);
+   lv_obj_center(confirm_lbl);
 
-    lv_obj_t *confirm_lbl = lv_label_create(confirm);
-    lv_label_set_text(confirm_lbl, "Switch to Agent");
-    lv_obj_set_style_text_font(confirm_lbl, FONT_HEADING, 0);
-    lv_obj_set_style_text_color(confirm_lbl, lv_color_hex(0x08080E), 0);
-    lv_obj_center(confirm_lbl);
+   /* Secondary button: Keep Ask mode (ghost / outlined). */
+   lv_obj_t *cancel = lv_obj_create(card);
+   lv_obj_remove_style_all(cancel);
+   lv_obj_set_size(cancel, 568, 64);
+   lv_obj_set_pos(cancel, 36, 694);
+   lv_obj_set_style_bg_opa(cancel, LV_OPA_TRANSP, 0);
+   lv_obj_set_style_border_width(cancel, 1, 0);
+   lv_obj_set_style_border_color(cancel, lv_color_hex(0x2A2A3A), 0);
+   lv_obj_set_style_radius(cancel, 32, 0);
+   lv_obj_clear_flag(cancel, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_add_flag(cancel, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_add_event_cb(cancel, consent_cancel_cb, LV_EVENT_CLICKED, NULL);
 
-    /* Secondary button: Keep Ask mode (ghost / outlined). */
-    lv_obj_t *cancel = lv_obj_create(card);
-    lv_obj_remove_style_all(cancel);
-    lv_obj_set_size(cancel, 568, 64);
-    lv_obj_set_pos(cancel, 36, 694);
-    lv_obj_set_style_bg_opa(cancel, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(cancel, 1, 0);
-    lv_obj_set_style_border_color(cancel, lv_color_hex(0x2A2A3A), 0);
-    lv_obj_set_style_radius(cancel, 32, 0);
-    lv_obj_clear_flag(cancel, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_add_flag(cancel, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_add_event_cb(cancel, consent_cancel_cb, LV_EVENT_CLICKED, NULL);
-
-    lv_obj_t *cancel_lbl = lv_label_create(cancel);
-    lv_label_set_text(cancel_lbl, "Keep Ask mode");
-    lv_obj_set_style_text_font(cancel_lbl, FONT_BODY, 0);
-    lv_obj_set_style_text_color(cancel_lbl, lv_color_hex(TH_TEXT_DIM), 0);
-    lv_obj_center(cancel_lbl);
+   lv_obj_t *cancel_lbl = lv_label_create(cancel);
+   lv_label_set_text(cancel_lbl, "Keep Ask mode");
+   lv_obj_set_style_text_font(cancel_lbl, FONT_BODY, 0);
+   lv_obj_set_style_text_color(cancel_lbl, lv_color_hex(TH_TEXT_DIM), 0);
+   lv_obj_center(cancel_lbl);
 }
 
 static void done_click_cb(lv_event_t *e)

--- a/main/ui_mode_sheet.h
+++ b/main/ui_mode_sheet.h
@@ -27,6 +27,11 @@ void ui_mode_sheet_hide(void);
 /* Returns true if the sheet is currently visible. */
 bool ui_mode_sheet_visible(void);
 
+/* TT #724 (3.4): true when an Advanced-drawer override is active (engine pin
+ * other than AUTO, or privacy lock on) — i.e. the effective route may differ
+ * from the plain mode default. Drives the " · modified" mode-chip suffix. */
+bool ui_mode_sheet_is_modified(void);
+
 /* Show the Agent-mode consent modal standalone — for callers outside the
  * mode sheet (e.g. the Settings TinkerClaw row). On Switch: on_confirm is
  * invoked. On Keep Ask / scrim-dismiss: on_cancel is invoked (may be NULL

--- a/main/ui_settings.c
+++ b/main/ui_settings.c
@@ -96,24 +96,6 @@ static inline void feed_wdt(void) {
 #define TAB_TINKERCLAW 0xF43F5E
 #define TAB_ONBOARD 0x8E5BFF /* P5b: violet — distinct from existing four */
 
-/* TT #328 Wave 13 — tap callback for the K144 health chip on the Onboard
- * voice-mode row.  Triggers voice_onboard_reset_failover() which sends
- * sys.reset to the K144 daemon + re-runs the warmup probe.  Pre-Wave-13
- * the chip was display-only; the user had no software path to escape an
- * UNAVAILABLE state without rebooting Tab5. */
-static void k144_chip_tap_cb(lv_event_t *e) {
-   (void)e;
-   extern esp_err_t voice_onboard_reset_failover(void);
-   extern void ui_home_show_toast(const char *msg);
-   esp_err_t qe = voice_onboard_reset_failover();
-   if (qe == ESP_OK) {
-      ui_home_show_toast("Re-probing K144…");
-   } else {
-      /* Already in flight — be honest. */
-      ui_home_show_toast("K144 probe already running — try again in a few sec");
-   }
-}
-
 /* TT #328 Wave 14 — K144 hardware gauge.  Small label below the chip
  * showing NPU temperature + load + StackFlow daemon version.
  * Wave 15 extends this with a model inventory line summarising the
@@ -354,8 +336,6 @@ static lv_timer_t *s_vol_save_timer    = NULL;
 /* Voice tab system */
 /* v5: five flat radio rows (no tabs).  Indexed by voice_mode.
  * Row 4 = Onboard (K144 stacked LLM via Mate carrier) — added in TT #317 P5b. */
-static lv_obj_t *s_mode_row[5] = {NULL, NULL, NULL, NULL, NULL};
-static lv_obj_t *s_mode_row_dot[5] = {NULL, NULL, NULL, NULL, NULL};
 /* Back-compat pointers kept = NULL so legacy references compile. */
 static lv_obj_t *s_tab_local      = NULL;
 static lv_obj_t *s_tab_hybrid     = NULL;
@@ -369,54 +349,6 @@ static lv_obj_t *s_hybrid_content[4] = {NULL};
 static lv_obj_t *s_cloud_content[4]  = {NULL};
 static lv_obj_t *s_tinkerclaw_card   = NULL;
 static lv_obj_t *s_tinkerclaw_content[4] = {NULL};
-static uint8_t   s_active_tab     = 0;
-
-/* TT #328 Wave 4 — Cloud LLM picker.
- *
- * Pre-Wave-4 the Cloud row's description showed the live llm_model
- * NVS value as a read-only suffix; Settings had no UI to actually
- * choose between cloud models.  Users had to SSH Dragon and edit
- * config.yaml to switch between Haiku / Sonnet / GPT-4o / etc.
- *
- * Wave 4 adds a curated 5-chip picker rendered just below the mode
- * rows.  Tap a chip → write NVS llm_mdl + send config_update so
- * Dragon hot-swaps the backend.  Always visible (not gated on Cloud
- * being the active tab) so users can pre-select a model before
- * flipping to Cloud.  Selected chip gets the same amber-wash style
- * the active mode row uses for visual continuity.
- *
- * Selection of which models to expose: refreshed 2026-05-10 against
- * the live OpenRouter catalog (367 models).  Provider diversity +
- * tier coverage; rolling-alias `~` IDs let OpenRouter auto-pick the
- * latest dated revision so the picker doesn't rot.
- *   - Opus 4.7   : Anthropic flagship reasoning, Jan-2026 cutoff
- *   - Sonnet 4.6 : quality vision, mid-cost (workhorse)
- *   - Haiku      : rolling-latest cheap text+vision+tools
- *   - GPT-5.5    : OpenAI flagship
- *   - GPT-5.4 m  : OpenAI budget tier
- *   - Gemini Pro : rolling-latest Google flagship (1M ctx)
- *   - Gemini 3.1 : fastest cheap multimodal
- *   - Grok 4.3   : xAI latest
- *
- * Adding more models later = grow the array; UI re-flows automatically. */
-typedef struct {
-   const char *short_label; /* fits in chip ~120 px wide */
-   const char *full_label;  /* shown as description under chip */
-   const char *model_id;    /* what we send to Dragon as llm_model */
-} cloud_model_spec_t;
-static const cloud_model_spec_t s_cloud_models[] = {
-    {"Opus 4.7", "claude-opus-4.7", "anthropic/claude-opus-4.7"},
-    {"Sonnet", "claude-sonnet-4.6", "anthropic/claude-sonnet-4.6"},
-    {"Haiku", "claude-haiku-latest", "~anthropic/claude-haiku-latest"},
-    {"GPT-5.5", "gpt-5.5", "openai/gpt-5.5"},
-    {"GPT-5.4 m", "gpt-5.4-mini", "openai/gpt-5.4-mini"},
-    {"Gemini Pro", "gemini-pro-latest", "~google/gemini-pro-latest"},
-    {"Gemini 3.1", "gemini-3.1-flash-lite", "google/gemini-3.1-flash-lite"},
-    {"Grok 4.3", "grok-4.3", "x-ai/grok-4.3"},
-};
-#define CLOUD_MODEL_COUNT (sizeof(s_cloud_models) / sizeof(s_cloud_models[0]))
-static lv_obj_t *s_model_chip[CLOUD_MODEL_COUNT] = {NULL};
-static int s_active_model_idx = -1; /* -1 = current NVS value not in our curated list */
 
 /* Cap Wave 4 (TT #642) — LLM engine override chips + STT/TTS status
  * labels.  Three chips (AUTO / K144 / OPENROUTER) directly under the
@@ -747,172 +679,7 @@ static void cb_autorotate(lv_event_t *e)
     }
 }
 
-/* ── Voice mode logic ───────────────────────────────────────────────── */
-
-static void send_voice_config(void)
-{
-    uint8_t mode = tab5_settings_get_voice_mode();
-    char model[64] = {0};
-    tab5_settings_get_llm_model(model, sizeof(model));
-    ESP_LOGI(TAG, "Sending voice config: mode=%d model=%s", mode, model);
-
-    if (!voice_is_connected()) {
-        ESP_LOGW(TAG, "Voice not connected — config will apply on reconnect");
-        return;
-    }
-
-    esp_err_t err = voice_send_config_update((int)mode, model);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to send voice config: %s", esp_err_to_name(err));
-    }
-}
-
-static void _mode_row_style(lv_obj_t *row, bool selected)
-{
-    if (!row) return;
-    if (selected) {
-        /* Amber left bar + faint amber wash. Spec shot-09. */
-        lv_obj_set_style_border_side(row, LV_BORDER_SIDE_LEFT, 0);
-        lv_obj_set_style_border_width(row, 3, 0);
-        lv_obj_set_style_border_color(row, lv_color_hex(AMBER), 0);
-        lv_obj_set_style_border_opa(row, LV_OPA_COVER, 0);
-        lv_obj_set_style_bg_color(row, lv_color_hex(AMBER), 0);
-        lv_obj_set_style_bg_opa(row, 10, 0);  /* ~4 % amber wash */
-    } else {
-        lv_obj_set_style_border_width(row, 0, 0);
-        lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
-    }
-}
-
-static void voice_tab_switch(uint8_t new_tab)
-{
-    if (new_tab == s_active_tab) return;
-    if (new_tab > 4) return;
-    _mode_row_style(s_mode_row[s_active_tab], false);
-    _mode_row_style(s_mode_row[new_tab], true);
-    s_active_tab = new_tab;
-    tab5_settings_set_voice_mode(new_tab);
-    ESP_LOGI(TAG, "Voice mode: %d (%s)", new_tab,
-             new_tab == 0   ? "local"
-             : new_tab == 1 ? "hybrid"
-             : new_tab == 2 ? "cloud"
-             : new_tab == 3 ? "tinkerclaw"
-                            : "onboard");
-    /* W3-B (cross-stack cohesion audit 2026-05-11): pre-W3-A this
-     * branched mode 4 (ONBOARD) into a clamp-to-0 path because Dragon
-     * would error-revert on unknown vmode=4.  After W3-A (TinkerBox
-     * PR #274) Dragon recognises ONBOARD + SOLO cleanly via
-     * select_backends_for_mode; the clamp is no longer needed. */
-    send_voice_config();
-}
-
-/* Audit E3 (2026-04-20): tapping TinkerClaw from Settings used to hot-switch
- * into voice_mode=3 with zero guardrails — the easiest path to the memory-
- * bypass boundary had the weakest consent.  The mode sheet has always shown
- * a modal before the same switch; Settings now reuses it via
- * ui_agent_consent_show(). Consent-mode switch deferred until confirm. */
-static void consent_confirm_tc_cb(void *ctx)
-{
-    (void)ctx;
-    voice_tab_switch(3);
-}
-
-static void consent_cancel_tc_cb(void *ctx)
-{
-    (void)ctx;
-    /* No-op — voice_tab_switch never ran, so nothing to revert. */
-}
-
-/* TT #328 Wave 4 — model-chip styling.  Mirrors _mode_row_style so
- * the picker reads as part of the same composition. */
-static void _model_chip_style(lv_obj_t *chip, bool selected) {
-   if (!chip) return;
-   if (selected) {
-      lv_obj_set_style_border_width(chip, 2, 0);
-      lv_obj_set_style_border_color(chip, lv_color_hex(AMBER), 0);
-      lv_obj_set_style_border_opa(chip, LV_OPA_COVER, 0);
-      lv_obj_set_style_bg_color(chip, lv_color_hex(AMBER), 0);
-      lv_obj_set_style_bg_opa(chip, 18, 0); /* ~7 % wash */
-   } else {
-      lv_obj_set_style_border_width(chip, 1, 0);
-      lv_obj_set_style_border_color(chip, lv_color_hex(0x1E1E2A), 0);
-      lv_obj_set_style_border_opa(chip, LV_OPA_COVER, 0);
-      lv_obj_set_style_bg_opa(chip, LV_OPA_TRANSP, 0);
-   }
-}
-
-/* TT #328 Wave 4 — repaint the Cloud-row description so it reflects
- * the freshly-picked model.  s_mode_row[2] is the Cloud row; child
- * label index 2 is the description (idx 0 = dot, idx 1 = name). */
-static void _cloud_row_refresh_desc(void) {
-   if (s_active_model_idx < 0 || s_active_model_idx >= (int)CLOUD_MODEL_COUNT) return;
-   if (!s_mode_row[2]) return;
-   /* The description is the second LABEL child of the row.  Linear
-    * scan because rows host the dot + 2 labels and we don't store
-    * the label pointer directly. */
-   int label_seen = 0;
-   int n = lv_obj_get_child_count(s_mode_row[2]);
-   for (int i = 0; i < n; i++) {
-      lv_obj_t *c = lv_obj_get_child(s_mode_row[2], i);
-      if (!lv_obj_check_type(c, &lv_label_class)) continue;
-      if (label_seen == 1) {
-         lv_label_set_text(c, s_cloud_models[s_active_model_idx].full_label);
-         return;
-      }
-      label_seen++;
-   }
-}
-
-/* TT #328 Wave 4 — model-chip tap handler. */
-static void cb_model_pick(lv_event_t *e) {
-   intptr_t idx = (intptr_t)lv_event_get_user_data(e);
-   if (idx < 0 || idx >= (int)CLOUD_MODEL_COUNT) return;
-   if (idx == s_active_model_idx) return; /* no-op tap */
-
-   /* Persist + send to Dragon. */
-   tab5_settings_set_llm_model(s_cloud_models[idx].model_id);
-   ESP_LOGI(TAG, "Wave 4: picked cloud model %s (%s)", s_cloud_models[idx].short_label, s_cloud_models[idx].model_id);
-
-   /* Repaint chips (deselect old, select new) */
-   if (s_active_model_idx >= 0) _model_chip_style(s_model_chip[s_active_model_idx], false);
-   s_active_model_idx = (int)idx;
-   _model_chip_style(s_model_chip[idx], true);
-
-   /* Cloud-row description refresh + send config_update.  The
-    * config_update is a no-op when Dragon WS is down (logged + skipped
-    * in send_voice_config); the NVS value still persists so the next
-    * connect picks it up via session_start. */
-   _cloud_row_refresh_desc();
-   send_voice_config();
-}
-
 /* ── Cap Wave 4 (TT #642): LLM engine chip styling + handlers ──────── */
-
-static const char *_eng_chip_label(int idx) {
-   switch (idx) {
-      case LLM_ENG_AUTO:
-         return "AUTO";
-      case LLM_ENG_K144:
-         return "K144";
-      case LLM_ENG_OPENROUTER:
-         return "OPENROUTER";
-      default:
-         return "?";
-   }
-}
-
-static const char *_eng_chip_short(int idx) {
-   switch (idx) {
-      case LLM_ENG_AUTO:
-         return "auto";
-      case LLM_ENG_K144:
-         return "k144";
-      case LLM_ENG_OPENROUTER:
-         return "openrouter";
-      default:
-         return "?";
-   }
-}
 
 /* True when the engine chip should accept taps; AUTO is always
  * enabled; K144 needs failover_state==READY; OPENROUTER needs or_key. */
@@ -943,27 +710,6 @@ static void _eng_chip_style(lv_obj_t *chip, bool selected, bool enabled) {
    }
    /* Grey text + reduced opacity when unreachable; reads as "disabled". */
    lv_obj_set_style_opa(chip, enabled ? LV_OPA_COVER : LV_OPA_40, 0);
-}
-
-static void cb_engine_pick(lv_event_t *e) {
-   intptr_t idx = (intptr_t)lv_event_get_user_data(e);
-   if (idx < 0 || idx >= LLM_ENG_COUNT) return;
-   bool enabled = _eng_chip_enabled((int)idx);
-   if (!enabled) {
-      tab5_debug_obs_event("eng.llm", "tap_unavailable");
-      return;
-   }
-   uint8_t prev = tab5_settings_get_llm_engine();
-   if ((uint8_t)idx == prev) return;
-   tab5_settings_set_llm_engine((uint8_t)idx);
-   ESP_LOGI(TAG, "Wave 4: llm_engine override → %s", _eng_chip_short((int)idx));
-   tab5_debug_obs_event("eng.llm", _eng_chip_short((int)idx));
-   /* Repaint chips (deselect old, select new). */
-   for (int i = 0; i < LLM_ENG_COUNT; i++) {
-      if (s_eng_chip[i]) {
-         _eng_chip_style(s_eng_chip[i], i == (int)idx, _eng_chip_enabled(i));
-      }
-   }
 }
 
 /* Map current vmode to a human-readable STT/TTS engine string.  Called
@@ -1004,20 +750,12 @@ static const char *_tts_engine_label(uint8_t vmode, uint8_t llm_eng) {
    }
 }
 
-/* Single click handler for all 5 radio rows. Mode index comes via user_data. */
-static void cb_tab_local(lv_event_t *e)
-{
-    intptr_t idx = (intptr_t)lv_event_get_user_data(e);
-    if (idx < 0 || idx >= 5) return;
-    if ((uint8_t)idx == 3 && s_active_tab != 3) {
-        /* Going from any mode -> Agent: gate the switch behind the consent
-         * modal.  If already on Agent the tap is a no-op and no modal is
-         * needed (no tier change). */
-        extern void ui_agent_consent_show(void (*)(void *), void (*)(void *), void *);
-        ui_agent_consent_show(consent_confirm_tc_cb, consent_cancel_tc_cb, NULL);
-        return;
-    }
-    voice_tab_switch((uint8_t)idx);
+/* TT #724 (3.2): the read-only mode row opens the picker — the single mode
+ * authority. Settings no longer hosts a second radio. */
+static void cb_open_mode_picker(lv_event_t *e) {
+   (void)e;
+   extern void ui_mode_sheet_show(void);
+   ui_mode_sheet_show();
 }
 
 static void cb_mic_mute(lv_event_t *e)
@@ -1861,308 +1599,54 @@ lv_obj_t *ui_settings_create(void)
     int s_voice_section_top = y;
     y = mk_section(s_scroll, "VOICE MODE", acc_voice, y);
 
-    /* v5 flat vertical radio rows. Each row = colored dot + name + desc;
-     * selected row gets an amber left bar + faint amber wash. */
-    s_active_tab = tab5_settings_get_voice_mode();
-    if (s_active_tab > 4) s_active_tab = 0;
+    /* TT #724 (3.2/3.5): the picker is the single mode authority now. Settings
+     * shows a read-only current-mode row that opens it; the old radio plus the
+     * ENGINES + CLOUD LLM pickers moved into the picker (Advanced drawer). */
     {
-       /* TT #723: names from th_mode_names (single source). Solo (vmode 5) is
-        * intentionally still omitted from this radio — it's added properly in
-        * the Wave 3 picker redesign. */
-       /* Cloud description reflects the LIVE llm_model from NVS so the
-        * row doesn't lie when the user has picked, say, gemini or gpt-4o
-        * instead of the original Claude default.  Condensed to the short
-        * form ("gemini-3-flash-preview" -> "gemini-3-flash-preview"
-        * truncated to fit the row). */
-       char cloud_desc[48] = "Cloud LLM";
-       {
-          char lm[64] = {0};
-          tab5_settings_get_llm_model(lm, sizeof(lm));
-          if (lm[0]) {
-             const char *slash = strchr(lm, '/');
-             const char *tail = slash ? slash + 1 : lm;
-             snprintf(cloud_desc, sizeof(cloud_desc), "%.47s", tail);
-          }
-       }
-       const char *mode_descs[5] = {
-           "Moonshine \xe2\x80\xa2 NPU",           "Cloud STT/TTS", cloud_desc, "Agents \xe2\x80\xa2 Memory",
-           "On-device LLM \xe2\x80\xa2 No Dragon", /* TT #723: was "K144" (brand leak) */
-       };
-       static const uint32_t mode_dot_col[5] = {
-           TAB_LOCAL, TAB_HYBRID, TAB_CLOUD, TAB_TINKERCLAW, TAB_ONBOARD,
-       };
-       const int row_h = 64;
-       const int row_w = CONTENT_W;
-       for (int i = 0; i < 5; i++) {
-          lv_obj_t *row = lv_obj_create(s_scroll);
-          lv_obj_remove_style_all(row);
-          lv_obj_set_pos(row, SIDE_PAD, y + i * (row_h + 2));
-          lv_obj_set_size(row, row_w, row_h);
-          lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
-          lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE);
-          lv_obj_add_event_cb(row, cb_tab_local, LV_EVENT_CLICKED, (void *)(intptr_t)i);
-          if (i < 4) {
-             lv_obj_set_style_border_color(row, lv_color_hex(HAIR_COLOR), 0);
-          }
-          lv_obj_t *dot = lv_obj_create(row);
-          lv_obj_remove_style_all(dot);
-          lv_obj_set_size(dot, 10, 10);
-          lv_obj_set_pos(dot, 18, (row_h - 10) / 2);
-          lv_obj_set_style_bg_color(dot, lv_color_hex(mode_dot_col[i]), 0);
-          lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
-          lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
-          lv_obj_t *nm = lv_label_create(row);
-          lv_label_set_text(nm, th_mode_names[i]);
-          lv_obj_set_style_text_font(nm, FONT_BODY, 0);
-          lv_obj_set_style_text_color(nm, lv_color_hex(TEXT_PRIMARY), 0);
-          lv_obj_set_pos(nm, 44, 12);
-          lv_obj_t *dc = lv_label_create(row);
-          lv_label_set_text(dc, mode_descs[i]);
-          lv_obj_set_style_text_font(dc, FONT_SMALL, 0);
-          lv_obj_set_style_text_color(dc, lv_color_hex(TEXT_DIM), 0);
-          lv_obj_set_style_text_letter_space(dc, 2, 0);
-          lv_obj_set_pos(dc, 44, 38);
-          s_mode_row[i] = row;
-          s_mode_row_dot[i] = dot;
+       extern const uint32_t th_mode_colors[];
+       uint8_t vm = tab5_settings_get_voice_mode();
+       if (vm >= VOICE_MODE_COUNT) vm = 0;
 
-          /* TT #328 Wave 7 — health chip for the Onboard row.  Pre-Wave-7
-           * the user could tap the Onboard radio with no idea whether
-           * K144 was actually warm; the row would silently switch and
-           * the user would discover failure mid-turn.  Render the
-           * voice_onboard_failover_state() as a small right-aligned
-           * pill on row index 4 only (other modes don't have a
-           * comparable health gate that benefits from this surface).
-           *
-           * TT #328 Wave 13 — the chip is now tappable + triggers a
-           * software reset of the K144 daemon (sys.reset + re-warmup).
-           * Pre-Wave-13 there was no way to escape an UNAVAILABLE
-           * state without rebooting Tab5 itself. */
-          if (i == 4) {
-             /* Wave 16 — track the chip widget at file scope so
-              * `ui_settings_update()` can re-render its label/color
-              * when the failover state transitions during a Settings-
-              * hidden interval.  refresh_k144_chip() handles ALL
-              * label/color logic + the worker-fetch trigger; we just
-              * place + style the widget here.  Pre-Wave-16 the chip
-              * was a local var captured at first build and never
-              * updated, so a Tab5 navigated away during UNAVAILABLE
-              * and back after recovery showed the stale red chip
-              * until a full Tab5 reboot. */
-             lv_obj_t *chip = lv_label_create(row);
-             s_k144_chip_lbl = chip;
-             s_k144_last_chip_fs = -1; /* force refresh_k144_chip to run */
-             lv_label_set_text(chip, "—");
-             lv_obj_set_style_text_font(chip, FONT_SMALL, 0);
-             lv_obj_set_style_text_letter_space(chip, 2, 0);
-             /* Right-aligned within the row, centred vertically. */
-             lv_obj_set_pos(chip, row_w - 200, (row_h - 14) / 2);
-             /* Wave 13 — make the chip tappable.  Internal padding
-              * gives ~30 px tall × 200 px wide hit area, generous
-              * enough for fat-fingered users.  Default LVGL 9
-              * doesn't bubble events from a CLICKABLE child to the
-              * parent row, so the tap doesn't also flip the radio
-              * to Onboard mode (which would be confusing). */
-             lv_obj_add_flag(chip, LV_OBJ_FLAG_CLICKABLE);
-             lv_obj_set_style_pad_all(chip, 8, 0);
-             lv_obj_add_event_cb(chip, k144_chip_tap_cb, LV_EVENT_CLICKED, NULL);
+       lv_obj_t *row = lv_obj_create(s_scroll);
+       lv_obj_remove_style_all(row);
+       lv_obj_set_pos(row, SIDE_PAD, y);
+       lv_obj_set_size(row, CONTENT_W, 64);
+       lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+       lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE);
+       lv_obj_add_event_cb(row, cb_open_mode_picker, LV_EVENT_CLICKED, NULL);
 
-             /* TT #328 Wave 14 — K144 hardware gauge.  Sits below the
-              * chip showing live NPU temp + load + daemon version.
-              * Populated async via tab5_worker job (UART round-trip
-              * is ~150 ms; can't run on LVGL thread).  Pre-fill with
-              * em-dash placeholder so the row layout doesn't shift
-              * when the worker callback lands a few hundred ms later. */
-             s_k144_gauge_lbl = lv_label_create(row);
-             lv_label_set_text(s_k144_gauge_lbl, "—");
-             lv_obj_set_style_text_font(s_k144_gauge_lbl, FONT_SMALL, 0);
-             lv_obj_set_style_text_color(s_k144_gauge_lbl, lv_color_hex(TEXT_DIM), 0);
-             lv_obj_set_style_text_letter_space(s_k144_gauge_lbl, 1, 0);
-             /* Position below the chip (chip is at y=(row_h-14)/2 ≈ 38;
-              * gauge sits ~24 px below — fits inside the 90 px row
-              * without overflowing into the next radio row). */
-             lv_obj_set_pos(s_k144_gauge_lbl, row_w - 240, (row_h - 14) / 2 + 22);
+       lv_obj_t *dot = lv_obj_create(row);
+       lv_obj_remove_style_all(dot);
+       lv_obj_set_size(dot, 10, 10);
+       lv_obj_set_pos(dot, 18, (64 - 10) / 2);
+       lv_obj_set_style_bg_color(dot, lv_color_hex(th_mode_colors[vm]), 0);
+       lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+       lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
 
-             /* TT #328 Wave 15 — model inventory line.  Lives in the
-              * parent scroll container (NOT the row) because row_h=64
-              * is too tight to fit chip + gauge + inventory without
-              * clipping past the row bottom.  Positioned with x=SIDE_PAD
-              * (left-aligned full-width) just below the rows section
-              * by deferring `lv_obj_set_pos` until after the layout
-              * advance below.  See line where `s_k144_models_lbl`
-              * gets repositioned with the final y. */
-             s_k144_models_lbl = lv_label_create(s_scroll);
-             lv_label_set_text(s_k144_models_lbl, "—");
-             lv_obj_set_style_text_font(s_k144_models_lbl, FONT_SMALL, 0);
-             lv_obj_set_style_text_color(s_k144_models_lbl, lv_color_hex(TEXT_DIM), 0);
-             lv_obj_set_style_text_letter_space(s_k144_models_lbl, 1, 0);
-             /* Provisional position; overwritten right below the
-              * VOICE MODE rows are laid out (we know `y` advances
-              * by 5 * (row_h + 2) + 12 there). */
-             lv_obj_set_pos(s_k144_models_lbl, SIDE_PAD, y + 5 * (row_h + 2) - 4);
+       lv_obj_t *nm = lv_label_create(row);
+       lv_label_set_text(nm, th_mode_names[vm]);
+       lv_obj_set_style_text_font(nm, FONT_BODY, 0);
+       lv_obj_set_style_text_color(nm, lv_color_hex(TEXT_PRIMARY), 0);
+       lv_obj_set_pos(nm, 44, 12);
 
-             /* Wave 16 — initial chip render + (when READY) kick off
-              * the worker fetch.  Both responsibilities now live in
-              * refresh_k144_chip so they stay synchronized with the
-              * post-build update path. */
-             refresh_k144_chip();
-          }
+       lv_obj_t *dc = lv_label_create(row);
+       lv_label_set_text(dc, "Tap to choose mode \xe2\x80\xa2 smartness \xe2\x80\xa2 advanced");
+       lv_obj_set_style_text_font(dc, FONT_SMALL, 0);
+       lv_obj_set_style_text_color(dc, lv_color_hex(TEXT_DIM), 0);
+       lv_obj_set_style_text_letter_space(dc, 2, 0);
+       lv_obj_set_pos(dc, 44, 38);
 
-          if (i == s_active_tab) _mode_row_style(row, true);
-          feed_wdt();
-       }
-       y += 5 * (row_h + 2) + 12;
-       /* TT #328 Wave 15 — re-position the inventory label here, where
-        * `y` finally points at the post-rows region.  Advance `y` by
-        * one FONT_SMALL line + 6 px gap so subsequent sections
-        * (CLOUD LLM caption) don't collide with it. */
-       if (s_k144_models_lbl != NULL) {
-          lv_obj_set_pos(s_k144_models_lbl, SIDE_PAD, y - 6);
-          y += 18;
-       }
+       lv_obj_t *chev = lv_label_create(row);
+       lv_label_set_text(chev, ">");
+       lv_obj_set_style_text_font(chev, FONT_BODY, 0);
+       lv_obj_set_style_text_color(chev, lv_color_hex(TEXT_DIM), 0);
+       lv_obj_align(chev, LV_ALIGN_RIGHT_MID, -18, 0);
+
+       y += 64 + 12;
     }
     s_local_card = s_hybrid_card = s_cloud_card = s_tinkerclaw_card = NULL;
-
-    /* TT #328 Wave 4 — Cloud LLM picker chips.
-     * Five horizontal chips below the mode rows.  Always rendered
-     * (not gated on Cloud being active) so users can pre-select a
-     * model before flipping to Cloud.  Selection persists to NVS
-     * llm_mdl + sends config_update to Dragon — Dragon hot-swaps
-     * the OpenRouter backend without a session restart. */
-    {
-       /* Resolve current llm_model NVS value to an index in our
-        * curated list.  -1 means the saved value is something we
-        * don't surface in this picker (legacy / power-user / off-
-        * catalog).  In that case the chip row renders all
-        * unselected, with a small "(custom)" caption above. */
-       char cur_model[64] = {0};
-       tab5_settings_get_llm_model(cur_model, sizeof(cur_model));
-       s_active_model_idx = -1;
-       for (int i = 0; i < (int)CLOUD_MODEL_COUNT; i++) {
-          if (strcmp(cur_model, s_cloud_models[i].model_id) == 0) {
-             s_active_model_idx = i;
-             break;
-          }
-       }
-
-       /* Section caption — reuses the amber accent from the parent
-        * VOICE MODE section, so it reads as a continuation. */
-       lv_obj_t *cap = lv_label_create(s_scroll);
-       lv_label_set_text(cap, s_active_model_idx >= 0 ? "CLOUD LLM" : "CLOUD LLM (custom — tap to override)");
-       lv_obj_set_pos(cap, SIDE_PAD, y);
-       lv_obj_set_style_text_color(cap, lv_color_hex(AMBER), 0);
-       lv_obj_set_style_text_font(cap, FONT_SECONDARY, 0);
-       lv_obj_set_style_text_letter_space(cap, 4, 0);
-       y += 26;
-
-       const int chip_w = (CONTENT_W - 4 * 8) / (int)CLOUD_MODEL_COUNT; /* 4 gaps of 8 px */
-       const int chip_h = 56;
-       const int gap = 8;
-       for (int i = 0; i < (int)CLOUD_MODEL_COUNT; i++) {
-          lv_obj_t *chip = lv_obj_create(s_scroll);
-          lv_obj_remove_style_all(chip);
-          lv_obj_set_size(chip, chip_w, chip_h);
-          lv_obj_set_pos(chip, SIDE_PAD + i * (chip_w + gap), y);
-          lv_obj_set_style_bg_color(chip, lv_color_hex(CARD_COLOR), 0);
-          lv_obj_set_style_bg_opa(chip, LV_OPA_COVER, 0);
-          lv_obj_set_style_radius(chip, 12, 0);
-          lv_obj_set_style_border_width(chip, 1, 0);
-          lv_obj_set_style_border_color(chip, lv_color_hex(0x1E1E2A), 0);
-          lv_obj_clear_flag(chip, LV_OBJ_FLAG_SCROLLABLE);
-          lv_obj_add_flag(chip, LV_OBJ_FLAG_CLICKABLE);
-          lv_obj_add_event_cb(chip, cb_model_pick, LV_EVENT_CLICKED, (void *)(intptr_t)i);
-
-          lv_obj_t *lbl = lv_label_create(chip);
-          lv_label_set_text(lbl, s_cloud_models[i].short_label);
-          lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
-          lv_obj_set_style_text_color(lbl, lv_color_hex(TEXT_PRIMARY), 0);
-          lv_obj_center(lbl);
-
-          s_model_chip[i] = chip;
-          if (i == s_active_model_idx) _model_chip_style(chip, true);
-       }
-       y += chip_h + 16;
-    }
-    /* Card BG for the combined VOICE MODE + CLOUD LLM block (Wave 5
-     * visual reorg).  s_voice_section_top is captured below at the
-     * VOICE MODE section header. */
     mk_card_bg(s_scroll, s_voice_section_top, y);
     y += 24;
-
-    /* ── Cap Wave 4 (TT #642): ENGINES section ─────────────────────
-     *
-     * Sits under the Cloud LLM picker — same amber accent so it reads
-     * as a continuation of VOICE MODE.  Three chips for LLM engine
-     * override (AUTO / K144 / OPENROUTER); two read-only status lines
-     * for STT + TTS so the user can see what each capability is
-     * currently doing under the active vmode.  Greyed chips = backend
-     * unreachable. */
-    int s_engines_section_top = y;
-    {
-       lv_obj_t *cap = lv_label_create(s_scroll);
-       lv_label_set_text(cap, "ENGINES");
-       lv_obj_set_pos(cap, SIDE_PAD, y);
-       lv_obj_set_style_text_color(cap, lv_color_hex(AMBER), 0);
-       lv_obj_set_style_text_font(cap, FONT_SECONDARY, 0);
-       lv_obj_set_style_text_letter_space(cap, 4, 0);
-       y += 26;
-
-       /* "LLM ENGINE" row label + chip row (3 chips). */
-       mk_row_label(s_scroll, "LLM engine", y);
-       const int eng_chip_h = 44;
-       const int eng_chip_w = (CONTENT_W - 2 * 8) / LLM_ENG_COUNT; /* 2 gaps of 8 */
-       uint8_t cur_eng = tab5_settings_get_llm_engine();
-       for (int i = 0; i < LLM_ENG_COUNT; i++) {
-          lv_obj_t *chip = lv_obj_create(s_scroll);
-          lv_obj_remove_style_all(chip);
-          lv_obj_set_size(chip, eng_chip_w, eng_chip_h);
-          lv_obj_set_pos(chip, SIDE_PAD + i * (eng_chip_w + 8), y + ROW_H + 4);
-          lv_obj_set_style_bg_color(chip, lv_color_hex(CARD_COLOR), 0);
-          lv_obj_set_style_bg_opa(chip, LV_OPA_COVER, 0);
-          lv_obj_set_style_radius(chip, 10, 0);
-          lv_obj_set_style_border_width(chip, 1, 0);
-          lv_obj_set_style_border_color(chip, lv_color_hex(0x1E1E2A), 0);
-          lv_obj_clear_flag(chip, LV_OBJ_FLAG_SCROLLABLE);
-          lv_obj_add_flag(chip, LV_OBJ_FLAG_CLICKABLE);
-          lv_obj_add_event_cb(chip, cb_engine_pick, LV_EVENT_CLICKED, (void *)(intptr_t)i);
-
-          lv_obj_t *lbl = lv_label_create(chip);
-          lv_label_set_text(lbl, _eng_chip_label(i));
-          lv_obj_set_style_text_font(lbl, FONT_BODY, 0);
-          lv_obj_set_style_text_color(lbl, lv_color_hex(TEXT_PRIMARY), 0);
-          lv_obj_center(lbl);
-
-          s_eng_chip[i] = chip;
-          _eng_chip_style(chip, i == cur_eng, _eng_chip_enabled(i));
-       }
-       y += ROW_H + 4 + eng_chip_h + 12;
-
-       /* STT engine — read-only status row.  Wave 4b: real chip
-        * picker after Dragon's config_update grows an stt_override
-        * field. */
-       mk_row_label(s_scroll, "STT engine", y);
-       s_eng_stt_lbl = lv_label_create(s_scroll);
-       if (s_eng_stt_lbl) {
-          lv_obj_set_pos(s_eng_stt_lbl, RIGHT_X, y + (ROW_H - 14) / 2);
-          lv_obj_set_style_text_color(s_eng_stt_lbl, lv_color_hex(TEXT_DIM), 0);
-          lv_obj_set_style_text_font(s_eng_stt_lbl, FONT_SECONDARY, 0);
-          lv_label_set_text(s_eng_stt_lbl, _stt_engine_label(tab5_settings_get_voice_mode()));
-       }
-       y += ROW_H + 4;
-
-       /* TTS engine — read-only status row. */
-       mk_row_label(s_scroll, "TTS engine", y);
-       s_eng_tts_lbl = lv_label_create(s_scroll);
-       if (s_eng_tts_lbl) {
-          lv_obj_set_pos(s_eng_tts_lbl, RIGHT_X, y + (ROW_H - 14) / 2);
-          lv_obj_set_style_text_color(s_eng_tts_lbl, lv_color_hex(TEXT_DIM), 0);
-          lv_obj_set_style_text_font(s_eng_tts_lbl, FONT_SECONDARY, 0);
-          lv_label_set_text(s_eng_tts_lbl, _tts_engine_label(tab5_settings_get_voice_mode(), cur_eng));
-       }
-       y += ROW_H + 16;
-    }
-    /* Card BG for ENGINES section (Wave 4 + Wave 5 visual reorg). */
-    mk_card_bg(s_scroll, s_engines_section_top, y);
-    y += 24; /* breathing-room gap before next section */
 
     /* ── Cap Wave 5 (TT #644): PRIVACY section ─────────────────────
      *


### PR DESCRIPTION
## Summary
Rebuilds `ui_mode_sheet.c` from the leaky 3-dial picker into a **mode-primary reason-row picker** (epic #720, Wave 3.2/3.3/3.4 → #724). The picker now sets `vmode` directly for all six modes; routing already keys off `vmode`, so `tab5_mode_resolve`/the dials are retired from the picker UI (left intact for the debug `/mode` endpoint).

- **Reason-row picker** — six mode rows; the selected row expands to show *why you'd pick it* + what leaves the device. Tapping commits `vmode` directly. Capability gating dims/refuses unavailable modes (TinkerON cold, Solo no key); the TinkerAgent memory-bypass consent modal is preserved via `ui_agent_consent_show`.
- **Smartness knob** (Fast/Balanced/Smart) — sets the *real* model for the only two modes where Tab5 picks it: Cloud→`llm_model`, Solo→`or_mdl_llm` (Haiku/Sonnet/Opus). Greyed for fixed-brain modes (Local/Hybrid/TinkerON/TinkerAgent). Corrects the original cosmetic-only `int_tier` wiring.
- **Advanced drawer** — collapsed by default; expands to engine pins (Auto/K144/OpenRouter), exact-model picker, on-device privacy lock, and daily spend cap, relocated out of Settings. Any override surfaces a " · modified" suffix on the home/chat mode chip.
- **Settings** — the duplicate VOICE-MODE radio is replaced by a read-only current-mode row that opens the picker; the ENGINES + CLOUD LLM blocks (now in the drawer) are removed, along with their dead helpers.

## Verification
- `idf.py build` clean (ESP-IDF 5.5.2); `git-clang-format --diff origin/main` clean on all changed files.
- Host tests: 4/4 pass.
- Live on Tab5 192.168.1.90: all six modes select + commit (`/voice`+`/settings` reflect vmode); dimmed TinkerON refuses with toast; Smartness greys for fixed-brain + sets Opus on "Smart" (int_tier=2, llm_model=opus-4.7); Advanced drawer engine/model/privacy/cap all persist; home chip shows " · modified"; Settings read-only row opens the picker; TinkerAgent consent modal commits vmode=3.
- Routing verified via serial: each vmode triggers its correct branch (Local/Hybrid/Cloud/SOLO_DIRECT) — routing core untouched.

## Notes
- Pre-existing infra bug surfaced (not in this branch): `debug_server` `max_uri_handlers=80` < ~97 registered handlers, so late endpoints like `/events` silently 404, blocking the `/events`-based e2e harness. Follow-up: bump the cap or trim endpoints.

## Test plan
- [ ] CI: host-tests + clang-format green
- [ ] Re-confirm picker + Settings row on device after merge

refs #724