### PR TITLE
Ambient orb upgrades — Living + Glanceable (4 layers)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-ambient-orb-upgrades.md
+++ b/docs/superpowers/plans/2026-05-26-ambient-orb-upgrades.md
@@ -1,0 +1,103 @@
+# Ambient Orb Upgrades Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (firmware on a physical device — stateful flash/verify, not subagent-parallelizable). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make the resting home orb feel alive, glanceably informative, and premium-volumetric, via four additive layers — without breaking the orb's "one motion per state" rule or the ESP32-P4 / LVGL 9 render budget.
+
+**Architecture:** All work lands in `main/ui_orb.{c,h}` (+ one small accessor in `main/ui_notification.{c,h}`). Layers attach to existing objects (`s_body`, `s_spec`, `s_halo`, `s_inner_core`) and the existing timers (`s_idle_breath_timer`, `s_tilt_timer`). No new orb state. Each layer is gated behind a flag in the existing `ui_orb_fx_t` so it's independently togglable via `/orb/fx`, and surfaced in `ui_orb_motion_state_t` via `/orb/motion`.
+
+**Tech Stack:** ESP-IDF 5.5.2, LVGL 9.x, ESP32-P4, C. Spec: `docs/superpowers/specs/2026-05-26-ambient-orb-upgrades-design.md`.
+
+**Verification model (firmware — read this):** No LVGL unit-test harness. Each phase's "test" is the real loop: `. /home/rebelforce/esp/esp-idf/export.sh && idf.py build` clean → `git-clang-format --binary clang-format-18 --diff origin/main main/ui_orb.c` clean → `idf.py -p /dev/ttyACM0 flash` → on-device checks via the debug server (`TOK=05eed3b13bf62d92cfd8ac424438b9f2`, Tab5 `192.168.1.90:8080`): `GET /screenshot.jpg` (pace + retry on 429; reboot clears a stuck busy-flag per #734), `GET /orb/fx`, `GET /orb/motion`, `POST /orb/fx?...`. Because the orb runs continuously, **also confirm no render-budget regression**: after each phase watch `GET /info` `heap_min` + serial for `mutex timeout` / `TASK_WDT` over ~60 s of IDLE.
+
+**Branch:** `feat/ambient-orb-upgrades` (off main). Commit after each task.
+
+**Budget rules (NON-NEGOTIABLE — these have caused mutex-timeout stalls before):**
+- No `shadow_width` ≥16 px on objects ≥200 px (A2 contact-glow is a pre-baked/solid low-opa ellipse, NOT a live shadow).
+- No ≥5-stop `lv_grad_dsc_t` on the ~280 px body at high invalidation (A1 rim-light is a thin edge element, not a body gradient).
+- No `transform_scale` on a gradient-bg object.
+- `lv_arc` `bg_angles` within 0–360 (use `lv_arc_set_rotation`).
+- Allowed: opa animations on existing objects, small-object position moves, thin rim/border elements, palette repaints on the ~2 s tick, pre-baked static assets.
+
+---
+
+### Task 0: Extend fx + motion structs (shared scaffolding)
+
+**Files:** Modify `main/ui_orb.h`, `main/ui_orb.c`.
+
+- [ ] **Step 1:** In `ui_orb.h`, extend `ui_orb_fx_t` with the new layer toggles (append, don't reorder existing fields):
+  ```c
+  bool rim_light;     /* A1: secondary cool counter-light */
+  bool contact_glow;  /* A2: grounding ellipse beneath the orb */
+  bool organic;       /* B1+B2: irregular breath + organic drift */
+  bool ambient_accent;/* C: one prioritized glanceable rim/ember */
+  bool event_pulse;   /* D: "noticed" double-pulse on events */
+  ```
+- [ ] **Step 2:** In `ui_orb.h`, extend `ui_orb_motion_state_t` with: `uint8_t accent_signal; /* 0 none 1 unread 2 health 3 cap */`, `uint8_t accent_opa;`, `uint8_t breath_jitter_pct;`.
+- [ ] **Step 3:** In `ui_orb.c`, default the new fx flags ON at init (so the upgrades are live by default) where `s_fx` is initialized; populate the new motion fields in `ui_orb_get_motion_state`.
+- [ ] **Step 4:** Build + format. Commit `feat(orb): fx + motion scaffolding for ambient upgrades`.
+
+---
+
+### Task 1 — Phase A: Premium depth
+
+**Files:** Modify `main/ui_orb.c` (object creation in `ui_orb_create`, palette repaint path).
+
+- [ ] **Step 1 (A2 contact-glow):** In `ui_orb_create`, before the body is created (so it's behind), add `s_contact_glow`: a low-opa (≈22) solid rounded ellipse, width ≈ body_w*0.9, height ≈ 24 px, positioned just below the body's bottom edge, radius = height/2, color = a dark warm shadow tone derived from the circadian palette (NOT `shadow_width`). Gate render on `s_fx.contact_glow`.
+- [ ] **Step 2 (A1 rim-light):** Add `s_rim` as a child sibling of the body: a thin ring/edge element (border-only `lv_obj`, `border_width`≈2, `bg_opa`=0) sized = body, `border_color` = a cool counter-light tint of the palette, `border_opa`≈40, **only the lower-opposite arc visible** — implement as a full thin ring at low opa (cheap) OR a small offset highlight on the opposite edge; choose the ring (simplest, budget-safe). Gate on `s_fx.rim_light`.
+- [ ] **Step 3 (A3 specular polish):** Soften `s_spec` — lower its peak `bg_opa` slightly and/or increase radius so the highlight falloff reads glossier. Pure styling tweak at creation.
+- [ ] **Step 4:** Wire `s_contact_glow` + `s_rim` colors into the existing circadian palette repaint function (so they re-tint on hour change) and NULL-reset them in `ui_orb_destroy`.
+- [ ] **Step 5:** Build + format + flash. Verify via `/screenshot.jpg` on home IDLE: orb reads volumetric (cool rim opposite the warm highlight) + grounded (soft glow beneath). Toggle each via `POST /orb/fx` and screenshot to confirm independent on/off. Confirm `heap_min` stable + no `mutex timeout` over 60 s.
+- [ ] **Step 6:** Commit `feat(orb): premium depth — rim-light + contact-glow + specular polish (Phase A)`.
+
+---
+
+### Task 2 — Phase B: Organic life
+
+**Files:** Modify `main/ui_orb.c` (idle breath timer cb, tilt/drift timer cb).
+
+- [ ] **Step 1 (B1 irregular breath):** In the idle-breath path, when `s_fx.organic`, modulate the breath: each cycle pick a new period within `IDLE_BREATH_*_MS * (1.0 ± 0.15)` and amplitude target within ±15 %, using a cheap LCG/`esp_random()`-seeded jitter. Store `breath_jitter_pct` for telemetry. Keep the same opa channel.
+- [ ] **Step 2 (B2 organic drift):** In the specular drift target computation (the lissajous in `s_tilt_timer` cb), when `s_fx.organic`, add a slow secondary wander = sum of two low-freq sines with incommensurate periods (e.g. 0.013 Hz + 0.021 Hz) scaled to ±~6 px, added to the lissajous target so the highlight path never exactly repeats. Same `s_spec` position channel — no new timer.
+- [ ] **Step 3:** Build + format + flash. Verify on home IDLE with the device held still in a quiet room (so tilt+mic are quiet): the highlight visibly drifts on a non-repeating path and the breath is non-metronomic. Toggle `organic` off via `/orb/fx` → confirm it reverts to the prior periodic motion. Confirm no budget regression (drift is small-object position moves; breath is opa — both cheap).
+- [ ] **Step 4:** Commit `feat(orb): organic life — irregular breath + organic drift (Phase B)`.
+
+---
+
+### Task 3 — Phase C: Ambient accent
+
+**Files:** Modify `main/ui_notification.{c,h}` (add accessor), `main/ui_orb.c` (accent resolver + render).
+
+- [ ] **Step 1:** In `ui_notification.{c,h}` add `int ui_notification_active_count(void);` returning the count of un-dismissed/active channel notifications (reads the existing dedupe/now-card/snooze ring state — return the number currently considered "pending" for the user). Keep it cheap + lock-safe.
+- [ ] **Step 2 (resolver):** In `ui_orb.c` add `static uint8_t accent_resolve(void)` returning the priority winner: `1` if `ui_notification_active_count() > 0`; else `2` if health degraded (`!voice_is_connected()` AND current vmode needs Dragon [0/1/2/3], OR vmode==4 AND `voice_onboard_failover_state() != READY`); else `3` if `tab5_budget_get_cap_mils() > 0 && tab5_budget_get_today_mils() >= (cap*8)/10`; else `0`. Suppress (return 0) when state != IDLE or sleep_phase != AWAKE.
+- [ ] **Step 3 (render):** Reuse `s_rim` (from Phase A) OR add `s_accent` thin ring. Drive its `border_color` + `border_opa` from `accent_resolve()` on the existing ~2 s repaint hook: signal 1 → channel-tone/amber ember (slow opa breath), 2 → cool desaturated tint, 3 → warm rim with opa scaled 80→100 % of cap. Signal 0 → opa 0. Gate on `s_fx.ambient_accent`. Store `accent_signal`/`accent_opa` for telemetry.
+- [ ] **Step 4:** Build + format + flash. Verify each branch on device: (a) inject a channel_message (`POST /debug/inject_ws` or trigger a notification) → unread ember; (b) force Dragon offline (kill WS / `POST /voice/reconnect` mid-down) in a Dragon mode → cool rim; (c) set `cap_mils` low + `spent_mils` near it via `POST /settings` → warm rim. Confirm only ONE shows at a time per priority. Confirm accent vanishes in non-IDLE + sleep.
+- [ ] **Step 5:** Commit `feat(orb): ambient accent — one prioritized glanceable channel (Phase C)`.
+
+---
+
+### Task 4 — Phase D: Event micro-pulse
+
+**Files:** Modify `main/ui_orb.c` (pulse helper + public hook), wire from `ui_home.c` notification + mode-change paths if a hook is needed.
+
+- [ ] **Step 1:** In `ui_orb.c` add `void ui_orb_event_pulse(void)` (public, declared in `ui_orb.h`): a one-shot that runs two brief halo `bg_opa` bumps (~150–250 ms each, +~40 opa over baseline) via the existing pulse/anim path. Gate on `s_fx.event_pulse`. Suppress during PROCESSING (comet owns motion) + quiet hours.
+- [ ] **Step 2:** Call `ui_orb_event_pulse()` from: (a) the incoming `channel_message` handler path (where `ui_notification` surfaces a new message), and (b) `ui_orb_paint_for_mode` (mode change). Use the minimal wiring; if the message path is in `ui_notification.c`/`voice_ws_proto.c`, call via the public hook.
+- [ ] **Step 3:** Build + format + flash. Verify: trigger a mode change (`POST /mode?m=N`) → orb double-pulses; inject a channel message → orb double-pulses. Confirm no pulse during PROCESSING.
+- [ ] **Step 4:** Commit `feat(orb): event micro-pulse — "noticed" reaction (Phase D)`.
+
+---
+
+### Task 5 — Final regression + docs
+
+- [ ] **Step 1:** 60–120 s IDLE soak on home with all layers on: `GET /info` heap_min stable, serial shows no `mutex timeout` / `TASK_WDT`, `GET /orb/motion` shows live drift/breath/accent values changing.
+- [ ] **Step 2:** `git-clang-format --diff origin/main main/ui_orb.c main/ui_orb.h main/ui_notification.*` clean; `idf.py build` clean.
+- [ ] **Step 3:** Update `GET /orb/fx` / `/orb/motion` debug docs in CLAUDE.md if the endpoints' fields are documented there.
+- [ ] **Step 4:** Commit any remaining + finish via superpowers:finishing-a-development-branch.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Layer A → Task 1; Layer B → Task 2; Layer C → Task 3 (+ notification accessor); Layer D → Task 4; observability (fx/motion) → Task 0; budget discipline → enforced in each task's technique choice + verified in each phase's soak check. ✅
+- **Placeholder scan:** Per-task code is described against named real objects/timers/accessors (`s_spec`, `s_idle_breath_*`, `s_tilt_timer`, `ui_orb_fx_t`, `voice_is_connected`, `tab5_budget_*`). Exact line-level code is written against the live functions during execution (the module is 2,436 LOC; tasks name the function + object + math + gate, which is the actionable unit for this codebase). No "TBD/handle edge cases." ✅
+- **Type consistency:** `s_fx`/`ui_orb_fx_t` new flags, `ui_orb_motion_state_t` new fields, `ui_orb_event_pulse`, `ui_notification_active_count`, `accent_resolve` used consistently across tasks. ✅
+- **Risk:** the only cross-file dependencies are `ui_notification_active_count` (Task 3) and the pulse wiring (Task 4); both have a clear single call site. Everything else is contained to `ui_orb.c`.

--- a/docs/superpowers/specs/2026-05-26-ambient-orb-upgrades-design.md
+++ b/docs/superpowers/specs/2026-05-26-ambient-orb-upgrades-design.md
@@ -1,0 +1,175 @@
+# Ambient Orb Upgrades — "Living + Glanceable" — Design Spec (2026-05-26)
+
+Builds on the orb redesign (`docs/superpowers/specs/2026-05-14-orb-redesign-design.md`,
+shipped as `main/ui_orb.{c,h}`, PR #513). This spec adds **ambient** (resting-state)
+upgrades that make the home orb feel like a living, glanceable, volumetric object —
+without breaking the orb's two load-bearing invariants:
+
+1. **One active motion per state** (`ui_orb.h` contract).
+2. **The ESP32-P4 / LVGL 9 render budget** (see "Budget discipline" below).
+
+## Goal
+
+The orb is already rich: a lit-sphere with a 4-state machine
+(IDLE / LISTENING / PROCESSING / SPEAKING), circadian palette, hardware reactivity
+(BMI270 tilt-spec, ES7210 mic-RMS bloom, SC202CS presence-dim), a sleep cycle
+(AWAKE / DROWSY / ASLEEP), and an FX playground (`expand/spin/glass/rainbow/shake`).
+
+What's missing is **ambient quality at rest**: when nothing is happening, the orb is
+a fairly static gradient sphere. We want the resting orb to (a) feel *alive*, (b) be
+*glanceably informative* about the state of the user's world, and (c) read as a
+*premium, volumetric* object — all three, chosen by the user.
+
+This is scoped to the **IDLE / resting** experience. LISTENING / PROCESSING / SPEAKING
+motion is unchanged; the premium base layer and the ambient accent still render in
+those states, but no new per-state motion is added.
+
+## Architecture: four additive layers
+
+All layers attach to the existing `ui_orb` objects (`s_body`, `s_spec`, `s_halo`,
+`s_inner_core`) and timers (`s_idle_breath_timer`, `s_tilt_timer`). No new state is
+added to the 4-state machine.
+
+### Layer A — Premium depth (base quality, always on, no new motion)
+
+Static or palette-driven visual richness. Renders in every state.
+
+- **A1 Secondary rim-light.** A thin, low-opacity **cool counter-light** along the
+  edge *opposite* the warm specular highlight. Gives the sphere true two-light volume
+  instead of a single top-lit gradient. Implemented as a thin edge element (arc or a
+  clipped ring/border), repainted only on circadian palette changes — never per tick.
+- **A2 Contact-glow.** A soft, low-opacity ellipse beneath the orb to ground it and
+  suggest float/depth. **Pre-baked as a solid-color ellipse** with radial-ish opacity
+  via a static asset or a single low-opa rounded object — **not** a live `shadow_width`
+  blur (that busts the budget on a ≥200 px object). Static; repaints with palette only.
+- **A3 Specular polish.** Soften the existing `s_spec` highlight's opacity falloff so it
+  reads like light on a glossy surface rather than a flat blob. This refines the *target*
+  of the existing tilt+lissajous drift; it does not add a motion channel.
+
+### Layer B — Organic life (enhances the existing single idle motion)
+
+The orb already has (1) an idle breath (`s_idle_breath_timer`, opa channel on the halo)
+and (2) a lissajous specular drift (`s_spec` position via `s_tilt_timer`). Layer B makes
+both feel organic. **No new motion channel is introduced** — both enhancements ride the
+existing channels, so the "one motion per state" budget is preserved.
+
+- **B1 Irregular breath.** Add ±~15 % jitter to the idle breath's period and amplitude so
+  it breathes like a living thing rather than a metronome. Same opa channel; the jitter is
+  a per-cycle modulation of `s_idle_breath_period_ms` / target opa.
+- **B2 Organic drift.** Layer a slow secondary wander (sum of two slow sines, or a small
+  value-noise walk) on top of the existing lissajous specular drift so the highlight never
+  retraces the same path — the orb is subtly alive **even when the device is still and the
+  room is dark** (i.e. when IMU tilt and mic RMS are both quiet). Same `s_spec` position
+  channel; the wander is an additive offset to the lissajous target.
+
+### Layer C — Ambient accent (one prioritized glanceable channel)
+
+A single subtle **accent** at rest that surfaces only the **highest-priority** ambient
+signal — never more than one at a time, so the orb never becomes a soup of competing
+colors. The accent behaves like the existing **presence-dim** layer: a slow global
+channel on top of the base, **not** counted as a per-state motion.
+
+Rendered as a thin **rim** (border color + opacity on the body, or a thin ring sibling)
+and/or a slow **ember** opacity breath, updated at low frequency (the existing ~2 s home
+refresh tick, via a new `ui_orb_repaint_*`-style hook). Priority, resolved each tick:
+
+| Pri | Signal | Source | Visual |
+|-----|--------|--------|--------|
+| 1 | Unread channel messages | new `ui_notification_active_count()` | faint colored ember (channel-tone or neutral amber), gentle breath |
+| 2 | Degraded health | `voice_is_connected()` false in a Dragon mode, **or** `voice_onboard_failover_state() != READY` in vmode 4 | faint **cool desaturation** rim (calm, not alarming) |
+| 3 | Near daily cap | `tab5_budget_get_today_mils() >= 0.8 * tab5_budget_get_cap_mils()` (cap > 0) | faint **warm** rim, opacity scales from 80 %→100 % of cap |
+| — | none | — | no accent (clean orb) |
+
+Notes:
+- The accent is **suppressed during DROWSY/ASLEEP** (don't light up a sleeping orb) and
+  during LISTENING/PROCESSING/SPEAKING (the state visuals own the orb then).
+- Health "degraded" must be **mode-aware**: Solo (vmode 5) and TinkerON (vmode 4, warm)
+  don't need Dragon, so Dragon-offline is *not* degraded in those modes.
+- Dependency: notifications currently expose **no** unread count — add a small
+  `ui_notification_active_count()` accessor (reads the existing dedupe/snooze ring state).
+
+### Layer D — Event micro-pulse ("noticed")
+
+A gentle **double-pulse** (two brief halo-opa bumps, ~150–250 ms each) when a notable
+event lands, so the orb visibly "notices":
+
+- Incoming `channel_message` (routed through `ui_notification.c`).
+- Voice-mode change (the existing `ui_orb_paint_for_mode` hook).
+
+One-shot transient on the existing pulse/halo opa channel — **not** a sustained motion,
+so it does not violate the per-state motion budget. Suppressed while a higher-priority
+state animation is mid-flight (PROCESSING comet) and during quiet hours.
+
+## Budget discipline (non-negotiable)
+
+Every effect MUST stay inside the documented LVGL 9 / ESP32-P4 render budget. From prior
+incidents (LEARNINGS + reference memory):
+
+- **No** `shadow_width` ≥ 16 px on objects ≥ 200 px at ≥ 5 Hz invalidation (or ≥ 8 px on a
+  20 Hz tilt-driven object) → mutex-timeout stalls. (Drives A2 = pre-baked, not live blur.)
+- **No** multi-stop (≥ 5) `lv_grad_dsc_t` on the ~280 px body at ≥ 30 Hz invalidation →
+  continuous mutex timeout. (Rim-light A1 is a thin edge element, not a re-rastered body
+  gradient.)
+- **No** `transform_scale` on a gradient-bg object → re-rasterize per tick.
+- `lv_arc` `bg_angles` must stay within 0–360 (use `lv_arc_set_rotation`).
+
+Allowed techniques only: **opacity animations** on existing objects, **position moves of
+small objects** (the specular), **thin rim/border** elements, **infrequent palette
+repaints** (circadian / accent on the 2 s tick), and **pre-baked static** assets.
+
+## Motion-budget accounting (the "one motion per state" rule)
+
+| State | The one motion | Plus (non-motion global channels) |
+|-------|----------------|-----------------------------------|
+| IDLE | organic specular drift (B2, enhanced existing) | breath (B1, existing opa), presence-dim, ambient accent (C), premium base (A) |
+| LISTENING | voice-bloom + listening-lean (unchanged) | tilt-spec, premium base (A) |
+| PROCESSING | skill-comet (unchanged) | premium base (A) |
+| SPEAKING | steady warm halo (unchanged) | premium base (A) |
+
+The ambient accent (C) and presence-dim are slow global multipliers/tints, not motions —
+the same accounting the orb redesign already uses for presence-dim. Event pulse (D) is a
+transient one-shot, not a sustained motion.
+
+## Observability + control
+
+Extend the existing surfaces rather than add new ones:
+
+- **`ui_orb_fx_t`** (`/orb/fx`): add toggles `rim_light`, `contact_glow`, `organic`
+  (B1+B2), `ambient_accent`, `event_pulse` so each layer is independently togglable for
+  tuning + A/B comparison.
+- **`ui_orb_motion_state_t`** (`/orb/motion`): add `accent_signal` (enum: none/unread/
+  health/cap), `accent_opa`, and `breath_jitter` so the live behavior is pollable.
+
+## Phasing (for the implementation plan)
+
+1. **Phase 1 — Layer A (premium depth):** rim-light, contact-glow, specular polish. Pure
+   visual, low risk, no new data sources. Highest visual payoff per unit risk.
+2. **Phase 2 — Layer B (organic life):** irregular breath + organic drift. Tuning-heavy
+   (get the jitter/wander tasteful, not jittery).
+3. **Phase 3 — Layer C (ambient accent):** add `ui_notification_active_count()`, the
+   priority resolver, and the rim/ember render. Mode-aware health gating.
+4. **Phase 4 — Layer D (event micro-pulse).**
+
+Each phase builds + flashes + verifies on Tab5 (no LVGL unit harness): clean
+`idf.py build`, `git-clang-format --diff origin/main` clean, on-device screenshot + a
+short heap-stability check (the orb runs continuously — confirm no mutex-timeout / heap
+drift after each phase, since render-budget regressions show up as sustained stalls).
+
+## Out of scope (YAGNI)
+
+- External-data tints (weather, calendar) — no data source on-device today.
+- Simultaneous multi-signal display in Layer C (priority shows exactly one).
+- Audio-reactive *idle* motion — mic RMS drives LISTENING bloom by design; idle stays
+  calm.
+- Any new orb state or change to the LISTENING/PROCESSING/SPEAKING motion.
+
+## Success criteria
+
+- At rest, in a still/dark room, the orb is visibly (subtly) alive — the highlight drifts
+  organically and the breath is non-metronomic.
+- The orb reads as volumetric (two-light) and grounded (contact glow), not a flat gradient.
+- A single glance communicates the top ambient signal (unread / degraded / near-cap) via
+  color, with no text and no competing signals.
+- A notable event produces a clear "noticed" pulse.
+- No render-budget regression: continuous-run heap + frame stability unchanged from
+  baseline after all four layers.

--- a/docs/superpowers/specs/2026-05-26-ambient-orb-upgrades-design.md
+++ b/docs/superpowers/specs/2026-05-26-ambient-orb-upgrades-design.md
@@ -38,10 +38,12 @@ Static or palette-driven visual richness. Renders in every state.
   edge *opposite* the warm specular highlight. Gives the sphere true two-light volume
   instead of a single top-lit gradient. Implemented as a thin edge element (arc or a
   clipped ring/border), repainted only on circadian palette changes — never per tick.
-- **A2 Contact-glow.** A soft, low-opacity ellipse beneath the orb to ground it and
-  suggest float/depth. **Pre-baked as a solid-color ellipse** with radial-ish opacity
-  via a static asset or a single low-opa rounded object — **not** a live `shadow_width`
-  blur (that busts the budget on a ≥200 px object). Static; repaints with palette only.
+- **A2 Contact-glow.** ~~A soft, low-opacity ellipse beneath the orb to ground it.~~
+  **DROPPED during implementation after on-device evaluation:** the home screen is deep
+  black and the orb reads as floating in space, so a grounding glow/shadow has no surface
+  to fall on — every hard-edged variant (dark or warm) read as a distinct "bar" beneath
+  the orb, and a soft blurred glow busts the render budget (TT #547). A1 (rim-light)
+  carries the premium-depth goal on its own. The `fx.contact_glow` flag was removed.
 - **A3 Specular polish.** Soften the existing `s_spec` highlight's opacity falloff so it
   reads like light on a glossy surface rather than a flat blob. This refines the *target*
   of the existing tilt+lissajous drift; it does not add a motion channel.

--- a/main/debug_server_metrics.c
+++ b/main/debug_server_metrics.c
@@ -272,6 +272,9 @@ static esp_err_t orb_motion_handler(httpd_req_t *req) {
       cJSON_AddNumberToObject(root, "idle_breath_opa", st.idle_breath_opa);
       cJSON_AddNumberToObject(root, "state", st.state);
       cJSON_AddNumberToObject(root, "sleep_phase", st.sleep_phase);
+      cJSON_AddNumberToObject(root, "accent_signal", st.accent_signal);
+      cJSON_AddNumberToObject(root, "accent_opa", st.accent_opa);
+      cJSON_AddNumberToObject(root, "breath_jitter_pct", st.breath_jitter_pct);
       cJSON_AddNumberToObject(root, "uptime_ms", st.uptime_ms);
    }
    return send_json_resp(req, root);
@@ -295,6 +298,11 @@ static esp_err_t orb_fx_handler(httpd_req_t *req) {
       if (httpd_query_key_value(q, "glass", v, sizeof(v)) == ESP_OK) fx.glass = (atoi(v) != 0);
       if (httpd_query_key_value(q, "rainbow", v, sizeof(v)) == ESP_OK) fx.rainbow = (atoi(v) != 0);
       if (httpd_query_key_value(q, "shake", v, sizeof(v)) == ESP_OK) fx.shake = (atoi(v) != 0);
+      /* TT #724 ambient upgrade toggles. */
+      if (httpd_query_key_value(q, "rim_light", v, sizeof(v)) == ESP_OK) fx.rim_light = (atoi(v) != 0);
+      if (httpd_query_key_value(q, "organic", v, sizeof(v)) == ESP_OK) fx.organic = (atoi(v) != 0);
+      if (httpd_query_key_value(q, "ambient_accent", v, sizeof(v)) == ESP_OK) fx.ambient_accent = (atoi(v) != 0);
+      if (httpd_query_key_value(q, "event_pulse", v, sizeof(v)) == ESP_OK) fx.event_pulse = (atoi(v) != 0);
       ui_orb_set_fx(&fx);
    }
    cJSON *root = cJSON_CreateObject();
@@ -303,6 +311,10 @@ static esp_err_t orb_fx_handler(httpd_req_t *req) {
    cJSON_AddBoolToObject(root, "glass", fx.glass);
    cJSON_AddBoolToObject(root, "rainbow", fx.rainbow);
    cJSON_AddBoolToObject(root, "shake", fx.shake);
+   cJSON_AddBoolToObject(root, "rim_light", fx.rim_light);
+   cJSON_AddBoolToObject(root, "organic", fx.organic);
+   cJSON_AddBoolToObject(root, "ambient_accent", fx.ambient_accent);
+   cJSON_AddBoolToObject(root, "event_pulse", fx.event_pulse);
    return send_json_resp(req, root);
 }
 

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1381,6 +1381,10 @@ void ui_home_update_status(void)
      * check is microsecond-scale on the no-op path. */
     ui_orb_repaint_if_hour_changed();
 
+    /* TT #724 (Phase C): refresh the orb's ambient accent (pending messages /
+     * degraded health / near cap) on the same ~2 s cadence. */
+    ui_orb_ambient_tick();
+
     /* TT #328 Wave 11 P0 #16 — keep the orb status pip in sync with the
      * branching state so the user sees what tap will do at a glance. */
     paint_orb_pip_for_context();

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -111,6 +111,11 @@ static void notif_show_async_cb(void *arg) {
       return;
    }
 
+   /* TT #724 (orb Phase D): a fresh (non-duplicate) message → the orb gives a
+    * gentle "noticed" double-pulse. No-op if the orb isn't resting/awake. */
+   extern void ui_orb_event_pulse(void);
+   ui_orb_event_pulse();
+
    const char *ch = msg->channel[0] ? msg->channel : "?";
    const char *sender = msg->sender[0] ? msg->sender : "Someone";
    const char *preview = msg->preview[0] ? msg->preview : "(no preview)";

--- a/main/ui_notification.c
+++ b/main/ui_notification.c
@@ -235,6 +235,10 @@ void ui_notification_init(void) {
    ESP_LOGI(TAG, "snooze walker armed (tick=%u ms, delay=%u ms)", (unsigned)SNOOZE_TICK_MS, (unsigned)SNOOZE_DELAY_MS);
 }
 
+/* TT #724 (orb ambient accent): deferred/pending message count = snooze ring
+ * depth. Read on the LVGL thread (same thread the snooze walker mutates on). */
+int ui_notification_active_count(void) { return s_snooze_count; }
+
 void ui_notification_reply_current(const char *text) {
    if (!s_last_now_msg_valid) {
       ESP_LOGW(TAG, "reply requested but no now-card message in cache");

--- a/main/ui_notification.h
+++ b/main/ui_notification.h
@@ -55,6 +55,11 @@ void ui_notification_show(const channel_message_t *msg);
  */
 void ui_notification_init(void);
 
+/* TT #724 (orb ambient accent): count of deferred/pending channel messages
+ * the user hasn't dealt with yet (the snooze ring). 0 = inbox quiet. Cheap;
+ * call on the LVGL thread (the snooze walker mutates on that thread too). */
+int ui_notification_active_count(void);
+
 /* W7-E.3: enqueue the most recently shown now-card message into the
  * snooze ring with `fire_at = now + 15 min`.  Overflow (>8) drops the
  * oldest entry.  Wired to the SNOOZE button in ui_home.  No-op if no

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -228,8 +228,20 @@ static int s_ambient_body_stop_last;
  * ambient_apply when audio rises (lit-from-within effect). */
 static uint32_t s_body_bot_base;
 
-/* TT #555 FX state — all default off (current behaviour preserved). */
-static ui_orb_fx_t s_fx = {0};
+/* TT #555 FX state — legacy effects default off (current behaviour preserved).
+ * TT #724 ambient upgrades default ON so the "Living + Glanceable" orb is the
+ * out-of-box experience; still individually togglable via /orb/fx. */
+static ui_orb_fx_t s_fx = {
+    .rim_light = true,
+    .organic = true,
+    .ambient_accent = true,
+    .event_pulse = true,
+};
+/* TT #724 telemetry mirrors (read by ui_orb_get_motion_state). */
+static uint8_t s_accent_signal = 0;
+static uint8_t s_accent_opa = 0;
+static uint8_t s_breath_jitter_pct = 0;
+static lv_obj_t *s_rimlight = NULL;        /* A1 cool counter-light + C ambient-accent override */
 static lv_obj_t *s_glass_ring = NULL;      /* top-inside highlight when fx.glass */
 static lv_timer_t *s_spin_timer = NULL;    /* drives transform_rotation when fx.spin */
 static lv_timer_t *s_rainbow_timer = NULL; /* slow hue cycle when fx.rainbow */
@@ -808,6 +820,13 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
    lv_obj_clear_flag(s_saved_burst, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_add_flag(s_saved_burst, LV_OBJ_FLAG_HIDDEN);
 
+   /* TT #724 Phase A2 (contact-glow) intentionally dropped after on-device
+    * evaluation: the home screen is deep black and the orb reads as floating
+    * in space, so a grounding glow/shadow has no surface to fall on — every
+    * hard-edged variant (dark or warm) read as a distinct "bar" beneath the
+    * orb, and a soft blurred glow busts the render budget (TT #547). The
+    * rim-light (A1) carries the premium-depth goal on its own. */
+
    /* Halo FIRST so it sits BEHIND s_body in z-order (LVGL draws siblings
     * in creation order).  s_body's opa-cover gradient masks the part of
     * the halo overlapping the orb; only the outer "bloom" ring shows. */
@@ -889,6 +908,25 @@ void ui_orb_create(lv_obj_t *parent, int cx, int cy) {
       lv_obj_set_style_border_opa(s_rim, 0, 0);
       lv_obj_remove_flag(s_rim, LV_OBJ_FLAG_CLICKABLE);
       lv_obj_clear_flag(s_rim, LV_OBJ_FLAG_SCROLLABLE);
+   }
+
+   /* TT #724 Phase A1 — rim-light: a thin COOL counter-light ring on the
+    * sphere silhouette, opposite the warm specular, for two-light volume.
+    * Border-only (cheap — no fill raster, no blur).  Held at a low base opa
+    * when fx.rim_light; Phase C re-colours/opacifies this same ring to carry
+    * the ambient accent (it takes precedence over the cool base). */
+   s_rimlight = lv_obj_create(parent);
+   if (s_rimlight) {
+      lv_obj_remove_style_all(s_rimlight);
+      lv_obj_set_size(s_rimlight, ORB_SIZE, ORB_SIZE);
+      lv_obj_set_pos(s_rimlight, cx - ORB_SIZE / 2, cy - ORB_SIZE / 2);
+      lv_obj_set_style_radius(s_rimlight, LV_RADIUS_CIRCLE, 0);
+      lv_obj_set_style_bg_opa(s_rimlight, 0, 0);
+      lv_obj_set_style_border_width(s_rimlight, 2, 0);
+      lv_obj_set_style_border_color(s_rimlight, lv_color_hex(0x6E8CB0), 0); /* cool counter-light */
+      lv_obj_set_style_border_opa(s_rimlight, s_fx.rim_light ? 46 : 0, 0);
+      lv_obj_remove_flag(s_rimlight, LV_OBJ_FLAG_CLICKABLE);
+      lv_obj_clear_flag(s_rimlight, LV_OBJ_FLAG_SCROLLABLE);
    }
 
    /* Skill-rim comet — sibling AFTER s_body so it draws on top.
@@ -1046,6 +1084,7 @@ void ui_orb_destroy(void) {
    s_spec = NULL;
    s_halo = NULL;
    s_rim = NULL;
+   s_rimlight = NULL;
    s_comet = NULL;
    s_inner_core = NULL;
    /* Keep s_body_canvas_buf allocated — it's PSRAM, reused across
@@ -1334,6 +1373,9 @@ bool ui_orb_get_motion_state(ui_orb_motion_state_t *out) {
    out->idle_breath_opa = (uint8_t)s_idle_breath_last_opa;
    out->state = (uint8_t)s_state;
    out->sleep_phase = (uint8_t)s_sleep_phase;
+   out->accent_signal = s_accent_signal;
+   out->accent_opa = s_accent_opa;
+   out->breath_jitter_pct = s_breath_jitter_pct;
    out->uptime_ms = (uint32_t)(esp_timer_get_time() / 1000);
    return true;
 }
@@ -1542,6 +1584,8 @@ void ui_orb_set_fx(const ui_orb_fx_t *fx) {
       fx_shake_stop();
    if (fx->glass != old.glass) fx_glass_apply(fx->glass);
    if (!fx->expand && old.expand) fx_apply_scale(); /* snap back to 1.0× */
+   /* TT #724 Phase A — apply depth-layer toggles live. */
+   if (s_rimlight && fx->rim_light != old.rim_light) lv_obj_set_style_border_opa(s_rimlight, fx->rim_light ? 46 : 0, 0);
 }
 
 void ui_orb_get_fx(ui_orb_fx_t *out) {

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -25,10 +25,13 @@
 #include "esp_timer.h" /* esp_timer_get_time for RECORDING caption timer (PR 2) */
 #include "imu.h"       /* tab5_imu_read for tilt-driven specular drift */
 #include "lvgl.h"
+#include "settings.h"             /* TT #724 accent: voice_mode + budget accessors */
 #include "ui_core.h"              /* tab5_lv_async_call for cross-thread repaints */
+#include "ui_notification.h"      /* TT #724 accent: ui_notification_active_count */
 #include "voice.h"                /* voice_get_current_rms for the LISTENING bloom */
 #include "voice_dictation.h"      /* pipeline-state types (PR 2) */
 #include "voice_dictation_lvgl.h" /* LVGL-marshalled subscriber (PR 2) */
+#include "voice_onboard.h"        /* TT #724 accent: voice_onboard_failover_state */
 #include "widget.h"               /* widget_tone_t for paint_for_tone */
 
 static const char *TAG = "ui_orb";
@@ -1400,6 +1403,69 @@ bool ui_orb_get_motion_state(ui_orb_motion_state_t *out) {
    out->uptime_ms = (uint32_t)(esp_timer_get_time() / 1000);
    return true;
 }
+
+/* ── TT #724 Phase C: ambient accent ────────────────────────────────────
+ * One prioritized glanceable signal surfaced on the s_rimlight ring at rest.
+ * Behaves like presence-dim: a slow global channel, not a per-state motion.
+ * Only ONE signal shows at a time; suppressed unless the orb is the calm
+ * resting surface (IDLE + AWAKE). */
+static uint8_t accent_resolve(void) {
+   if (s_state != ORB_STATE_IDLE) return 0;
+   if (s_sleep_phase != SLEEP_AWAKE) return 0;
+   if (ui_notification_active_count() > 0) return 1; /* pri 1: pending messages */
+   /* pri 2: degraded health — mode-aware (Solo + warm-TinkerON need no Dragon). */
+   uint8_t vm = tab5_settings_get_voice_mode();
+   bool needs_dragon =
+       (vm == VOICE_MODE_LOCAL || vm == VOICE_MODE_HYBRID || vm == VOICE_MODE_CLOUD || vm == VOICE_MODE_TINKERCLAW);
+   if (needs_dragon && !voice_is_connected()) return 2;
+   if (vm == VOICE_MODE_ONBOARD && voice_onboard_failover_state() != 2 /* M5_FAIL_READY */) return 2;
+   /* pri 3: near the daily spend cap (≥80%). */
+   uint32_t cap = tab5_budget_get_cap_mils();
+   if (cap > 0 && tab5_budget_get_today_mils() >= (cap * 8) / 10) return 3;
+   return 0;
+}
+
+static void ui_orb_apply_accent(void) {
+   if (!s_rimlight) return;
+   uint8_t sig = s_fx.ambient_accent ? accent_resolve() : 0;
+   s_accent_signal = sig;
+   if (sig == 0) {
+      /* No accent → restore the A1 base cool counter-light (or off). */
+      s_accent_opa = 0;
+      lv_obj_set_style_border_color(s_rimlight, lv_color_hex(0x6E8CB0), 0);
+      lv_obj_set_style_border_opa(s_rimlight, s_fx.rim_light ? 46 : 0, 0);
+      return;
+   }
+   uint32_t col;
+   uint8_t opa;
+   switch (sig) {
+      case 1: /* pending messages — amber ember */
+         col = 0xFFB000;
+         opa = 84;
+         break;
+      case 2: /* degraded health — calm cool, not alarming */
+         col = 0x5C7FB0;
+         opa = 60;
+         break;
+      default: { /* 3: near cap — warm rim, intensifies 80→100% of cap */
+         uint32_t cap = tab5_budget_get_cap_mils();
+         uint32_t today = tab5_budget_get_today_mils();
+         float frac = cap ? (float)today / (float)cap : 0.0f;
+         if (frac > 1.0f) frac = 1.0f;
+         float t = (frac - 0.8f) / 0.2f;
+         if (t < 0.0f) t = 0.0f;
+         if (t > 1.0f) t = 1.0f;
+         opa = (uint8_t)(50.0f + t * 40.0f);
+         col = 0xE8A33C;
+      } break;
+   }
+   s_accent_opa = opa;
+   lv_obj_set_style_border_color(s_rimlight, lv_color_hex(col), 0);
+   lv_obj_set_style_border_opa(s_rimlight, opa, 0);
+}
+
+/* Public: pumped from ui_home's ~2 s refresh tick. */
+void ui_orb_ambient_tick(void) { ui_orb_apply_accent(); }
 
 /* ── TT #555 FX playground ──────────────────────────────────────────── */
 

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -198,6 +198,14 @@ static lv_timer_t *s_idle_breath_timer = NULL; /* TT #543: idle-only slow breath
 static uint32_t s_idle_breath_period_ms = IDLE_BREATH_AWAKE_MS;
 static uint32_t s_last_interaction_ms = 0;
 
+/* TT #724 Phase B1 — organic breath: a phase accumulator + per-cycle ±15%
+ * jitter on period + amplitude so the breath isn't a metronome. Only used
+ * when s_fx.organic; otherwise the original fixed-period path runs. */
+static float s_breath_phase = 0.0f;        /* 0..1 within the current cycle */
+static uint32_t s_breath_cycle_period = 0; /* jittered period for this cycle (0 = reroll) */
+static int s_breath_cycle_amp = 0;         /* jittered amplitude for this cycle */
+static uint32_t s_breath_last_ms = 0;      /* last tick time for dt integration */
+
 /* Forward declarations — body_pulse + idle_breath helpers are defined
  * alongside the paint helpers near the bottom of the file but the state
  * machine in ui_orb_set_state needs them earlier. */
@@ -532,9 +540,22 @@ static void tilt_tick_cb(lv_timer_t *t) {
    float wobble_x = wobble_amp * sinf(wx * two_pi);
    float wobble_y = wobble_amp * sinf(wy * two_pi + 1.2f);
 
-   lv_obj_set_pos(s_spec,
-                  s_spec_rest_x_eff + (int)(dx + drift_x + wobble_x),
-                  s_spec_rest_y_eff + (int)(dy + drift_y + wobble_y));
+   /* TT #724 B2 — organic wander: a much SLOWER, slightly larger sine pair
+    * (23 s / 37 s) that migrates the lissajous figure-eight's home base
+    * around over tens of seconds, so the highlight never settles into an
+    * obviously-repeating path even when the device is dead still and the
+    * room is silent. Same s_spec position channel — not a new motion. */
+   float wander_x = 0.0f, wander_y = 0.0f;
+   if (s_fx.organic) {
+      float ax = (float)(t_ms % 23000) / 23000.0f;
+      float ay = (float)(t_ms % 37000) / 37000.0f;
+      const float wander_amp = 5.0f;
+      wander_x = wander_amp * sinf(ax * two_pi);
+      wander_y = wander_amp * sinf(ay * two_pi + 2.1f);
+   }
+
+   lv_obj_set_pos(s_spec, s_spec_rest_x_eff + (int)(dx + drift_x + wobble_x + wander_x),
+                  s_spec_rest_y_eff + (int)(dy + drift_y + wobble_y + wander_y));
 }
 
 static void tilt_start(void) {
@@ -2215,12 +2236,41 @@ static void idle_breath_tick_cb(lv_timer_t *t) {
    if (s_state != ORB_STATE_IDLE) return;
    uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
    uint32_t period = s_idle_breath_period_ms ? s_idle_breath_period_ms : IDLE_BREATH_AWAKE_MS;
-   float phase = (float)(t_ms % period) / (float)period;
+   float phase;
+   int amp = IDLE_BREATH_AMPLITUDE;
+   if (s_fx.organic) {
+      /* TT #724 B1: integrate a phase accumulator so we can vary the period
+       * per cycle (the old `t_ms % period` jumps phase if period changes).
+       * At each cycle boundary, reroll period + amplitude ±15% via a tiny
+       * LCG → the breath reads like a living thing, not a metronome. */
+      uint32_t dt = s_breath_last_ms ? (t_ms - s_breath_last_ms) : 200;
+      s_breath_last_ms = t_ms;
+      if (s_breath_cycle_period == 0) {
+         s_breath_cycle_period = period;
+         s_breath_cycle_amp = IDLE_BREATH_AMPLITUDE;
+      }
+      s_breath_phase += (float)dt / (float)s_breath_cycle_period;
+      if (s_breath_phase >= 1.0f) {
+         s_breath_phase -= 1.0f;
+         static uint32_t lcg = 0x9E3779B9u;
+         lcg = lcg * 1664525u + 1013904223u;
+         float jp = 0.85f + (float)((lcg >> 8) & 0xFF) / 255.0f * 0.30f;  /* 0.85..1.15 */
+         float ja = 0.85f + (float)((lcg >> 16) & 0xFF) / 255.0f * 0.30f; /* 0.85..1.15 */
+         s_breath_cycle_period = (uint32_t)((float)period * jp);
+         s_breath_cycle_amp = (int)((float)IDLE_BREATH_AMPLITUDE * ja);
+         s_breath_jitter_pct = (uint8_t)(jp >= 1.0f ? (jp - 1.0f) * 100.0f : (1.0f - jp) * 100.0f);
+      }
+      phase = s_breath_phase;
+      amp = s_breath_cycle_amp;
+   } else {
+      phase = (float)(t_ms % period) / (float)period;
+      s_breath_jitter_pct = 0;
+   }
    /* sin(2π·phase) → half-rectified so the halo only adds (never goes
     * negative); ramps 0 → A → 0 over the cycle. */
    float s = sinf(phase * 6.28318530718f);
    if (s < 0.0f) s = 0.0f;
-   int opa = (int)(s * (float)IDLE_BREATH_AMPLITUDE);
+   int opa = (int)(s * (float)amp);
    if (opa == s_idle_breath_last_opa) return;
    s_idle_breath_last_opa = opa;
    lv_obj_set_style_bg_opa(s_halo, (lv_opa_t)opa, LV_PART_MAIN);

--- a/main/ui_orb.c
+++ b/main/ui_orb.c
@@ -209,6 +209,10 @@ static uint32_t s_breath_cycle_period = 0; /* jittered period for this cycle (0 
 static int s_breath_cycle_amp = 0;         /* jittered amplitude for this cycle */
 static uint32_t s_breath_last_ms = 0;      /* last tick time for dt integration */
 
+/* TT #724 Phase D — event micro-pulse: while set, the idle breath yields the
+ * halo so the "noticed" double-pulse owns it cleanly. */
+static uint32_t s_event_pulse_until_ms = 0;
+
 /* Forward declarations — body_pulse + idle_breath helpers are defined
  * alongside the paint helpers near the bottom of the file but the state
  * machine in ui_orb_set_state needs them earlier. */
@@ -438,6 +442,7 @@ static void paint_body_for_hour(int hour) {
 }
 
 void ui_orb_paint_for_mode(uint8_t mode) {
+   bool mode_changed = (mode != s_last_painted_mode);
    s_last_painted_mode = mode;
    if (!s_body) return;
    /* PR 2: pipeline-state paint takes precedence — don't shadow the
@@ -447,6 +452,7 @@ void ui_orb_paint_for_mode(uint8_t mode) {
     * correctly when the pipeline returns. */
    if (ui_orb_pipeline_active()) return;
    paint_body_for_hour(orb_effective_hour());
+   if (mode_changed) ui_orb_event_pulse(); /* TT #724 D: "noticed" on mode change */
 }
 
 void ui_orb_paint_for_tone(widget_tone_t tone) {
@@ -695,6 +701,34 @@ static void halo_anim_to(int target_opa) {
    int cur = lv_obj_get_style_bg_opa(s_halo, LV_PART_MAIN);
    lv_anim_set_values(&a, cur, target_opa);
    lv_anim_set_time(&a, ORB_SPEAKING_FADE_MS);
+   lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
+   lv_anim_start(&a);
+}
+
+/* TT #724 Phase D — event micro-pulse: a gentle two-bump halo glow so the orb
+ * visibly "notices" a notable event (incoming channel message / mode change).
+ * One-shot transient (auto-reverse ×2), not a sustained motion. Suppressed
+ * while PROCESSING (the comet owns motion) and while the orb is drowsy/asleep
+ * (don't startle a resting orb). */
+void ui_orb_event_pulse(void) {
+   if (!s_fx.event_pulse || !s_halo) return;
+   if (s_state == ORB_STATE_PROCESSING) return;
+   /* Don't startle a drowsy/asleep orb. AWAKE ⟺ breath period at the AWAKE
+    * value (sleep phases lengthen it); s_sleep_phase is declared further down,
+    * so use this earlier-visible proxy. */
+   if (s_idle_breath_period_ms != IDLE_BREATH_AWAKE_MS) return;
+   uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
+   s_event_pulse_until_ms = now + 820; /* ~2×(180 up + 180 down) + slack */
+   int base = lv_obj_get_style_bg_opa(s_halo, LV_PART_MAIN);
+   lv_anim_delete(s_halo, halo_opa_anim_cb);
+   lv_anim_t a;
+   lv_anim_init(&a);
+   lv_anim_set_var(&a, s_halo);
+   lv_anim_set_exec_cb(&a, halo_opa_anim_cb);
+   lv_anim_set_values(&a, base, base + 50 > 255 ? 255 : base + 50);
+   lv_anim_set_time(&a, 180);          /* rise */
+   lv_anim_set_playback_time(&a, 180); /* fall back to base */
+   lv_anim_set_repeat_count(&a, 2);    /* two "noticed" pulses */
    lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
    lv_anim_start(&a);
 }
@@ -2301,6 +2335,8 @@ static void idle_breath_tick_cb(lv_timer_t *t) {
    if (ui_orb_pipeline_active()) return;
    if (s_state != ORB_STATE_IDLE) return;
    uint32_t t_ms = (uint32_t)(esp_timer_get_time() / 1000);
+   /* TT #724 D: yield the halo while a "noticed" pulse owns it. */
+   if (t_ms < s_event_pulse_until_ms) return;
    uint32_t period = s_idle_breath_period_ms ? s_idle_breath_period_ms : IDLE_BREATH_AWAKE_MS;
    float phase;
    int amp = IDLE_BREATH_AMPLITUDE;

--- a/main/ui_orb.h
+++ b/main/ui_orb.h
@@ -147,6 +147,11 @@ int ui_orb_get_effective_hour(void);
  *  day. */
 void ui_orb_repaint_if_hour_changed(void);
 
+/** TT #724 (Phase C): re-resolve + paint the ambient accent (one prioritized
+ *  glanceable signal: pending messages / degraded health / near daily cap).
+ *  Called from ui_home's ~2 s refresh tick. Cheap; LVGL-thread only. */
+void ui_orb_ambient_tick(void);
+
 /** Voice-mode aware orb paint.  Called by ui_home on mode cycle.
  *  Currently ignores `mode` (all modes paint with the circadian palette)
  *  but the hook stays for future mode-tinted variants. */

--- a/main/ui_orb.h
+++ b/main/ui_orb.h
@@ -157,6 +157,11 @@ void ui_orb_ambient_tick(void);
  *  but the hook stays for future mode-tinted variants. */
 void ui_orb_paint_for_mode(uint8_t mode);
 
+/** TT #724 (Phase D): one-shot "noticed" double-pulse on a notable event
+ *  (incoming channel message / mode change). No-op when fx.event_pulse off,
+ *  while PROCESSING, or while the orb is drowsy/asleep. LVGL-thread only. */
+void ui_orb_event_pulse(void);
+
 /** Widget-tone orb override — claimed when a live widget takes the slot.
  *  Bypasses the circadian palette for the tone's color pair. */
 void ui_orb_paint_for_tone(widget_tone_t tone);

--- a/main/ui_orb.h
+++ b/main/ui_orb.h
@@ -96,6 +96,9 @@ typedef struct {
    uint8_t idle_breath_opa;  /* base breath opa contribution to halo */
    uint8_t state;            /* ui_orb_state_t (IDLE/LISTENING/PROCESSING/SPEAKING) */
    uint8_t sleep_phase;      /* 0=AWAKE, 1=DROWSY, 2=ASLEEP */
+   uint8_t accent_signal;    /* TT #724 (Phase C): 0 none, 1 unread, 2 health, 3 cap */
+   uint8_t accent_opa;       /* current ambient-accent rim opa */
+   uint8_t breath_jitter_pct; /* TT #724 (Phase B): current breath period jitter % (0..30) */
    uint32_t uptime_ms;
 } ui_orb_motion_state_t;
 
@@ -116,6 +119,11 @@ typedef struct {
    bool glass;   /* glassmorphism: translucent body + top highlight ring */
    bool rainbow; /* slow palette hue cycle, replaces circadian while active */
    bool shake;   /* IMU shake detection → brief startle response (organism reaction) */
+   /* TT #724 ambient upgrades ("Living + Glanceable") — default ON. */
+   bool rim_light;      /* A1: secondary cool counter-light for volume */
+   bool organic;        /* B1+B2: irregular breath + non-repeating drift */
+   bool ambient_accent; /* C: one prioritized glanceable rim (unread/health/cap) */
+   bool event_pulse;    /* D: "noticed" double-pulse on events */
 } ui_orb_fx_t;
 
 void ui_orb_set_fx(const ui_orb_fx_t *fx);


### PR DESCRIPTION
## Summary
Makes the resting home orb feel alive, glanceably informative, and premium-volumetric — within the "one motion per state" rule and the ESP32-P4/LVGL render budget. Spec: `docs/superpowers/specs/2026-05-26-ambient-orb-upgrades-design.md`; plan: `docs/superpowers/plans/2026-05-26-ambient-orb-upgrades.md`.

- **Phase A — premium depth:** a thin cool counter-light rim (`s_rimlight`) gives the sphere two-light volume. (Contact-glow A2 was *dropped after device eval* — on a black "space" screen a grounding glow reads as a bar and a soft blur busts the budget; the rim-light carries depth alone.)
- **Phase B — organic life:** the idle breath gets per-cycle ±15% period/amplitude jitter (phase accumulator) and the specular gains a slow 23s/37s wander on top of the existing lissajous — alive even when still and dark.
- **Phase C — ambient accent:** one prioritized glanceable rim — pending messages (new `ui_notification_active_count()`) > degraded health (mode-aware) > near daily cap (≥80%). Resolved each ~2s tick; never a signal soup; suppressed off-IDLE/asleep.
- **Phase D — event micro-pulse:** a gentle two-bump halo "noticed" glow on incoming channel message / mode change. Transient; suppressed in PROCESSING + drowsy/asleep.

All four gated behind new `ui_orb_fx_t` flags (default ON) and surfaced via `/orb/fx` + `/orb/motion`.

## Verification (on Tab5 192.168.1.90)
- Phase A: cool rim renders, orb floats cleanly (screenshot).
- Phase B: `/orb/motion` `breath_jitter_pct` cycles (0→10→14→13), specular moving.
- Phase C: `cap_mils=1` → `accent_signal=3, accent_opa=90` (warm rim); clears to 0 on reset.
- Phase D: halo_opa peaks 74 on mode change (idle breath only ~28) → pulse confirmed.
- **60s IDLE soak: heap_min identical start→end (zero drift), no mutex-timeout/WDT**, SRAM frag 2%, LVGL pool frag 1%.
- Host-tests 4/4; `idf.py build` clean; `git-clang-format --diff origin/main` clean.

## Test plan
- [ ] CI: host-tests + clang-format green
- [ ] Re-confirm rim + accent + pulse on device after merge

refs #724