### PR TITLE
Mode picker bug-fix waves (Solo model / Smartness honesty / privacy feedback / picker-voice / handler cap)

### DIFF
--- a/main/debug_server.c
+++ b/main/debug_server.c
@@ -683,8 +683,11 @@ esp_err_t tab5_debug_server_init(void)
      * registrations silently drop with httpd 404. */
     /* TT #370: solo-mode synthetic test endpoints add /solo/sse_test +
      * /solo/llm_test + /solo/rag_test in subsequent commits.  Bumped
-     * 72 → 80 to absorb them and leave a 4-slot cushion. */
-    config.max_uri_handlers = 80;
+     * 72 → 80 to absorb them and leave a 4-slot cushion.
+     * TT #724: the family modules now register ~97 handlers; at 80 the late
+     * ones (/events, /debug/inject_*, ...) silently failed to register and
+     * 404'd — which blocked the e2e harness. Bumped to 110 (count + headroom). */
+    config.max_uri_handlers = 110;
     config.lru_purge_enable = true;
     config.max_open_sockets = 16;         /* Needs headroom for rapid API calls (nav+info pairs) */
     config.recv_wait_timeout = 5;         /* 5s recv timeout (default 5) */

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -1526,7 +1526,7 @@ void ui_home_update_status(void)
             case ST_NO_WIFI:     sys = "OFFLINE";   col = TH_STATUS_RED; break;
             case ST_DRAGON_DOWN:
                if (onboard_healthy) {
-                  sys = "ONBOARD";
+                  sys = "ON-DEVICE";
                   col = TH_MODE_ONBOARD;
                } else {
                   sys = "NO DRAGON";
@@ -1542,14 +1542,14 @@ void ui_home_update_status(void)
                 } else if (onboard_healthy && degraded) {
                    /* Onboard mode: Dragon-side degraded reasons aren't
                     * relevant to user-facing chat — show ONBOARD. */
-                   sys = "ONBOARD";
+                   sys = "ON-DEVICE";
                    col = TH_MODE_ONBOARD;
                 } else if (degraded) {
                    /* Reconnecting / Remote / Dragon-unreachable, etc. */
                    sys = degraded;
                    col = 0xFBBF24; /* amber-hot -- attention, not error */
                 } else if (onboard_healthy) {
-                   sys = "ONBOARD";
+                   sys = "ON-DEVICE";
                    col = TH_MODE_ONBOARD;
                 } else {
                    sys = "ONLINE";

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -519,16 +519,18 @@ static void update_mode_ui(uint8_t mode)
    if (s_mode_dot) widget_mode_dot_set_mode(s_mode_dot, mode);
    if (s_mode_name) lv_label_set_text(s_mode_name, th_mode_names[mode]);
    if (s_mode_sub) {
-      /* TT #724 (3.4): an Advanced-drawer override (engine pin / privacy lock)
-       * makes the effective route differ from the plain mode — flag it. */
+      /* TT #724 (3.4): an Advanced-drawer override (engine pin / privacy lock /
+       * custom model) makes the effective route differ from the plain mode.
+       * Show a short amber "MODIFIED" instead of appending to the tagline so it
+       * stays salient and never overruns the dropdown chevron at the right edge. */
       extern bool ui_mode_sheet_is_modified(void);
       s_badge_modified = ui_mode_sheet_is_modified();
       if (s_badge_modified) {
-         char buf[64];
-         snprintf(buf, sizeof(buf), "%s \xe2\x80\xa2 modified", s_mode_tagline[mode]);
-         lv_label_set_text(s_mode_sub, buf);
+         lv_label_set_text(s_mode_sub, "MODIFIED");
+         lv_obj_set_style_text_color(s_mode_sub, lv_color_hex(TH_AMBER), 0);
       } else {
          lv_label_set_text(s_mode_sub, s_mode_tagline[mode]);
+         lv_obj_set_style_text_color(s_mode_sub, lv_color_hex(TH_TEXT_DIM), 0);
       }
    }
    /* TT #723: place the tagline after the (variable-length) canonical name so

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -860,7 +860,7 @@ static void show_agent_consent(void) {
    lv_obj_add_event_cb(cancel, consent_cancel_cb, LV_EVENT_CLICKED, NULL);
 
    lv_obj_t *cancel_lbl = lv_label_create(cancel);
-   lv_label_set_text(cancel_lbl, "Keep Ask mode");
+   lv_label_set_text(cancel_lbl, "Keep current mode");
    lv_obj_set_style_text_font(cancel_lbl, FONT_BODY, 0);
    lv_obj_set_style_text_color(cancel_lbl, lv_color_hex(TH_TEXT_DIM), 0);
    lv_obj_center(cancel_lbl);

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -467,8 +467,21 @@ static void build_smartness(void) {
    lv_obj_set_pos(lab, SIDE_PAD, 0);
 
    bool fixed = s_mode_meta[s_sel_vmode].fixed_brain;
-   uint8_t tier = tab5_settings_get_int_tier();
-   if (tier > 2) tier = 0;
+   /* TT #724: reflect the ACTUAL model, not int_tier (which drifts). Map the
+    * mode's model field to a tier; -1 (custom / off-catalog) highlights none. */
+   int tier = -1;
+   {
+      char m[64] = {0};
+      if (s_sel_vmode == VOICE_MODE_SOLO)
+         tab5_settings_get_or_mdl_llm(m, sizeof(m));
+      else
+         tab5_settings_get_llm_model(m, sizeof(m));
+      for (int i = 0; i < 3; i++)
+         if (strcmp(m, s_smart_cloud[i]) == 0) {
+            tier = i;
+            break;
+         }
+   }
    const char *names[3] = {"Fast", "Balanced", "Smart"};
    int seg_w = (MS_W - 2 * SIDE_PAD - 2 * 6) / 3;
    for (int i = 0; i < 3; i++) {
@@ -657,7 +670,24 @@ static void build_advanced(void) {
 }
 
 bool ui_mode_sheet_is_modified(void) {
-   return tab5_settings_get_llm_engine() != LLM_ENG_AUTO || tab5_settings_get_privacy_lock();
+   if (tab5_settings_get_llm_engine() != LLM_ENG_AUTO) return true;
+   if (tab5_settings_get_privacy_lock()) return true;
+   /* TT #724 (#4): a custom (off-tier) model on a model-picking mode is also a
+    * deviation from the plain Smartness default. */
+   uint8_t vm = tab5_settings_get_voice_mode();
+   if (vm == VOICE_MODE_CLOUD || vm == VOICE_MODE_SOLO) {
+      char m[64] = {0};
+      if (vm == VOICE_MODE_SOLO)
+         tab5_settings_get_or_mdl_llm(m, sizeof(m));
+      else
+         tab5_settings_get_llm_model(m, sizeof(m));
+      if (m[0]) {
+         for (int i = 0; i < 3; i++)
+            if (strcmp(m, s_smart_cloud[i]) == 0) return false;
+         return true; /* model set but not a tier default => custom */
+      }
+   }
+   return false;
 }
 
 /* ── Agent consent modal ─────────────────────────────────────────────── */

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -546,8 +546,14 @@ static void adv_engine_cb(lv_event_t *e) {
 static void adv_model_cb(lv_event_t *e) {
    uint8_t idx = (uint8_t)(uintptr_t)lv_event_get_user_data(e);
    if (idx >= ADV_MODEL_COUNT) return;
-   tab5_settings_set_llm_model(s_adv_models[idx].model_id);
-   voice_send_config_update((int)s_sel_vmode, (char *)s_adv_models[idx].model_id);
+   const char *model = s_adv_models[idx].model_id;
+   /* Solo reads or_mdl_llm; every other cloud mode reads llm_model. Mirror
+    * smart_click_cb so an exact-model override actually takes effect (TT #724). */
+   if (s_sel_vmode == VOICE_MODE_SOLO)
+      tab5_settings_set_or_mdl_llm(model);
+   else
+      tab5_settings_set_llm_model(model);
+   voice_send_config_update((int)s_sel_vmode, (char *)model);
    build_advanced();
 }
 
@@ -614,7 +620,10 @@ static void build_advanced(void) {
       lv_obj_set_scroll_dir(scroll, LV_DIR_HOR);
       lv_obj_set_scrollbar_mode(scroll, LV_SCROLLBAR_MODE_OFF);
       char cur_model[64] = {0};
-      tab5_settings_get_llm_model(cur_model, sizeof(cur_model));
+      if (s_sel_vmode == VOICE_MODE_SOLO)
+         tab5_settings_get_or_mdl_llm(cur_model, sizeof(cur_model));
+      else
+         tab5_settings_get_llm_model(cur_model, sizeof(cur_model));
       int cx = 0;
       for (uint32_t i = 0; i < ADV_MODEL_COUNT; i++) {
          bool sel = (strcmp(cur_model, s_adv_models[i].model_id) == 0);

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -185,6 +185,20 @@ void ui_mode_sheet_show(void)
      * keys off the persisted vmode, and tab5_mode_resolve stays only for the
      * debug /mode-from-tiers path. No tier resync needed here. */
 
+    /* TT #724 (#7): don't layer the picker over an active voice session. If a
+     * turn is mid-flight (in-place listening / processing / speaking), cancel
+     * it so the picker is the sole foreground surface — opening the picker is a
+     * deliberate context switch (matches the mid-turn cancel on commit). */
+    voice_state_t vs = voice_get_state();
+    if (vs != VOICE_STATE_IDLE && vs != VOICE_STATE_READY) {
+       voice_cancel();
+    }
+    {
+       extern bool ui_voice_is_visible(void);
+       extern void ui_voice_hide(void);
+       if (ui_voice_is_visible()) ui_voice_hide();
+    }
+
     /* Overlay scrim — fills the screen, dim semi-transparent, tappable
      * to dismiss.  lv_layer_top() keeps it above home + any other screen. */
     s_overlay = lv_obj_create(lv_layer_top());

--- a/main/ui_mode_sheet.c
+++ b/main/ui_mode_sheet.c
@@ -307,7 +307,7 @@ static void commit_mode(uint8_t vmode) {
       ESP_LOGI(TAG, "vmode change while voice in state %d — cancelling first", (int)vs);
       tab5_debug_obs_event("mode.cancel_for_switch", "");
       voice_cancel();
-      ui_home_show_toast("Switched mode — current turn stopped");
+      ui_home_show_toast("Switched mode - current turn stopped");
    }
 
    tab5_settings_set_voice_mode(vmode);

--- a/main/voice.c
+++ b/main/voice.c
@@ -1653,6 +1653,18 @@ esp_err_t voice_connect_async(const char *dragon_host, uint16_t dragon_port, boo
 
 esp_err_t voice_start_listening(void)
 {
+   /* TT #724 (#7): don't start a voice turn while the mode picker is open. A
+    * spurious wakeword (or stray tap) would otherwise render the listening UI
+    * on top of the picker — they coexisted before. The picker is a deliberate
+    * interaction; let it win until the user closes it. */
+   {
+      extern bool ui_mode_sheet_visible(void);
+      if (ui_mode_sheet_visible()) {
+         ESP_LOGI(TAG, "voice_start_listening refused — mode picker open");
+         return ESP_ERR_INVALID_STATE;
+      }
+   }
+
    /* TT #317 Phase 6b: in Onboard mode the K144's own mic + chain handles
     * the whole turn — no Tab5 mic, no Dragon WS.  Short-circuit BEFORE the
     * mic_mute / ws_live checks since those are about Tab5's mic + Dragon

--- a/main/voice.c
+++ b/main/voice.c
@@ -1834,7 +1834,7 @@ esp_err_t voice_start_dictation(void)
           return ESP_ERR_NO_MEM;
        }
        ESP_LOGI(TAG, "Offline dictation recording -> %s", path);
-       ui_home_show_toast("Dragon offline — recording to SD; will transcribe when back");
+       ui_home_show_toast("Dragon offline - recording to SD; will transcribe when back");
     } else {
        /* W4-A: fresh turn_id for the dictation turn. */
        gen_turn_id();
@@ -2016,7 +2016,7 @@ esp_err_t voice_stop_listening(void)
       /* Finalise the SD WAV → Note state RECORDED.  The transcription
        * queue picks it up automatically when Dragon's back. */
       ui_notes_stop_recording(NULL);
-      ui_home_show_toast("Saved offline — will sync to Notes when Dragon's back");
+      ui_home_show_toast("Saved offline - will sync to Notes when Dragon's back");
       voice_reset_activity_timestamp();
       voice_set_state(VOICE_STATE_READY, "offline_saved");
       /* PR 1: pipeline transition — offline path queues an upload-when-
@@ -2375,7 +2375,7 @@ esp_err_t voice_send_text(const char *text)
               * couldn't land — surface that distinctly so the user
               * knows to either turn the lock off OR bring K144 up. */
              if (tab5_settings_get_privacy_lock()) {
-                ui_home_show_toast("Privacy lock on — K144 not ready");
+                ui_home_show_toast("Privacy lock on - K144 not ready");
              } else {
                 ui_home_show_toast("Onboard LLM not ready");
              }

--- a/main/voice_onboard.c
+++ b/main/voice_onboard.c
@@ -562,7 +562,12 @@ static void onboard_failover_text_job(void *arg) {
       }
    } else {
       if (tab5_ui_try_lock(150)) {
-         ui_home_show_toast("Onboard LLM unavailable");
+         /* TT #724: when privacy lock is ON the K144 dispatch was FORCED (the
+          * lock refuses Dragon/OpenRouter), so a failure here means the chosen
+          * mode silently couldn't run. Say so explicitly — matches the
+          * dispatch-time toast in voice.c so the async path isn't a dead end. */
+         ui_home_show_toast(tab5_settings_get_privacy_lock() ? "Privacy lock on - on-device LLM failed"
+                                                             : "Onboard LLM unavailable");
          tab5_ui_unlock();
       }
       ESP_LOGW(TAG, "K144 failover failed (%s) for prompt '%s'", esp_err_to_name(ie), prompt);
@@ -1240,7 +1245,7 @@ static void onboard_chain_drain_task(void *arg) {
    s_chain_handle = h;
    voice_set_state(VOICE_STATE_LISTENING, "K144");
    if (tab5_ui_try_lock(150)) {
-      ui_home_show_toast("Onboard chat — speak at the K144");
+      ui_home_show_toast("Onboard chat - speak at the K144");
       tab5_ui_unlock();
    }
    ESP_LOGI(TAG, "chain ready — entering drain loop");


### PR DESCRIPTION
## Summary
Six verified bug-fix waves from an intensive on-device QA pass on the merged mode-picker (#738). refs #724.

1. **Solo Advanced exact-model** writes `or_mdl_llm` (was `llm_model` → no effect in Solo).
2. **Smartness honesty** — segment reflects the actual model, not stale `int_tier`; custom model → "modified".
3. **Home chip** clean amber **MODIFIED** badge (no chevron overlap).
4. **Naming** — top-bar `ONBOARD`→`ON-DEVICE`; consent `Keep Ask mode`→`Keep current mode`.
5. **Privacy-lock feedback** — privacy-aware K144-failure toast (dispatch + async); de-tofu'd 5 toast em-dashes.
6. **Picker/voice** — picker won't coexist with voice (cancel on open + refuse voice-start while open); `max_uri_handlers` 80→110 so `/events` + `/debug/*` register (unblocks the e2e harness).

## Verification
On-device per wave; `story_smoke` 14/14; host-tests 4/4; build + clang-format clean. Cherry-picked clean onto current main (post-#738/#739).

## Test plan
- [ ] CI green; re-confirm Solo model pick + privacy toast on device