### PR TITLE
UI polish: chat/voice typography tofu + CAPPED top-bar overflow

### DIFF
--- a/main/md_strip.c
+++ b/main/md_strip.c
@@ -57,6 +57,28 @@ void md_strip_inline(const char *in, char *out, size_t out_cap)
             continue;
         }
 
+        /* TT #724: ASCII-fold the "smart" typography LLMs love to emit but
+         * the Montserrat UI subset lacks (they render as tofu boxes):
+         *   U+2018/2019 ' '  → '   U+201C/201D " " → "   U+2013/2014 – — → -
+         * All are 3-byte UTF-8 starting E2 80 xx.  Bullet (E2 80 A2) and
+         * ellipsis (E2 80 A6) ARE in the subset (this stripper emits them),
+         * so they pass through untouched. */
+        if (c == (char)0xE2 && i + 2 < n && in[i + 1] == (char)0x80) {
+           unsigned char b3 = (unsigned char)in[i + 2];
+           char repl = 0;
+           if (b3 == 0x98 || b3 == 0x99)
+              repl = '\'';
+           else if (b3 == 0x9C || b3 == 0x9D)
+              repl = '"';
+           else if (b3 == 0x93 || b3 == 0x94)
+              repl = '-';
+           if (repl) {
+              out[oi++] = repl;
+              i += 3;
+              continue;
+           }
+        }
+
         out[oi++] = c;
         i++;
     }

--- a/main/ui_home.c
+++ b/main/ui_home.c
@@ -623,22 +623,24 @@ lv_obj_t *ui_home_create(void)
     lv_obj_add_flag(s_sys_label, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_event_cb(s_sys_label, sys_click_cb, LV_EVENT_CLICKED, NULL);
 
-    /* TT #584 — TinkerON armed indicator beside ONLINE.  Same visual
-     * idiom: 8 px dot + small-caps label.  Position: ~120 px to the
-     * right of ONLINE (font is monospace-ish at 14 px ≈ 8 px/char;
-     * "ONLINE" + letter_space=3 is ~7 chars × 11 = ~80 px, so +100 is
-     * a safe gap).  Hidden when K144 is UNAVAILABLE. */
+    /* TT #584 — TinkerON armed indicator beside the sys-label.  Same visual
+     * idiom: 8 px dot + small-caps label.
+     * TT #724: bumped +120 → +175.  Montserrat is PROPORTIONAL, so the wide
+     * sys states ("CAPPED", "NO DRAGON" = 9 ch, "ON-DEVICE") are far wider than
+     * "ONLINE" and overran the dot at +120, colliding with this pill.  +175
+     * gives the sys-label ~157 px — clears the longest state.  Hidden when
+     * K144 is UNAVAILABLE. */
     s_tinkeron_dot = lv_obj_create(s_screen);
     lv_obj_remove_style_all(s_tinkeron_dot);
     lv_obj_set_size(s_tinkeron_dot, 8, 8);
-    lv_obj_set_pos(s_tinkeron_dot, SIDE_PAD + 120, 32);
+    lv_obj_set_pos(s_tinkeron_dot, SIDE_PAD + 175, 32);
     lv_obj_set_style_radius(s_tinkeron_dot, 4, 0);
     lv_obj_set_style_bg_color(s_tinkeron_dot, lv_color_hex(TH_AMBER), 0);
     lv_obj_set_style_bg_opa(s_tinkeron_dot, LV_OPA_COVER, 0);
 
     s_tinkeron_label = lv_label_create(s_screen);
     lv_label_set_text(s_tinkeron_label, "TINKERON OFF");
-    lv_obj_set_pos(s_tinkeron_label, SIDE_PAD + 138, 26);
+    lv_obj_set_pos(s_tinkeron_label, SIDE_PAD + 193, 26);
     lv_obj_set_style_text_font(s_tinkeron_label, FONT_SMALL, 0);
     lv_obj_set_style_text_color(s_tinkeron_label, lv_color_hex(TH_TEXT_SECONDARY), 0);
     lv_obj_set_style_text_letter_space(s_tinkeron_label, 3, 0);
@@ -650,9 +652,9 @@ lv_obj_t *ui_home_create(void)
     s_vision_dot = lv_obj_create(s_screen);
     lv_obj_remove_style_all(s_vision_dot);
     lv_obj_set_size(s_vision_dot, 8, 8);
-    /* Position past "TINKERON OFF" label (longest case at ~+278).
-     * Clear with a small gap so the indicator reads as standalone. */
-    lv_obj_set_pos(s_vision_dot, SIDE_PAD + 320, 32);
+    /* Position past "TINKERON OFF" label. TT #724: the pill moved +138→+193,
+     * so its longest text ends ~+360; place the vision dot clear of that. */
+    lv_obj_set_pos(s_vision_dot, SIDE_PAD + 378, 32);
     lv_obj_set_style_radius(s_vision_dot, 4, 0);
     lv_obj_set_style_bg_color(s_vision_dot, lv_color_hex(TH_STATUS_GREEN), 0);
     lv_obj_set_style_bg_opa(s_vision_dot, LV_OPA_COVER, 0);
@@ -1537,8 +1539,12 @@ void ui_home_update_status(void)
             case ST_QUIET:       sys = "QUIET";     col = 0x7A7A82;      break;
             default:
                 if (capped) {
-                    sys = "CAPPED \xe2\x80\xa2 LOCAL TODAY";
-                    col = TH_STATUS_RED;
+                   /* TT #724: "CAPPED \xe2\x80\xa2 LOCAL TODAY" (~210 px) ran past the
+                    * TinkerON dot at x=160 and collided with its pill. Shortened
+                    * to "CAPPED" (the red colour already conveys the trust-break;
+                    * the budget detail lives in Settings \xe2\x86\x92 Budget). */
+                   sys = "CAPPED";
+                   col = TH_STATUS_RED;
                 } else if (onboard_healthy && degraded) {
                    /* Onboard mode: Dragon-side degraded reasons aren't
                     * relevant to user-facing chat — show ONBOARD. */

--- a/tests/host/test_md_strip.c
+++ b/tests/host/test_md_strip.c
@@ -114,21 +114,41 @@ static int test_inline_in_place_safe(void) {
    return 0;
 }
 
+/* TT #724: smart quotes/dashes fold to ASCII (font lacks them → tofu). */
+static int test_inline_asciifies_smart_typography(void) {
+   char out[64];
+   md_strip_inline("I\xE2\x80\x99m here \xE2\x80\x94 what\xE2\x80\x99s up", out, sizeof out);
+   CHECK_EQ_STR(out, "I'm here - what's up");
+   md_strip_inline("\xE2\x80\x9Chi\xE2\x80\x9D", out, sizeof out);
+   CHECK_EQ_STR(out, "\"hi\"");
+   return 0;
+}
+
+/* TT #724: bullet (•) + ellipsis (…) stay — they ARE in the font subset. */
+static int test_inline_keeps_bullet_and_ellipsis(void) {
+   char out[64];
+   md_strip_inline("a \xE2\x80\xA2 b \xE2\x80\xA6", out, sizeof out);
+   CHECK_EQ_STR(out, "a \xE2\x80\xA2 b \xE2\x80\xA6");
+   return 0;
+}
+
 int main(void) {
    struct {
       const char *name;
       int (*fn)(void);
    } tests[] = {
-      {"inline_bold_pair", test_inline_bold_pair},
-      {"inline_italic_pair", test_inline_italic_pair},
-      {"inline_heading_stripped_at_line_start", test_inline_heading_stripped_at_line_start},
-      {"inline_bullet_becomes_unicode", test_inline_bullet_becomes_unicode},
-      {"inline_null_input_safe", test_inline_null_input_safe},
-      {"inline_truncation_terminates", test_inline_truncation_terminates},
-      {"ellipsis_appended_on_truncation", test_ellipsis_appended_on_truncation},
-      {"tool_markers_stripped", test_tool_markers_stripped},
-      {"tool_markers_case_insensitive", test_tool_markers_case_insensitive},
-      {"inline_in_place_safe", test_inline_in_place_safe},
+       {"inline_bold_pair", test_inline_bold_pair},
+       {"inline_italic_pair", test_inline_italic_pair},
+       {"inline_heading_stripped_at_line_start", test_inline_heading_stripped_at_line_start},
+       {"inline_bullet_becomes_unicode", test_inline_bullet_becomes_unicode},
+       {"inline_null_input_safe", test_inline_null_input_safe},
+       {"inline_truncation_terminates", test_inline_truncation_terminates},
+       {"ellipsis_appended_on_truncation", test_ellipsis_appended_on_truncation},
+       {"tool_markers_stripped", test_tool_markers_stripped},
+       {"tool_markers_case_insensitive", test_tool_markers_case_insensitive},
+       {"inline_in_place_safe", test_inline_in_place_safe},
+       {"inline_asciifies_smart_typography", test_inline_asciifies_smart_typography},
+       {"inline_keeps_bullet_and_ellipsis", test_inline_keeps_bullet_and_ellipsis},
    };
    size_t n = sizeof(tests) / sizeof(tests[0]);
    for (size_t i = 0; i < n; i++) {


### PR DESCRIPTION
## Summary
Two pre-existing UI imperfections caught during QA. refs #724.

- **Chat/voice typography tofu** — `md_strip_inline` now ASCII-folds the "smart" punctuation LLMs emit but the Montserrat UI subset lacks (U+2018/2019 → `'`, U+201C/201D → `"`, U+2013/2014 → `-`). Bullet (•) + ellipsis (…) are kept (they ARE in the subset). Fixes "I⬚m"/"What⬚s" tofu in chat bubbles + voice overlay. Host test added.
- **Top-bar overflow** — the long sys-label states ("CAPPED · LOCAL TODAY", and the proportional-font-wide "NO DRAGON"/"ON-DEVICE") overran the TinkerON pill at +120 px. Shortened "CAPPED · LOCAL TODAY" → "CAPPED" and shifted the TinkerON + vision indicators right (+175 / +378) so any sys state clears.

## Verification
On Tab5: chat bubbles render apostrophes cleanly; forced CAPPED shows "● CAPPED   ● TINKERON OFF" with a clean gap. Host-tests 4/4 (incl. 2 new asciify cases); build + clang-format clean.

## Test plan
- [ ] CI green