### PR TITLE
docs: Wave 1 — TinkerTab content (18 Diátaxis pages)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,39 @@ browse by type.
 ## I want to…
 
 - **Use it** → [Get started](tutorials/getting-started.md)
-- **Build / modify it** → [Flash the firmware](how-to/flash-firmware.md)
-- **Integrate with it** → [Debug server reference](reference/debug-server.md)
+- **Build / modify it** → [Set up a dev environment](how-to/dev-setup.md)
+- **Integrate with it** → [Reference index](reference/README.md)
+- **Run it in production** → [Run a Tab5 in production](how-to/deploy.md)
 - **Understand it** → [How the stack fits together](explanation/how-the-stack-fits-together.md)
+
+## By audience
+
+- **Tinkerer / end-user** → [Get started](tutorials/getting-started.md),
+  [Your first voice conversation](tutorials/your-first-voice-conversation.md),
+  then [Switch voice modes](how-to/switch-voice-modes.md),
+  [Use the camera](how-to/use-the-camera.md),
+  [Dictate and take notes](how-to/dictate-and-take-notes.md),
+  [Enable the TinkerON wakeword](how-to/enable-tinkeron-wakeword.md).
+- **Developer / contributor** →
+  [Set up a dev environment](how-to/dev-setup.md),
+  [Flash the firmware](how-to/flash-firmware.md),
+  [Run the e2e test harness](how-to/run-the-e2e-test-harness.md);
+  [TinkerTab architecture](explanation/architecture.md),
+  [The voice pipeline](explanation/the-voice-pipeline.md),
+  [LVGL on ESP32-P4](explanation/lvgl-on-esp32p4.md);
+  [Firmware file map](reference/firmware-file-map.md).
+- **API / protocol integrator** →
+  [WebSocket protocol](reference/websocket-protocol.md),
+  [Debug server](reference/debug-server.md),
+  [Voice modes](reference/voice-modes.md),
+  [NVS settings](reference/nvs-settings.md),
+  [Observability events](reference/observability-events.md),
+  [Hardware](reference/hardware.md).
+- **Operator** →
+  [Connect a Tab5 to a Dragon](how-to/connect-to-dragon.md),
+  [Run a Tab5 in production](how-to/deploy.md),
+  [Recover a stuck device](how-to/recover-a-stuck-device.md);
+  [The TinkerON / K144 chain](explanation/the-tinkeron-k144-chain.md).
 
 ## By Diátaxis type
 
@@ -26,30 +56,45 @@ browse by type.
 | Page | What you get |
 |---|---|
 | [Get started](tutorials/getting-started.md) | Unbox → flash → first boot → "Hey Tinker" → first voice turn. |
+| [Your first voice conversation](tutorials/your-first-voice-conversation.md) | Hold a real multi-turn conversation: ask, follow up, cancel, type, dictate. |
 
-### How-to guides — task-oriented (audience: developer / operator / integrator)
+### How-to guides — task-oriented (audience: tinkerer / developer / operator)
 
-| Page | When to use it |
-|---|---|
-| [Flash the firmware](how-to/flash-firmware.md) | Build and load the firmware onto a Tab5, with recovery + troubleshooting. |
-| _dev-setup_ (planned, Wave 1) | Stand up a full development environment. |
-| _deploy_ (planned, Wave 1) | Run it in production / fleet operation. |
+| Page | When to use it | Audience |
+|---|---|---|
+| [Switch voice modes](how-to/switch-voice-modes.md) | Change the privacy/speed/cost trade-off across the six tiers. | tinkerer |
+| [Use the camera](how-to/use-the-camera.md) | Take a photo, record video, send an image into chat. | tinkerer |
+| [Dictate and take notes](how-to/dictate-and-take-notes.md) | Capture a longer thought hands-free → title + summary in Notes. | tinkerer |
+| [Enable the TinkerON wakeword](how-to/enable-tinkeron-wakeword.md) | Go fully hands-free with "Hey Tinker" on the K144 module. | tinkerer |
+| [Set up a dev environment](how-to/dev-setup.md) | Stand up the ESP-IDF toolchain to build and modify the firmware. | developer |
+| [Flash the firmware](how-to/flash-firmware.md) | Build and load the firmware, with recovery + troubleshooting. | developer |
+| [Run the e2e test harness](how-to/run-the-e2e-test-harness.md) | Drive a Tab5 through long user-story flows for regression testing. | developer |
+| [Connect a Tab5 to a Dragon](how-to/connect-to-dragon.md) | Point a device at a Dragon — first-time, new network, or repair. | operator |
+| [Run a Tab5 in production](how-to/deploy.md) | Operate one or more devices day-to-day (OTA, monitoring). | operator |
+| [Recover a stuck device](how-to/recover-a-stuck-device.md) | The cheapest-first recovery ladder for a misbehaving device. | operator |
 
 ### Reference — look up facts (audience: integrator / developer)
 
 | Page | Covers |
 |---|---|
+| [Reference index](reference/README.md) | The reference section's own map. |
+| [WebSocket protocol](reference/websocket-protocol.md) | The Tab5 client side of the Dragon WebSocket — every frame and magic tag. |
 | [Debug server](reference/debug-server.md) | The `:8080` HTTP control API — endpoints, bearer-token auth, the post-Wave-23b handler module map. |
+| [Voice modes](reference/voice-modes.md) | The six tiers, on-the-wire behavior, routing codes, failover guards. |
+| [NVS settings](reference/nvs-settings.md) | Every persistent settings key in the `"settings"` namespace. |
+| [Observability events](reference/observability-events.md) | The `/events` ring — every event kind and detail format. |
+| [Hardware](reference/hardware.md) | The Tab5 SoC, peripherals, audio pipeline, M5-Bus, and memory rules. |
+| [Firmware file map](reference/firmware-file-map.md) | Where everything lives under `main/` — find the right home for a change. |
 
 ### Explanation — understand why (audience: developer)
 
 | Page | Helps you understand |
 |---|---|
 | [How the stack fits together](explanation/how-the-stack-fits-together.md) | What the Tab5, Dragon, and K144/TinkerON each do, and the six voice modes. |
-
-> **Wave 1** fills out the four-audience content: hardware build/mods, voice/UI
-> usage, troubleshooting, and architecture. The pages above are the validated
-> seed pages — one per Diátaxis type — that prove the templates end-to-end.
+| [TinkerTab architecture](explanation/architecture.md) | How the firmware is layered internally and why the boundaries fall where they do. |
+| [The voice pipeline](explanation/the-voice-pipeline.md) | How a turn becomes an answer — STT → LLM → TTS, the state machine, and the audio path. |
+| [LVGL on ESP32-P4](explanation/lvgl-on-esp32p4.md) | Why the UI is hide/show, why `lv_async_call` is banned, and the render-budget footguns. |
+| [The TinkerON / K144 chain](explanation/the-tinkeron-k144-chain.md) | How the on-device chain works, talks StackFlow, and self-heals. |
 
 ## Standards + shared assets
 
@@ -67,7 +112,7 @@ browse by type.
 
 ## Other in-repo docs (to be slotted into Diátaxis in later waves)
 
-These predate the Diátaxis restructure and remain in `docs/` for now:
+These predate or supplement the Diátaxis pages and remain in `docs/` for now:
 
 - [`HARDWARE.md`](HARDWARE.md) · [`hardware-mods.md`](hardware-mods.md) ·
   [`VOICE_PIPELINE.md`](VOICE_PIPELINE.md) · [`WIDGETS.md`](WIDGETS.md) ·

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,276 @@
+---
+audience: developer
+type: explanation
+prerequisites: [how-the-stack-fits-together.md](how-the-stack-fits-together.md)
+last-verified: 2026-05-29
+---
+# TinkerTab architecture — how the firmware is built and why
+
+## The question
+
+You are about to read or change the [Tab5](../../GLOSSARY.md) firmware and you
+want the mental model first: what runs on the device, what runs on the
+[Dragon](../../GLOSSARY.md), how the firmware is organized internally, and why
+the boundaries fall where they do. This page draws that model.
+
+It is the firmware-side companion to
+[how the stack fits together](how-the-stack-fits-together.md), which maps the
+four repos at the product level. That page answers "how do Tab5, Dragon, and
+TinkerON relate?"; this one answers "how is the *TinkerTab* firmware itself put
+together, and why?" It does not give you a recipe — for building and flashing
+see [the dev-setup how-to](../how-to/dev-setup.md) and
+[flash the firmware](../how-to/flash-firmware.md).
+
+## The model
+
+### Thin face, fat brain
+
+TinkerTab is the firmware for the M5Stack Tab5: an ESP32-P4 with a 720×1280 MIPI
+DSI display, a 4-mic TDM array, an ES8388 speaker, an SC202CS camera, and Wi-Fi
+through a hosted ESP32-C6. It is deliberately a **thin client**. It owns the
+hardware and the native [LVGL](../../GLOSSARY.md) UI; it owns no intelligence.
+
+```
+        +-----------------------------+                 +-------------------------------+
+        |  Tab5  (TinkerTab — this repo)|  one WebSocket  |  Dragon Q6A  (TinkerBox)      |
+        |  "the face" — thin client    | <==============> |  "the brain" — all intelligence|
+        |                              |  ws://host:3502  |                               |
+        |  - LVGL v9 UI                |  /ws/voice       |  - STT (Moonshine)            |
+        |  - 4-mic array + ES8388 spkr |   audio frames > |  - LLM (llama-server / cloud) |
+        |  - SC202CS camera, touch     | < STT/LLM/TTS    |  - TTS (Piper / Kokoro)       |
+        |  - SD card, NVS settings     |   config/events  |  - embeddings + memory + RAG  |
+        |  - ESP32-P4 + ESP32-C6 Wi-Fi |                  |  - sessions, REST API, dashboard|
+        +-----------------------------+                  +-------------------------------+
+```
+
+The split is sharp and the [`CLAUDE.md`](../../CLAUDE.md) "Repo Separation"
+section states it as a rule:
+
+- **TinkerTab owns** the LVGL UI, mic/speaker/camera/touch, SD card, Wi-Fi, and
+  [NVS](../../GLOSSARY.md) settings. It *sends* audio frames, text turns, and
+  device registration; it *receives* STT results, LLM responses, TTS audio, and
+  config updates. Storage on the device is the SD card (audio recordings,
+  offline queue) and NVS (settings). **There is no database on the Tab5.**
+- **TinkerBox (the Dragon)** owns STT, the LLM, TTS, embeddings, sessions, the
+  conversation engine, the REST API, the dashboard, and the database. All
+  intelligence is here.
+
+The wire contract between the two lives in TinkerBox's
+[`docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md);
+Tab5 implements the client side. The cross-stack picture is in TinkerBox's
+[`docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md).
+
+### The four firmware layers
+
+Inside the firmware, the code is organized into four layers, from hardware up to
+UI. The `main/` directory holds all of them.
+
+```
++--------------------------------------------------------------+
+|  UI layer — LVGL v9                                          |
+|  ui_core, ui_home, ui_voice, ui_chat, ui_settings, ...       |
+|  one orb across home + voice; overlays hidden, not destroyed |
++--------------------------------------------------------------+
+|  Dragon link — the one WebSocket                            |
+|  voice.c (state machine + mic/playback tasks)                |
+|  voice_ws_proto.c (frame routing)  voice_modes.c (6 modes)   |
++--------------------------------------------------------------+
+|  Coordination — what runs when                              |
+|  mode_manager (IDLE <-> VOICE)   service_registry (lifecycle)|
++--------------------------------------------------------------+
+|  Hardware drivers                                           |
+|  audio (ES8388), mic (ES7210), camera (SC202CS), imu, rtc,   |
+|  battery, wifi (C6 via SDIO), sdcard, touch (GT911), display |
++--------------------------------------------------------------+
+```
+
+### The service registry — one lifecycle for every subsystem
+
+Every heavy subsystem is wrapped in a uniform service lifecycle so the firmware
+can bring it up, tear it down, and recover it through one interface rather than
+ad-hoc init code scattered across `main.c`. The state machine is:
+
+```
+NONE -> INITIALIZED -> RUNNING -> STOPPED -> RUNNING -> ...
+                                     \-> ERROR (needs recovery)
+```
+
+There are five services, defined in `main/service_registry.{c,h}` with one
+implementation file each:
+
+| Service | File | Owns |
+|---|---|---|
+| `STORAGE` | `service_storage.c` | SD card (SDMMC) + NVS |
+| `DISPLAY` | `service_display.c` | LVGL + DSI panel bring-up |
+| `AUDIO` | `service_audio.c` | I2S, ES8388 DAC, ES7210 mic |
+| `NETWORK` | `service_network.c` | Wi-Fi (STA, connect, reconnect) |
+| `DRAGON` | `service_dragon.c` | the voice WebSocket lifecycle |
+
+Each service exposes `init` / `start` / `stop` so the boot path and the mode
+manager can sequence them deterministically instead of inferring init order from
+call sites. This is the pattern `CLAUDE.md` calls out as "better than Mooncake
+for embedded" — it is the firmware's spine.
+
+### The mode manager — one heavy subsystem at a time
+
+The ESP32-P4 shares roughly 512 KB of internal SRAM between FreeRTOS and the DMA
+pool, and three subsystems contend for that DMA RAM: SDIO Wi-Fi, I2S audio, and
+MIPI DSI video. Run them all at once and allocations fail. The **mode manager**
+(`main/mode_manager.{c,h}`) enforces that only one heavy subsystem runs at a
+time. The device is always in exactly one mode:
+
+| Mode | Active services | Purpose |
+|---|---|---|
+| `IDLE` | Wi-Fi | No streaming, no voice |
+| `STREAMING` | Wi-Fi + MJPEG + Touch WS | Legacy desktop streaming (retired path) |
+| `VOICE` | Wi-Fi + Voice WS + Mic + Speaker | Voice assistant |
+| `BROWSING` | Wi-Fi + MJPEG + Touch WS | Reserved (same as STREAMING) |
+
+Mode switches are mutex-protected and idempotent: the manager stops the old
+mode's services, waits for DMA to settle, then starts the new mode's services.
+In practice today the firmware lives in `IDLE` and `VOICE` — the CDP
+browser-streaming path that drove `STREAMING` was retired (see "Why it's built
+this way" below), so `mode_manager` is now a thin mutex wrapper around
+`voice_connect` / `voice_disconnect`, kept because `ui_voice`, `ui_notes`, and
+`service_dragon` flip modes from several tasks.
+
+### The Dragon link — one WebSocket, many message types
+
+The Tab5 holds exactly one persistent [WebSocket](../../GLOSSARY.md) to the
+Dragon at `ws://<host>:3502/ws/voice`, and *all* traffic multiplexes over it:
+voice, text, vision, video, config, and observability. Three files carry it:
+
+- **`voice.c`** — the public voice API, the voice state machine
+  (`IDLE`/`CONNECTING`/`READY`/`LISTENING`/`PROCESSING`/`SPEAKING`/`RECONNECTING`),
+  the mic-capture task, the playback drain task, and the reconnect watchdog.
+- **`voice_ws_proto.c`** — the frame-routing layer: the JSON RX dispatcher, the
+  binary magic-tag dispatcher (`VID0` video / `AUD0` call audio / untagged raw
+  PCM → STT), the `esp_websocket_client` event callback, and the UI-async
+  helpers.
+- **`voice_modes.c`** — the six-tier voice-mode dispatcher that decides where a
+  text turn is routed.
+
+Untagged binary frames are raw 16 kHz mono PCM going straight into STT — that is
+the legacy mic path and it stays magic-less for backward compatibility. Tagged
+frames carry a 4-byte magic plus a big-endian length: `VID0` for JPEG video both
+directions, `AUD0` for call-mode PCM.
+
+### Where a voice turn runs — the six modes
+
+The same orb tap or wakeword fires a turn, but *where the work happens* depends
+on the active [voice mode](../../GLOSSARY.md):
+
+| Mode | STT | LLM | TTS | Needs Dragon? |
+|---|---|---|---|---|
+| 0 — Local | Moonshine (Dragon) | Dragon-local | Piper (Dragon) | Yes |
+| 1 — Hybrid | OpenRouter | Dragon-local | OpenRouter | Yes |
+| 2 — Cloud | OpenRouter | OpenRouter | OpenRouter | Yes (audio pipe) |
+| 3 — TinkerClaw | Dragon | [TinkerClaw](../../GLOSSARY.md) gateway | Dragon | Yes (audio pipe) |
+| 4 — Onboard (K144) | K144 | K144 | K144 | **No** |
+| 5 — Solo | OpenRouter | OpenRouter | OpenRouter | **No** |
+
+Modes 0–3 are real on-the-wire `voice_mode` values. Modes 4 and 5 are
+**Tab5-side-only**: they downconvert to `0` on the wire so the Dragon never sees
+them, and the `config_update` ACK handler in `voice.c` filters out the Dragon's
+echo so local NVS keeps the true 4/5 value. The active mode persists in the NVS
+`vmode` key.
+
+### The optional on-device module — TinkerON / K144
+
+The K144 ([TinkerON](../../GLOSSARY.md)) is an M5Stack LLM Module Kit (AX630C NPU)
+that stacks onto the Tab5 over the M5-Bus (UART or USB transport) through a
+Module13.2 Mate carrier. When present it adds always-on "Hey Tinker" wakeword and
+can run a whole voice turn — ASR, LLM, and TTS — entirely on-device with no
+Dragon (voice mode 4). It is strictly additive: the firmware enforces six
+modularity rules so the Tab5 **never depends** on it being present, gray-outs
+the relevant UI when it is absent, and degrades gracefully on hot-unplug. The
+K144 surface lives in `voice_m5_llm.c`, `voice_onboard.c`, and
+`voice_wakeword.c`, and talks the [StackFlow](../../GLOSSARY.md) JSON protocol
+over the M5-Bus.
+
+### The boot sequence
+
+`main/main.c` brings the layers up bottom-first so each layer can rely on the
+one below it:
+
+1. Platform init — I2C bus, IO expanders, Wi-Fi power
+2. Service init — allocate and configure hardware for all five services
+3. Peripheral drivers — camera, IMU, RTC, battery
+4. Service start — Storage → Display → Audio → Network
+5. Dragon link start (needs Wi-Fi)
+6. LVGL init and splash screen
+7. Home screen transition with deferred overlay creation
+8. Debug HTTP server start (port 8080)
+9. NTP time sync (best-effort)
+10. Serial command loop
+
+The voice WebSocket connects silently at boot and the device registers
+immediately, so the first mic tap does not pay a 5–15 s connect cost.
+
+### Observing the running system
+
+The firmware is built to be driven and inspected from a workstation. The
+[debug server](../reference/debug-server.md) on port 8080 exposes screenshots,
+touch injection, navigation, voice control, and K144 diagnostics. Internally,
+`tab5_debug_obs_event(kind, detail)` writes to a 256-entry ring read via
+`GET /events?since=N`, which the Python end-to-end harness in `tests/e2e/` polls
+to drive long user-story flows. This observability surface is part of the
+architecture, not an afterthought — it is how the device is tested without a
+human watching the screen.
+
+## Why it's built this way
+
+- **Thin client, fat brain.** The ESP32-P4's ~512 KB of tight internal SRAM
+  cannot host a useful LLM. Pushing all intelligence to the Dragon keeps the
+  firmware small, lets the brain upgrade independently (a new model is a Dragon
+  deploy, not a reflash), and lets one Dragon serve a fleet of faces. The cost is
+  a hard dependency on the Dragon for modes 0–3 — which is exactly why the
+  optional on-device fallback (mode 4) and the direct-cloud path (mode 5) exist.
+
+- **The service registry over ad-hoc init.** Five subsystems with hardware that
+  can fail and need recovery is enough complexity to justify a uniform
+  lifecycle. The alternative — init code threaded through `main.c` with implicit
+  ordering — made recovery and mode switching error-prone. The explicit
+  `NONE → INITIALIZED → RUNNING → STOPPED → ERROR` state machine gives the mode
+  manager a clean contract to sequence against. `CLAUDE.md` records the decision
+  not to adopt M5Stack's Mooncake here: the service registry is the better fit
+  for this embedded target.
+
+- **One heavy subsystem at a time.** SDIO Wi-Fi, I2S audio, and MIPI DSI all draw
+  from the same scarce internal DMA RAM. Without the mode manager's
+  stop-old → settle → start-new discipline, switching between video streaming and
+  voice exhausted the DMA pool and crashed. The `heap_watchdog.c` safety net
+  catches the residual case: when `MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL` free
+  drops below 16 KB for two consecutive 60 s samples, it reboots (honoring a
+  voice-active grace window) so a radio-silent device recovers without a
+  serial reflash.
+
+- **One WebSocket, many message types.** Multiplexing voice, text, vision, video,
+  config, and events over a single persistent connection avoids connection churn
+  on a memory-constrained device and keeps the protocol in one place. The binary
+  magic-tag scheme (`VID0` / `AUD0` / untagged) lets one socket carry several
+  binary payload kinds while keeping the legacy raw-PCM mic path unchanged.
+
+- **Voice-first, not a remote display.** The Tab5 originally shipped a CDP
+  browser-streaming path (MJPEG video + touch relay over port 3501). It was
+  retired in PR #155 because the product is the voice assistant, not a remote
+  screen. Doubling down on voice is what differentiates the Tab5 from every other
+  IoT display. The `STREAMING`/`BROWSING` modes and their old driver files
+  (`dragon_link`, `mjpeg_stream`, `udp_stream`, `touch_ws`, `mdns_discovery`) are
+  gone; the mode enum retains the names for compatibility but the firmware reaches
+  the Dragon only over the voice WebSocket.
+
+- **Each repo stands alone.** TinkerTab is documented as its own front door and
+  cross-links the other three repos as peers rather than nesting under a single
+  umbrella. A reader who learns one repo's layout can navigate any of them, but
+  each is fully self-contained — which is why the deep wire contract and the
+  cross-stack map live in TinkerBox, and this repo links to them rather than
+  copying them.
+
+## See also
+
+- [How the stack fits together](how-the-stack-fits-together.md) · [Getting started](../tutorials/getting-started.md)
+- [Dev setup](../how-to/dev-setup.md) · [Flash the firmware](../how-to/flash-firmware.md) · [Deploy](../how-to/deploy.md)
+- [Debug server reference](../reference/debug-server.md) · [GLOSSARY](../../GLOSSARY.md)
+- System architecture (cross-stack): [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md)
+- Wire protocol: [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md)

--- a/docs/explanation/lvgl-on-esp32p4.md
+++ b/docs/explanation/lvgl-on-esp32p4.md
@@ -1,0 +1,122 @@
+---
+audience: developer
+type: explanation
+prerequisites: none
+last-verified: 2026-05-29
+---
+# LVGL on the ESP32-P4 — why the UI is built the way it is
+
+## The question
+
+The [Tab5](../../GLOSSARY.md)'s entire UI is [LVGL](../../GLOSSARY.md) v9.2.2 on
+an ESP32-P4 — a microcontroller with ~512 KB of tight internal SRAM driving a
+720×1280 display. This page explains the constraints that shaped how the UI is
+written: where LVGL config lives, why overlays are hidden instead of destroyed,
+why `lv_async_call` is banned, and the rendering patterns that quietly bust the
+render budget. It is the *why* behind the rules; for the file layout see the
+[firmware file map](../reference/firmware-file-map.md).
+
+## The model
+
+### Memory: a TLSF pool you grow yourself
+
+LVGL allocates from a TLSF heap. On the Tab5 the base pool is a **64 KB**
+BSS-allocated chunk (`CONFIG_LV_MEM_SIZE_KILOBYTES=64`), and `main.c` adds a
+**2 MB PSRAM-backed pool** at boot with `lv_mem_add_pool()`. The key
+misconception to unlearn:
+
+```
+CONFIG_LV_MEM_POOL_EXPAND_SIZE_KILOBYTES=4096
+```
+
+is **not** an auto-expand trigger. LVGL 9.2.2 has **no** auto-expand; that value
+is only the TLSF per-pool max-size ceiling
+(`TLSF_MAX_POOL_SIZE = LV_MEM_SIZE + LV_MEM_POOL_EXPAND_SIZE`). The only way to
+grow the heap is the explicit `lv_mem_add_pool()` call. The base pool was
+dropped from 96 KB to 64 KB to free internal-SRAM headroom; pushing it to 128 KB+
+aborts at boot.
+
+### Config lives in `sdkconfig.defaults`, not `lv_conf.h`
+
+The ESP-IDF LVGL component sets `CONFIG_LV_CONF_SKIP=1`, so **`lv_conf.h` is
+completely ignored**. Every LVGL setting must go in `sdkconfig.defaults`. Verify
+a setting actually took with `grep "SETTING" build/config/sdkconfig.h` after a
+build. `sdkconfig` changes need `idf.py fullclean build` — incremental builds
+cache stale config.
+
+### Rendering: partial mode, two PSRAM buffers
+
+The display runs `LV_DISPLAY_RENDER_MODE_PARTIAL` with two 144 KB draw buffers
+in PSRAM (DIRECT mode tears on DPI). The DPI peripheral DMAs straight out of
+PSRAM, so the firmware calls `esp_cache_msync()` after CPU framebuffer writes to
+keep the cache coherent. Asserts are off
+(`CONFIG_LV_USE_ASSERT_MALLOC=n`, `..._NULL=n`) so an alloc failure crashes fast
+with a backtrace instead of hanging in a `while(1)` that trips the 60 s WDT.
+
+### Internal-SRAM fragmentation and the hide/show pattern
+
+`heap_caps_get_free_size()` *lies* — total free is not usable free. What matters
+is `heap_caps_get_largest_free_block()`. Creating and destroying LVGL overlays
+allocates and frees many small objects from internal SRAM; over hours this
+fragments the heap until total free looks healthy but no single block is large
+enough and allocations fail.
+
+The fix is **hide/show, not create/destroy**. Settings, Chat, and Voice overlays
+are created once and toggled with `lv_obj_add_flag(LV_OBJ_FLAG_HIDDEN)` /
+`lv_obj_remove_flag(...)`. `dismiss_all_overlays()` hides; it does not destroy.
+Overlays with live timers/animations *must* be hidden (destroying corrupts the
+timer linked list). Destroy only when permanently replacing (e.g. New Chat).
+
+A **fragmentation watchdog** (`heap_watchdog.c`) is the safety net: if the
+internal-SRAM largest free block stays below ~30 KB for ~3 minutes it triggers a
+controlled reboot (honoring a voice-active grace window).
+
+### `lv_async_call` is not thread-safe — use `tab5_lv_async_call`
+
+LVGL 9.x's `lv_async_call` does `lv_malloc` + `lv_timer_create` against the
+unprotected TLSF heap. The codebase treated it as thread-safe for years (a wrong
+comment in `ui_core.c`) and it was the real root cause of a long-residual crash
+class. The rule now: **always call `tab5_lv_async_call(cb, arg)`** (it wraps the
+site under `tab5_ui_lock`), never the LVGL primitive directly. All 49 call sites
+were converted; a new direct call is a regression.
+
+### Render-budget footguns
+
+A handful of LVGL features quietly stall the UI task into a continuous
+"mutex timeout" on large or frequently-invalidated objects:
+
+| Pattern | Symptom | Use instead |
+|---|---|---|
+| `transform_scale` on a `bg_grad` object | re-rasterizes the gradient every tick | animate `bg_opa` on a sibling solid object |
+| `bg_angles(270, 630)` for a full ring | wraps past 360, renders invisible | `bg_angles(0,360)` + `lv_arc_set_rotation(270)` |
+| `shadow_width ≥16 px` on a ≥200 px / ≥5 Hz object | busts the render budget | `bg_opa` or a pre-rendered blur sprite |
+| 5-stop gradient on a 280 px body @ 30 Hz | continuous mutex timeout | fewer stops, pre-rendered sprite, or a baked-dither canvas |
+
+The broader lesson from the orb-aliveness arc: **subtraction over addition** —
+each visual layer added made it worse; the keeper had ember/rings/counter-phase
+*removed*.
+
+## Why it's built this way
+
+- **The P4 is memory-bound, not compute-bound, for UI.** The dominant failure
+  mode is not "too slow to render" but "ran out of a contiguous block." Every
+  pattern above — the PSRAM pool, hide/show, the watchdog — is about keeping the
+  largest free block healthy, not about frame rate.
+
+- **A single draw thread means a single lock.** The UI task is the only thread
+  allowed to touch LVGL objects after a screen is created; background tasks must
+  marshal through `tab5_lv_async_call`. This is why the thread-safety of that one
+  primitive mattered so much.
+
+- **Fail fast beats hang.** Disabling LVGL asserts trades a clean abort backtrace
+  for a `while(1)` WDT hang — a deliberate choice that made the crash class
+  debuggable.
+
+## See also
+
+- [Firmware file map](../reference/firmware-file-map.md) ·
+  [Hardware reference](../reference/hardware.md)
+- [Recover a stuck device](../how-to/recover-a-stuck-device.md) — the
+  fragmentation watchdog in practice.
+- [TinkerTab architecture](architecture.md) · deep dive:
+  [`../STABILITY-INVESTIGATION.md`](../STABILITY-INVESTIGATION.md)

--- a/docs/explanation/the-tinkeron-k144-chain.md
+++ b/docs/explanation/the-tinkeron-k144-chain.md
@@ -1,0 +1,138 @@
+---
+audience: developer
+type: explanation
+prerequisites: none
+last-verified: 2026-05-29
+---
+# The TinkerON / K144 chain — how on-device voice works and why
+
+## The question
+
+The [Tab5](../../GLOSSARY.md) can run a whole voice turn — wakeword, ASR, LLM,
+TTS — with **no [Dragon](../../GLOSSARY.md) at all**, on a small module stacked
+on its back. This page explains how that on-device chain works, why it talks the
+[StackFlow](../../GLOSSARY.md) protocol over a UART, how it self-heals when the
+module wedges, and why it is strictly optional. To *enable* it, see
+[Enable the TinkerON wakeword](../how-to/enable-tinkeron-wakeword.md).
+
+## The model
+
+### What the module is
+
+**K144 / [TinkerON](../../GLOSSARY.md)** is an M5Stack LLM Module Kit built
+around an **AX630C NPU** (4 GB, 3.2 TOPS). "TinkerON" is the user-facing brand;
+**K144 / AX630C / sherpa-ncnn** are the canonical hardware identifiers in logs
+and code. It runs its own Linux + a service daemon and ships with on-device
+models: a streaming ASR (`sherpa-ncnn` zipformer), a KWS model, a small LLM
+(`qwen2.5-0.5B`), a TTS voice, and YOLO detection.
+
+### The physical stack
+
+```
+   ┌──────────────┐
+   │   K144        │  AX630C NPU — ASR + LLM + TTS + KWS + YOLO
+   └──────┬───────┘
+          │  M5-Bus (UART Port C, or USB transport)
+   ┌──────┴───────┐
+   │ Module13.2    │  LLM Mate carrier  ── REQUIRED
+   │ LLM Mate      │  (passes M5-Bus through; provides power feed)
+   └──────┬───────┘
+          │  M5-Bus
+   ┌──────┴───────┐
+   │   Tab5        │  its own USB-C powers the whole stack (~1.5 W K144 load)
+   └──────────────┘
+```
+
+The Mate carrier is not optional: stacking the K144 directly on the Tab5
+collides the 5V rails and wedges the NPU silicon. The Tab5's own USB-C powers
+everything through the M5-Bus.
+
+### The transport and the protocol
+
+The Tab5 talks to the K144 over the M5-Bus — historically a **UART** on Port C
+(TX GPIO 6, RX GPIO 7), starting at 115200 8N1 and bumping to **1.5 Mbps** for
+audio throughput; a later pivot added a **USB functionfs** transport (two
+userspace bridges on the K144 for StackFlow JSON + YOLO frames). Either way the
+wire protocol is **StackFlow**: newline-delimited JSON, one socket surviving
+many inference calls (no length-prefix framing).
+
+```
+setup  ──►  ack: data:"None", then a work_id (e.g. "llm.1000")
+infer  ──►  stream: {"object":"llm.utf-8.stream","data":{"delta":...,"finish":bool}}
+```
+
+Verified `sys.*` verbs: `sys.ping`, `sys.hwinfo`, `sys.lsmode`, `sys.reset`,
+`sys.reboot`, `sys.version`. (`sys.list` / `sys.status` / `sys.uptime` /
+`sys.log` are **not** real — probed.)
+
+### The two on-device features
+
+| Feature | What it does |
+|---|---|
+| **Always-on wakeword** | The Tab5's own mic array is pumped over the M5-Bus into the K144's ASR ([`ext_pcm`](../../GLOSSARY.md)). A lenient matcher catches "Hey Tinker" and fires a normal voice turn. |
+| **Onboard turn (voice mode 4)** | ASR + LLM + TTS all run on the K144. A user speaks at the stack → on-device ASR + LLM → per-utterance TTS streamed back over the transport → the Tab5 upsamples and plays it. No Dragon. |
+
+The wakeword fires through the regular orb-tap path, so the actual turn still
+respects the active [voice mode](../../GLOSSARY.md) routing. The matcher is
+**open-vocabulary**: it accepts a family of ASR renderings
+(`tinker` / `thinker` / `hicker` / `hick` / `hanker`) because the streaming
+zipformer renders "Hey Tinker" inconsistently — changing the wake phrase is a
+one-string edit, no model retraining.
+
+### Self-healing
+
+The K144 daemon wedges intermittently. The chain manages this proactively rather
+than relying on a human:
+
+- **Warmup gate.** Boot runs a probe + one synchronous inference to map the model
+  into NPU memory (up to a 6-minute cold-start budget). Success flips the
+  failover gate READY; any failure flips it UNAVAILABLE.
+- **Reactive watchdog.** Polls the chain; on a stall it escalates
+  `kick → unavailable_kick → sys.reset → sys.reboot` (full K144 Linux reboot
+  after repeated failures). All automatic, rate-limited.
+- **Preventive maintenance.** A `sys.reboot` every ~4 h of READY uptime (in a
+  quiet window) clears accumulated daemon state; a periodic UART resync pause
+  gives the receiver an idle window to re-lock the bit clock at 1.5 Mbps.
+- **Suppression.** Wakeword is suppressed during a full voice turn + 1 s grace so
+  Tinker's own TTS reply does not self-wake; the `ext_pcm` pump pauses during a
+  turn so the Tab5 mic routes to the Dragon.
+
+The whole surface is observable via `GET /m5`, `POST /m5/reset`, and the
+`m5.*` / `error.k144` [observability events](../reference/observability-events.md).
+
+### Modularity rules (non-negotiable)
+
+The K144 is an addon. Six rules keep the Tab5 from ever depending on it:
+boot-path-agnostic, no feature regresses when it is absent, capability detection
+gates everything, the UI grays out absent features, hot-unplug is graceful, and
+no `#ifdef` guards. The Tab5 is a complete product without a K144.
+
+## Why it's built this way
+
+- **A real offline fallback.** Modes 0–3 hard-depend on the Dragon. The K144
+  gives the Tab5 a genuine no-Dragon path (mode 4) plus hands-free wakeword — the
+  product's headline feature — without forcing every user to buy the module.
+
+- **StackFlow over a custom protocol.** The K144 ships its daemon and JSON wire
+  format; meeting it where it is (newline-delimited JSON, `work_id` handles) was
+  cheaper and more robust than rebuilding the K144 firmware. The JSON parser
+  tolerates the UART framing errors that 1.5 Mbps produces.
+
+- **Manage the hardware quirks, don't pretend they're gone.** The 1.5 Mbps clock
+  drift, daemon state accumulation, and ES7210 codec drift are real. The chain's
+  watchdog + preventive reboots + resync pause *manage* them so the device stays
+  always-on; they are not claimed to be fixed.
+
+- **Lenient matching beats a brittle model.** A retrained custom wake model would
+  be more precise but locks the wake phrase in silicon. An open-vocabulary string
+  matcher over the ASR output trades a little precision for the freedom to change
+  the phrase in one line.
+
+## See also
+
+- [Enable the TinkerON wakeword](../how-to/enable-tinkeron-wakeword.md) ·
+  [Recover a stuck device](../how-to/recover-a-stuck-device.md)
+- [Voice modes reference](../reference/voice-modes.md) (mode 4) ·
+  [Debug server reference](../reference/debug-server.md) (`/m5`)
+- [How the stack fits together](how-the-stack-fits-together.md) ·
+  [The voice pipeline](the-voice-pipeline.md)

--- a/docs/explanation/the-voice-pipeline.md
+++ b/docs/explanation/the-voice-pipeline.md
@@ -1,0 +1,138 @@
+---
+audience: developer
+type: explanation
+prerequisites: none
+last-verified: 2026-05-29
+---
+# The voice pipeline — how a turn becomes an answer
+
+## The question
+
+You tap the orb (or say "Hey Tinker"), speak, and a few seconds — or a minute —
+later the [Tab5](../../GLOSSARY.md) answers out loud. This page explains what
+happens in between: the three stages a turn passes through, who runs each stage,
+and why the [Tab5](../../GLOSSARY.md) is built to be a thin pipe rather than the
+thing that thinks. It does not teach you how to *use* it — for that see
+[Your first voice conversation](../tutorials/your-first-voice-conversation.md).
+
+## The model
+
+A voice turn is **three stages**: speech-to-text (STT) → the LLM → text-to-speech
+(TTS). The Tab5 owns the microphone and speaker at the ends; the work in the
+middle happens wherever the active [voice mode](../../GLOSSARY.md) routes it
+(usually the [Dragon](../../GLOSSARY.md)).
+
+```
+   you speak
+      │
+      ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  Tab5 (the face)                                            │
+ │   ES7210 4-mic ─► I2S TDM RX ─► 48 kHz PCM ─► 3:1 down ─►   │
+ │   16 kHz mono PCM frames ──────────────────────────────────┐│
+ └────────────────────────────────────────────────────────────┼┘
+                                                               │ untagged
+                              one WebSocket  ws://host:3502     │ binary frames
+                                                               ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  Dragon (the brain)                                         │
+ │   STT (Moonshine) ─► transcript                             │
+ │        │                                                    │
+ │        ▼                                                    │
+ │   LLM (llama-server / cloud) ─► response text               │
+ │        │                                                    │
+ │        ▼                                                    │
+ │   TTS (Piper / Kokoro) ─► 16 kHz PCM ──────────────────────┐│
+ └────────────────────────────────────────────────────────────┼┘
+                                                               │ tts_start
+                                                               │ binary PCM
+                                                               │ tts_end
+ ┌─────────────────────────────────────────────────────────────┼┘
+ │  Tab5                                                       ▼
+ │   1:3 upsample ─► 48 kHz ─► I2S STD TX ─► ES8388 ─► speaker  │
+ └─────────────────────────────────────────────────────────────┘
+      │
+      ▼
+   you hear the answer
+```
+
+### The state machine
+
+The Tab5 tracks a turn through a state machine in `voice.c`, surfaced on every
+transition as a `voice.state` [observability event](../reference/observability-events.md):
+
+```
+IDLE ─► CONNECTING ─► READY ─► LISTENING ─► PROCESSING ─► SPEAKING ─► READY
+                                   │                          │
+                                   └──── cancel ──────────────┘──► READY/IDLE
+                        (RECONNECTING if the WS drops mid-turn)
+```
+
+- **LISTENING** — mic is streaming untagged 16 kHz PCM frames up the
+  [WebSocket](../../GLOSSARY.md).
+- **PROCESSING** — the Dragon is running STT + the LLM; the Tab5 sends keepalive
+  pings every ~15 s.
+- **SPEAKING** — TTS audio is streaming down (`tts_start` → binary PCM →
+  `tts_end`) and draining through the playback task.
+
+### Audio, end to end
+
+The hardware runs at **48 kHz**; STT wants **16 kHz**. The mic path downsamples
+3:1 on the way up and the playback path upsamples 1:3 on the way down. Capture
+is a 4-slot TDM read off the ES7210 (slot 0 = primary mic); playback is an STD
+Philips write to the ES8388. A dedicated playback drain task does
+producer-consumer I2S writes so the WS receive path never blocks on the speaker.
+
+### Three turn shapes
+
+The same pipeline serves three input shapes:
+
+| Shape | How it starts | What is sent | LLM reply? |
+|---|---|---|---|
+| **Voice (Ask)** | tap / wakeword | `start` → untagged PCM → `stop` | Yes (STT → LLM → TTS) |
+| **Dictation** | long-press | `start {"mode":"dictate"}` → PCM | No — STT only, + a `dictation_summary` |
+| **Text** | typed | `{"type":"text","content":"..."}` | Yes — skips STT, same context |
+
+### Where the work runs — the six modes
+
+The state machine is identical across modes; only the *backend* of each stage
+moves. See the [voice modes reference](../reference/voice-modes.md) for the full
+table. The headline: modes 0–3 need the Dragon; mode 4 (Onboard / K144) and
+mode 5 (Solo Direct) run a whole turn with **no Dragon**.
+
+## Why it's built this way
+
+- **Thin client, fat brain.** The ESP32-P4's ~512 KB internal SRAM cannot host a
+  useful LLM. Keeping STT/LLM/TTS on the Dragon means the model upgrades without
+  a reflash and one Dragon can serve a fleet of faces. The cost — a hard Dragon
+  dependency for modes 0–3 — is exactly why the on-device fallback (mode 4) and
+  direct-cloud path (mode 5) exist.
+
+- **Untagged PCM is the legacy mic contract.** Binary frames without a magic
+  prefix are always raw 16 kHz mono PCM going straight to STT. Tagged frames
+  (`VID0` video, `AUD0` call audio) were layered on later without breaking that
+  contract — see the [WebSocket protocol](../reference/websocket-protocol.md).
+
+- **Dictation is STT-only on purpose.** A dictation is content capture, not a
+  question. Suppressing the LLM reply and instead post-processing the transcript
+  into a title + summary matches what a note-taker wants.
+
+- **Boot-time silent connect.** The WS connects and the device registers at boot
+  so the first mic tap does not pay a 5–15 s connect cost. A reconnect watchdog
+  with exponential backoff keeps the link alive across Dragon restarts and Wi-Fi
+  blips.
+
+- **The encoder is gated, the decoder is ready.** OPUS would shrink the audio
+  frames, but the SILK NSQ encoder crashes mid-frame on the ESP32-P4 (issue
+  #264), so it is gated off in `voice_codec.h` while the decoder waits for a
+  Dragon→Tab5 OPUS TTS path. Wake word + AEC scaffolding (ESP-SR) was removed in
+  PR #162; the wakeword we ship today runs on the K144, not on-P4.
+
+## See also
+
+- [Voice modes reference](../reference/voice-modes.md) ·
+  [WebSocket protocol](../reference/websocket-protocol.md)
+- [Your first voice conversation](../tutorials/your-first-voice-conversation.md) ·
+  [Dictate and take notes](../how-to/dictate-and-take-notes.md)
+- [TinkerTab architecture](architecture.md) · [The TinkerON / K144 chain](the-tinkeron-k144-chain.md)
+- Legacy detail: [`../VOICE_PIPELINE.md`](../VOICE_PIPELINE.md)

--- a/docs/how-to/connect-to-dragon.md
+++ b/docs/how-to/connect-to-dragon.md
@@ -1,0 +1,111 @@
+---
+audience: operator
+type: how-to
+prerequisites: A flashed [Tab5](../../GLOSSARY.md) and a reachable [Dragon](../../GLOSSARY.md) server running [TinkerBox](https://github.com/lorcan35/TinkerBox)
+last-verified: 2026-05-29
+est-time: 10 min
+---
+# How to connect a Tab5 to a Dragon
+
+Use this when you need to point a [Tab5](../../GLOSSARY.md) at a
+[Dragon](../../GLOSSARY.md) server — first-time setup, moving to a new network,
+or repairing a connection that dropped. Assumes the firmware is already flashed
+(see [Flash the firmware](flash-firmware.md)) and a Dragon running
+[TinkerBox](https://github.com/lorcan35/TinkerBox) is reachable on your network
+(its voice [WebSocket](../../GLOSSARY.md) listens on **port 3502**).
+
+The Tab5 holds exactly one persistent WebSocket to the Dragon at
+`ws://<host>:3502/ws/voice`. It tries the configured host on the LAN first and
+falls back to the ngrok tunnel if `conn_m` allows it.
+
+## Steps
+
+You can set the Wi-Fi + Dragon address three ways. Pick one.
+
+### Option A — on-device (no computer)
+
+1. From the home screen, open **Settings → Network**.
+2. Run the **Wi-Fi** flow: scan, pick your SSID, enter the password. (First-boot
+   onboarding runs this automatically.)
+3. Set the **Dragon host** to the Dragon's IP (or hostname) and the **port** to
+   `3502`.
+4. The Tab5 saves these to [NVS](../../GLOSSARY.md) (`wifi_ssid`, `wifi_pass`,
+   `dragon_host`, `dragon_port`) and reconnects.
+
+### Option B — at build time
+
+Set the compiled defaults in `sdkconfig.defaults` before flashing:
+
+```
+CONFIG_TAB5_WIFI_SSID="YourNetwork"
+CONFIG_TAB5_WIFI_PASS="YourPassword"
+CONFIG_TAB5_DRAGON_HOST="192.168.1.91"   # your Dragon's IP
+CONFIG_TAB5_DRAGON_PORT=3502
+```
+
+These are only the fallback — any value the user sets on-device (Option A) or
+over the wire (Option C) wins and persists across reboots.
+
+### Option C — over the debug server
+
+Write the keys remotely with the [debug server](../reference/debug-server.md)
+(needs the bearer token from the serial boot log):
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<tab5-ip>:8080/settings \
+     -d '{"dragon_host":"192.168.1.91","dragon_port":3502}'
+# → {"ok":true}
+```
+
+## Verify it worked
+
+1. **Find the Dragon first** if you do not know its IP. From a workstation on
+   the same LAN:
+   ```bash
+   ping radxa-dragon-q6a
+   # or scan the subnet for the voice WS + dashboard + gateway ports
+   nmap -p 22,3502,18789 --open <subnet>/24
+   ```
+2. **Confirm the Tab5 connected** by reading its voice state over the debug
+   server:
+   ```bash
+   curl -s -H "Authorization: Bearer $TOKEN" http://<tab5-ip>:8080/voice \
+        | python3 -m json.tool
+   # → expect "connected": true and a state_name of READY (or IDLE)
+   ```
+3. **Send a test turn** end-to-end:
+   ```bash
+   curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<tab5-ip>:8080/chat \
+        -d '{"text":"reply with PONG"}'
+   # then re-read /voice for last_llm_text
+   ```
+
+## Troubleshooting
+
+- **`/voice` shows `connected: false`** → The Dragon is unreachable. Confirm the
+  host/port (`GET /settings`), that the Dragon's voice service is up
+  (`systemctl status tinkerclaw-voice` on the Dragon), and that both are on the
+  same network.
+- **Connected, then drops repeatedly** → The reconnect watchdog re-dials with
+  exponential backoff (10 s → 20 s → 40 s → 60 s). Persistent drops usually mean
+  Wi-Fi signal or a Dragon restart. Force an immediate retry with
+  `POST /voice/reconnect`.
+- **LAN works at home but not remotely** → The connection mode key `conn_m`
+  controls fallback: `0` = auto (LAN then ngrok), `1` = local only, `2` = remote
+  only. For an off-LAN device, leave it at `0` so the ngrok tunnel
+  (`wss://tinkerclaw-voice.ngrok.dev`) is available.
+- **Wi-Fi never associates after a reflash** → Re-check the SSID/password and
+  verify the ESP32-C6 SDIO co-processor is intact (Wi-Fi on the Tab5 runs
+  through a hosted C6 — see the [hardware reference](../reference/hardware.md)).
+- **Connected but every turn errors** → The link is fine but the pipeline is
+  failing on the Dragon side. Check `last_stt_text` / `last_llm_text` in
+  `/voice` and the Dragon logs (`journalctl -u tinkerclaw-voice`).
+
+## See also
+
+- [Switch voice modes](switch-voice-modes.md) · [Run a Tab5 in production](deploy.md)
+- [Debug server reference](../reference/debug-server.md) ·
+  [NVS settings reference](../reference/nvs-settings.md) (`dragon_host`,
+  `dragon_port`, `conn_m`)
+- [How the stack fits together](../explanation/how-the-stack-fits-together.md)

--- a/docs/how-to/dictate-and-take-notes.md
+++ b/docs/how-to/dictate-and-take-notes.md
@@ -1,0 +1,85 @@
+---
+audience: tinkerer
+type: how-to
+prerequisites: A booted [Tab5](../../GLOSSARY.md) connected to a [Dragon](../../GLOSSARY.md), SD card inserted
+last-verified: 2026-05-29
+est-time: 5 min
+---
+# How to dictate and take notes
+
+Use this when you want to capture a longer thought hands-free — dictate a few
+sentences and have the [Tab5](../../GLOSSARY.md) transcribe them, generate a
+title and summary, and file them in Notes. Unlike a normal voice turn (which is
+a short question/answer), **dictation** is STT-only: no LLM reply plays, the
+transcript is the product.
+
+Assumes the Tab5 is connected to a [Dragon](../../GLOSSARY.md) (dictation uses
+the Dragon's speech-to-text) and an SD card is inserted (for offline recording
+fallback).
+
+## Steps
+
+### Dictate from anywhere
+
+1. **Long-press** the mic/orb. This enters dictation mode and sends
+   `{"type":"start","mode":"dictate"}` to the Dragon.
+2. Speak — the orb tints and a **live waveform** tracks your voice. Partial
+   transcript text (`stt_partial` frames) appears as you talk, accumulating in a
+   64 KB buffer.
+3. **Stop** by pausing. After ~5 seconds of silence the device auto-stops (an
+   adaptive VAD calibrates the noise floor first). You can also tap stop.
+4. The Dragon post-processes the transcript and returns a `dictation_summary`
+   with an auto-generated **title + summary**. The note is saved.
+
+### Dictate from the Notes screen
+
+1. Open **Notes** (nav sheet → **Notes**).
+2. Tap **Record** to start the same dictation flow, scoped to a new note.
+3. Stop the same way. The note lands in the timeline with its title, summary,
+   and a play button for the captured audio.
+
+### Watch the pipeline state
+
+Dictation runs a small state machine: `IDLE → RECORDING → UPLOADING →
+TRANSCRIBING → SAVED` (or `FAILED`). The orb body tints per state and a caption
+shows the elapsed `M:SS` while recording. Read it live:
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/dictation_pipeline \
+     | python3 -m json.tool
+# → {"state":"RECORDING","reason":"NONE","started_ms":52065, ...}
+```
+
+## Verify it worked
+
+A successful dictation leaves a `SAVED` state and a note row. Check the pipeline
+state went green and that the note exists in the Notes timeline. The `reason`
+field carries the failure detail when `state` is `FAILED` (one of `CANCELLED`,
+`NETWORK`, `EMPTY`, `AUTH`, `NO_AUDIO`, `TOO_LONG`).
+
+## Troubleshooting
+
+- **Long-press refuses with a toast** → The mic is already busy (a voice turn or
+  another dictation is in flight), or `mic_mute` is set in
+  [NVS](../../GLOSSARY.md). Wait for the orb to return to idle, or clear
+  `mic_mute`.
+- **Note row shows a red FAILED chip** → Read the reason chip — `AUTH` means the
+  transcribe request was missing its bearer header (a historic bug, fixed); `NETWORK`
+  means the Dragon was unreachable; `NO AUDIO` / `EMPTY` means nothing was
+  captured; `TOO LONG` means it hit the 5-minute recording cap. Tap the per-row
+  **Retry** button (amber) to re-run a FAILED-with-audio note.
+- **Recording never auto-stops** → The adaptive VAD could not find a quiet
+  baseline (noisy room). Tap stop manually; the 5-minute hard cap will also
+  stop a runaway recording.
+- **Counter stuck on "N unprocessed"** → FAILED-with-audio notes that the queue
+  refuses to retry are not counted as unprocessed (fixed in a prior wave). Use
+  the top-bar **CLEAR N FAILED** button to clear them.
+
+## See also
+
+- [Your first voice conversation](../tutorials/your-first-voice-conversation.md)
+- [Switch voice modes](switch-voice-modes.md) ·
+  [Debug server reference](../reference/debug-server.md) (`/dictation_pipeline`)
+- [The voice pipeline](../explanation/the-voice-pipeline.md) — how STT, LLM, and
+  TTS chain together.

--- a/docs/how-to/enable-tinkeron-wakeword.md
+++ b/docs/how-to/enable-tinkeron-wakeword.md
@@ -1,0 +1,94 @@
+---
+audience: tinkerer
+type: how-to
+prerequisites: A [Tab5](../../GLOSSARY.md) with the K144/[TinkerON](../../GLOSSARY.md) module stacked on the Module13.2 LLM Mate carrier
+last-verified: 2026-05-29
+est-time: 10 min
+---
+# How to enable the TinkerON wakeword
+
+Use this when you want fully hands-free **"Hey Tinker"** wakeword on a
+[Tab5](../../GLOSSARY.md). The wakeword runs on the K144/[TinkerON](../../GLOSSARY.md)
+module: the Tab5's own microphone array is pumped over the M5-Bus into the K144's
+on-device ASR ([`ext_pcm`](../../GLOSSARY.md)), a lenient matcher catches "Hey
+Tinker," and a normal voice turn fires.
+
+Assumes the K144 module is **physically stacked correctly** — stack order is
+`Tab5 base → Module13.2 LLM Mate carrier → K144`. The Tab5's own USB-C powers
+the whole stack through the M5-Bus; the carrier and K144 USB-C ports are
+debug-only. Stacking the K144 directly on the Tab5 (no Mate carrier) causes 5V
+rail collisions that wedge the AX630C NPU.
+
+## Steps
+
+1. **Boot the Tab5 with the K144 stacked.** The firmware auto-arms the whole
+   chain on a clean boot — no manual commands. It auto-detects the K144 baud,
+   does a clean `asr.setup` at 115200, then bumps to 1.5 Mbps for the audio
+   pump.
+2. **Wait for warmup.** Cold-start NPU model load takes ~4.5 s. The chain arms
+   the wakeword once the warmup reaches READY.
+3. **Say "Hey Tinker."** The K144's sherpa-ncnn streaming ASR renders the phrase
+   inconsistently across sessions, so the matcher accepts a family of renderings
+   (`tinker` / `thinker` / `hicker` / `hick` / `hanker`). On a match the Tab5
+   starts a voice turn via the normal orb-tap path (so it respects your active
+   [voice mode](../../GLOSSARY.md) routing).
+4. **Speak your request** right after the wake, e.g. _"Hey Tinker — what time is
+   it?"_ The turn cycles LISTENING → PROCESSING → SPEAKING → READY.
+
+Self-wake is suppressed during a full voice turn (LISTENING / PROCESSING /
+RECONNECTING / SPEAKING) plus a 1 s post-turn grace, so Tinker's own TTS reply
+does not re-trigger the wakeword. The `ext_pcm` pump also pauses during a turn so
+the Tab5 mic routes to the Dragon while the turn runs.
+
+## Verify it worked
+
+Read the chain + wakeword state over the [debug server](../reference/debug-server.md):
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+
+# 1. Chain health — failover_state_name must be "ready"
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/m5 | python3 -m json.tool
+# → {"failover_state":2,"failover_state_name":"ready","uart_baud":1500000, ...}
+
+# 2. ext_pcm pump + wakeword obs (frames_pumped climbing, wakeword_active true)
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/tinkeron/extpcm \
+     | python3 -m json.tool
+```
+
+A successful wake fires a voice turn — watch `voice.state` go to LISTENING in
+the [`/events` ring](../reference/debug-server.md), and the serial log shows the
+ASR rendering it matched.
+
+## Troubleshooting
+
+- **`failover_state_name` is `unavailable`** → The K144 daemon wedged or never
+  warmed. Recover with `POST /m5/reset` (sends `sys.reset` to the
+  [StackFlow](../../GLOSSARY.md) daemon and re-runs warmup), then re-poll
+  `GET /m5`. The watchdog also auto-recovers, escalating to `sys.reboot` after 2
+  failed resets.
+- **Boot, but wakeword never arms** → Confirm the stack order (Mate carrier
+  required) and that warmup reached READY. The chain arms the wakeword on warmup
+  READY and on every successful reset.
+- **"Hey Tinker" not recognized** → The K144's ASR rendering may be outside the
+  matcher family. Check the serial log for the rendered partials; the matcher is
+  open-vocabulary (one string, no retraining) so the renderings list can be
+  widened.
+- **Double-fires / self-wake from the reply** → Suppression covers the full turn
+  + 1 s grace; if you still see it, the turn state may have snapped back early.
+  Check `voice.state` transitions in `/events`.
+- **It worked, then stopped after hours** → K144 daemon state accumulation. The
+  firmware does a preventive `sys.reboot` every ~4 h of READY uptime; a manual
+  `POST /m5/reset` clears a stuck daemon immediately. UART framing errors at
+  1.5 Mbps are real but the JSON parser recovers; a periodic UART resync pause
+  prevents accumulation.
+
+## See also
+
+- [Recover a stuck device](recover-a-stuck-device.md) — full K144 recovery
+  ladder.
+- [The TinkerON / K144 chain](../explanation/the-tinkeron-k144-chain.md) — how
+  the on-device chain works and why.
+- [Switch voice modes](switch-voice-modes.md) — Onboard (mode 4) runs the whole
+  turn on the K144 with no Dragon.
+- [Debug server reference](../reference/debug-server.md) — `/m5`, `/m5/reset`.

--- a/docs/how-to/recover-a-stuck-device.md
+++ b/docs/how-to/recover-a-stuck-device.md
@@ -1,0 +1,145 @@
+---
+audience: operator
+type: how-to
+prerequisites: A [Tab5](../../GLOSSARY.md) you can reach over the [debug server](../reference/debug-server.md), serial, or USB
+last-verified: 2026-05-29
+est-time: 15 min
+---
+# How to recover a stuck device
+
+Use this when a [Tab5](../../GLOSSARY.md) is misbehaving — frozen UI, voice
+stuck, wakeword dead, or fully unresponsive. Recovery has layers; try them
+cheapest-first. Assumes you can reach the device over the network
+([debug server](../reference/debug-server.md), port 8080), serial (115200 baud),
+or USB.
+
+## Steps
+
+Work down this ladder. Stop at the first one that fixes it.
+
+### 1. Force a voice/WebSocket reconnect
+
+If voice is stuck (no reply, "connecting" forever) but the UI responds:
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/voice/reconnect
+# then re-read state
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/voice | python3 -m json.tool
+```
+
+### 2. Cancel / clear a wedged voice turn
+
+A turn stuck in PROCESSING (e.g. after a transient `stt_empty`) can be snapped
+back:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/voice/cancel
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/voice/clear
+```
+
+### 3. Recover the K144 / TinkerON chain
+
+If wakeword or Onboard (mode 4) is dead, reset the
+[StackFlow](../../GLOSSARY.md) daemon on the K144 (no power-cycle needed,
+~10 s):
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/m5/reset
+# poll until failover_state_name is "ready"
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/m5 | python3 -m json.tool
+```
+
+If `/m5/reset` does not recover it, the daemon may need a full restart. From a
+dev host over Axera ADB (plug into the **K144's top USB-C**):
+
+```bash
+sudo adb shell systemctl restart llm-sys
+# then POST /m5/reset again
+```
+
+### 4. Reboot the Tab5
+
+If the UI itself is unresponsive but the network stack is alive:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/reboot
+```
+
+There is also a top-right reboot button on the home screen: tap shows a "Hold
+to reboot" toast, long-press reboots. The fragmentation watchdog will also
+auto-reboot on its own if internal SRAM's largest free block stays below
+threshold for ~3 minutes.
+
+### 5. OTA rollback (a bad firmware booted)
+
+If a new image boots but fails self-test, the bootloader auto-reverts on the
+next reboot (`CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`). Force it:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/ota/rollback
+```
+
+### 6. Reflash a known-good image (device bricked)
+
+When nothing on-device responds, serial-flash over USB. See
+[Flash the firmware](flash-firmware.md) for the full loop:
+
+```bash
+. ~/esp/esp-idf/export.sh
+cd ~/projects/TinkerTab
+idf.py -p /dev/ttyACM0 flash
+# if it stays in ROM download mode, kick a watchdog reset:
+python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+  --before no_reset --after watchdog_reset read_mac
+```
+
+### 7. Git rollback (a code regression)
+
+Every feature lands as one squash-merge commit on `main`, so each is
+revert-able. Undo the last landed feature and reflash:
+
+```bash
+cd ~/projects/TinkerTab
+git log --oneline -5
+git revert <sha>
+idf.py build && idf.py -p /dev/ttyACM0 flash
+```
+
+## Verify it worked
+
+After any layer, confirm the device is healthy:
+
+```bash
+# No auth needed
+curl -s http://<ip>:8080/info | python3 -m json.tool       # heap, mode, auth_required
+curl -s http://<ip>:8080/selftest | python3 -m json.tool   # health check
+# Then a voice round-trip
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/chat \
+     -d '{"text":"reply with PONG"}'
+```
+
+## Troubleshooting
+
+- **Cannot find the device on the network** → It is DHCP-assigned. Scan with
+  `nmap -p 8080 --open <subnet>/24`; the Tab5 is the host whose `GET /info`
+  returns `"auth_required": true`.
+- **`/reboot` returns but the device does not come back** → It may be in ROM
+  download mode after a flash. Kick a watchdog reset (layer 6) over serial.
+- **K144 reset "rejected — probe already in flight"** → A reset is already
+  cycling. Wait and re-poll `GET /m5`; do not spam `/m5/reset`.
+- **Repeated fragmentation-watchdog reboots** → A leak or sustained low
+  largest-free-block. Pull `/heap/history` and check for a screen that
+  create/destroys overlays instead of hide/show. This is a code bug, not an ops
+  fix.
+- **ES7210 mic codec drift (RMS stuck low after hours)** → Physically unplug the
+  USB-C for ~10 s to reset the codec.
+
+## See also
+
+- [Run a Tab5 in production](deploy.md) — the OTA + monitoring workflow.
+- [Enable the TinkerON wakeword](enable-tinkeron-wakeword.md) — K144 chain setup.
+- [Debug server reference](../reference/debug-server.md) — every recovery
+  endpoint.
+- [LVGL on ESP32-P4](../explanation/lvgl-on-esp32p4.md) — why the fragmentation
+  watchdog exists.

--- a/docs/how-to/run-the-e2e-test-harness.md
+++ b/docs/how-to/run-the-e2e-test-harness.md
@@ -1,0 +1,96 @@
+---
+audience: developer
+type: how-to
+prerequisites: A flashed [Tab5](../../GLOSSARY.md) on Wi-Fi with the [debug server](../reference/debug-server.md) reachable, Python 3, the bearer token
+last-verified: 2026-05-29
+est-time: 20 min
+---
+# How to run the e2e test harness
+
+Use this when you want to drive a [Tab5](../../GLOSSARY.md) through long
+user-story flows automatically — for regression testing after a change, or to
+reproduce a bug the harness has historically caught. The harness is a
+Python-driven scenario runner in [`tests/e2e/`](../../tests/e2e/) that exercises
+the firmware end-to-end through the [debug server](../reference/debug-server.md)
+HTTP API (`/touch`, `/navigate`, `/chat`, `/screen`, `/events`,
+`/screenshot.jpg`).
+
+Assumes the firmware is flashed, the Tab5 is on Wi-Fi, you know its IP, and you
+have the bearer token (printed to the serial boot log).
+
+## Steps
+
+1. **Point the harness at the device and authenticate.**
+   ```bash
+   cd ~/projects/TinkerTab
+   export TAB5_URL=http://192.168.1.90:8080      # your Tab5 IP
+   export TAB5_TOKEN=<bearer-token-from-NVS>
+   ```
+2. **Run a single scenario.**
+   ```bash
+   python3 tests/e2e/runner.py story_smoke
+   ```
+3. **Or run the full suite with a clean reboot first.**
+   ```bash
+   python3 tests/e2e/runner.py all --reboot
+   ```
+
+The scenarios:
+
+| Name | Duration | Coverage |
+|---|---|---|
+| `story_smoke` | ~5 min | Boot → mode set → home → text chat → camera → settings round-trip. |
+| `story_full` | ~10 min | All voice modes + Local text turn + photo capture + REC start/stop + Cloud text turn. |
+| `story_stress` | ~20 min | 6 cycles of (mode × screen × chat) with heap-watchdog assertions. |
+| `story_onboard` | ~30 s | vmode=4 K144 chain lifecycle. Skips if `/m5` reports `failover_state != READY`. |
+
+## Verify it worked
+
+Each run lands in `tests/e2e/runs/<scenario>-<timestamp>/` (gitignored):
+
+- `report.json` — machine-readable pass/fail per step + events captured.
+- `report.md` — human-readable table with inline screenshots.
+- `NN_<step>.jpg` — a screenshot per step.
+
+Open `report.md` and confirm the per-step pass count. The last full validation
+baseline was **smoke 14/14, full 24/24, stress 76/77** (a single LLM-timeout
+flake from Q6A latency, not a regression).
+
+## Adding a scenario
+
+Add a `def story_my_thing(r: Runner) -> None:` to `runner.py` and register it in
+`SCENARIOS`. Inside, call `r.step("name", lambda t: …)` — each step gets a
+timestamp, a screenshot, and the events that fired during it. Use `r.soft_step`
+for diagnostic reads where failure should not count as a hard fail. Failed
+assertions do **not** abort the run (you want to know how far the firmware
+gets). The `Tab5Driver` in [`tests/e2e/driver.py`](../../tests/e2e/driver.py)
+wraps the debug API: `tap`, `long_press`, `swipe`, `navigate`, `screen`, `chat`,
+`mode`, `await_event`, `await_voice_state`, `await_screen`, `screenshot`,
+`heap`, `metrics`.
+
+## Troubleshooting
+
+- **`Connection refused` / no response** → Wrong `TAB5_URL` or the Tab5 is not
+  on Wi-Fi. Confirm with `curl http://<ip>:8080/info` (no auth needed).
+- **Every authed step 401s** → Wrong or stale `TAB5_TOKEN`. The token changes
+  only if NVS is wiped; re-read it from the serial boot log.
+- **`story_onboard` skips immediately** → Expected when the K144 chain is not
+  READY (`/m5` reports `failover_state != READY`). Recover the chain first (see
+  [Recover a stuck device](recover-a-stuck-device.md)).
+- **`await_event` misses events that clearly fired** → A historic cursor-stealing
+  bug (a diagnostic snapshot advanced `_last_event_ms`); the fix uses
+  `events(peek=True)`. If you see it again in a new scenario, prefer
+  `await_voice_state` (which polls `/voice` current state too) over raw
+  `await_event`.
+- **A step times out waiting for an LLM reply** → Local mode (`vmode=0`) is slow
+  on the Q6A (~60–90 s/turn). Use a faster mode for the run, or raise the
+  await timeout.
+
+## See also
+
+- [Debug server reference](../reference/debug-server.md) — the API the harness
+  drives.
+- [Observability events reference](../reference/observability-events.md) — the
+  event kinds `await_event` polls.
+- [The voice pipeline](../explanation/the-voice-pipeline.md) — what the voice
+  scenarios are exercising.

--- a/docs/how-to/switch-voice-modes.md
+++ b/docs/how-to/switch-voice-modes.md
@@ -1,0 +1,181 @@
+---
+audience: tinkerer
+type: how-to
+prerequisites: [getting-started tutorial](../tutorials/getting-started.md), a [Tab5](../../GLOSSARY.md) booted and connected to Wi-Fi
+last-verified: 2026-05-29
+est-time: 5 min
+---
+# Switch voice modes
+
+Use this when you want to change how a [Tab5](../../GLOSSARY.md) runs a voice
+turn — trading privacy, speed, and cost. The Tab5 has six
+[voice modes](../../GLOSSARY.md): from fully local (free, slow, private) to fully
+cloud (fast, paid). This guide shows you what each mode does and three ways to
+switch: the on-device mode chip, the mode-picker sheet, and the
+[debug server](../reference/debug-server.md)'s `/mode` endpoint.
+
+Assumes the Tab5 is booted, on Wi-Fi, and — for modes that need it — paired with
+a [Dragon](../../GLOSSARY.md). Modes 4 and 5 run with no Dragon at all.
+
+## The six tiers
+
+| Mode | Name | STT | LLM | TTS | Latency | Cost | Needs Dragon? |
+|---|---|---|---|---|---|---|---|
+| **0** | Local | Moonshine | Dragon-local (NPU/Ollama, default ministral-3:3b) | Piper | 60–90 s | Free | Yes |
+| **1** | Hybrid | OpenRouter `gpt-audio-mini` | Dragon-local | OpenRouter `gpt-audio-mini` | 4–8 s | ~$0.02/req | Yes |
+| **2** | Full Cloud | OpenRouter `gpt-audio-mini` | User-selected (Haiku / Sonnet / GPT-4o) | OpenRouter `gpt-audio-mini` | 3–6 s | $0.03–0.08/req | Yes |
+| **3** | TinkerClaw | Moonshine (or OpenRouter) | TinkerClaw Gateway | Piper (or OpenRouter) | varies | varies | Yes |
+| **4** | Onboard (K144) | K144 sherpa-ncnn ASR | K144 LLM (qwen2.5-0.5B over UART) | K144 per-utterance synth | 2–3 s | Free | **No** |
+| **5** | Solo Direct | OpenRouter | OpenRouter (`or_mdl_llm`) | OpenRouter (`or_mdl_tts`, `or_voice`) | 3–6 s | $0.03–0.08/req | **No** |
+
+What each one is for:
+
+- **Local (0)** — the default. Everything runs on the Dragon, nothing leaves
+  your network. Slow on the Q6A's NPU (~60–90 s/turn) but free and fully
+  private.
+- **Hybrid (1)** — keep the LLM on the Dragon but send speech to OpenRouter for
+  fast, accurate STT/TTS. Best dollar-per-turn for a snappy assistant.
+- **Full Cloud (2)** — STT, LLM, and TTS all go to OpenRouter. Pick the cloud
+  model with the LLM model picker (only enabled in this mode). Fastest and
+  highest-quality; you pay per request.
+- **TinkerClaw (3)** — the [TinkerClaw](../../GLOSSARY.md) gateway runs the turn
+  (its own LLM choice + tools + browser automation); the Dragon becomes an audio
+  pipe. Use this for agentic tasks.
+- **Onboard / K144 (4)** — the [TinkerON](../../GLOSSARY.md) module runs the
+  whole turn on-device over the M5-Bus. No Dragon needed. Requires the K144
+  module stacked and warm (~4.5 s cold-start). Tab5-side-only.
+- **Solo Direct (5)** — the Tab5 talks straight to OpenRouter for STT/LLM/TTS
+  with no Dragon, using the `or_*` NVS keys + on-device RAG against
+  `/sdcard/rag.bin`. Needs an OpenRouter API key in NVS. Tab5-side-only.
+
+Modes 4 and 5 are **Tab5-side-only**: when the Tab5 reports its mode over the
+wire it downconverts them to `0` so the Dragon never sees them. The
+[NVS](../../GLOSSARY.md) key `vmode` still holds the true value (0–5). This is by
+design — see the [WebSocket protocol](../reference/debug-server.md) note in the
+troubleshooting section.
+
+## Steps
+
+Pick whichever path fits the situation.
+
+### Option A — the mode chip (one-tap cycle)
+
+1. On the home screen, find the **mode chip** below the orb. It shows the
+   current mode name (for example, `Local`).
+2. **Tap it** to cycle to the next mode, or **long-press the orb** to open the
+   full mode-picker sheet (Option B). The chip repaints to the new mode and a
+   `mode_switch` audio cue plays.
+
+The chat overlay carries the same affordance: the **mode badge** in the chat top
+bar cycles Local / Hybrid / Cloud on tap.
+
+### Option B — the mode-picker sheet
+
+1. **Long-press the orb** on home (or open **Settings → Voice**).
+2. The mode sheet lists the tiers. Tap the mode you want.
+3. For **Full Cloud (2)**, the **LLM model picker** is enabled — pick
+   Claude Haiku / Claude Sonnet / GPT-4o mini. The choice persists to the
+   `llm_mdl` NVS key.
+4. For **Solo Direct (5)**, if no OpenRouter key is set the UI prompts you to
+   scan a QR code (or POST the key — see the
+   [NVS settings reference](../reference/nvs-settings.md), `or_key`).
+
+The new mode persists immediately to NVS, so it survives a reboot.
+
+### Option C — the debug server `/mode` endpoint
+
+Switch a Tab5 remotely over HTTP. You need the bearer token (printed to the
+serial log on every boot) and the device IP. See the
+[debug server reference](../reference/debug-server.md) for token + discovery
+details.
+
+```bash
+# Export the token once
+export TOKEN="abcdef1234567890abcdef1234567890"
+
+# m = the tier number (0-5)
+curl -s -H "Authorization: Bearer $TOKEN" -X POST "http://<ip>:8080/mode?m=0"   # Local
+curl -s -H "Authorization: Bearer $TOKEN" -X POST "http://<ip>:8080/mode?m=1"   # Hybrid
+curl -s -H "Authorization: Bearer $TOKEN" -X POST "http://<ip>:8080/mode?m=3"   # TinkerClaw
+
+# Full Cloud takes an optional model id
+curl -s -H "Authorization: Bearer $TOKEN" -X POST \
+     "http://<ip>:8080/mode?m=2&model=anthropic/claude-sonnet-4-20250514"
+
+# Onboard (K144) and Solo Direct are Tab5-side-only modes
+curl -s -H "Authorization: Bearer $TOKEN" -X POST "http://<ip>:8080/mode?m=4"   # Onboard
+curl -s -H "Authorization: Bearer $TOKEN" -X POST "http://<ip>:8080/mode?m=5"   # Solo Direct
+```
+
+## Verify it worked
+
+Read back the live voice state and the persisted `vmode` key:
+
+```bash
+# 1. Voice state — confirms the WS is connected and shows the state machine
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/voice | python3 -m json.tool
+
+# 2. The persisted mode — vmode holds the true tier (0-5), even for 4/5
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/settings | python3 -m json.tool | grep vmode
+# → "vmode": 4
+```
+
+You can also watch the switch fire as an observability event. A mode change
+plays the `mode_switch` cue, which records a `ui.cue` event in the
+[`/events` ring](../reference/debug-server.md):
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "http://<ip>:8080/events?since=0" | python3 -m json.tool
+# → look for {"kind":"ui.cue","detail":"mode_switch err=0"}
+```
+
+Then send a test turn and confirm a reply comes back through the new pipeline:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/chat \
+     -d '{"text":"reply with PONG"}'
+# Poll /voice for last_llm_text, or wait for the chat.llm_done event.
+```
+
+## Troubleshooting
+
+- **Mode switched but Dragon shows mode 0 in its logs** → Expected for
+  **Onboard (4)** and **Solo Direct (5)**. The Tab5 downconverts those to `0` on
+  the wire so the Dragon never sees them; `voice.c` also filters out the Dragon's
+  ACK echo to keep local NVS at the true 4/5 value. Check `vmode` in
+  `GET /settings`, not the Dragon side. (`vmode` accepts 0–5; the
+  [NVS table](../reference/nvs-settings.md) documents the 0–4 range from before
+  Solo Direct landed — 5 is valid and live.)
+- **Onboard (4) refuses or falls back** → The K144 module must be stacked on the
+  Module13.2 LLM Mate carrier and **warm**. Check the chain with
+  `GET /m5` — `failover_state_name` must be `ready`. If it is `unavailable`,
+  recover with `POST /m5/reset` and re-poll `GET /m5`. See the
+  [debug server reference](../reference/debug-server.md) K144 section.
+- **Solo Direct (5) does nothing / prompts for a QR scan** → No OpenRouter key
+  in NVS. The route returns `SOLO_NO_KEY` until you set `or_key`. Provision it by
+  scanning the QR prompt or `POST /settings` (see the `or_*` keys in the
+  [NVS settings reference](../reference/nvs-settings.md)).
+- **Full Cloud (2) model picker is greyed out** → The LLM model picker is only
+  enabled in Full Cloud. Switch to mode 2 first, then choose the model.
+- **Cloud STT/TTS suddenly reverts to Local mid-session** → Auto-fallback. If a
+  cloud STT/TTS request fails, the Dragon falls back to local for that request
+  and sends a `config_update` with an `error` field; the Tab5 then auto-reverts
+  to Local. Re-select the cloud mode once connectivity is back.
+- **Switch refused mid-turn** → Changing the mode while a voice turn is in flight
+  auto-cancels the turn with a toast (the nav/voice chokepoint calls
+  `voice_cancel`). Wait for the orb to return to its idle state, then switch.
+- **Hit the daily spend cap** → The `cap_mils` NVS key caps daily LLM spend
+  (default $1.00/day). Exceeding it triggers a `cap_downgrade`, pulling you back
+  off paid cloud tiers. Raise the cap via `POST /settings` if you want to spend
+  more.
+
+## See also
+
+- [Voice mode definitions](../../GLOSSARY.md) — the canonical one-line spec for
+  each tier.
+- [Debug server reference](../reference/debug-server.md) — full `/mode`,
+  `/voice`, `/m5`, and `/events` endpoint detail.
+- [NVS settings reference](../reference/nvs-settings.md) — `vmode`, `llm_mdl`,
+  `or_*`, and `cap_mils` keys.
+- [How the stack fits together](../explanation/how-the-stack-fits-together.md) —
+  why the Tab5 is a thin client and the Dragon is the brain.

--- a/docs/how-to/use-the-camera.md
+++ b/docs/how-to/use-the-camera.md
@@ -1,0 +1,98 @@
+---
+audience: tinkerer
+type: how-to
+prerequisites: A booted [Tab5](../../GLOSSARY.md) with an SD card inserted
+last-verified: 2026-05-29
+est-time: 5 min
+---
+# How to use the camera
+
+Use this when you want to take a photo, record a short video, or send an image
+into a chat from a [Tab5](../../GLOSSARY.md). The Tab5 has a 2 MP SC202CS camera
+behind a MIPI-CSI viewfinder running at 1280×720. Photos and videos are written
+to the SD card; from a chat the capture can also upload to the
+[Dragon](../../GLOSSARY.md) so it threads inline.
+
+Assumes an SD card is inserted (captures need somewhere to write).
+
+## Steps
+
+### Take a photo
+
+1. Open the **Camera** screen (nav sheet → **Camera**, or
+   `POST /navigate?screen=camera` over the [debug server](../reference/debug-server.md)).
+2. Tap the **white circular shutter** button in the center of the bottom control
+   bar.
+3. The photo is saved as `/sdcard/IMG_NNNN.jpg` (a 4-digit counter that resumes
+   from existing files on boot).
+
+### Rotate the frame
+
+If the camera is mounted at an angle, set the software rotation. Tap the **Rot**
+button in the viewfinder to cycle 0° → 90° → 180° → 270° (clockwise). The choice
+persists to the `cam_rot` [NVS](../../GLOSSARY.md) key and applies to every
+capture before display/upload. You can also set it in **Settings** or via
+`POST /settings -d '{"cam_rot":1}'`.
+
+### Record a video
+
+1. On the Camera screen, tap the **red-bordered REC pill** (right of the
+   shutter).
+2. Recording captures motion-JPEG to `/sdcard/VID_NNNN.MJP` at 5 fps. The
+   `.MJP` extension is required — the FAT32 filesystem is in 8.3 short-name mode,
+   so `.mjpeg` would fail.
+3. Tap **REC** again to stop. Recording auto-stops at the 1500-frame cap
+   (5 minutes).
+4. Play it back with `ffplay -f mjpeg VID_NNNN.MJP` or VLC (both sniff the JPEG
+   magic bytes).
+
+### Send a photo into a chat
+
+Open the camera from the **chat overlay** with the **Send photo** button. After
+you capture, the image auto-uploads to the Dragon's `/api/media/upload` and a
+`user_media` [WebSocket](../../GLOSSARY.md) event threads it inline in the
+conversation.
+
+## Verify it worked
+
+Confirm a capture fired by watching the observability event ring on the debug
+server:
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+curl -s -H "Authorization: Bearer $TOKEN" "http://<ip>:8080/events?since=0" \
+     | python3 -m json.tool
+# → photo:  {"kind":"camera.capture","detail":"/sdcard/IMG_0001.jpg"}
+# → video:  {"kind":"camera.record_start","detail":"/sdcard/VID_0001.MJP"}
+#           {"kind":"camera.record_stop","detail":"...MJP frames=30 bytes=..."}
+```
+
+Or pull a live frame straight off the camera (no SD round-trip):
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -o frame.jpg http://<ip>:8080/camera
+```
+
+## Troubleshooting
+
+- **Camera screen is black / no frame** → The SC202CS needs
+  `CONFIG_CAMERA_SC202CS=y` in `sdkconfig`. If you built without it the sensor
+  will not initialize. The sensor is at SCCB address `0x36` (not `0x30`).
+- **Capture button does nothing** → No SD card, or it is full. Check
+  `GET /info` and the storage service. Captures need a writable
+  `/sdcard`.
+- **Video record crashes or won't start a second time** → The ESP32-P4 has a
+  single hardware JPEG engine shared between recording and the video-call
+  streamer; it is mutex-guarded. Do not record while a video call is active.
+- **Image looks rotated wrong** → Adjust `cam_rot` (0–3) — see the rotate step.
+- **Chat upload never threads** → Confirm the Dragon is reachable
+  (`/voice` shows `connected: true`) — the upload POSTs to the Dragon's
+  `/api/media/upload`.
+
+## See also
+
+- [Debug server reference](../reference/debug-server.md) — `/camera`,
+  `/navigate`, `/events`.
+- [NVS settings reference](../reference/nvs-settings.md) — `cam_rot`.
+- [Hardware reference](../reference/hardware.md) — the SC202CS sensor + JPEG
+  engine constraint.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -6,10 +6,21 @@ first run see [Get started](../tutorials/getting-started.md).
 
 ## Pages
 
+- [WebSocket protocol](websocket-protocol.md) — the Tab5 client side of the
+  Dragon WebSocket: every frame type and binary magic tag.
 - [Debug server](debug-server.md) — the Tab5's `:8080` HTTP control API:
   endpoints, bearer-token auth, and the post-Wave-23b handler module map.
+- [Voice modes](voice-modes.md) — the six tiers, on-the-wire behavior, routing
+  codes, and failover guards.
+- [NVS settings](nvs-settings.md) — every persistent settings key in the
+  `"settings"` namespace.
+- [Observability events](observability-events.md) — the `/events` ring: every
+  event kind and detail format.
+- [Hardware](hardware.md) — the SoC, peripherals, audio pipeline, M5-Bus, and
+  memory rules.
+- [Firmware file map](firmware-file-map.md) — where everything lives under
+  `main/`.
 
-> More reference pages land in **Wave 1** (the
-> [WebSocket protocol](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md)
-> client surface, NVS settings keys, serial commands, voice modes). See
-> [`../ROADMAP.md`](../ROADMAP.md).
+The canonical wire spec is the Dragon's
+[`docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md);
+see [`../ROADMAP.md`](../ROADMAP.md) for the documentation program waves.

--- a/docs/reference/firmware-file-map.md
+++ b/docs/reference/firmware-file-map.md
@@ -1,0 +1,128 @@
+---
+audience: developer
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# Firmware file map
+
+Authoritative, lookup-oriented map of the [Tab5](../../GLOSSARY.md) firmware
+source under [`main/`](../../main/). No tutorials here — use this to find the
+right home for a change. If you add or remove a file, update this page and the
+`CLAUDE.md` "Key Files" section.
+
+## Boot + infrastructure
+
+| File | Owns |
+|---|---|
+| `main/main.c` | Boot sequence: HW init → service bring-up → [LVGL](../../GLOSSARY.md) → watchdog; one-time init for audio cues + the notification snooze walker. |
+| `main/config.h` | Pin map, firmware version, OTA paths, voice-mode constants. |
+| `main/service_registry.{c,h}` | Service-pattern scaffolding (lifecycle for the five services). |
+| `main/service_audio.c` | Audio service (I2S, ES8388 DAC, ES7210 mic). |
+| `main/service_display.c` | LVGL + DSI panel bring-up. |
+| `main/service_dragon.c` | [Dragon](../../GLOSSARY.md)-link service (voice WS lifecycle). |
+| `main/service_network.c` | Wi-Fi service (STA, connect, reconnect). |
+| `main/service_storage.c` | SD card + NVS storage service. |
+| `main/task_worker.{c,h}` | Shared FreeRTOS job queue (kills per-action task leaks). |
+| `main/heap_watchdog.{c,h}` | Periodic heap + PSRAM monitoring → `/heap`. |
+
+## Debug server
+
+The debug server was thinned (TT #332, Wave 23b) from a 4,520-LOC monolith to
+849 LOC + 18 per-family modules. The core file owns the httpd lifecycle, bearer
+auth, and the family register calls.
+
+| File | Owns |
+|---|---|
+| `main/debug_server.{c,h}` | httpd lifecycle, bearer auth, `send_json_resp`, `/info` / `/index` / `/selftest`, 18 register calls. |
+| `main/debug_server_admin.c` | `/reboot`, `/sdcard`, widget injection. |
+| `main/debug_server_call.c` | `/video/*`, `/call/*`. |
+| `main/debug_server_camera.c` | `/screenshot`, `/screenshot.jpg`, `/camera`. |
+| `main/debug_server_chat.c` | `/chat`, `/chat/*`. |
+| `main/debug_server_codec.c` | `/codec/opus_test`. |
+| `main/debug_server_dictation.c` | `/dictation` (GET + POST). |
+| `main/debug_server_inject.c` | `/debug/inject_audio`, `_error`, `_ws` (harness only). |
+| `main/debug_server_input.c` | `/touch`, `/input/text` (LVGL touch-injection seqlock). |
+| `main/debug_server_m5.c` | `/m5`, `/m5/reset`, `/m5/refresh`, `/m5/models`. |
+| `main/debug_server_metrics.c` | `/tasks`, `/logs/tail`, `/battery`, `/display/brightness`, `/audio`, `/metrics`, `/events`, `/heap/history`, `/net/ping`. |
+| `main/debug_server_mode.c` | `/mode`. |
+| `main/debug_server_nav.c` | `/navigate`, `/screen`. |
+| `main/debug_server_obs.c` | `/log`, `/crashlog`, `/coredump`, `/heap_trace_*`, `/heap`. |
+| `main/debug_server_ota.c` | `/ota/check`, `/ota/apply`. |
+| `main/debug_server_settings.c` | `/settings` (GET + POST), `/nvs/erase`. |
+| `main/debug_server_voice.c` | `/voice`, `/voice/reconnect`, `/voice/cancel`, `/voice/clear`. |
+| `main/debug_server_wifi.c` | `/wifi/kick`, `/wifi/status`. |
+| `main/debug_server_internal.h` | shared `check_auth` + `send_json_resp` helpers. |
+| `main/debug_obs.{c,h}` | the 256-entry observability event ring behind `/events`. |
+
+Count live endpoints: `grep -c 'httpd_register_uri_handler' main/debug_server*.c`.
+
+## Hardware drivers
+
+| File | Owns |
+|---|---|
+| `main/audio.c` | ES8388 DAC via esp_codec_dev + STD TX / TDM RX I2S. |
+| `main/mic.c` | ES7210 quad-mic via esp_codec_dev. |
+| `main/camera.{c,h}` | esp_video V4L2 stack, SC202CS sensor. |
+| `main/imu.c` | BMI270 IMU via I2C. |
+| `main/sdcard.{c,h}` | SDMMC 4-bit, FAT32. |
+| `main/wifi.{c,h}` | Wi-Fi stack wrapper. |
+| `main/settings.{c,h}` | NVS-backed settings (see [NVS settings reference](nvs-settings.md)). |
+
+## Dragon voice link
+
+| File | Owns |
+|---|---|
+| `main/voice.{c,h}` | Voice public API + state machine + mic-capture/playback tasks + reconnect watchdog + channel-reply arming. |
+| `main/voice_ws_proto.{c,h}` | WS frame routing: JSON RX dispatcher, binary magic-tag dispatcher, `esp_websocket_client` callback, UI-async helpers. |
+| `main/voice_modes.{c,h}` | The six-tier [voice-mode](voice-modes.md) dispatcher + `voice_modes_route_text`. |
+| `main/voice_video.{c,h}` | Two-way video call: HW JPEG uplink + TJPGD downlink, `VID0` framing. |
+| `main/voice_codec.{c,h}` | OPUS capability negotiation (decoder ready, encoder gated off — issue #264). |
+| `main/mode_manager.{c,h}` | Voice-pipeline coordinator (IDLE ↔ VOICE); thin mutex wrapper. |
+
+## K144 / TinkerON
+
+| File | Owns |
+|---|---|
+| `bsp/tab5/uart_port_c.{c,h}` | Port C UART (recursive mutex serializes every K144 transaction). |
+| `main/m5_stackflow.{c,h}` | [StackFlow](../../GLOSSARY.md) JSON marshalling. |
+| `main/voice_m5_llm.{c,h}` | K144 sidecar (infer / TTS / wakeword setup-run-teardown). |
+| `main/voice_onboard.{c,h}` | vmode=4 lifecycle: warmup, per-text failover, autonomous chain, `reset_failover`. |
+| `main/voice_wakeword.{c,h}` | always-on wakeword matcher + state machine. |
+
+## UI framework + screens
+
+| File | Owns |
+|---|---|
+| `main/ui_core.{c,h}` | LVGL display init, screen management, `tab5_lv_async_call`. |
+| `main/ui_theme.{c,h}` | theme tokens. |
+| `main/ui_orb.{c,h}` | the ambient orb (5 hardware-aware behaviors, 4-state machine). |
+| `main/ui_home.{c,h}` | home (orb, clock, greeting, mode chip, nav sheet, widget slots). |
+| `main/ui_voice.{c,h}` | voice overlay. |
+| `main/ui_chat.{c,h}` + `chat_*.{c,h}` | chat overlay + header / input bar / message store / view / drawer / suggestions. |
+| `main/ui_settings.{c,h}` | settings overlay. |
+| `main/ui_wifi.{c,h}` / `ui_keyboard.{c,h}` | Wi-Fi setup / on-screen keyboard. |
+| `main/ui_camera.{c,h}` / `ui_video_pane.{c,h}` | camera viewfinder / downlink video pane. |
+| `main/ui_files.{c,h}` / `ui_notes.{c,h}` / `ui_sessions.{c,h}` / `ui_memory.{c,h}` | file browser / notes / sessions / memory. |
+| `main/ui_agents.{c,h}` | agents / TinkerClaw status + agent-skills chips. |
+| `main/ui_audio_cues.{c,h}` | pre-computed PCM cue buffers. |
+| `main/ui_notification.{c,h}` | channel_message router + dedupe/snooze rings + reply bridge. |
+| `main/ui_nav_sheet.{c,h}` / `ui_mode_sheet.{c,h}` / `ui_onboarding.{c,h}` | nav sheet / mode picker / first-boot flow. |
+| `main/voice_dictation.{c,h}` | dictation state machine + LVGL subscriber wrapper. |
+
+## Widgets + media + OTA
+
+| File | Owns |
+|---|---|
+| `main/widget.h` / `main/widget_store.c` | widget data model + bounded priority queue. |
+| `main/media_cache.{c,h}` | HTTP image downloader + PSRAM LRU + TJPGD decode. |
+| `main/ota.{c,h}` | OTA check/apply/mark-valid via `esp_https_ota` with auto-rollback. |
+| `partitions.csv` | dual-slot OTA partition table. |
+| `LEARNINGS.md` | institutional knowledge (read before any change). |
+
+## See also
+
+- [Hardware reference](hardware.md) · [Debug server reference](debug-server.md)
+- [TinkerTab architecture](../explanation/architecture.md) — the layering these
+  files implement.
+- `CLAUDE.md` "Key Files" — the canonical, always-current list.

--- a/docs/reference/hardware.md
+++ b/docs/reference/hardware.md
@@ -1,0 +1,98 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# Hardware reference
+
+Authoritative, lookup-oriented reference for the [Tab5](../../GLOSSARY.md)
+hardware the firmware targets. No tutorials here. All pin numbers are GPIO
+numbers on the ESP32-P4 SoC unless noted. The single source of truth is
+[`bsp/tab5/bsp_config.h`](../../bsp/tab5/bsp_config.h) — if a value here disagrees
+with that header, the header wins. For the full bus map, register details, and
+boot sequence see [`docs/HARDWARE.md`](../HARDWARE.md).
+
+## SoC: ESP32-P4
+
+| Field | Value |
+|---|---|
+| Architecture | RISC-V (rv32imafc) dual-core HP @ 360–400 MHz + 1 LP core |
+| Internal SRAM | ~512 KB (shared with FreeRTOS) — fragments under overlay create/destroy |
+| PSRAM | 32 MB Octal SPI — LVGL pool, mic buffers, media cache, video frames, JPEG scratch |
+| Flash | 16 MB QuadSPI — partition table in [`partitions.csv`](../../partitions.csv) (dual OTA slots) |
+| Crypto | HW AES-256, SHA, RSA, HMAC (mbedTLS for WS-TLS) |
+| JPEG engine | Single HW codec ("rxlink") — shared by call streamer + camera recording, mutex-guarded |
+| Wi-Fi / BT | **None native** — provided by a hosted ESP32-C6 over SDIO |
+| ESP-IDF | Pinned to **v5.5.2** (`dependencies.lock`) |
+
+## Peripherals
+
+| Subsystem | Part | Interface | Key facts |
+|---|---|---|---|
+| Display | ST7123 panel | MIPI DSI, 2 lanes | 720×1280 IPS, RGB565→RGB888, ~60 fps (LVGL flushes ~10 fps under load); backlight PWM on GPIO 22 |
+| Touch | GT911 | I2C | capacitive |
+| Camera | SC202CS (a.k.a. SC2336) | MIPI-CSI, 1-lane | 2 MP, SCCB address `0x36` (**not** `0x30`), RAW8 → ISP → RGB565, 1280×720 @ 30 fps; needs `CONFIG_CAMERA_SC202CS=y` |
+| Audio DAC | ES8388 | I2S TX (STD Philips) | speaker out; init via `es8388_codec_new()` only (never custom registers) |
+| Audio ADC | ES7210 | I2S RX (TDM 4-slot) | 4-mic array; slot 0 = MIC-L primary; both codecs share I2S_NUM_1 |
+| Wi-Fi | ESP32-C6 | SDIO | hosted co-processor (P4 has no native radio) |
+| SD card | SDMMC | 4-bit, SLOT 0 | FAT32 in 8.3 short-name mode (`CONFIG_FATFS_LFN_NONE=1`); LDO channel 4; coexists with Wi-Fi SDIO |
+| IMU | BMI270 | I2C | tilt / motion (orb specular) |
+| I/O expanders | 2× PI4IOE5V6416 | I2C | power rails, peripheral enables |
+
+## Audio pipeline facts
+
+| Item | Value |
+|---|---|
+| I2S mode | Mixed: TX = STD Philips (ES8388), RX = TDM 4-slot (ES7210), both on `I2S_NUM_1` |
+| Hardware rate | 48 kHz |
+| STT rate | 16 kHz — downsample 3:1 from 48 kHz |
+| TTS playback | upsample 1:3 from 16 kHz to 48 kHz |
+| Codec I2C addresses | 8-bit: ES7210 = `0x80`, ES8388 = `0x20` (**not** 7-bit) |
+| Slot mode | `I2S_SLOT_MODE_STEREO` for TDM multi-slot capture; MONO gets only slot 0 |
+
+## M5-Bus rear connector (K144 / TinkerON)
+
+| Item | Value |
+|---|---|
+| Carrier | Module13.2 LLM Mate required between Tab5 and K144 (direct stack collides 5V rails) |
+| Stack order | `Tab5 base → Mate (USB-C powered) → K144` |
+| UART | `UART_NUM_1`, TX = GPIO 6, RX = GPIO 7 (Port C UART, M5-Bus pins 16/15) |
+| Baud | 115200 8N1 for setup; bumps to 1.5 Mbps for the ext_pcm pump |
+| Avoid | UART0 (G37/G38) — collides with `idf.py monitor` |
+| Power | Tab5's own USB-C powers the whole stack via M5-Bus (~1.5 W at K144 full load) |
+
+## ESP32-P4 memory rules
+
+- **PSRAM for large buffers (>4 KB):**
+  `heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)`. Free with
+  `heap_caps_free()`, never `free()`.
+- **Never `vTaskDelete(NULL)`** — use `vTaskSuspend(NULL)` (P4 TLSP cleanup
+  crash).
+- **`heap_caps_get_free_size()` lies** — total free ≠ usable. Use
+  `heap_caps_get_largest_free_block()` for the largest contiguous block;
+  fragmentation makes total free look healthy while allocations fail.
+- **Stack sizes:** SDIO tasks 8 K+, mic task 4 K, WS task 8 K. All tasks doing
+  network + LVGL callbacks need ≥8 K.
+- **PSRAM cache coherency:** DPI DMA reads PSRAM directly — call
+  `esp_cache_msync()` after CPU writes to the framebuffer.
+
+## NVS layout
+
+Settings live in the `"settings"` [NVS](../../GLOSSARY.md) namespace (max key
+length 15 chars). See the [NVS settings reference](nvs-settings.md) for the full
+key table.
+
+## Power
+
+| Item | Value |
+|---|---|
+| Battery | 6 Ah LiPo |
+| Charge / fuel gauge | via the I2C bus (see `bsp_config.h`) |
+
+## See also
+
+- Full pinout + bus map + boot sequence: [`docs/HARDWARE.md`](../HARDWARE.md)
+- [Hardware mods](../hardware-mods.md) · [Firmware file map](firmware-file-map.md)
+- [TinkerTab architecture](../explanation/architecture.md) ·
+  [LVGL on ESP32-P4](../explanation/lvgl-on-esp32p4.md)

--- a/docs/reference/nvs-settings.md
+++ b/docs/reference/nvs-settings.md
@@ -1,0 +1,187 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# NVS settings keys
+
+Authoritative, lookup-oriented reference for the Tab5's persistent settings. No
+tutorials here — to read or write these keys from a workstation, see the
+[debug server reference](debug-server.md) (`GET`/`POST /settings`).
+
+Every runtime setting on the [Tab5](../../GLOSSARY.md) lives in the
+[NVS](../../GLOSSARY.md) (Non-Volatile Storage) flash key-value store. All keys
+below live in the **`"settings"` namespace**. The ESP-IDF NVS API caps key
+length at **15 characters** — that is why the keys are abbreviated (`vmode`,
+`llm_mdl`, `dragon_tok`). The API is in
+[`main/settings.h`](../../main/settings.h). Defaults shown as
+`NAME (config.h)` are compiled in from
+[`main/config.h`](../../main/config.h) (set via `sdkconfig.defaults` /
+`menuconfig`) and only apply until the user overrides them at runtime.
+
+## Reading and writing keys
+
+Read every setting as JSON, or write one, over the debug server:
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"   # from the serial boot log
+
+# Read all settings
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/settings \
+     | python3 -m json.tool
+
+# Write one (or more) keys
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/settings \
+     -d '{"brightness":60,"vmode":1}'
+
+# Wipe the whole namespace back to compiled defaults
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/nvs/erase
+```
+
+A `nvs` observability event (`detail: "erase"`) fires on `POST /nvs/erase`; see
+the debug server's [observability events](debug-server.md) section.
+
+## Network + identity
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `wifi_ssid` | str | `TAB5_WIFI_SSID` (config.h) | — | Wi-Fi network SSID. |
+| `wifi_pass` | str | `TAB5_WIFI_PASS` (config.h) | — | Wi-Fi network password. |
+| `dragon_host` | str | `TAB5_DRAGON_HOST` (config.h) | — | [Dragon](../../GLOSSARY.md) server hostname/IP. |
+| `dragon_port` | u16 | `TAB5_DRAGON_PORT` (config.h) | 1–65535 | Dragon server port. |
+| `device_id` | str | MAC-derived (12 hex chars) | — | Unique device identifier, auto-generated on first boot. |
+| `session_id` | str | `""` (empty) | — | Dragon conversation session ID for resume. |
+| `conn_m` | u8 | 0 | 0–2 | Connection mode: 0=auto (ngrok first then LAN), 1=local only, 2=remote only. Tab5-internal — never crosses the wire (see `voice_ws_start_client`). |
+| `auth_tok` | str | auto-generated (32 hex chars) | — | Debug server bearer auth token, generated on first boot. See the [debug server reference](debug-server.md). |
+| `dragon_tok` | str | `""` | — | Dragon REST API bearer token for outbound HTTP to gated endpoints (`/api/v1/tools`, `/api/v1/agent_log`, `/api/v1/sessions`, `/api/v1/memory`). Empty by default; provisioned via `POST /settings`. |
+
+## Display + audio
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `brightness` | u8 | 80 | 0–100 | Display brightness percentage. |
+| `volume` | u8 | 70 | 0–100 | Speaker volume percentage. |
+| `mic_mute` | u8 | 0 | 0–1 | Master mic mute — `voice_start_listening` refuses with a toast when set. |
+| `cam_rot` | u8 | 0 | 0–3 | Camera frame rotation in 90° steps applied in software after capture (0=none, 1=90° CW, 2=180°, 3=270° CW). Settings dropdown. |
+
+## Voice mode + LLM
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `vmode` | u8 | 0 | 0–4 | [Voice mode](../../GLOSSARY.md): 0=local, 1=hybrid, 2=cloud, 3=TinkerClaw, 4=onboard (K144). Mode 5 (Solo Direct) is set via the same key and is Tab5-side-only. |
+| `llm_mdl` | str | `anthropic/claude-3.5-haiku` | — | LLM model identifier for cloud mode. |
+
+The on-the-wire `config_update` always carries a `voice_mode` in `0..3`; modes 4
+(Onboard) and 5 (Solo Direct) are Tab5-side-only and downconvert to 0 over the
+WebSocket. See the [voice-modes table](#voice-mode-vmode-values) below and the
+[`config_update` glossary entry](../../GLOSSARY.md).
+
+## Solo Direct mode (`or_*`)
+
+These keys drive [voice mode 5 (Solo Direct)](../../GLOSSARY.md), where the Tab5
+talks straight to OpenRouter with no Dragon. The model keys default to a
+`~latest` alias that the alias resolver fills in.
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `or_key` | str | `""` | — | OpenRouter API key. Empty disables Solo mode — `voice_modes_route_text` returns `SOLO_NO_KEY` and the UI prompts a QR scan. Provisioned via QR scan or `POST /settings`. |
+| `or_mdl_llm` | str | `~latest` alias | — | OpenRouter LLM model for Solo mode. |
+| `or_mdl_stt` | str | `~latest` alias | — | OpenRouter STT model (audio in). |
+| `or_mdl_tts` | str | `~latest` alias | — | OpenRouter TTS model (audio out). |
+| `or_mdl_emb` | str | `~latest` alias | — | OpenRouter embedding model for Solo-mode RAG. |
+| `or_voice` | str | sensible default | — | OpenRouter TTS voice id. |
+| `or_mdl_audio` | str | `~latest` alias | — | Multimodal audio chat model — one `/chat/completions` call replaces the STT → LLM → TTS chain in Solo mode. |
+
+## Spend + intelligence dials
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `int_tier` | u8 | 0 | 0–2 | Intelligence dial: 0=fast, 1=balanced, 2=smart. |
+| `voi_tier` | u8 | 0 | 0–2 | Voice dial: 0=local Piper, 1=neutral, 2=studio OpenRouter. |
+| `aut_tier` | u8 | 0 | 0–1 | Autonomy dial: 0=ask first, 1=agent mode. |
+| `spent_mils` | u32 | 0 | 0–UINT32_MAX | Today's cumulative LLM spend in mils (1/1000 ¢). Resets when `spent_day` rolls to a new day. Wear-bounded to ~one commit per LLM turn. |
+| `spent_day` | u32 | 0 | 0–UINT32_MAX | Days-since-epoch of the last `spent_mils` write — the dayroll guard. |
+| `cap_mils` | u32 | 100000 | 0–UINT32_MAX | Per-day spend cap in mils (default $1.00/day). Exceeding it triggers `cap_downgrade` in `voice_send_config_update_ex`. |
+
+## Onboarding + skills
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `onboard` | u8 | 0 | 0–1 | Onboarding-flow completion marker (set once the user clears the welcome screens). |
+| `star_skills` | str | `""` | — | Comma-separated list of starred (pinned) skill/tool names. Read by `ui_skills.c` to sort starred tools first + apply amber tint + "PINNED" caption. Toggled by tap or `POST /settings`. |
+
+## Quiet hours
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `quiet_on` | u8 | 0 | 0–1 | Quiet-hours master switch. |
+| `quiet_start` | u8 | 22 | 0–23 | Quiet-hours start hour (local clock, 24h). |
+| `quiet_end` | u8 | 7 | 0–23 | Quiet-hours end hour; can wrap past midnight. |
+
+## Per-channel notification toggles
+
+All `ch_*_on` keys default **off** — the user opts in per platform via
+Settings → CHANNELS. `ui_notification.c` silently drops an incoming
+[`channel_message`](../../GLOSSARY.md) whose `channel` field maps to a disabled
+toggle (with a `ui.notif.channel_off` obs event). Unknown channels fail open.
+
+| Key | Type | Default | Range | Description |
+|---|---|---|---|---|
+| `ch_tg_on` | u8 | 0 | 0–1 | Telegram notification toggle. |
+| `ch_wa_on` | u8 | 0 | 0–1 | WhatsApp notification toggle. |
+| `ch_dc_on` | u8 | 0 | 0–1 | Discord notification toggle. |
+| `ch_sl_on` | u8 | 0 | 0–1 | Slack notification toggle. |
+| `ch_sg_on` | u8 | 0 | 0–1 | Signal notification toggle. |
+| `ch_im_on` | u8 | 0 | 0–1 | iMessage notification toggle. |
+| `ch_ma_on` | u8 | 0 | 0–1 | Matrix notification toggle. |
+| `ch_em_on` | u8 | 0 | 0–1 | Email notification toggle. |
+
+## Voice mode (`vmode`) values
+
+The `vmode` key encodes the six-tier voice mode. Values 4 and 5 are
+Tab5-side-only; the wire only ever sees `0..3`.
+
+| `vmode` | Mode | STT | LLM | TTS |
+|---|---|---|---|---|
+| 0 | Local | Moonshine | Dragon-local (NPU / llama-server / Ollama) | Piper |
+| 1 | Hybrid | OpenRouter `gpt-audio-mini` | Dragon-local | OpenRouter `gpt-audio-mini` |
+| 2 | Cloud | OpenRouter `gpt-audio-mini` | User-selected (`llm_mdl`) | OpenRouter `gpt-audio-mini` |
+| 3 | TinkerClaw | Moonshine (or OpenRouter) | TinkerClaw gateway | Piper (or OpenRouter) |
+| 4 | Onboard (K144) | K144 sherpa-ncnn ASR (chain) or text-only | K144 stacked LLM (qwen2.5-0.5B over UART) | K144 `single_speaker_english_fast` |
+| 5 | Solo Direct | OpenRouter (`or_mdl_stt`) | OpenRouter (`or_mdl_llm`) | OpenRouter (`or_mdl_tts`, `or_voice`) |
+
+## Notes
+
+- **Key length.** Keys are capped at 15 characters by the NVS API — do not add a
+  longer key.
+- **String vs scalar.** `str` keys hold UTF-8 byte strings; `u8`/`u16`/`u32`
+  are unsigned integers of that width.
+- **`config.h` defaults** apply only until the user (or a `POST /settings`) sets
+  a runtime value. After that, the NVS value wins across reboots.
+- **Token security.** `auth_tok` and `dragon_tok` are bearer secrets — treat a
+  `GET /settings` dump (which includes them) as sensitive.
+
+## Examples
+
+Switch to Hybrid mode and dim the screen in one write:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/settings \
+     -d '{"vmode":1,"brightness":50}'
+# → {"ok":true}
+```
+
+Provision Solo Direct mode without the QR flow:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/settings \
+     -d '{"vmode":5,"or_key":"sk-or-v1-...","or_mdl_llm":"openai/gpt-4o-mini"}'
+```
+
+Opt in to Telegram notifications:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -X POST http://<ip>:8080/settings \
+     -d '{"ch_tg_on":1}'
+```

--- a/docs/reference/observability-events.md
+++ b/docs/reference/observability-events.md
@@ -1,0 +1,89 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# Observability events reference
+
+Authoritative, lookup-oriented reference for the [Tab5](../../GLOSSARY.md)'s
+observability event ring. No tutorials here — to drive the device with these
+events see [Run the e2e test harness](../how-to/run-the-e2e-test-harness.md).
+
+`tab5_debug_obs_event(kind, detail)` (in
+[`main/debug_obs.c`](../../main/debug_obs.c)) writes to a **256-entry FIFO ring**
+(oldest evicted). `GET /events?since=N` on the [debug server](debug-server.md)
+returns every entry with `ms >= N`. Each entry is
+`{"ms": uptime_ms, "kind": "category.subkind", "detail": "..."}`. The `kind`
+buffer is **32 chars**, `detail` is **48 chars** — both silently truncate past
+those limits.
+
+> **Polling only.** A `/events` long-poll was tried and reverted — ESP-IDF's
+> httpd is single-task, so `vTaskDelay` blocked all other requests and
+> fragmented the heap (PANIC under load). Poll at ~250 ms instead.
+
+## Event kinds
+
+| Kind | Where it fires | Detail |
+|---|---|---|
+| `obs` | Boot | `"init"` once. |
+| `screen.navigate` | `POST /navigate` handler | target screen name. |
+| `voice.state` | `voice_set_state()` on every transition | `IDLE` / `CONNECTING` / `READY` / `LISTENING` / `PROCESSING` / `SPEAKING` / `RECONNECTING`. |
+| `ws.connect` / `ws.disconnect` | WS event handler | empty. |
+| `chat.llm_done` | WS `llm_done` handler | `llm_ms` value as a string. |
+| `camera.capture` | `capture_btn_cb` after photo saved | absolute SD path. |
+| `camera.record_start` / `camera.record_stop` | record toggle | path; `path frames=N bytes=N` on stop. |
+| `display.brightness` | `POST /display/brightness` | percentage. |
+| `audio.volume` / `audio.mic_mute` | `POST /audio` | new value. |
+| `nvs` | `POST /nvs/erase` | `"erase"`. |
+| `m5.warmup` | `voice_onboard_warmup_job` + `reset_failover_job` | `start` / `ready` / `unavailable`. |
+| `m5.chain` | chain start/stop | `start` / `stop`. |
+| `m5.reset` | `voice_onboard_reset_failover` | `start` / `ack_ok` / `ack_fail` / `auto_retry` / `recovered` / `fail`. |
+| `error.k144` | `mark_k144_unavailable` | `probe_fail` / `warmup_fail` / `reset_probe_fail` / `reset_warmup_fail`. |
+| `ui.cue` | `ui_audio_cues.c::cue_play_job` | `{cue_name} err={n}` (mode_switch / cancel / error / incoming_low / incoming_high). |
+| `ui.notif` | `ui_notification.c` after route decision | `{ch}/{sender} pri={p} surf={now\|toast}[ quiet]`. |
+| `ui.notif.channel_off` | router gate when `ch_*_on=0` | `{channel}`. |
+| `ui.notif.dedupe` | dedupe-ring hit | `drop {message_id}`. |
+| `ui.notif.now` | now-card button taps | `dismiss` / `reply` / `snooze`. |
+| `ui.notif.snooze` | snooze ring + walker | `added {ch}/{sender} in=900s` / `overflow` / `defer_quiet` / `refire`. |
+| `ui.notif.reply` | `channel_reply` round-trip | `armed ...` / `dictated ...` / `sent ...` / `ack_ok` / `ack_fail {err}` / `no_cache` / `send_fail err={n}`. |
+| `agent_skills` | `ui_agents.c::fetch_agent_skills_job` | `count={n} observed={k}` or `skip vmode={n}`. |
+
+## Reading the ring
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+
+# Everything since boot
+curl -s -H "Authorization: Bearer $TOKEN" "http://<ip>:8080/events?since=0" \
+     | python3 -m json.tool
+
+# Only events after uptime_ms=50000 (a tighter window for one test step)
+curl -s -H "Authorization: Bearer $TOKEN" "http://<ip>:8080/events?since=50000" \
+     | python3 -m json.tool
+```
+
+A sample entry:
+
+```json
+{"ms": 52310, "kind": "voice.state", "detail": "LISTENING"}
+```
+
+## Notes
+
+- **Truncation is a known footgun.** `camera.record_start` once truncated to
+  `camera.record_s` against the old 16-char `kind` buffer (bumped to 32). Keep
+  new `kind` strings under 32 chars and `detail` under 48.
+- **Cursor management.** The e2e harness must not let a diagnostic read advance
+  its event cursor — use `events(peek=True)` for snapshots, or
+  `await_voice_state` (which also polls `/voice` current state) to dodge the
+  boot-`READY` race.
+
+## See also
+
+- [Debug server reference](debug-server.md) — the `/events` endpoint + the rest
+  of the control API.
+- [Run the e2e test harness](../how-to/run-the-e2e-test-harness.md) — the
+  harness that polls these events.
+- [TinkerTab architecture](../explanation/architecture.md) — why this
+  observability surface is part of the design.

--- a/docs/reference/voice-modes.md
+++ b/docs/reference/voice-modes.md
@@ -1,0 +1,93 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# Voice modes reference
+
+Authoritative, lookup-oriented reference for the [Tab5](../../GLOSSARY.md)'s
+six [voice modes](../../GLOSSARY.md). No tutorials here — to change a mode see
+[Switch voice modes](../how-to/switch-voice-modes.md).
+
+A voice mode decides **where** the three pipeline stages — speech-to-text (STT),
+the LLM, and text-to-speech (TTS) — run for a given turn. The active mode is the
+[NVS](../../GLOSSARY.md) key `vmode` (0–5). Routing lives in
+[`main/voice_modes.c`](../../main/voice_modes.c).
+
+## The six tiers
+
+| `vmode` | Mode | STT | LLM | TTS | Latency | Cost | Needs Dragon? |
+|---|---|---|---|---|---|---|---|
+| 0 | Local | Moonshine (Dragon) | Dragon-local (NPU / llama-server / Ollama, default ministral-3:3b ~67 s/turn median) | Piper (Dragon) | 60–90 s | Free | Yes |
+| 1 | Hybrid | OpenRouter `gpt-audio-mini` | Dragon-local | OpenRouter `gpt-audio-mini` | 4–8 s | ~$0.02/req | Yes |
+| 2 | Full Cloud | OpenRouter `gpt-audio-mini` | User-selected (`llm_mdl`: Haiku / Sonnet / GPT-4o) | OpenRouter `gpt-audio-mini` | 3–6 s | $0.03–0.08/req | Yes (audio pipe) |
+| 3 | TinkerClaw | Moonshine (or OpenRouter) | [TinkerClaw](../../GLOSSARY.md) gateway | Piper (or OpenRouter) | varies | varies | Yes (audio pipe) |
+| 4 | Onboard (K144) | K144 sherpa-ncnn ASR (chain) or text-only (failover) | K144 stacked LLM (qwen2.5-0.5B over UART) | K144 `single_speaker_english_fast` | 2–3 s | Free | **No** |
+| 5 | Solo Direct | OpenRouter (`or_mdl_stt`) | OpenRouter (`or_mdl_llm`) | OpenRouter (`or_mdl_tts`, `or_voice`) | 3–6 s | $0.03–0.08/req | **No** |
+
+## On-the-wire behavior
+
+| Aspect | Detail |
+|---|---|
+| Wire value range | `config_update.voice_mode` is always `0..3`. |
+| Modes 4 + 5 | Tab5-side-only. They downconvert to `0` on the wire so the Dragon never sees them. |
+| ACK echo filtering | `voice.c` filters the Dragon's `config_update` ACK echo so local NVS `vmode` keeps the true 4/5 value. |
+| Persistence | `vmode` (NVS); `llm_mdl` for the Cloud model; `or_*` keys for Solo Direct. |
+
+## Per-mode notes
+
+| Mode | Notes |
+|---|---|
+| Local (0) | The default. Nothing leaves your network. Slow on the Q6A NPU but free + fully private. |
+| Hybrid (1) | LLM stays Dragon-local; speech goes to OpenRouter for fast, accurate STT/TTS. Best dollar-per-turn for snappy. |
+| Full Cloud (2) | The LLM model picker is **only enabled in this mode** (writes `llm_mdl`). |
+| TinkerClaw (3) | The TinkerClaw gateway (`localhost:18789`) runs the turn with its own LLM + tools + browser automation; the Dragon becomes an audio pipe. |
+| Onboard (4) | Requires the K144 module stacked + warm (~4.5 s cold-start). Used for failover (Local → Onboard when Dragon is unreachable ≥30 s + K144 warm) and as a chosen mode (every turn → K144). |
+| Solo Direct (5) | Tab5 → OpenRouter directly, no Dragon. Needs `or_key`. On-device RAG against `/sdcard/rag.bin`. TT #379 multimodal audio chat (`or_mdl_audio`) collapses STT→LLM→TTS into one `/chat/completions` call. |
+
+## Routing decision codes
+
+`voice_modes_route_text` returns a route per turn:
+
+| Route | When |
+|---|---|
+| `LOCAL` / `HYBRID` / `CLOUD` / `TINKERCLAW` | Normal dispatch for modes 0–3. |
+| `LOCAL_ONBOARD` | Local-mode failover to the K144 (Dragon unreachable ≥30 s + K144 warm). |
+| `SOLO_DIRECT` | Mode 5 with a valid `or_key`. |
+| `SOLO_NO_KEY` | Mode 5 with no OpenRouter key set — the UI prompts a QR scan. |
+
+## Failover + guards
+
+| Behavior | Detail |
+|---|---|
+| Cloud STT/TTS auto-fallback | If a cloud STT/TTS request fails, the Dragon falls back to local for that request and sends `config_update` with an `error` field → the Tab5 auto-reverts to Local. |
+| Local → Onboard failover | `vmode=0` + Dragon WS unreachable ≥30 s + K144 warm + a text turn → routed to the K144. Toast: "Using onboard LLM"; reverts on Dragon reconnect. |
+| Mode change mid-turn | Auto-cancels the in-flight turn with a toast (the nav/voice chokepoint calls `voice_cancel`). |
+| Daily spend cap | `cap_mils` (default $1.00/day) — exceeding it triggers `cap_downgrade`, pulling off paid tiers. |
+
+## Examples
+
+Switch over the [debug server](debug-server.md):
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+curl -s -H "Authorization: Bearer $TOKEN" -X POST "http://<ip>:8080/mode?m=1"   # Hybrid
+curl -s -H "Authorization: Bearer $TOKEN" -X POST \
+     "http://<ip>:8080/mode?m=2&model=anthropic/claude-sonnet-4-20250514"        # Cloud + model
+```
+
+Confirm the persisted tier:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/settings \
+     | python3 -m json.tool | grep vmode
+# → "vmode": 4
+```
+
+## See also
+
+- [Switch voice modes](../how-to/switch-voice-modes.md) — the task guide.
+- [NVS settings reference](nvs-settings.md) — `vmode`, `llm_mdl`, `or_*`, `cap_mils`.
+- [WebSocket protocol](websocket-protocol.md) — `config_update` + mode downconversion.
+- [The voice pipeline](../explanation/the-voice-pipeline.md) — what each stage does.

--- a/docs/reference/websocket-protocol.md
+++ b/docs/reference/websocket-protocol.md
@@ -1,0 +1,137 @@
+---
+audience: integrator
+type: reference
+prerequisites: none
+last-verified: 2026-05-29
+---
+# WebSocket protocol (Tab5 client side)
+
+Authoritative, lookup-oriented reference for the messages the
+[Tab5](../../GLOSSARY.md) sends and receives over its single
+[WebSocket](../../GLOSSARY.md) to the [Dragon](../../GLOSSARY.md). No tutorials
+here.
+
+The Tab5 holds **one** persistent WebSocket at `ws://<host>:3502/ws/voice`
+(falling back to `wss://tinkerclaw-voice.ngrok.dev:443`). All traffic —
+voice, text, vision, video, config, and channel messaging — multiplexes over
+it. The **canonical full spec is the Dragon's**
+[`docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md);
+this page documents the **client side** that the Tab5 implements.
+
+## Frame kinds
+
+There are two frame kinds on the wire:
+
+- **Text frames** — UTF-8 JSON with a `"type"` field.
+- **Binary frames** — either untagged raw PCM, or an 8-byte-prefixed tagged
+  payload.
+
+> **WS send gotcha.** ESP-IDF's WS transport masks frames **in place** — never
+> pass a string literal to `esp_transport_ws_send_raw()`; copy to a mutable
+> buffer first.
+
+## Binary frame magic tags
+
+Non-audio binary payloads carry an 8-byte prefix: a 4-byte magic + a 4-byte
+big-endian length, then `payload[len]`. **Untagged** binary frames are raw
+16 kHz mono int16 PCM routed straight into STT — the legacy mic path, which
+stays magic-less for backward compatibility.
+
+| Magic | Direction | Length field | Payload | Module |
+|---|---|---|---|---|
+| `VID0` | both | 4 bytes BE u32 | JPEG frame | `voice_video.c` — camera uplink + downlink playback |
+| `AUD0` | both | 4 bytes BE u32 | raw 16 kHz mono int16 PCM | `voice.c` call mode — `VOICE_MODE_CALL` wraps mic frames as `AUD0` (bypasses STT) |
+| _(none)_ | Tab5 → Dragon | — | raw 16 kHz mono int16 PCM | legacy mic path → STT |
+
+Wire layout: `"VID0"` (4 bytes) + `len_be` (4 bytes) + `payload[len]`. Same
+shape for `"AUD0"`.
+
+## Tab5 → Dragon (sending)
+
+| `type` | Payload / shape | Purpose |
+|---|---|---|
+| `register` | `{"device_id":"...","session_id":"..."}` | First frame on connect — identifies the device + resumes a session. |
+| `start` | optional `{"mode":"dictate"}` | Begin a voice/dictation turn; followed by untagged PCM frames. |
+| `stop` | — | End the audio stream for the current turn. |
+| `cancel` | — | Abort current processing. |
+| `ping` | — | JSON keepalive heartbeat (every ~15 s during processing). |
+| `text` | `{"content":"..."}` | A typed turn — skips STT, same conversation context. |
+| `config_update` | `{"voice_mode":0..3,"llm_model":"..."}` | Swap [voice mode](../../GLOSSARY.md) / model. `cloud_mode` bool still accepted for backward compat. |
+| `clear` | — | Reset conversation context. (Was documented as `clear_history`; the implementation has always used `clear`.) |
+| `channel_reply` | `{"channel":"telegram","thread_id":"<id>","text":"<reply>"}` | Reply to a received `channel_message`; Dragon ACKs with `channel_reply_ack`. |
+
+**Mode downconversion.** `config_update.voice_mode` is always in `0..3` on the
+wire. Modes **4** (Onboard / K144) and **5** (Solo Direct) are Tab5-side-only:
+the Tab5 downconverts them to `0` so the Dragon never sees them, and `voice.c`
+filters the Dragon's ACK echo so local [NVS](../../GLOSSARY.md) (`vmode`) keeps
+the true 4/5 value. This is a protocol feature — the on-the-wire shape stays
+`0..3` as the Tab5 grows new local-only modes.
+
+## Dragon → Tab5 (receiving)
+
+| `type` | Shape / notes | Purpose |
+|---|---|---|
+| `session_start` | `session_id` | Session id for NVS persistence. |
+| `stt` / `stt_partial` | transcription text | Final / streaming transcription (partial for dictation). |
+| `llm` | streamed text | LLM response text. |
+| `llm_done` | timing | LLM generation complete. |
+| `tool_call` | `{"tool":"web_search","args":{...}}` | Tool invocation — show activity indicator. |
+| `tool_result` | `{"tool":"...","result":{...},"execution_ms":N}` | Tool completion. |
+| `tts_start` / binary TTS / `tts_end` | — | TTS audio playback bracketing. |
+| `dictation_summary` | `{"title":"...","summary":"..."}` | Post-processing of a dictation. |
+| `pong` | — | Keepalive response. |
+| `config_update` | applied config + `cloud_mode` + `fleet_summary` | ACK echoing the applied backend config. `fleet_summary` carries per-device vision capability used to enable/disable the vision chip. |
+| `error` | error details | Error report. A transient `stt_empty` / `pipeline_failed` snaps `voice_state` back to READY/IDLE. |
+
+### Rich media (Dragon → Tab5)
+
+| `type` | Shape | Purpose |
+|---|---|---|
+| `media` | `{"media_type":"image","url":"...","width":N,"height":N,"alt":"..."}` | Inline rendered image bubble (Dragon renders code/tables to JPEG). |
+| `card` | `{"title":"...","subtitle":"...","image_url":"...","description":"..."}` | Rich preview card (orange accent border). |
+| `audio_clip` | `{"url":"...","duration_s":2.3,"label":"..."}` | Inline audio. |
+| `text_update` | `{"text":"cleaned text"}` | Replace the last AI bubble's text (after stripping rendered code blocks). |
+
+### Channel messaging (Dragon → Tab5)
+
+| `type` | Shape | Purpose |
+|---|---|---|
+| `channel_message` | `{"channel":"tg","message_id":"...","thread_id":"...","sender":{"display_name":"...","starred":bool},"text":"...","preview":"...","priority":"low|normal|high","needs_reply":bool}` | Incoming third-party platform message (Telegram / WhatsApp / Discord / Slack / Signal / iMessage / Matrix / Email). Routed to toast or now-card; gated by `ch_*_on` NVS toggles. |
+| `channel_reply_ack` | `{"channel":"telegram","thread_id":"...","ok":bool,"platform_message_id":"..."}` | Confirms a Tab5-sent `channel_reply` was delivered. On `ok=true` the Tab5 toasts "Replied via {channel}". |
+
+### Widget platform (Dragon → Tab5)
+
+Skills on the Dragon emit typed widget state the Tab5 renders opinionatedly:
+`widget_live`, `widget_live_update`, `widget_live_dismiss`, `widget_card`,
+`widget_list`, `widget_chart`, `widget_prompt`, `widget_dismiss`. The Tab5 sends
+`widget_action` and `widget_capability` back. Unknown widget types are ignored
+(forward-compat). See [`WIDGETS.md`](../WIDGETS.md).
+
+## Examples
+
+A registration + typed turn (Tab5 → Dragon), JSON text frames:
+
+```json
+{"type":"register","device_id":"a1b2c3d4e5f6","session_id":""}
+{"type":"text","content":"What time is it?"}
+```
+
+A mode switch to Hybrid (Tab5 → Dragon) — note the wire value stays `0..3`:
+
+```json
+{"type":"config_update","voice_mode":1,"llm_model":"anthropic/claude-3.5-haiku"}
+```
+
+A `VID0` video frame on the wire (conceptual byte layout):
+
+```
+56 49 44 30   00 00 12 34   <0x1234 bytes of JPEG ...>
+'V''I''D''0'  len = 4660
+```
+
+## See also
+
+- Canonical wire spec: [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md)
+- [Voice modes reference](voice-modes.md) · [Observability events](observability-events.md)
+- [The voice pipeline](../explanation/the-voice-pipeline.md) ·
+  [TinkerTab architecture](../explanation/architecture.md)

--- a/docs/tutorials/your-first-voice-conversation.md
+++ b/docs/tutorials/your-first-voice-conversation.md
@@ -1,0 +1,87 @@
+---
+audience: tinkerer
+type: tutorial
+prerequisites: A flashed, booted [Tab5](../../GLOSSARY.md) connected to Wi-Fi and a [Dragon](../../GLOSSARY.md) (finish [Get started](getting-started.md) first)
+last-verified: 2026-05-29
+est-time: 15 min
+---
+# Your first voice conversation
+
+By the end you will have held a real back-and-forth conversation with your
+[Tab5](../../GLOSSARY.md): asked a question out loud, heard it answer, asked a
+follow-up that builds on the first, and dictated a longer note. This is a
+learning-by-doing walkthrough; every step has a visible result so you know it
+worked.
+
+This picks up where [Get started](getting-started.md) leaves off — there you
+flashed the firmware and confirmed a single voice turn. Here you learn the
+day-to-day rhythm of talking to the device.
+
+## Before you start
+
+- A **Tab5** that boots to the home screen with the breathing orb.
+- It is **on Wi-Fi** and connected to a **Dragon** (the status reads connected).
+- The speaker volume is up — check **Settings → Audio** if you hear nothing.
+
+## Steps
+
+1. **Start listening.** With the K144/[TinkerON](../../GLOSSARY.md) module
+   present, just say **"Hey Tinker."** Without it, **tap the orb** on the home
+   screen.
+   _You should see:_ the orb shift to its **LISTENING** state (it leans/ripples)
+   and the say-pill prompt below it change to indicate it is hearing you.
+
+2. **Ask a question.** Say something with a clear answer, e.g.
+   _"What's the capital of France?"_ then stop talking.
+   _You should see:_ the orb move to **PROCESSING** while the
+   [Dragon](../../GLOSSARY.md) transcribes your speech and runs the LLM, then to
+   **SPEAKING** as the answer plays through the speaker.
+
+3. **Wait for it to finish, then ask a follow-up.** Say **"Hey Tinker"** again
+   (or tap the orb) and ask something that depends on the first answer, e.g.
+   _"And how many people live there?"_
+   _You should see:_ the answer reference the previous turn — the conversation
+   has memory because the Dragon keeps a session. The orb cycles
+   LISTENING → PROCESSING → SPEAKING → READY again.
+
+4. **Cancel a turn you didn't mean.** Start listening, then tap the **stop**
+   button (or the X) under the orb before you finish.
+   _You should see:_ the orb snap straight back to **READY/IDLE** — no answer
+   plays. This is your escape hatch any time a turn goes sideways.
+
+5. **Type instead of talk.** Open the **Chat** overlay, type a message, and send
+   it.
+   _You should see:_ your text appear as a bubble and the answer stream back
+   in — same conversation context as voice, it just skips speech-to-text.
+
+6. **Dictate a longer note.** **Long-press** the mic/orb to enter dictation
+   mode and speak a few sentences, then pause.
+   _You should see:_ a live waveform while you talk, partial transcript text
+   appearing, and after ~5 seconds of silence it auto-stops. The Dragon then
+   returns a generated **title + summary** and the note is saved.
+
+## What you built
+
+You now have the full conversational loop in muscle memory: wake or tap to
+start, speak, let it process and answer, follow up with context, cancel when
+needed, type when quiet, and dictate when you have a lot to say. A healthy
+multi-turn session looks like this on the serial log (115200 baud), once per
+turn:
+
+```
+I (xxxx) voice: state IDLE -> LISTENING
+I (xxxx) voice: state LISTENING -> PROCESSING
+I (xxxx) voice: state PROCESSING -> SPEAKING
+I (xxxx) voice: state SPEAKING -> READY
+```
+
+## Next
+
+- [Switch voice modes](../how-to/switch-voice-modes.md) — trade privacy, speed,
+  and cost (local vs cloud vs onboard).
+- [Dictate and take notes](../how-to/dictate-and-take-notes.md) — the full
+  dictation + Notes workflow.
+- [Enable the TinkerON wakeword](../how-to/enable-tinkeron-wakeword.md) — go
+  fully hands-free with "Hey Tinker."
+- [The voice pipeline](../explanation/the-voice-pipeline.md) — what actually
+  happens between your words and the answer.


### PR DESCRIPTION
## docs: Wave 1 — TinkerTab content (Diátaxis, 4 audiences)

Stacked on the merged Wave 0 foundation (#743). Fills in TinkerTab's documentation across all four audiences using the Wave 0 templates + STYLE.md, mined from CLAUDE.md / README / internal docs.

**18 new pages:**
- **Tutorials:** your-first-voice-conversation
- **How-to (×7):** connect-to-dragon · switch-voice-modes · use-the-camera · dictate-and-take-notes · enable-tinkeron-wakeword · recover-a-stuck-device · run-the-e2e-test-harness
- **Reference (×6):** websocket-protocol · nvs-settings · voice-modes · observability-events · hardware · firmware-file-map
- **Explanation (×4):** architecture · the-voice-pipeline · lvgl-on-esp32p4 · the-tinkeron-k144-chain

`docs/README.md` re-indexed by Diátaxis type **and** audience. Every page carries the standard `last-verified` header. **markdown-link-check: PASS** (0 broken).

Next: Wave 2 (TinkerBox), Wave 3 (PingOS), Wave 4 (TinkerClaw), Wave 5 (cross-cutting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
