### PR TITLE
docs: Wave 5 — cross-cutting capstone (unbox-to-assistant, voice-mode guide, stack overview)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ browse by type.
 
 | Page | What you get |
 |---|---|
+| [From unboxing to a working voice assistant](tutorials/unbox-to-working-assistant.md) | **Start here.** The full end-to-end journey across both halves of the stack: flash the Tab5, bring up the Dragon, link them, and hold your first conversation. |
 | [Get started](tutorials/getting-started.md) | Unbox → flash → first boot → "Hey Tinker" → first voice turn. |
 | [Your first voice conversation](tutorials/your-first-voice-conversation.md) | Hold a real multi-turn conversation: ask, follow up, cancel, type, dictate. |
 
@@ -62,6 +63,7 @@ browse by type.
 
 | Page | When to use it | Audience |
 |---|---|---|
+| [Choose your voice mode](how-to/choose-your-voice-mode.md) | Decide *which* of the six tiers fits — privacy vs latency vs cost vs offline. | tinkerer |
 | [Switch voice modes](how-to/switch-voice-modes.md) | Change the privacy/speed/cost trade-off across the six tiers. | tinkerer |
 | [Use the camera](how-to/use-the-camera.md) | Take a photo, record video, send an image into chat. | tinkerer |
 | [Dictate and take notes](how-to/dictate-and-take-notes.md) | Capture a longer thought hands-free → title + summary in Notes. | tinkerer |
@@ -90,6 +92,7 @@ browse by type.
 
 | Page | Helps you understand |
 |---|---|
+| [The Tinker stack](explanation/the-tinker-stack.md) | The contributor's whole-system map: the four repos, who owns what, how data flows, and where each repo's docs live. |
 | [How the stack fits together](explanation/how-the-stack-fits-together.md) | What the Tab5, Dragon, and K144/TinkerON each do, and the six voice modes. |
 | [TinkerTab architecture](explanation/architecture.md) | How the firmware is layered internally and why the boundaries fall where they do. |
 | [The voice pipeline](explanation/the-voice-pipeline.md) | How a turn becomes an answer — STT → LLM → TTS, the state machine, and the audio path. |

--- a/docs/explanation/the-tinker-stack.md
+++ b/docs/explanation/the-tinker-stack.md
@@ -1,0 +1,208 @@
+---
+audience: developer
+type: explanation
+prerequisites: none
+last-verified: 2026-05-29
+---
+# The Tinker stack — how the pieces fit
+
+## The question
+
+You are a new contributor staring at four repositories and you want to know,
+before you read anything else: **what are these projects, who owns what, how does
+data flow between them, and where do I go for the next level of detail?** This is
+the map you read first. It does not teach you to do anything — for that, start
+with the [getting-started tutorial](../tutorials/getting-started.md). It also
+does not re-derive the architecture, the wire protocol, or the boot sequence;
+those have their own pages and this one links to them.
+
+There are two related explanation pages and it is worth knowing which to read
+when:
+
+- **This page** is the contributor's whole-system orientation: the four repos,
+  the ownership boundaries, and the doc map.
+- [How the stack fits together](how-the-stack-fits-together.md) is the shorter
+  product-level "how do these relate?" answer.
+- [TinkerTab architecture](architecture.md) goes one level deeper into *this*
+  repo's firmware internals.
+
+## The model
+
+The live product is two devices talking over **one WebSocket**, with an optional
+on-device LLM module hanging off the [Tab5](../../GLOSSARY.md), and two more
+repos that are part of the family but are not on the voice-turn hot path.
+
+```
+                       THE LIVE PRODUCT (two boxes, one socket)
+
+   +-------------------------------+                      +---------------------------------+
+   |  Tab5  (TinkerTab firmware)    |    one WebSocket     |  Dragon Q6A  (TinkerBox)        |
+   |  "THE FACE" — thin client      | <==================> |  "THE BRAIN" — all intelligence |
+   |                                |   ws://host:3502     |                                 |
+   |  - LVGL v9 UI, touch           |   /ws/voice          |  - STT (Moonshine)              |
+   |  - 4-mic array, ES8388 spkr    |  audio frames  ===>  |  - LLM (llama-server / cloud)   |
+   |  - SC202CS camera              |  text / config ===>  |  - TTS (Piper / Kokoro)         |
+   |  - SD card, NVS settings       |  <=== STT/LLM/TTS    |  - embeddings, memory, RAG      |
+   |  - ESP32-P4 + ESP32-C6 Wi-Fi   |  <=== events/config  |  - sessions, REST API, dashboard|
+   +---------------+----------------+                      +----------------+----------------+
+                   |                                                        |
+          M5-Bus UART / USB                                       voice mode 3 (localhost)
+                   |                                                        |
+   +---------------v----------------+                      +----------------v----------------+
+   |  K144 / TinkerON module        |                      |  TinkerClaw gateway  :18789     |
+   |  (AX630C NPU) — OPTIONAL        |                      |  agent sidecar — OPTIONAL       |
+   |  - on-device ASR (sherpa-ncnn) |                      |  - own LLM choice + tools       |
+   |  - on-device LLM + TTS         |                      |  - browser automation           |
+   |  - always-on "Hey Tinker"      |                      |  (Dragon becomes an audio pipe) |
+   +--------------------------------+                      +---------------------------------+
+
+
+   PingOS  — a SEPARATE product.  Turn any website into a REST API via a Chrome
+             MV3 bridge + ahead-of-time compilation.  Not on the voice-turn path;
+             shares the stack's docs conventions and peer-links as family.
+```
+
+### Who owns what
+
+The ownership boundary between the face and the brain is the single most
+important rule in the stack, and both `CLAUDE.md` files state it as law. Code
+that crosses the line is a bug.
+
+| Concern | Lives in | Repo |
+|---|---|---|
+| LVGL UI, screens, the orb | Tab5 | [TinkerTab](https://github.com/lorcan35/TinkerTab) |
+| Mic / speaker / camera / touch / IMU / SD / Wi-Fi | Tab5 | TinkerTab |
+| Device settings ([NVS](../../GLOSSARY.md)) | Tab5 | TinkerTab |
+| Speech-to-text (STT) | Dragon | [TinkerBox](https://github.com/lorcan35/TinkerBox) |
+| LLM inference + the multi-model router | Dragon | TinkerBox |
+| Text-to-speech (TTS) | Dragon | TinkerBox |
+| Embeddings, memory, RAG, sessions | Dragon | TinkerBox |
+| Conversation engine, REST API, dashboard, database | Dragon | TinkerBox |
+| The WebSocket wire contract | Dragon (spec) | TinkerBox `docs/protocol.md` |
+| On-device wakeword + on-device voice turn | K144 module | TinkerTab (`voice_m5_llm.c`, `voice_onboard.c`, `voice_wakeword.c`) |
+| Agent loop + tool execution + browser (voice mode 3) | TinkerClaw gateway | [TinkerClaw](https://github.com/lorcan35/TinkerClaw) |
+| Website-to-API automation | PingOS | [PingOS](https://github.com/lorcan35/PingOS) |
+
+The blunt version, straight from the repo separation rules:
+
+- **Tab5 (TinkerTab)** is a deliberately *thin client*. It owns hardware I/O and
+  the native UI but **no intelligence and no database**. It sends audio frames,
+  text turns, and device registration; it receives STT results, LLM responses,
+  TTS audio, and config updates. On-device storage is the SD card (recordings,
+  offline queue) and NVS (settings) only.
+- **Dragon (TinkerBox)** is the *brain*. STT, the LLM, TTS, embeddings, memory,
+  sessions, the dashboard, OTA, and the database all live here. The brain can
+  upgrade independently of the firmware — a new model is a Dragon deploy, not a
+  reflash, and one Dragon can serve a fleet of faces.
+- **K144 / TinkerON** is an *optional* module stacked onto the Tab5. When present
+  it adds always-on "Hey Tinker" wakeword and can run an entire voice turn — ASR,
+  LLM, TTS — on-device with no Dragon. The firmware enforces six modularity rules
+  so the Tab5 **never depends** on it being present.
+- **TinkerClaw** is the *optional* agent sidecar (OpenClaw-derived) on the Dragon
+  at `localhost:18789`. Voice mode 3 routes the turn through it; in that mode the
+  Dragon's own conversation engine, tools, and memory are bypassed and the Dragon
+  becomes an audio pipe.
+- **PingOS** is a *separate product*: a gateway that turns any website into a
+  REST API through a Chrome MV3 extension bridge and ahead-of-time compilation.
+  It is part of the Tinker family and shares these docs conventions, but it is
+  not on the voice-turn hot path — treat its README as the front door.
+
+### A voice turn, end to end
+
+The default path (voice mode 0) shows the data flow:
+
+```
+  you speak
+     │
+     ▼
+  Tab5 mic (ES7210, 48 kHz, 4-ch TDM) ─ slot 0 ─ downsample 3:1 ─► 16 kHz mono PCM
+     │
+     ▼  binary frames over the one WebSocket
+  Dragon: STT (Moonshine) ─► transcript ─► LLM (llama-server) ─► reply text ─► TTS (Piper)
+     │
+     ▼  16 kHz PCM frames back down the same WebSocket
+  Tab5 playback ─ upsample 1:3 ─► 48 kHz ─► ES8388 DAC ─► speaker
+     │
+     ▼
+  you hear the answer
+```
+
+The same orb tap or wakeword fires every turn, but *where the work happens*
+depends on the active [voice mode](../../GLOSSARY.md):
+
+| Mode | STT | LLM | TTS | Needs Dragon? |
+|---|---|---|---|---|
+| 0 — Local | Moonshine (Dragon) | Dragon-local | Piper (Dragon) | Yes |
+| 1 — Hybrid | OpenRouter | Dragon-local | OpenRouter | Yes |
+| 2 — Cloud | OpenRouter | OpenRouter | OpenRouter | Yes (audio pipe) |
+| 3 — TinkerClaw | Dragon | [TinkerClaw](../../GLOSSARY.md) gateway | Dragon | Yes (audio pipe) |
+| 4 — Onboard (K144) | K144 | K144 | K144 | **No** |
+| 5 — Solo | OpenRouter | OpenRouter | OpenRouter | **No** |
+
+Modes 0–3 are real on-the-wire `voice_mode` values. Modes 4 and 5 are
+**Tab5-side-only**: they downconvert to `0` on the wire so the Dragon never sees
+them. The full table is in the [voice-modes reference](../reference/voice-modes.md).
+
+### Where each repo's docs live
+
+When you need the next level of detail, this is where to go. Cross-repo links
+point at each repo's front door, never deep into its internals — internal paths
+move, the README is stable.
+
+| You want… | Go to | Repo |
+|---|---|---|
+| Use the device end to end | [getting-started tutorial](../tutorials/getting-started.md) | TinkerTab |
+| Build + flash the firmware | [dev setup](../how-to/dev-setup.md) · [flash the firmware](../how-to/flash-firmware.md) | TinkerTab |
+| The firmware internals + why | [TinkerTab architecture](architecture.md) | TinkerTab |
+| Hardware pinout + IC list | [hardware reference](../reference/hardware.md) | TinkerTab |
+| Drive the device from a workstation | [debug-server reference](../reference/debug-server.md) | TinkerTab |
+| The on-device K144 chain | [the TinkerON / K144 chain](the-tinkeron-k144-chain.md) | TinkerTab |
+| The cross-stack system map | [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md) | TinkerBox |
+| The WebSocket wire contract | [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md) | TinkerBox |
+| Run / deploy the brain | [TinkerBox README](https://github.com/lorcan35/TinkerBox) | TinkerBox |
+| The agent sidecar | [TinkerClaw README](https://github.com/lorcan35/TinkerClaw) | TinkerClaw |
+| Website-to-API automation | [PingOS README](https://github.com/lorcan35/PingOS) | PingOS |
+| Any unfamiliar term | [GLOSSARY](../../GLOSSARY.md) (carried in every repo) | all |
+
+Two facts make this navigable. First, every repo carries the **same** standard
+header, peer block, and [GLOSSARY](../../GLOSSARY.md) core, so a reader who
+learns one repo's conventions can read any of them — that is the contract in
+[`STYLE.md`](../../STYLE.md). Second, the deep wire contract and the cross-stack
+map live **once**, in TinkerBox, and the other repos link to them rather than
+copying them.
+
+## Why it's built this way
+
+- **Thin client, fat brain.** The [ESP32-P4](../../GLOSSARY.md) has roughly
+  512 KB of tight internal SRAM; it cannot host a useful LLM. Pushing all
+  intelligence to the Dragon keeps the firmware small, lets the brain upgrade on
+  its own cadence, and lets one Dragon serve many faces. The cost is a hard
+  dependency on the Dragon for modes 0–3 — which is exactly why the optional
+  on-device fallback (mode 4) and the direct-cloud path (mode 5) exist.
+- **One WebSocket, many message types.** Multiplexing voice, text, vision, video,
+  config, and events over a single persistent connection avoids connection churn
+  on a memory-constrained device and keeps the protocol in one place. Binary
+  frames carry a 4-byte magic tag (`VID0` video, `AUD0` call audio) or are
+  untagged raw PCM bound for STT.
+- **Each repo stands alone.** Rather than one umbrella front door, the four repos
+  cross-link as peers (the "Part of the Tinker stack" block). Each is fully
+  documented on its own, so a contributor can land in any repo and find their
+  bearings without first reading three others.
+- **Optional pieces are strictly additive.** TinkerON (mode 4), TinkerClaw
+  (mode 3), and PingOS are all opt-in. The core product — Tab5 plus Dragon over
+  one WebSocket — works with none of them present, and the firmware degrades
+  gracefully when an optional module is absent or hot-unplugged.
+- **PingOS is family, not a dependency.** It shares the stack's docs conventions
+  and peer-links as one of the four repos, but it solves a different problem
+  (website automation) and is not required for the voice assistant to work. It is
+  on this map so a contributor knows what it is and is *not* — not because a voice
+  turn ever touches it.
+
+## See also
+
+- [How the stack fits together](how-the-stack-fits-together.md) · [TinkerTab architecture](architecture.md)
+- [Getting started](../tutorials/getting-started.md) · [Dev setup](../how-to/dev-setup.md) · [Flash the firmware](../how-to/flash-firmware.md)
+- [Voice-modes reference](../reference/voice-modes.md) · [Debug-server reference](../reference/debug-server.md) · [GLOSSARY](../../GLOSSARY.md)
+- System architecture (cross-stack): [TinkerBox `docs/ARCHITECTURE.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/ARCHITECTURE.md)
+- Wire protocol: [TinkerBox `docs/protocol.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/protocol.md)
+- Peer repos: [TinkerBox](https://github.com/lorcan35/TinkerBox) · [TinkerClaw](https://github.com/lorcan35/TinkerClaw) · [PingOS](https://github.com/lorcan35/PingOS)

--- a/docs/how-to/choose-your-voice-mode.md
+++ b/docs/how-to/choose-your-voice-mode.md
@@ -1,0 +1,141 @@
+---
+audience: tinkerer
+type: how-to
+prerequisites: [getting-started tutorial](../tutorials/getting-started.md), a [Tab5](../../GLOSSARY.md) booted and on Wi-Fi
+last-verified: 2026-05-29
+est-time: 5 min
+---
+# Choose your voice mode
+
+Use this when you have decided you need to change voice modes but cannot decide
+**which** of the six tiers to pick. The [Tab5](../../GLOSSARY.md) runs a voice
+turn through one of six [voice modes](../../GLOSSARY.md), and they trade off
+along four axes that pull against each other: **privacy**, **latency**, **cost**,
+and whether it works **offline** (with no [Dragon](../../GLOSSARY.md) on the
+network). This guide helps you pick; the separate
+[Switch voice modes](switch-voice-modes.md) guide shows you the buttons to press
+once you have.
+
+If you just want the authoritative spec for each tier — STT/LLM/TTS per stage,
+on-the-wire behavior, routing codes — read the
+[voice modes reference](../reference/voice-modes.md) instead. This page is a
+decision aid, not a spec.
+
+## The four axes that matter
+
+Every mode is a point on these four axes. Decide which one you care about most
+right now, then read down the matching column.
+
+- **Privacy** — does any audio or text leave your network? Local (0) and Onboard
+  (4) keep everything on hardware you own. Hybrid (1) sends speech to the cloud
+  but keeps the LLM on your Dragon. Full Cloud (2), TinkerClaw with cloud models
+  (3), and Solo Direct (5) send your turn to a third party (OpenRouter).
+- **Latency** — how long from "stop talking" to "hear the answer." On-device and
+  cloud are fast (2–8 s); the fully-local Dragon path is slow (60–90 s) because
+  the Q6A NPU runs the LLM itself.
+- **Cost** — Local, Onboard, and the Dragon-local half of Hybrid are free. The
+  cloud tiers bill per request through OpenRouter; the daily spend is capped by
+  the `cap_mils` [NVS](../../GLOSSARY.md) key (default $1.00/day).
+- **Offline** — does the mode need a Dragon reachable on the network at all?
+  Onboard (4) and Solo Direct (5) are the only two that run a complete turn with
+  **no Dragon**: Onboard on the K144 module, Solo Direct straight to OpenRouter.
+
+## The trade-off matrix
+
+| `vmode` | Mode | Privacy | Latency | Cost | Offline (no Dragon)? |
+|---|---|---|---|---|---|
+| 0 | Local | Full — nothing leaves your network | 60–90 s | Free | No |
+| 1 | Hybrid | LLM stays local; speech goes to cloud | 4–8 s | ~$0.02/req | No |
+| 2 | Full Cloud | None — STT + LLM + TTS all cloud | 3–6 s | Free | No (needs Dragon as audio pipe) |
+| 3 | TinkerClaw | Depends on the gateway's model choice | varies | varies | No (needs Dragon as audio pipe) |
+| 4 | Onboard (K144) | Full — runs on the stacked module | 2–3 s | Free | **Yes** |
+| 5 | Solo Direct | None — Tab5 → OpenRouter directly | 3–6 s | $0.03–0.08/req | **Yes** |
+
+Two modes are **Tab5-side-only**: Onboard (4) and Solo Direct (5). When the Tab5
+reports its mode over the wire it downconverts those to `0` so the Dragon never
+sees them — the `vmode` NVS key still holds the true value. That is why these two
+can run with no Dragon at all.
+
+## Pick this if…
+
+| If you want… | Pick | Why |
+|---|---|---|
+| Maximum privacy, and you don't mind waiting | **Local (0)** | The default. STT (Moonshine), LLM, and TTS (Piper) all run on your Dragon. Nothing leaves your network. Slow on the Q6A NPU but free and fully private. |
+| A snappy assistant for the lowest cost | **Hybrid (1)** | Keeps the LLM on your Dragon for privacy + free inference, but sends speech to OpenRouter for fast, accurate STT/TTS. Best dollar-per-turn. |
+| The fastest, highest-quality answers | **Full Cloud (2)** | STT, LLM, and TTS all go to OpenRouter. The LLM model picker (Haiku / Sonnet / GPT-4o) is **only enabled in this mode**. You pay per request. |
+| Tools, browser automation, agentic tasks | **TinkerClaw (3)** | The [TinkerClaw](../../GLOSSARY.md) gateway runs the turn with its own LLM choice plus tools and browser automation; the Dragon becomes an audio pipe. |
+| Hands-free, on-device, no Dragon at all | **Onboard / K144 (4)** | The [TinkerON](../../GLOSSARY.md) module runs the whole turn over the M5-Bus. Free, private, ~2–3 s, works with the Dragon off. Requires the K144 stacked and warm (~4.5 s cold-start). |
+| The Tab5 to work away from your Dragon, with cloud quality | **Solo Direct (5)** | The Tab5 talks straight to OpenRouter for STT/LLM/TTS using the `or_*` NVS keys, plus on-device RAG against `/sdcard/rag.bin`. Needs an OpenRouter API key. |
+
+### Quick decision shortcuts
+
+- **"I value privacy above everything."** → Local (0) when the Dragon is on, or
+  Onboard (4) for fast + private + offline.
+- **"I want it fast and cheap, and I trust my Dragon."** → Hybrid (1).
+- **"I want the smartest possible answer."** → Full Cloud (2) with Sonnet.
+- **"I'm away from home / the Dragon is off."** → Onboard (4) if the K144 is
+  stacked; otherwise Solo Direct (5).
+- **"I need it to actually *do* things (browse, call tools)."** → TinkerClaw (3).
+
+## How to switch once you've chosen
+
+You do not change modes here — the mechanics live in their own guide. There are
+three ways:
+
+1. **The mode chip** below the orb on home — tap to cycle.
+2. **The mode-picker sheet** — long-press the orb (or Settings → Voice).
+3. **The [debug server](../reference/debug-server.md) `/mode` endpoint** — switch
+   a device remotely over HTTP.
+
+The full step-by-step, including the Full Cloud model picker and the OpenRouter
+key prompt for Solo Direct, is in
+[Switch voice modes](switch-voice-modes.md).
+
+## Verify it worked
+
+After switching, confirm the persisted tier matches what you chose:
+
+```bash
+export TOKEN="abcdef1234567890abcdef1234567890"
+curl -s -H "Authorization: Bearer $TOKEN" http://<ip>:8080/settings \
+     | python3 -m json.tool | grep vmode
+# → "vmode": 4
+```
+
+The `vmode` key holds the true tier (0–5), even for Onboard (4) and Solo Direct
+(5) which report as `0` over the wire to the Dragon.
+
+## Troubleshooting
+
+- **Picked Onboard (4) but it won't run** → The K144/[TinkerON](../../GLOSSARY.md)
+  module must be stacked on the Module13.2 LLM Mate carrier and **warm**. Check
+  `GET /m5` — `failover_state_name` must be `ready`. Recover with
+  `POST /m5/reset`. See [Enable the TinkerON wakeword](enable-tinkeron-wakeword.md)
+  and [Recover a stuck device](recover-a-stuck-device.md).
+- **Picked Solo Direct (5) but it prompts for a QR scan** → No OpenRouter key in
+  NVS. The route returns `SOLO_NO_KEY` until you set `or_key`. See the `or_*`
+  keys in the [NVS settings reference](../reference/nvs-settings.md).
+- **Picked a cloud tier but it reverts to Local mid-session** → Auto-fallback. If
+  a cloud STT/TTS request fails, the Dragon falls back to local for that request
+  and sends a `config_update` with an `error` field, and the Tab5 reverts to
+  Local. Re-select the cloud mode once connectivity is back.
+- **Hit the daily spend cap on a cloud tier** → The `cap_mils` NVS key caps daily
+  LLM spend (default $1.00/day). Exceeding it triggers a `cap_downgrade` off the
+  paid tiers. Raise the cap via `POST /settings` if you want to spend more.
+
+## See also
+
+- [Switch voice modes](switch-voice-modes.md) — the mechanics: chip, sheet, and
+  the `/mode` endpoint.
+- [Voice modes reference](../reference/voice-modes.md) — the authoritative spec:
+  STT/LLM/TTS per stage, on-the-wire behavior, routing codes, failover guards.
+- [Enable the TinkerON wakeword](enable-tinkeron-wakeword.md) — go fully
+  hands-free with Onboard (4) on the K144 module.
+- [NVS settings reference](../reference/nvs-settings.md) — `vmode`, `llm_mdl`,
+  `or_*`, and `cap_mils`.
+- [How the stack fits together](../explanation/how-the-stack-fits-together.md) —
+  why the Tab5 is a thin client and the Dragon is the brain.
+- The Dragon's side of these modes: see
+  [**TinkerBox**](https://github.com/lorcan35/TinkerBox)'s
+  [`docs/reference/voice-modes.md`](https://github.com/lorcan35/TinkerBox/blob/main/docs/reference/voice-modes.md)
+  for what each tier costs the Dragon's pipeline.

--- a/docs/tutorials/unbox-to-working-assistant.md
+++ b/docs/tutorials/unbox-to-working-assistant.md
@@ -1,0 +1,241 @@
+---
+audience: tinkerer
+type: tutorial
+prerequisites: An M5Stack Tab5 + USB-C cable, a Dragon (or any Linux box) for the brain, and a computer to flash from
+last-verified: 2026-05-29
+est-time: 60 min
+---
+# From unboxing to a working voice assistant
+
+By the end you will have built the whole stack from scratch: flashed firmware
+onto a brand-new [Tab5](../../GLOSSARY.md), brought up a
+[Dragon](../../GLOSSARY.md) to be its brain, connected the two, and said
+**"Hey Tinker"** to hold your first spoken conversation. This is a
+learning-by-doing walkthrough; every milestone has a result you can see or hear
+so you know it worked.
+
+This is the **front door** of the docs. It is the one page that walks the full
+journey across both halves of the stack. It does not go deep on any single
+step — instead, each milestone hands you off to a focused guide if you want more
+detail or hit trouble. Read the whole page once, then follow it with both
+devices in front of you.
+
+## How the stack fits, in one breath
+
+The product is two devices talking over **one WebSocket**:
+
+- **The Tab5 is the face.** It owns the screen, the microphone, and the speaker.
+  It holds no intelligence — it captures your voice and plays back answers.
+- **The Dragon is the brain.** Speech-to-text, the LLM, and text-to-speech all
+  run there. It is a Radxa Dragon Q6A, but for this tutorial any Linux box with
+  Python 3.12+ works.
+
+You need both. The journey is three milestones — **flash the face**, **wake the
+brain**, **introduce them** — and then you talk. For the full mental model, read
+[How the stack fits together](../explanation/how-the-stack-fits-together.md);
+you do not need it to finish this page.
+
+## Before you start
+
+- An **M5Stack Tab5** (ESP32-P4) and a **USB-C cable**.
+- A computer with **ESP-IDF v5.5.2** installed — the exact version the firmware
+  is pinned to. If you do not have it:
+  ```bash
+  mkdir -p ~/esp && cd ~/esp
+  git clone -b v5.5.2 --recursive https://github.com/espressif/esp-idf.git
+  cd esp-idf && ./install.sh esp32p4
+  ```
+- A **Dragon** (or any Linux box) with **Python 3.12+** and network access. For
+  cloud voice modes you also want an **OpenRouter API key**; the default Local
+  mode needs no key.
+- Your **Wi-Fi SSID and password**. Both devices must be on the **same network**.
+
+---
+
+## Milestone 1 — Flash the face
+
+You will turn a bare Tab5 into a booted device showing its home screen.
+
+1. **Clone the firmware and enter it.**
+   ```bash
+   git clone https://github.com/lorcan35/TinkerTab.git
+   cd TinkerTab
+   ```
+   _You should see:_ a `TinkerTab/` directory containing `main/`, `docs/`, and a
+   top-level `CMakeLists.txt`.
+
+2. **Tell the Tab5 your Wi-Fi (and a placeholder Dragon address).** Open
+   `sdkconfig.defaults` and set:
+   ```
+   CONFIG_TAB5_WIFI_SSID="YourNetwork"
+   CONFIG_TAB5_WIFI_PASS="YourPassword"
+   CONFIG_TAB5_DRAGON_HOST="192.168.1.91"   # update in Milestone 3 once you know it
+   CONFIG_TAB5_DRAGON_PORT=3502
+   ```
+   The Dragon address can stay a placeholder for now — you will set the real one
+   in Milestone 3, on-device, without reflashing.
+   _You should see:_ the four values updated in the file.
+
+3. **Activate ESP-IDF in this terminal** (do this in every new shell):
+   ```bash
+   . ~/esp/esp-idf/export.sh
+   ```
+   _You should see:_ `Done! You can now compile ESP-IDF projects.`
+
+4. **Build the firmware.** The first build downloads components and takes
+   several minutes.
+   ```bash
+   idf.py set-target esp32p4
+   idf.py build
+   ```
+   _You should see:_ `Project build complete.` and a `build/tinkertab.bin`.
+
+5. **Flash it over USB.** Plug the Tab5 in, then flash (use the port your board
+   enumerated as — check with `ls /dev/ttyACM* /dev/ttyUSB*`):
+   ```bash
+   idf.py -p /dev/ttyACM0 flash
+   ```
+   _You should see:_ `Hash of data verified.` and `Leaving... Hard resetting`.
+
+6. **If the screen stays dark (ROM download mode), kick a watchdog reset.**
+   ESP32-P4 boards commonly need this after a flash:
+   ```bash
+   python -m esptool --chip esp32p4 -p /dev/ttyACM0 \
+     --before no_reset --after watchdog_reset read_mac
+   ```
+   _You should see:_ the MAC address printed and the Tab5 boot. Skip this if the
+   screen already lit up.
+
+**Milestone 1 result:** the Tab5 boots past the splash to the **home screen**
+with the ambient orb breathing gently, and the Wi-Fi indicator lights up once it
+joins your network. The connection status will still read *disconnected* — the
+Dragon is not up yet. That is expected.
+
+> Stuck on the build or flash? The full loop, recovery, and troubleshooting live
+> in [How to flash the firmware](../how-to/flash-firmware.md).
+
+---
+
+## Milestone 2 — Wake the brain
+
+You will get the Dragon voice server live on **port 3502**, answering a health
+check over the network. This half of the journey lives in the
+[**TinkerBox**](https://github.com/lorcan35/TinkerBox) repo — the brain is its
+own project with its own front door.
+
+1. **Follow TinkerBox's getting-started tutorial.** It walks you from a clone to
+   the `dragon_voice` service running on port 3502:
+   [TinkerBox — Get your Dragon running](https://github.com/lorcan35/TinkerBox/blob/main/docs/tutorials/get-dragon-running.md).
+
+2. **Note the Dragon's IP address** on your network — you will point the Tab5 at
+   it next. From the Dragon itself, `hostname -I` prints it; from your
+   workstation you can find it on the same LAN with:
+   ```bash
+   ping radxa-dragon-q6a
+   # or scan the subnet for the voice WS + dashboard + gateway ports
+   nmap -p 22,3502,18789 --open <subnet>/24
+   ```
+
+3. **Confirm the brain answers** over the network from your workstation:
+   ```bash
+   curl -s http://<dragon-ip>:3502/health
+   # → expect a JSON health response, not a connection refused
+   ```
+
+**Milestone 2 result:** `curl` to the Dragon's `:3502/health` returns a healthy
+JSON response from another machine on the same network. The brain is awake and
+listening.
+
+> Putting the Dragon into always-on production (systemd, tunnels, OTA) is a
+> separate task — see
+> [TinkerBox — Deploy on a Dragon](https://github.com/lorcan35/TinkerBox/blob/main/docs/how-to/deploy-on-a-dragon.md).
+
+---
+
+## Milestone 3 — Introduce them
+
+You will point the Tab5 at the Dragon and watch the WebSocket come up.
+
+1. **On the Tab5, open Settings → Network.** (First-boot onboarding may have
+   already walked you through Wi-Fi.)
+
+2. **Set the Dragon host and port.** Enter the Dragon's IP from Milestone 2 and
+   port **3502**. The Tab5 saves these to [NVS](../../GLOSSARY.md) and reconnects
+   on its own.
+
+3. **Watch the link come up.** The Tab5 holds exactly one persistent
+   [WebSocket](../../GLOSSARY.md) to the Dragon at `ws://<dragon-ip>:3502/ws/voice`,
+   registers the device, and starts a session.
+
+**Milestone 3 result:** the home screen's status reads **connected**. You can
+prove it from your workstation over the Tab5's
+[debug server](../reference/debug-server.md) (the bearer token prints on the
+serial boot log):
+
+```bash
+export TOKEN="<32-hex-token-from-serial-boot-log>"
+curl -s -H "Authorization: Bearer $TOKEN" http://<tab5-ip>:8080/voice \
+     | python3 -m json.tool
+# → expect "connected": true and a state_name of READY (or IDLE)
+```
+
+> The three ways to set the address (on-device, at build time, over the debug
+> server) plus connection troubleshooting are in
+> [How to connect a Tab5 to a Dragon](../how-to/connect-to-dragon.md).
+
+---
+
+## Milestone 4 — Talk to it
+
+Both halves are live and linked. Now hold a conversation.
+
+1. **Start listening.** With the K144/[TinkerON](../../GLOSSARY.md) module the
+   wakeword is always on — just say **"Hey Tinker."** Without it, **tap the orb**
+   on the home screen.
+   _You should see:_ the orb shift to its **LISTENING** state — it leans and
+   ripples, and the prompt below it changes to show it is hearing you.
+
+2. **Ask a question with a clear answer**, e.g. _"What time is it?"_ or
+   _"What's the capital of France?"_ — then stop talking.
+   _You should see and hear:_ the orb move to **PROCESSING** while the Dragon
+   transcribes your speech and runs the LLM, then to **SPEAKING** as the answer
+   plays through the speaker.
+
+3. **Ask a follow-up** that depends on the first answer, e.g.
+   _"And how many people live there?"_
+   _You should see:_ the answer reference the previous turn — the Dragon keeps a
+   session, so the conversation has memory.
+
+**Milestone 4 result:** a spoken answer comes out of the Tab5's speaker. A
+successful turn looks like this on the serial log (115200 baud):
+
+```
+I (xxxx) voice: state IDLE -> LISTENING
+I (xxxx) voice: state LISTENING -> PROCESSING
+I (xxxx) voice: state PROCESSING -> SPEAKING
+I (xxxx) voice: state SPEAKING -> READY
+```
+
+---
+
+## What you built
+
+You now have a complete, self-hosted voice assistant: the Tab5 captures your
+speech and streams it over one WebSocket to the Dragon, which runs
+speech-to-text, the LLM, and text-to-speech, and streams the answer back to play
+through the speaker. Both halves run on your own hardware — no cloud required,
+though [cloud and hybrid modes](../how-to/switch-voice-modes.md) are a setting
+away when you want faster or smarter models.
+
+## Next
+
+- [Your first voice conversation](your-first-voice-conversation.md) — the
+  day-to-day rhythm: follow-ups, cancelling, typing, and dictation.
+- [Switch voice modes](../how-to/switch-voice-modes.md) — trade privacy, speed,
+  and cost across the six tiers (local, hybrid, cloud, onboard, solo).
+- [Enable the TinkerON wakeword](../how-to/enable-tinkeron-wakeword.md) — go
+  fully hands-free with "Hey Tinker."
+- [The voice pipeline](../explanation/the-voice-pipeline.md) — what actually
+  happens between your words and the answer.
+- The brain's own docs live in
+  [**TinkerBox**](https://github.com/lorcan35/TinkerBox) — start at its README.


### PR DESCRIPTION
Final docs wave. The end-to-end hero tutorial (unbox → working voice assistant), a voice-mode decision guide (privacy/latency/cost/offline), and the whole-stack overview. `docs/README.md` puts the unbox tutorial at the top as 'Start here'. Link-check PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)