### PR TITLE
fix(dictation): W0 quick-wins — dead handler, backend gate, 4-hr cap stop-frame

### DIFF
--- a/main/voice.c
+++ b/main/voice.c
@@ -888,13 +888,36 @@ static void mic_capture_task(void *arg)
               break;
            }
 
-           /* PR 1: parallel 5-min hard cap on dictation.  Mirrors the ASK
-            * cap above — log, drive the pipeline state machine into
-            * FAILED with reason TOO_LONG, and break out of the mic loop
-            * using the same pattern that's proven safe in ASK mode. */
+           /* Parallel 4-hr hard cap on dictation (MAX_RECORD_FRAMES_DICT).
+            *
+            * Dictation audit 2026-05-29 (S1-4): this cap fires from INSIDE
+            * the mic loop — a SELF-initiated stop — unlike the user-stop
+            * path, which is driven externally by voice_stop_listening()
+            * (that function sends the WS stop frame + sets state, then the
+            * loop notices !s_mic_running and exits).  The old cap code only
+            * drove the local FSM to FAILED/TOO_LONG and broke: it never
+            * sent Dragon `{"type":"stop"}` (so Dragon was left mid-session
+            * and the WS turn wedged) and never reset voice_state (stuck at
+            * LISTENING).  A 4-hour dictation is VALID content, so the right
+            * move is a clean stop: send the stop frame so Dragon finishes,
+            * transcribes what it has, and saves the (truncated) note —
+            * exactly the dictate branch of voice_stop_listening.  We inline
+            * it here rather than calling voice_stop_listening() because we
+            * ARE the mic task (that function drains on s_mic_running, which
+            * only clears after this loop exits → would self-deadlock). */
            if (voice_get_mode() == VOICE_MODE_DICTATE && frames_sent >= MAX_RECORD_FRAMES_DICT) {
-              ESP_LOGW(TAG, "Dictation hit 4-hr safety cap — auto-stopping");
-              voice_dictation_set_state(DICT_FAILED, DICT_FAIL_TOO_LONG, (uint32_t)(esp_timer_get_time() / 1000));
+              ESP_LOGW(TAG, "Dictation hit 4-hr safety cap — auto-stopping (clean stop)");
+              esp_err_t cap_stop_err = voice_ws_send_text("{\"type\":\"stop\"}");
+              if (cap_stop_err == ESP_OK) {
+                 voice_dictation_set_state(DICT_TRANSCRIBING, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
+                 voice_set_state(VOICE_STATE_PROCESSING, "dictation_cap");
+              } else {
+                 /* WS gone — mirror voice_stop_listening's connection-lost
+                  * branch: surface NETWORK + drop to IDLE so we don't wedge. */
+                 ESP_LOGW(TAG, "Cap stop frame failed — connection lost");
+                 voice_dictation_set_state(DICT_FAILED, DICT_FAIL_NETWORK, (uint32_t)(esp_timer_get_time() / 1000));
+                 voice_set_state(VOICE_STATE_IDLE, "dictation_cap_no_ws");
+              }
               break;
            }
 
@@ -968,10 +991,12 @@ static void mic_capture_task(void *arg)
         /* TT #572 follow-up: dictation no longer auto-stops on
          * silence — user taps Stop manually.  The post-loop send-stop
          * here used to fire when the silence-counter break above
-         * triggered.  Now the loop only exits via user-initiated stop
-         * or the 4-hr cap; the stop frame is already sent by those
-         * code paths, so this block is a dead branch.  Left as a
-         * no-op for clarity. */
+         * triggered.  The loop now exits only via user-initiated stop
+         * (voice_stop_listening sends the WS stop frame externally) or
+         * the 4-hr cap (which sends its own stop frame inline — see the
+         * cap branch above, fixed in the 2026-05-29 dictation audit).
+         * Both paths send the stop frame, so this block is genuinely a
+         * no-op — left here only to document where the old send lived. */
 
         ESP_LOGI(TAG, "Mic session end (frames=%d) — back to idle", frames_sent);
         /* #284: drop back to outer while(1) and wait for the next

--- a/main/voice_dictation.h
+++ b/main/voice_dictation.h
@@ -52,7 +52,13 @@ typedef enum {
    DICT_FAIL_NETWORK,   /* Other HTTP error / WS disconnect / open failed */
    DICT_FAIL_EMPTY,     /* Dragon returned 200 with empty STT text */
    DICT_FAIL_NO_AUDIO,  /* WAV missing or unreadable / Dragon got no PCM */
-   DICT_FAIL_TOO_LONG,  /* hit 5-min hard cap during recording */
+   DICT_FAIL_TOO_LONG,  /* recording exceeded the hard cap.  The 4-hr
+                         * dictation cap (voice.c MAX_RECORD_FRAMES_DICT,
+                         * = 720000 frames; was wrongly documented as
+                         * "5-min" pre-2026-05-29) now clean-stops to
+                         * SAVED instead of failing, so this reason is
+                         * reserved — kept for the reason taxonomy + the
+                         * /dictation_pipeline debug contract + orb render. */
    DICT_FAIL_CANCELLED, /* user tapped cancel */
 } dict_fail_t;
 

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -856,19 +856,43 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       ESP_LOGI(TAG, "Dictation post-process started");
       voice_set_state(VOICE_STATE_PROCESSING, "Generating summary...");
    } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
-      /* TinkerBox#94 H4: LLM failed or wasn't available.  Note already
-       * saved (the transcript landed via the prior `stt` event); user
-       * just doesn't get an auto-generated title/summary.  Clear the
-       * "Generating summary..." caption and toast the friendly
-       * message. */
+      /* TinkerBox#94 H4: Dragon's STT + auto-note-create completed but
+       * the LLM summary step failed (no_llm_available, generation
+       * error, etc.).  The transcript IS captured — the note already
+       * exists on Dragon and the `stt` event already landed the text —
+       * so the user's intent was saved; only the auto title/summary is
+       * missing.  Clear the "Generating summary..." caption, toast the
+       * friendly message, drive the dictation pipeline to SAVED (NOT
+       * left stuck at TRANSCRIBING), and surface a local Tab5 note from
+       * the transcript.
+       *
+       * Dictation audit 2026-05-29 (S1-2): a SECOND
+       * `dictation_postprocessing_error` branch used to live later in
+       * this if/else chain and owned the FSM→SAVED + local-note work,
+       * but it was unreachable (this branch matched first), so every
+       * Local dictation that hit the summary-error path — the COMMON
+       * path on the llama-server Local backend — left the pipeline
+       * wedged at TRANSCRIBING with no note.  Merged here; the dead
+       * branch was deleted. */
       cJSON *msg = cJSON_GetObjectItem(root, "message");
       const char *m = cJSON_IsString(msg) ? msg->valuestring : "Note saved — summary unavailable";
-      ESP_LOGW(TAG, "Dictation post-process error: %s", m);
+      cJSON *err = cJSON_GetObjectItem(root, "error");
+      const char *err_str = (cJSON_IsString(err) && err->valuestring) ? err->valuestring : "unknown";
+      ESP_LOGW(TAG, "Dictation post-process error: %s (%s) — pipeline → SAVED (note already exists)", m, err_str);
       char buf[160];
       strncpy(buf, m, sizeof(buf) - 1);
       buf[sizeof(buf) - 1] = '\0';
       voice_async_toast(strdup(buf));
-      voice_set_state(VOICE_STATE_READY, "dictation_done");
+      voice_set_state(VOICE_STATE_READY, "dictation_postprocessing_error");
+      voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
+      /* Surface the dictation as a local Tab5 note (Path B: FAB / home
+       * Dictate chip — Path A's local "+ NEW VOICE NOTE" slot already
+       * owns its own row; ui_notes_add_dictated_async no-ops if a local
+       * slot is already active so we don't duplicate). */
+      const char *transcript = voice_get_dictation_text();
+      if (transcript && transcript[0]) {
+         ui_notes_add_dictated_async(transcript);
+      }
    } else if (strcmp(type_str, "dictation_postprocessing_cancelled") == 0) {
       /* TinkerBox#94 H4: a NEW dictation superseded the prior in-flight
        * post-process.  The new dictation will emit its own
@@ -968,30 +992,6 @@ void voice_ws_proto_handle_text(const char *data, int len) {
       cJSON *ntitle = cJSON_GetObjectItem(root, "title");
       ESP_LOGI(TAG, "Dragon auto-created note: id=%s title=\"%s\"", cJSON_IsString(nid) ? nid->valuestring : "?",
                cJSON_IsString(ntitle) ? ntitle->valuestring : "?");
-   } else if (strcmp(type_str, "dictation_postprocessing_error") == 0) {
-      /* PR 2 polish: Dragon's STT + auto-note-create completed but the
-       * LLM summary step failed (no_llm_available, generation error,
-       * etc.).  The note IS saved on Dragon (it was created from the
-       * STT transcript before the LLM step), so transition the pipeline
-       * to SAVED rather than leaving it stuck at TRANSCRIBING.  We use
-       * SAVED here even though there's no title/summary because the
-       * user's intent was captured — the note exists, just without an
-       * auto-generated heading.  Tab5's Notes screen will pick it up
-       * on next sync with a fallback title from the transcript. */
-      cJSON *err = cJSON_GetObjectItem(root, "error");
-      const char *err_str = (cJSON_IsString(err) && err->valuestring) ? err->valuestring : "unknown";
-      ESP_LOGW(TAG, "Dictation post-processing failed: %s — pipeline → SAVED (note already exists)", err_str);
-      voice_set_state(VOICE_STATE_READY, "dictation_postprocessing_error");
-      voice_dictation_set_state(DICT_SAVED, DICT_FAIL_NONE, (uint32_t)(esp_timer_get_time() / 1000));
-      /* PR 3 follow-up: same local-note creation path as
-       * dictation_summary above.  Dragon auto-created its own note
-       * before the LLM step failed, so the transcript is the user's
-       * captured content even though we don't have a title/summary.
-       * Surface it on Tab5's Notes timeline. */
-      const char *transcript = voice_get_dictation_text();
-      if (transcript && transcript[0]) {
-         ui_notes_add_dictated_async(transcript);
-      }
    } else if (strcmp(type_str, "llm_done") == 0) {
       cJSON *ms = cJSON_GetObjectItem(root, "llm_ms");
       ESP_LOGI(TAG, "LLM done (%.0fms) | heap_dma_free=%u largest=%u", cJSON_IsNumber(ms) ? ms->valuedouble : 0.0,


### PR DESCRIPTION
## Summary
W0 "stop the bleeding" quick-wins from the 2026-05-29 cross-stack dictation audit (Tab5 side). Each has a verified root cause from the audit.

- **S1-2** — `voice_ws_proto.c` had **two** `dictation_postprocessing_error` branches; the first (toast+READY only) matched, so the second (FSM→SAVED + local note) was unreachable. Every Local dictation hitting the summary-error path wedged at TRANSCRIBING with no note. Merged the FSM + note work into the single live handler; deleted the dead branch.
- **S1-4** — the 4-hr dictation cap fired from inside the mic loop but never sent Dragon `{"type":"stop"}` (Dragon left mid-session, WS wedged) and never reset `voice_state` (stuck LISTENING). It now clean-stops (Dragon finishes + saves the truncated note), NETWORK/IDLE fallback if the WS is gone.
- **S3-6** — `DICT_FAIL_TOO_LONG` header said "5-min hard cap"; the constant is 720000 frames (4 hr) — off by ~48×.

## Verification
- `idf.py build` (ESP32-P4) green; `git-clang-format --diff origin/main` clean.
- Host suite green (the dictation FSM host tests are unaffected by these handler/cap fixes).
- Live verification: deferred to the stacked redesign PR's flash pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)