### PR TITLE
fix(heap_wd): stop sram_exhausted false-reboot + throttle always-on YOLO

### DIFF
--- a/main/heap_watchdog.c
+++ b/main/heap_watchdog.c
@@ -81,14 +81,28 @@ static const char *TAG = "heap_wd";
  * drops RX packets, WS starves, and we get the voice.c:1528 hard-kick
  * reboot (reset_reason=SW, no coredump).
  *
- * This detector fires when `internal_largest < 20 KB` sustained for
- * 2 consecutive checks (2 min).  20 KB gives ~6 KB of margin above the
- * observed 14 KB SDIO demand.  2-min sustained avoids false positives
- * from transient dips during a single screen transition.  The abort
- * path saves a coredump so future regressions are diagnosable; the
- * current silent cascade just leaves the user with a reboot. */
-#define HEAP_WD_INT_EXHAUST_BLOCK_MIN    (20 * 1024)  /* 20KB largest block */
-#define HEAP_WD_INT_EXHAUST_REBOOT_COUNT 2             /* 2 consecutive = 2 min */
+ * This detector WARNS when `internal_largest < 20 KB` (early observability)
+ * but the REBOOT is DISABLED (REBOOT_COUNT = INT_MAX), matching the sibling
+ * DMA-pool detector below.
+ *
+ * Rationale (2026-05-31, from a serial-coredump root-cause of a reboot
+ * crash-loop — Panic reason "heap_wd: sram_exhausted", heap_watchdog.c:237):
+ * the 20 KB trip sits ~6 KB ABOVE the ~14 KB SDIO peak demand, so at
+ * 14-20 KB largest the SDIO driver still allocates and WiFi/voice/UI all
+ * keep working — yet heap_wd was aborting a FUNCTIONAL device every few
+ * minutes under sustained camera/voice load.  This is the exact "rebooting
+ * because an internal pool is low when everything the user sees is fine"
+ * pattern the DMA detector below was already disabled for, on what is
+ * essentially the same pool (DMA-capable internal == internal SRAM on the
+ * ESP32-P4: /heap reports identical free/largest for both).
+ *
+ * We keep the per-check ESP_LOGE warning + the 60 s heap breakdown for
+ * observability, and leave genuine WS/SDIO starvation recovery to the
+ * WiFi/reconnect watchdogs.  Only re-enable (small positive count) paired
+ * with a real fix that addresses the underlying internal-SRAM consumer
+ * (likely camera/YOLO DMA buffers — the proper follow-up). */
+#define HEAP_WD_INT_EXHAUST_BLOCK_MIN (20 * 1024) /* 20KB — WARN threshold only */
+#define HEAP_WD_INT_EXHAUST_REBOOT_COUNT INT_MAX  /* reboot DISABLED — see above */
 
 /* DMA pool exhaustion thresholds (audit #80):
  * WiFi driver + TLS need DMA-capable buffers for RX/TX descriptors. When

--- a/main/vision_service.c
+++ b/main/vision_service.c
@@ -29,6 +29,17 @@ static const char *TAG = "vision_svc";
 
 #define POLL_INTERVAL_MS 500u /* config re-read cadence when disabled */
 #define MIN_TICK_MS 333u      /* hard floor matches K144 USB-FFS budget */
+/* 2026-05-31: ambient-inference throttle.  The always-on vision loop is the
+ * dominant internal-SRAM consumer (camera DQBUF + the HW-JPEG encoder's
+ * transient DMA descriptors every cycle), which drives the largest free
+ * internal block down toward the SDIO ~14 KB floor and was the root cause of
+ * the heap_wd "sram_exhausted" + voice.c WS-starvation reboots.  process_one_
+ * frame() already costs ~1.5 s on the K144 round-trip; this floor spaces
+ * cycles to ~once per period so those transient internal allocations happen
+ * far less often.  Presence detection at ~0.25-0.3 Hz is ample — the Welcome
+ * rule uses a 5-min cooldown anyway (VS_WELCOME_COOLDOWN_MS).  Throttle, not
+ * disable, per owner decision 2026-05-31. */
+#define VS_AMBIENT_MIN_PERIOD_MS 2000u
 #define VS_MAX_BOXES 8
 #define VS_INPUT_W 320
 #define VS_INPUT_H 320
@@ -497,6 +508,7 @@ static void vision_service_task(void *arg) {
 
       uint32_t period_ms = 1000u / rate;
       if (period_ms < MIN_TICK_MS) period_ms = MIN_TICK_MS;
+      if (period_ms < VS_AMBIENT_MIN_PERIOD_MS) period_ms = VS_AMBIENT_MIN_PERIOD_MS;
       vTaskDelay(pdMS_TO_TICKS(period_ms));
    }
 }


### PR DESCRIPTION
## Bug / Problem
Tab5 reboots on a cycle — "runs fine for a few minutes, then crashes," repeatedly.

## Root Cause (on-device serial coredump)
`Panic reason: heap_wd: sram_exhausted` at `heap_watchdog.c:237`. The `#182` internal-SRAM exhaustion detector aborts when the largest free internal block sits below **20 KB for 2 min** — but the real failure point is the SDIO driver's **~14 KB** demand (documented in the same file). In the 14–20 KB band the device is fully functional (SDIO/WiFi/voice/UI all work), yet heap_wd was rebooting it under sustained vision load. This is the exact *"reboot a working device because an internal pool is low"* pattern the sibling **DMA-pool detector was already disabled for** (`HEAP_WD_DMA_REBOOT_COUNT = INT_MAX`) — and on the ESP32-P4 the DMA-capable-internal and internal pools are the same memory.

The consumer driving the pressure is the **always-on YOLO/vision pipeline** (`vision_service`, 2 Hz, 24 KB internal HW-JPEG buffer, camera DQBUF every cycle; `welcome_fires_total: 0`).

## Fix
- **`heap_watchdog.c`** — disable the `sram_exhausted` *reboot* (`HEAP_WD_INT_EXHAUST_REBOOT_COUNT` `2 → INT_MAX`), keep the WARN log + 60 s heap breakdown for observability. Mirrors the DMA-detector decision on the same pool.
- **`vision_service.c`** — add `VS_AMBIENT_MIN_PERIOD_MS = 2000` floor on the ambient loop → **0.5 Hz → 0.28 Hz**, internal-SRAM steady-state **52 → 58 KB**, far fewer transient HW-JPEG DMA dips, less camera/K144/power load. Presence detection preserved (Welcome uses a 5-min cooldown). The 24 KB JPEG buffer **cannot** move to PSRAM (HW JPEG engine rejects it on cache-alignment; documented in-file).

## Verification (Tab5 192.168.1.90)
- Serial-coredump repro: stressed largest internal block down to **exactly 14 KB** → the abort **never fired** (`count=1/2147483647`), **0 reboots**.
- YOLO cadence measured at **0.28 Hz** post-throttle; vision still detecting.
- Clean boot, camera+YOLO stress, uptime monotonic, 0 panic/abort.

## Notes
- **Pre-existing** class (#182 / Wave-15), not introduced by recent work.
- A second, deeper reboot path (`voice.c` zombie-WiFi `SW` reset at the genuine ~14 KB SDIO-starvation point) shares this root cause and only triggers under abusive load; the throttle widens the margin. Fully closing it would mean disabling always-on vision (owner chose throttle-and-keep). Follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)