### PR TITLE
fix(voice): typed turns never reach Dragon — K144-failover hijack

### DIFF
--- a/main/voice_modes.c
+++ b/main/voice_modes.c
@@ -177,7 +177,12 @@ void voice_modes_route_text(const char *text, voice_modes_route_result_t *out) {
    if (s_ws_last_alive_us) {
       down_ms = (uint32_t)((esp_timer_get_time() - s_ws_last_alive_us) / 1000);
    }
-   if (down_ms >= M5_FAILOVER_GRACE_MS && tab5_settings_get_voice_mode() == VMODE_LOCAL) {
+   /* 2026-05-31: also require the WS to be genuinely disconnected.  The
+    * down_ms timer alone mis-fired this failover for every typed turn on a
+    * live connection (the s_ws_last_alive_us stamp was only set on connect —
+    * see voice_ws_proto.c RX-stamp fix); gating on the real connection state
+    * guarantees a healthy Dragon link always wins the turn. */
+   if (down_ms >= M5_FAILOVER_GRACE_MS && tab5_settings_get_voice_mode() == VMODE_LOCAL && !voice_is_connected()) {
       esp_err_t fe = voice_onboard_send_text(text);
       if (fe == ESP_OK) {
          ESP_LOGI(TAG, "Local-mode failover engaged — routed to K144 (down=%ums)", (unsigned)down_ms);

--- a/main/voice_ws_proto.c
+++ b/main/voice_ws_proto.c
@@ -1806,6 +1806,15 @@ void voice_ws_proto_event_handler(void *arg, esp_event_base_t base, int32_t even
       case WEBSOCKET_EVENT_DATA:
          if (!data) break;
          s_last_activity_us = esp_timer_get_time();
+         /* TT #317 Phase 4 fix (2026-05-31): refresh the K144-failover liveness
+          * stamp on EVERY Dragon RX.  It was previously set only on
+          * WEBSOCKET_EVENT_CONNECTED and never refreshed, so after
+          * M5_FAILOVER_GRACE_MS (30 s) of a perfectly healthy connection
+          * down_ms stayed >= grace and EVERY Local-mode typed turn wrongly
+          * failed over to the (task-full) K144 and never reached Dragon —
+          * voice turns escaped because they bypass voice_modes_route_text.
+          * Stamping here makes down_ms measure real Dragon silence. */
+         s_ws_last_alive_us = esp_timer_get_time();
          if (data->op_code == WS_TRANSPORT_OPCODES_TEXT && data->data_len > 0) {
             ESP_LOGI(TAG, "WS recv text (%d bytes): %.*s", data->data_len, data->data_len > 200 ? 200 : data->data_len,
                      data->data_ptr);


### PR DESCRIPTION
## Bug
Typed/chat turns get no reply in Local mode (and effectively any Dragon mode), while **voice** turns work. The text is reported \`sent:true\` but Dragon never receives it.

## Root Cause (on-device serial + Dragon journal)
In Local mode every **typed** turn fails over to the K144 onboard LLM, which is \`task full\` (busy running the wakeword ASR), so the turn dies and never reaches Dragon. Voice turns escape this because they stream PCM directly and bypass \`voice_modes_route_text\`.

The K144-failover gate fires when \`down_ms >= M5_FAILOVER_GRACE_MS\` (30s), where \`down_ms = now - s_ws_last_alive_us\`. But **\`s_ws_last_alive_us\` is stamped only on \`WEBSOCKET_EVENT_CONNECTED\` and never refreshed** — so despite its name it measures *time since connect*, and after 30s of a perfectly healthy connection it stays \`>= grace\` permanently, hijacking every typed turn. (Right next to it, \`s_last_activity_us\` *is* stamped on every RX but is dead — written, never read.)

## Fix
- **`voice_ws_proto.c`** — refresh \`s_ws_last_alive_us\` on every Dragon RX (\`WEBSOCKET_EVENT_DATA\`), so \`down_ms\` measures real Dragon silence.
- **`voice_modes.c`** — also gate the failover on \`!voice_is_connected()\`, so a genuinely-live WS always wins the turn regardless of the timer.

## Verification (Tab5 192.168.1.90, text sent >30s post-connect — the exact failing window)
| Mode | Result |
|---|---|
| **Local** (Granite, 4.1s) | "BANANA" ✓ |
| **Cloud** (gpt-4o-mini) | full 3-course constraint-satisfying menu ✓ |
| **TinkerClaw** (MiniMax-M2.7) | accurate TCP/UDP explanation ✓ |
| **Solo** (OpenRouter direct) | quantum-entanglement + MANGO replies ✓ |

Before the fix, Dragon's journal showed the text was **never received**; after, `text_turn_gate: Text input ...` + a reply every time. Screenshots captured for each mode.

## Note (follow-up, not in this PR)
Separately observed a WS-zombie reboot: Dragon drops the WS after 30s without a PONG (`No PONG received after 30.0 seconds`); Tab5's zombie watchdog escalates to a hard WiFi kick that can fail (`esp_wifi_start ... ESP_FAIL`) → controlled reboot. Real recurring stability issue, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)